### PR TITLE
fix(file-explorer): bound thumbnail provider execution

### DIFF
--- a/PowerToys.slnx
+++ b/PowerToys.slnx
@@ -64,6 +64,7 @@
     </Project>
     <Project Path="src/common/UnitTests-CommonLib/UnitTests-CommonLib.vcxproj" Id="1a066c63-64b3-45f8-92fe-664e1cce8077" />
     <Project Path="src/common/UnitTests-CommonUtils/UnitTests-CommonUtils.vcxproj" Id="8b5cfb38-ccba-40a8-ad7a-89c57b070884" />
+    <Project Path="src/common/UnitTests-CommonUtils/ThumbnailProviderTestHelper.vcxproj" Id="f82a86e7-7c58-48c1-a923-5d735e17d5ab" />
     <Project Path="src/common/updating/UnitTests/UpdatingUnitTests.vcxproj" Id="a1b2c3d4-e5f6-7890-abcd-ef1234567890" />
     <Project Path="src/common/updating/updating.vcxproj" Id="17da04df-e393-4397-9cf0-84dabe11032e" />
     <Project Path="src/common/version/version.vcxproj" Id="cc6e41ac-8174-4e8a-8d22-85dd7f4851df" />

--- a/src/common/FilePreviewCommon/BgcodeHelper.cs
+++ b/src/common/FilePreviewCommon/BgcodeHelper.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -15,6 +16,7 @@ namespace Microsoft.PowerToys.FilePreviewCommon
     public static class BgcodeHelper
     {
         private const uint MagicNumber = 'G' | 'C' << 8 | 'D' << 16 | 'E' << 24;
+        private const uint MaximumThumbnailDataSize = 64 * 1024 * 1024;
 
         /// <summary>
         /// Gets any thumbnails found in a bgcode file.
@@ -23,6 +25,9 @@ namespace Microsoft.PowerToys.FilePreviewCommon
         /// <returns>The thumbnails found in a bgcode file.</returns>
         public static IEnumerable<BgcodeThumbnail> GetThumbnails(BinaryReader reader)
         {
+            ArgumentNullException.ThrowIfNull(reader);
+
+            EnsureRemaining(reader, 10);
             var magicNumber = reader.ReadUInt32();
 
             if (magicNumber != MagicNumber)
@@ -42,11 +47,18 @@ namespace Microsoft.PowerToys.FilePreviewCommon
 
             while (reader.BaseStream.Position < reader.BaseStream.Length)
             {
+                var blockStart = reader.BaseStream.Position;
+                EnsureRemaining(reader, 8);
                 var blockType = (BgcodeBlockType)reader.ReadUInt16();
                 var compression = (BgcodeCompressionType)reader.ReadUInt16();
                 var uncompressedSize = reader.ReadUInt32();
 
-                var size = compression == BgcodeCompressionType.NoCompression ? uncompressedSize : reader.ReadUInt32();
+                if (compression != BgcodeCompressionType.NoCompression)
+                {
+                    EnsureRemaining(reader, 4);
+                }
+
+                var storedSize = compression == BgcodeCompressionType.NoCompression ? uncompressedSize : reader.ReadUInt32();
 
                 switch (blockType)
                 {
@@ -55,16 +67,17 @@ namespace Microsoft.PowerToys.FilePreviewCommon
                     case BgcodeBlockType.PrintMetadataBlock:
                     case BgcodeBlockType.SlicerMetadataBlock:
                     case BgcodeBlockType.GCodeBlock:
-                        reader.BaseStream.Seek(2 + size, SeekOrigin.Current); // Skip
-
+                        SkipBytes(reader, 2); // Encoding
+                        SkipBytes(reader, storedSize);
                         break;
 
                     case BgcodeBlockType.ThumbnailBlock:
+                        EnsureRemaining(reader, 2);
                         var format = (BgcodeThumbnailFormat)reader.ReadUInt16();
 
-                        reader.BaseStream.Seek(4, SeekOrigin.Current); // Skip width and height
+                        SkipBytes(reader, 4); // Width and height
 
-                        var data = ReadAndDecompressData(reader, compression, (int)size);
+                        var data = ReadAndDecompressData(reader, compression, storedSize, uncompressedSize);
 
                         if (data != null)
                         {
@@ -72,11 +85,19 @@ namespace Microsoft.PowerToys.FilePreviewCommon
                         }
 
                         break;
+
+                    default:
+                        throw new InvalidDataException("Unsupported block type.");
                 }
 
                 if (checksum == BgcodeChecksumType.CRC32)
                 {
-                    reader.BaseStream.Seek(4, SeekOrigin.Current); // Skip checksum
+                    SkipBytes(reader, 4);
+                }
+
+                if (reader.BaseStream.Position <= blockStart)
+                {
+                    throw new InvalidDataException("The BGCODE parser made no forward progress.");
                 }
             }
         }
@@ -100,29 +121,83 @@ namespace Microsoft.PowerToys.FilePreviewCommon
                 .FirstOrDefault();
         }
 
-        private static byte[]? ReadAndDecompressData(BinaryReader reader, BgcodeCompressionType compression, int size)
+        private static byte[]? ReadAndDecompressData(
+            BinaryReader reader,
+            BgcodeCompressionType compression,
+            uint storedSize,
+            uint uncompressedSize)
         {
             // Though the spec doesn't actually mention it, the reference encoder code never applies compression to thumbnails data
             // which makes complete sense as this data is PNG, JPEG or QOI encoded so already compressed as much as possible!
             switch (compression)
             {
                 case BgcodeCompressionType.NoCompression:
-                    return reader.ReadBytes(size);
+                    EnsureThumbnailDataSize(storedSize);
+                    EnsureRemaining(reader, storedSize);
+                    return ReadBytesExactly(reader, (int)storedSize);
 
                 case BgcodeCompressionType.DeflateAlgorithm:
-                    var buffer = new byte[size];
+                    EnsureThumbnailDataSize(storedSize);
+                    EnsureThumbnailDataSize(uncompressedSize);
+                    EnsureRemaining(reader, storedSize);
+                    var compressedData = ReadBytesExactly(reader, (int)storedSize);
+                    var buffer = new byte[(int)uncompressedSize];
 
-                    using (var deflateStream = new DeflateStream(reader.BaseStream, CompressionMode.Decompress, true))
+                    using (var compressedStream = new MemoryStream(compressedData, false))
+                    using (var deflateStream = new DeflateStream(compressedStream, CompressionMode.Decompress))
                     {
-                        deflateStream.ReadExactly(buffer, 0, size);
+                        try
+                        {
+                            deflateStream.ReadExactly(buffer);
+                        }
+                        catch (EndOfStreamException ex)
+                        {
+                            throw new InvalidDataException("The BGCODE compressed block is truncated.", ex);
+                        }
                     }
 
                     return buffer;
 
                 default:
-                    reader.BaseStream.Seek(size, SeekOrigin.Current); // Skip unknown or unsupported compression types
+                    SkipBytes(reader, storedSize);
 
                     return null;
+            }
+        }
+
+        private static void EnsureThumbnailDataSize(uint size)
+        {
+            // BGCODE thumbnails are already encoded PNG, JPEG, or QOI images. A 64 MiB encoded-image
+            // ceiling is far above normal slicer previews while bounding every parser-owned byte array.
+            if (size > MaximumThumbnailDataSize)
+            {
+                throw new InvalidDataException("The BGCODE thumbnail block exceeds the 64 MiB limit.");
+            }
+        }
+
+        private static byte[] ReadBytesExactly(BinaryReader reader, int count)
+        {
+            var data = reader.ReadBytes(count);
+            if (data.Length != count)
+            {
+                throw new InvalidDataException("The BGCODE block is truncated.");
+            }
+
+            return data;
+        }
+
+        private static void SkipBytes(BinaryReader reader, uint count)
+        {
+            EnsureRemaining(reader, count);
+            reader.BaseStream.Seek(count, SeekOrigin.Current);
+        }
+
+        private static void EnsureRemaining(BinaryReader reader, uint count)
+        {
+            var remaining = reader.BaseStream.Length - reader.BaseStream.Position;
+            if (remaining < 0 || (ulong)remaining < count)
+            {
+                throw new InvalidDataException("The BGCODE block is truncated.");
             }
         }
     }

--- a/src/common/UnitTests-CommonUtils/ThumbnailProvider.Tests.cpp
+++ b/src/common/UnitTests-CommonUtils/ThumbnailProvider.Tests.cpp
@@ -1,0 +1,1178 @@
+#include "pch.h"
+#include "TestHelpers.h"
+#include "ThumbnailProviderTestProtocol.h"
+
+#include <TlHelp32.h>
+#include <Shlwapi.h>
+#include <thumbnail_provider.h>
+#include <wil/com.h>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace UnitTestsCommonUtils
+{
+    namespace
+    {
+        class NoProgressStream : public IStream
+        {
+        public:
+            IFACEMETHODIMP QueryInterface(REFIID riid, void** object) override
+            {
+                if (!object)
+                {
+                    return E_POINTER;
+                }
+
+                if (riid == IID_IUnknown || riid == IID_ISequentialStream || riid == IID_IStream)
+                {
+                    *object = static_cast<IStream*>(this);
+                    AddRef();
+                    return S_OK;
+                }
+
+                *object = nullptr;
+                return E_NOINTERFACE;
+            }
+
+            IFACEMETHODIMP_(ULONG)
+            AddRef() override
+            {
+                return InterlockedIncrement(&m_referenceCount);
+            }
+
+            IFACEMETHODIMP_(ULONG)
+            Release() override
+            {
+                return InterlockedDecrement(&m_referenceCount);
+            }
+
+            long reference_count() const
+            {
+                return m_referenceCount;
+            }
+
+            IFACEMETHODIMP Read(void*, ULONG, ULONG* bytesRead) override
+            {
+                if (bytesRead)
+                {
+                    *bytesRead = 0;
+                }
+
+                return S_OK;
+            }
+
+            IFACEMETHODIMP Write(const void*, ULONG, ULONG*) override
+            {
+                return E_NOTIMPL;
+            }
+
+            IFACEMETHODIMP Seek(LARGE_INTEGER, DWORD, ULARGE_INTEGER*) override
+            {
+                return E_NOTIMPL;
+            }
+
+            IFACEMETHODIMP SetSize(ULARGE_INTEGER) override
+            {
+                return E_NOTIMPL;
+            }
+
+            IFACEMETHODIMP CopyTo(IStream*, ULARGE_INTEGER, ULARGE_INTEGER*, ULARGE_INTEGER*) override
+            {
+                return E_NOTIMPL;
+            }
+
+            IFACEMETHODIMP Commit(DWORD) override
+            {
+                return E_NOTIMPL;
+            }
+
+            IFACEMETHODIMP Revert() override
+            {
+                return E_NOTIMPL;
+            }
+
+            IFACEMETHODIMP LockRegion(ULARGE_INTEGER, ULARGE_INTEGER, DWORD) override
+            {
+                return E_NOTIMPL;
+            }
+
+            IFACEMETHODIMP UnlockRegion(ULARGE_INTEGER, ULARGE_INTEGER, DWORD) override
+            {
+                return E_NOTIMPL;
+            }
+
+            IFACEMETHODIMP Stat(STATSTG*, DWORD) override
+            {
+                return E_NOTIMPL;
+            }
+
+            IFACEMETHODIMP Clone(IStream**) override
+            {
+                return E_NOTIMPL;
+            }
+
+        private:
+            long m_referenceCount = 1;
+        };
+
+        std::filesystem::path get_cmd_path()
+        {
+            wchar_t systemDirectory[MAX_PATH]{};
+            GetSystemDirectoryW(systemDirectory, ARRAYSIZE(systemDirectory));
+            return std::filesystem::path{ systemDirectory } / L"cmd.exe";
+        }
+
+        std::filesystem::path get_ping_path()
+        {
+            wchar_t systemDirectory[MAX_PATH]{};
+            GetSystemDirectoryW(systemDirectory, ARRAYSIZE(systemDirectory));
+            return std::filesystem::path{ systemDirectory } / L"ping.exe";
+        }
+
+        std::wstring quote_argument(const std::filesystem::path& argument)
+        {
+            return L"\"" + argument.wstring() + L"\"";
+        }
+
+        struct contained_processes
+        {
+            DWORD parent_id = 0;
+            DWORD descendant_id = 0;
+        };
+
+        std::optional<contained_processes> find_contained_processes(
+            const std::wstring& uniqueParentExecutable,
+            const wchar_t* descendantExecutable)
+        {
+            wil::unique_handle snapshot{ CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) };
+            if (!snapshot || snapshot.get() == INVALID_HANDLE_VALUE)
+            {
+                return std::nullopt;
+            }
+
+            std::vector<PROCESSENTRY32W> processes;
+            PROCESSENTRY32W entry{ sizeof(entry) };
+            if (!Process32FirstW(snapshot.get(), &entry))
+            {
+                return std::nullopt;
+            }
+
+            do
+            {
+                processes.push_back(entry);
+            } while (Process32NextW(snapshot.get(), &entry));
+
+            for (const auto& parent : processes)
+            {
+                if (_wcsicmp(parent.szExeFile, uniqueParentExecutable.c_str()) != 0)
+                {
+                    continue;
+                }
+
+                for (const auto& child : processes)
+                {
+                    if (child.th32ParentProcessID == parent.th32ProcessID &&
+                        _wcsicmp(child.szExeFile, descendantExecutable) == 0)
+                    {
+                        return contained_processes{ parent.th32ProcessID, child.th32ProcessID };
+                    }
+                }
+            }
+
+            return std::nullopt;
+        }
+
+        std::filesystem::path get_process_image(HANDLE process)
+        {
+            std::wstring imagePath(32'768, L'\0');
+            DWORD length = static_cast<DWORD>(imagePath.size());
+            if (!QueryFullProcessImageNameW(process, 0, imagePath.data(), &length))
+            {
+                return {};
+            }
+
+            imagePath.resize(length);
+            return imagePath;
+        }
+
+        struct process_termination_observation
+        {
+            DWORD initial_wait = WAIT_FAILED;
+            bool fallback_termination_used = false;
+            bool exit_code_read = false;
+            DWORD exit_code = STILL_ACTIVE;
+        };
+
+        process_termination_observation observe_process_termination(HANDLE process) noexcept
+        {
+            process_termination_observation observation;
+            if (!process)
+            {
+                return observation;
+            }
+
+            observation.initial_wait = WaitForSingleObject(process, 2'000);
+            if (observation.initial_wait != WAIT_OBJECT_0)
+            {
+                observation.fallback_termination_used =
+                    TerminateProcess(process, ERROR_TIMEOUT) != FALSE;
+                WaitForSingleObject(process, 2'000);
+            }
+
+            observation.exit_code_read =
+                GetExitCodeProcess(process, &observation.exit_code) != FALSE;
+            return observation;
+        }
+
+        class nonthrowing_temp_directory
+        {
+        public:
+            nonthrowing_temp_directory()
+            {
+                wchar_t tempPath[MAX_PATH]{};
+                Assert::IsTrue(GetTempPathW(ARRAYSIZE(tempPath), tempPath) != 0);
+
+                wchar_t uniquePath[MAX_PATH]{};
+                Assert::IsTrue(GetTempFileNameW(tempPath, L"PTP", 0, uniquePath) != 0);
+                m_path = uniquePath;
+
+                std::error_code error;
+                std::filesystem::remove(m_path, error);
+                if (error)
+                {
+                    cleanup();
+                    Assert::Fail(L"Could not prepare the test-owned timeout directory.");
+                }
+
+                error.clear();
+                std::filesystem::create_directory(m_path, error);
+                if (error)
+                {
+                    cleanup();
+                    Assert::Fail(L"Could not create the test-owned timeout directory.");
+                }
+            }
+
+            ~nonthrowing_temp_directory() noexcept
+            {
+                cleanup();
+            }
+
+            nonthrowing_temp_directory(const nonthrowing_temp_directory&) = delete;
+            nonthrowing_temp_directory& operator=(const nonthrowing_temp_directory&) = delete;
+
+            const std::filesystem::path& path() const noexcept
+            {
+                return m_path;
+            }
+
+            bool cleanup() noexcept
+            {
+                if (m_path.empty())
+                {
+                    return true;
+                }
+
+                for (int attempt = 0; attempt < 10; ++attempt)
+                {
+                    std::error_code error;
+                    std::filesystem::remove_all(m_path, error);
+                    error.clear();
+                    const auto stillExists = std::filesystem::exists(m_path, error);
+                    if (!error && !stillExists)
+                    {
+                        m_path.clear();
+                        return true;
+                    }
+
+                    Sleep(50);
+                }
+
+                return false;
+            }
+
+        private:
+            std::filesystem::path m_path;
+        };
+
+        struct provider_case
+        {
+            const wchar_t* executable;
+            const wchar_t* sample;
+            const wchar_t* extension;
+        };
+
+        constexpr provider_case providers[] = {
+            { L"PowerToys.SvgThumbnailProvider.exe", L"src\\modules\\previewpane\\UnitTests-SvgThumbnailProvider\\HelperFiles\\file1.svg", L".svg" },
+            { L"PowerToys.PdfThumbnailProvider.exe", L"src\\modules\\previewpane\\UnitTests-PdfThumbnailProvider\\HelperFiles\\sample.pdf", L".pdf" },
+            { L"PowerToys.GcodeThumbnailProvider.exe", L"src\\modules\\previewpane\\UnitTests-GcodeThumbnailProvider\\HelperFiles\\sample.gcode", L".gcode" },
+            { L"PowerToys.BgcodeThumbnailProvider.exe", L"src\\modules\\previewpane\\UnitTests-BgcodeThumbnailProvider\\HelperFiles\\sample.bgcode", L".bgcode" },
+            { L"PowerToys.QoiThumbnailProvider.exe", L"src\\modules\\previewpane\\UnitTests-QoiThumbnailProvider\\HelperFiles\\sample.qoi", L".qoi" },
+            { L"PowerToys.StlThumbnailProvider.exe", L"src\\modules\\previewpane\\UnitTests-StlThumbnailProvider\\HelperFiles\\sample.stl", L".stl" },
+        };
+
+        enum class configuration_source
+        {
+            unresolved,
+            environment,
+            self_discovery,
+        };
+
+        struct integration_configuration
+        {
+            std::filesystem::path module;
+            std::filesystem::path executable_directory;
+            std::filesystem::path repository_root;
+            configuration_source executable_directory_source = configuration_source::unresolved;
+            configuration_source repository_root_source = configuration_source::unresolved;
+        };
+
+        const wchar_t* configuration_source_name(configuration_source source)
+        {
+            switch (source)
+            {
+            case configuration_source::environment:
+                return L"environment override";
+            case configuration_source::self_discovery:
+                return L"self-discovery";
+            default:
+                return L"unresolved";
+            }
+        }
+
+        const wchar_t* launch_status_name(thumbnail_provider::launch_status status)
+        {
+            switch (status)
+            {
+            case thumbnail_provider::launch_status::completed:
+                return L"completed";
+            case thumbnail_provider::launch_status::timed_out:
+                return L"timed_out";
+            default:
+                return L"failed";
+            }
+        }
+
+        char module_anchor;
+
+        std::filesystem::path get_test_module_path()
+        {
+            HMODULE module = nullptr;
+            if (!GetModuleHandleExW(
+                    GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                    reinterpret_cast<LPCWSTR>(&module_anchor),
+                    &module))
+            {
+                return {};
+            }
+
+            std::wstring modulePath(MAX_PATH, L'\0');
+            while (true)
+            {
+                SetLastError(ERROR_SUCCESS);
+                const auto length =
+                    GetModuleFileNameW(module, modulePath.data(), static_cast<DWORD>(modulePath.size()));
+                if (length == 0)
+                {
+                    return {};
+                }
+
+                if (length < modulePath.size())
+                {
+                    modulePath.resize(length);
+                    return modulePath;
+                }
+
+                if (modulePath.size() >= 32'768)
+                {
+                    return {};
+                }
+
+                modulePath.resize(modulePath.size() * 2);
+            }
+        }
+
+        std::optional<std::pair<std::filesystem::path, std::filesystem::path>>
+        discover_build_layout(const std::filesystem::path& modulePath)
+        {
+            auto candidate = modulePath.parent_path();
+            while (!candidate.empty())
+            {
+                const auto configuration = candidate.filename().wstring();
+                const auto platform = candidate.parent_path().filename().wstring();
+                const auto supportedConfiguration =
+                    _wcsicmp(configuration.c_str(), L"Release") == 0 ||
+                    _wcsicmp(configuration.c_str(), L"Debug") == 0;
+                const auto supportedPlatform =
+                    _wcsicmp(platform.c_str(), L"x64") == 0 ||
+                    _wcsicmp(platform.c_str(), L"ARM64") == 0;
+                if (supportedConfiguration && supportedPlatform)
+                {
+                    return std::pair{
+                        candidate.lexically_normal(),
+                        candidate.parent_path().parent_path().lexically_normal()
+                    };
+                }
+
+                const auto parent = candidate.parent_path();
+                if (parent == candidate)
+                {
+                    break;
+                }
+
+                candidate = parent;
+            }
+
+            return std::nullopt;
+        }
+
+        integration_configuration resolve_integration_configuration(
+            const std::filesystem::path& modulePath,
+            const std::filesystem::path& executableDirectoryOverride,
+            const std::filesystem::path& repositoryRootOverride)
+        {
+            integration_configuration configuration;
+            configuration.module = modulePath.lexically_normal();
+            const auto discovered = discover_build_layout(modulePath);
+
+            if (!executableDirectoryOverride.empty())
+            {
+                configuration.executable_directory = executableDirectoryOverride.lexically_normal();
+                configuration.executable_directory_source = configuration_source::environment;
+            }
+            else if (discovered)
+            {
+                configuration.executable_directory = discovered->first;
+                configuration.executable_directory_source = configuration_source::self_discovery;
+            }
+
+            if (!repositoryRootOverride.empty())
+            {
+                configuration.repository_root = repositoryRootOverride.lexically_normal();
+                configuration.repository_root_source = configuration_source::environment;
+            }
+            else if (discovered)
+            {
+                configuration.repository_root = discovered->second;
+                configuration.repository_root_source = configuration_source::self_discovery;
+            }
+
+            return configuration;
+        }
+
+        void append_configuration_issue(std::wstring& diagnostics, const std::wstring& issue)
+        {
+            if (!diagnostics.empty())
+            {
+                diagnostics += L"\n";
+            }
+
+            diagnostics += L"- ";
+            diagnostics += issue;
+        }
+
+        std::wstring widen_ascii(const std::string& value)
+        {
+            return { value.begin(), value.end() };
+        }
+
+        std::wstring validate_integration_configuration(const integration_configuration& configuration)
+        {
+            std::wstring diagnostics;
+            std::error_code error;
+            bool executableDirectoryValid = false;
+            bool repositoryRootValid = false;
+
+            if (configuration.module.empty() ||
+                !configuration.module.is_absolute() ||
+                !std::filesystem::is_regular_file(configuration.module, error))
+            {
+                append_configuration_issue(
+                    diagnostics,
+                    L"Loaded Common.Utils.UnitTests module path is unavailable or invalid: " +
+                        configuration.module.wstring());
+            }
+
+            error.clear();
+            if (configuration.executable_directory.empty())
+            {
+                append_configuration_issue(
+                    diagnostics,
+                    L"Could not derive the x64/ARM64 Release/Debug executable directory from the loaded test module.");
+            }
+            else if (!configuration.executable_directory.is_absolute() ||
+                     !std::filesystem::is_directory(configuration.executable_directory, error))
+            {
+                append_configuration_issue(
+                    diagnostics,
+                    L"Thumbnail-provider executable directory is unavailable or invalid: " +
+                        configuration.executable_directory.wstring());
+            }
+            else
+            {
+                executableDirectoryValid = true;
+            }
+
+            error.clear();
+            if (configuration.repository_root.empty())
+            {
+                append_configuration_issue(
+                    diagnostics,
+                    L"Could not derive the repository root from the loaded test module.");
+            }
+            else if (!configuration.repository_root.is_absolute() ||
+                     !std::filesystem::is_regular_file(configuration.repository_root / L"PowerToys.slnx", error))
+            {
+                append_configuration_issue(
+                    diagnostics,
+                    L"Repository root is unavailable or does not contain PowerToys.slnx: " +
+                        configuration.repository_root.wstring());
+            }
+            else
+            {
+                repositoryRootValid = true;
+            }
+
+            for (const auto& provider : providers)
+            {
+                if (executableDirectoryValid)
+                {
+                    error.clear();
+                    const auto application = configuration.executable_directory / provider.executable;
+                    if (!std::filesystem::is_regular_file(application, error))
+                    {
+                        append_configuration_issue(
+                            diagnostics,
+                            L"Missing provider executable: " + application.wstring());
+                    }
+                }
+
+                if (repositoryRootValid)
+                {
+                    error.clear();
+                    const auto sample = configuration.repository_root / provider.sample;
+                    if (!std::filesystem::is_regular_file(sample, error))
+                    {
+                        append_configuration_issue(
+                            diagnostics,
+                            L"Missing provider sample: " + sample.wstring());
+                    }
+                }
+            }
+
+            return diagnostics;
+        }
+
+        std::filesystem::path get_environment_path(const wchar_t* name)
+        {
+            const auto length = GetEnvironmentVariableW(name, nullptr, 0);
+            if (length == 0)
+            {
+                return {};
+            }
+
+            std::wstring value(length, L'\0');
+            if (GetEnvironmentVariableW(name, value.data(), length) != length - 1)
+            {
+                return {};
+            }
+
+            value.resize(length - 1);
+            return value;
+        }
+    }
+
+    TEST_CLASS (ThumbnailProviderTests)
+    {
+    public:
+        TEST_METHOD (CopySvgStream_ZeroByteSuccessfulRead_ReturnsReadFault)
+        {
+            TestHelpers::TempFile outputFile{ L"", L".svg" };
+            NoProgressStream stream;
+
+            const auto result = thumbnail_provider::copy_stream_to_file(&stream, outputFile.path());
+
+            Assert::AreEqual(HRESULT_FROM_WIN32(ERROR_READ_FAULT), result);
+        }
+
+        TEST_METHOD (CopyStream_ForwardProgress_PreservesBytes)
+        {
+            const BYTE expected[] = { 0x3c, 0x73, 0x76, 0x67, 0x3e };
+            wil::com_ptr<IStream> stream;
+            stream.attach(SHCreateMemStream(expected, ARRAYSIZE(expected)));
+            Assert::IsNotNull(stream.get());
+            TestHelpers::TempFile outputFile{ L"", L".svg" };
+
+            const auto result = thumbnail_provider::copy_stream_to_file(stream.get(), outputFile.path());
+
+            Assert::AreEqual(S_OK, result);
+            std::ifstream file(outputFile.path(), std::ios::binary);
+            const std::vector<BYTE> actual(
+                (std::istreambuf_iterator<char>(file)),
+                std::istreambuf_iterator<char>());
+            Assert::AreEqual(ARRAYSIZE(expected), actual.size());
+            Assert::IsTrue(std::equal(std::begin(expected), std::end(expected), actual.begin()));
+        }
+
+        TEST_METHOD (ParseTimeout_UsesConfiguredBoundedValue)
+        {
+            Assert::AreEqual<DWORD>(thumbnail_provider::default_timeout_ms, thumbnail_provider::parse_timeout(L""));
+            Assert::AreEqual<DWORD>(thumbnail_provider::minimum_timeout_ms, thumbnail_provider::parse_timeout(L"1000"));
+            Assert::AreEqual<DWORD>(45'000, thumbnail_provider::parse_timeout(L"45000"));
+            Assert::AreEqual<DWORD>(thumbnail_provider::maximum_timeout_ms, thumbnail_provider::parse_timeout(L"300000"));
+            Assert::AreEqual<DWORD>(thumbnail_provider::default_timeout_ms, thumbnail_provider::parse_timeout(L"0"));
+            Assert::AreEqual<DWORD>(thumbnail_provider::default_timeout_ms, thumbnail_provider::parse_timeout(L"999"));
+            Assert::AreEqual<DWORD>(thumbnail_provider::default_timeout_ms, thumbnail_provider::parse_timeout(L"300001"));
+            Assert::AreEqual<DWORD>(thumbnail_provider::default_timeout_ms, thumbnail_provider::parse_timeout(L"4294967296"));
+            Assert::AreEqual<DWORD>(thumbnail_provider::default_timeout_ms, thumbnail_provider::parse_timeout(L"45000ms"));
+            Assert::AreEqual<DWORD>(thumbnail_provider::default_timeout_ms, thumbnail_provider::parse_timeout(L"invalid"));
+        }
+
+        TEST_METHOD (ReleaseStream_NullAndValidPointersAreSafe)
+        {
+            IStream* nullStream = nullptr;
+            thumbnail_provider::release_stream(nullStream);
+            Assert::IsNull(nullStream);
+
+            NoProgressStream stream;
+            stream.AddRef();
+            IStream* streamPointer = &stream;
+
+            thumbnail_provider::release_stream(streamPointer);
+
+            Assert::IsNull(streamPointer);
+            Assert::AreEqual<long>(1, stream.reference_count());
+        }
+
+        TEST_METHOD (ResolveIntegrationConfiguration_SelfDiscoversSupportedBuildLayouts)
+        {
+            const wchar_t* configurations[] = { L"Release", L"Debug" };
+            const wchar_t* platforms[] = { L"x64", L"ARM64" };
+            for (const auto platformName : platforms)
+            {
+                for (const auto configurationName : configurations)
+                {
+                    const auto repositoryRoot = std::filesystem::path{ L"C:\\repo" };
+                    const auto executableDirectory =
+                        repositoryRoot / platformName / configurationName;
+                    const auto module =
+                        executableDirectory /
+                        L"tests\\UnitTestsCommonUtils\\Common.Utils.UnitTests.dll";
+
+                    const auto configuration =
+                        resolve_integration_configuration(module, {}, {});
+
+                    Assert::AreEqual(
+                        executableDirectory.c_str(),
+                        configuration.executable_directory.c_str());
+                    Assert::AreEqual(
+                        repositoryRoot.c_str(),
+                        configuration.repository_root.c_str());
+                    Assert::IsTrue(
+                        configuration.executable_directory_source ==
+                        configuration_source::self_discovery);
+                    Assert::IsTrue(
+                        configuration.repository_root_source ==
+                        configuration_source::self_discovery);
+                }
+            }
+        }
+
+        TEST_METHOD (ResolveIntegrationConfiguration_EnvironmentOverridesSelfDiscovery)
+        {
+            const auto module = std::filesystem::path{
+                L"C:\\repo\\x64\\Release\\tests\\UnitTestsCommonUtils\\Common.Utils.UnitTests.dll"
+            };
+            const auto executableOverride =
+                std::filesystem::path{ L"D:\\provider-build" };
+            const auto repositoryOverride =
+                std::filesystem::path{ L"E:\\provider-source" };
+
+            const auto configuration = resolve_integration_configuration(
+                module,
+                executableOverride,
+                repositoryOverride);
+
+            Assert::AreEqual(
+                executableOverride.c_str(),
+                configuration.executable_directory.c_str());
+            Assert::AreEqual(
+                repositoryOverride.c_str(),
+                configuration.repository_root.c_str());
+            Assert::IsTrue(
+                configuration.executable_directory_source ==
+                configuration_source::environment);
+            Assert::IsTrue(
+                configuration.repository_root_source ==
+                configuration_source::environment);
+        }
+
+        TEST_METHOD (LaunchInJob_BuiltProviderExecutablesCompleteWithinDefaultBudget)
+        {
+            constexpr wchar_t executableDirectoryEnvironmentVariable[] =
+                L"POWERTOYS_THUMBNAIL_PROVIDER_EXECUTABLE_DIRECTORY";
+            constexpr wchar_t repositoryRootEnvironmentVariable[] =
+                L"POWERTOYS_REPOSITORY_ROOT";
+
+            const auto configuration = resolve_integration_configuration(
+                get_test_module_path(),
+                get_environment_path(executableDirectoryEnvironmentVariable),
+                get_environment_path(repositoryRootEnvironmentVariable));
+
+            const auto configurationMessage =
+                L"Executable integration configuration: test module=" +
+                configuration.module.wstring() +
+                L"; executable directory source=" +
+                configuration_source_name(configuration.executable_directory_source) +
+                L"; executable directory=" +
+                configuration.executable_directory.wstring() +
+                L"; repository root source=" +
+                configuration_source_name(configuration.repository_root_source) +
+                L"; repository root=" +
+                configuration.repository_root.wstring();
+            Logger::WriteMessage(configurationMessage.c_str());
+
+            const auto configurationIssues =
+                validate_integration_configuration(configuration);
+            if (!configurationIssues.empty())
+            {
+                const auto message =
+                    L"Executable thumbnail-provider integration configuration is invalid:\n" +
+                    configurationIssues +
+                    L"\nExpected the loaded Common.Utils.UnitTests module under "
+                    L"<repository>\\x64|ARM64\\Release|Debug\\tests\\UnitTestsCommonUtils, "
+                    L"or set absolute " +
+                    executableDirectoryEnvironmentVariable +
+                    L" and " +
+                    repositoryRootEnvironmentVariable +
+                    L" overrides. This test cannot skip or pass without all-six-provider coverage.";
+                Assert::Fail(message.c_str());
+                return;
+            }
+
+            TestHelpers::TempDirectory tempDirectory;
+            std::chrono::milliseconds slowest{};
+            size_t executions = 0;
+            size_t successes = 0;
+            std::wstring failures;
+            for (size_t index = 0; index < ARRAYSIZE(providers); ++index)
+            {
+                const auto& provider = providers[index];
+                const auto application =
+                    configuration.executable_directory / provider.executable;
+                const auto source =
+                    configuration.repository_root / provider.sample;
+                const auto input = std::filesystem::path{ tempDirectory.path() } /
+                                   (L"provider-" + std::to_wstring(index) + provider.extension);
+                ++executions;
+
+                const auto startMessage =
+                    L"Provider execution " +
+                    std::to_wstring(index + 1) +
+                    L"/" +
+                    std::to_wstring(ARRAYSIZE(providers)) +
+                    L": " +
+                    provider.executable +
+                    L"; input=" +
+                    source.wstring();
+                Logger::WriteMessage(startMessage.c_str());
+
+                std::error_code copyError;
+                std::filesystem::copy_file(
+                    source,
+                    input,
+                    std::filesystem::copy_options::overwrite_existing,
+                    copyError);
+                if (copyError)
+                {
+                    const auto resultMessage =
+                        L"Provider execution " +
+                        std::to_wstring(index + 1) +
+                        L"/" +
+                        std::to_wstring(ARRAYSIZE(providers)) +
+                        L" result: " +
+                        provider.executable +
+                        L"; status=not_launched; copy_error=" +
+                        std::to_wstring(copyError.value()) +
+                        L" (" +
+                        widen_ascii(copyError.message()) +
+                        L").";
+                    Logger::WriteMessage(resultMessage.c_str());
+                    failures += L"\n- " + resultMessage;
+                    continue;
+                }
+
+                const auto start = std::chrono::steady_clock::now();
+                thumbnail_provider::launch_result result;
+                try
+                {
+                    result = thumbnail_provider::launch_in_job(
+                        application,
+                        L"\"" + input.wstring() + L"\" 256",
+                        thumbnail_provider::default_timeout_ms);
+                }
+                catch (const std::exception& exception)
+                {
+                    const auto resultMessage =
+                        L"Provider execution " +
+                        std::to_wstring(index + 1) +
+                        L"/" +
+                        std::to_wstring(ARRAYSIZE(providers)) +
+                        L" result: " +
+                        provider.executable +
+                        L"; status=exception; message=" +
+                        widen_ascii(exception.what()) +
+                        L".";
+                    Logger::WriteMessage(resultMessage.c_str());
+                    failures += L"\n- " + resultMessage;
+                    continue;
+                }
+                catch (...)
+                {
+                    const auto resultMessage =
+                        L"Provider execution " +
+                        std::to_wstring(index + 1) +
+                        L"/" +
+                        std::to_wstring(ARRAYSIZE(providers)) +
+                        L" result: " +
+                        provider.executable +
+                        L"; status=unknown_exception.";
+                    Logger::WriteMessage(resultMessage.c_str());
+                    failures += L"\n- " + resultMessage;
+                    continue;
+                }
+
+                const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::steady_clock::now() - start);
+                slowest = (std::max)(slowest, elapsed);
+
+                auto output = input;
+                output.replace_extension(L".bmp");
+                std::error_code outputError;
+                const auto outputExists =
+                    std::filesystem::is_regular_file(output, outputError);
+                const auto succeeded =
+                    result.status == thumbnail_provider::launch_status::completed &&
+                    result.exit_code == 0 &&
+                    outputExists;
+
+                const auto resultMessage =
+                    L"Provider execution " +
+                    std::to_wstring(index + 1) +
+                    L"/" +
+                    std::to_wstring(ARRAYSIZE(providers)) +
+                    L" result: " +
+                    provider.executable +
+                    L"; status=" +
+                    launch_status_name(result.status) +
+                    L"; exit_code=" +
+                    std::to_wstring(result.exit_code) +
+                    L"; error=" +
+                    std::to_wstring(result.error) +
+                    L"; bitmap=" +
+                    (outputExists ? L"present" : L"missing") +
+                    L"; elapsed_ms=" +
+                    std::to_wstring(elapsed.count()) +
+                    L".";
+                Logger::WriteMessage(resultMessage.c_str());
+
+                if (succeeded)
+                {
+                    ++successes;
+                }
+                else
+                {
+                    failures += L"\n- " + resultMessage;
+                }
+            }
+
+            const auto summary =
+                L"Provider execution summary: attempted=" +
+                std::to_wstring(executions) +
+                L"/" +
+                std::to_wstring(ARRAYSIZE(providers)) +
+                L"; succeeded=" +
+                std::to_wstring(successes) +
+                L"/" +
+                std::to_wstring(ARRAYSIZE(providers)) +
+                L"; slowest_ms=" +
+                std::to_wstring(slowest.count()) +
+                L"; default_budget_ms=" +
+                std::to_wstring(thumbnail_provider::default_timeout_ms) +
+                L".";
+            Logger::WriteMessage(summary.c_str());
+
+            Assert::AreEqual<size_t>(ARRAYSIZE(providers), executions);
+            if (!failures.empty())
+            {
+                const auto message =
+                    L"One or more provider executions failed after all six were attempted:" +
+                    failures;
+                Assert::Fail(message.c_str());
+            }
+
+            Assert::AreEqual<size_t>(ARRAYSIZE(providers), successes);
+            Assert::IsTrue(slowest.count() < thumbnail_provider::default_timeout_ms);
+        }
+
+        TEST_METHOD (LaunchInJob_Timeout_TerminatesParentAndDescendant)
+        {
+            nonthrowing_temp_directory tempDirectory;
+            static std::atomic_uint64_t invocation{};
+            const auto uniqueName =
+                L"containment_cmd_" +
+                std::to_wstring(GetCurrentProcessId()) +
+                L"_" +
+                std::to_wstring(GetTickCount64()) +
+                L"_" +
+                std::to_wstring(invocation.fetch_add(1)) +
+                L".exe";
+            const auto isolatedCmd = tempDirectory.path() / uniqueName;
+            std::filesystem::copy_file(get_cmd_path(), isolatedCmd);
+
+            const auto pingPath = get_ping_path();
+            const auto arguments =
+                L"/d /s /c \"\"" +
+                pingPath.wstring() +
+                L"\" -n 120 127.0.0.1 >nul\"";
+            const auto start = std::chrono::steady_clock::now();
+            auto launch = std::async(
+                std::launch::async,
+                [&] {
+                    return thumbnail_provider::launch_in_job(isolatedCmd, arguments, 5'000);
+                });
+
+            std::optional<contained_processes> processes;
+            TestHelpers::WaitFor(
+                [&] {
+                    processes = find_contained_processes(uniqueName, L"ping.exe");
+                    return processes.has_value();
+                },
+                std::chrono::seconds{ 4 });
+
+            wil::unique_handle parentProcess;
+            wil::unique_handle descendantProcess;
+            std::filesystem::path parentImage;
+            std::filesystem::path descendantImage;
+            if (processes)
+            {
+                parentProcess.reset(OpenProcess(
+                    SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_TERMINATE,
+                    FALSE,
+                    processes->parent_id));
+                descendantProcess.reset(OpenProcess(
+                    SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_TERMINATE,
+                    FALSE,
+                    processes->descendant_id));
+                if (parentProcess)
+                {
+                    parentImage = get_process_image(parentProcess.get());
+                }
+
+                if (descendantProcess)
+                {
+                    descendantImage = get_process_image(descendantProcess.get());
+                }
+            }
+
+            const auto result = launch.get();
+            const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - start);
+
+            const auto parentObservation =
+                observe_process_termination(parentProcess.get());
+            const auto descendantObservation =
+                observe_process_termination(descendantProcess.get());
+            parentProcess.reset();
+            descendantProcess.reset();
+            const auto cleanupSucceeded = tempDirectory.cleanup();
+
+            Assert::IsTrue(processes.has_value(), L"Did not observe the isolated cmd.exe -> ping.exe process tree before timeout.");
+            Assert::IsTrue(!parentImage.empty(), L"Could not retain a handle to the isolated parent process.");
+            Assert::IsTrue(!descendantImage.empty(), L"Could not retain a handle to the ping descendant.");
+            Assert::IsTrue(
+                _wcsicmp(parentImage.c_str(), isolatedCmd.c_str()) == 0,
+                L"The observed parent did not originate from the unique test-owned cmd.exe copy.");
+            Assert::IsTrue(
+                _wcsicmp(descendantImage.filename().c_str(), L"ping.exe") == 0,
+                L"The observed descendant was not ping.exe.");
+            Assert::IsTrue(result.status == thumbnail_provider::launch_status::timed_out);
+            Assert::AreEqual<DWORD>(ERROR_TIMEOUT, result.error);
+            Assert::IsTrue(elapsed < std::chrono::seconds{ 10 });
+            Assert::AreEqual<DWORD>(processes->parent_id, result.process_id);
+            Assert::AreEqual<DWORD>(
+                WAIT_OBJECT_0,
+                parentObservation.initial_wait,
+                L"The direct parent process survived the timeout and required exact-handle fallback termination.");
+            Assert::AreEqual<DWORD>(
+                WAIT_OBJECT_0,
+                descendantObservation.initial_wait,
+                L"The ping descendant survived the timeout and required exact-handle fallback termination.");
+            Assert::IsFalse(parentObservation.fallback_termination_used);
+            Assert::IsFalse(descendantObservation.fallback_termination_used);
+            Assert::IsTrue(parentObservation.exit_code_read);
+            Assert::IsTrue(descendantObservation.exit_code_read);
+            Assert::AreNotEqual<DWORD>(STILL_ACTIVE, parentObservation.exit_code);
+            Assert::AreNotEqual<DWORD>(STILL_ACTIVE, descendantObservation.exit_code);
+            Assert::IsTrue(
+                cleanupSucceeded,
+                L"The bounded non-throwing cleanup could not remove the unique test-owned executable directory.");
+
+            const auto message =
+                L"Timeout containment and cleanup verified zero orphan/artifact: parent PID " +
+                std::to_wstring(processes->parent_id) +
+                L" and ping descendant PID " +
+                std::to_wstring(processes->descendant_id) +
+                L" both terminated after " +
+                std::to_wstring(elapsed.count()) +
+                L" ms; exact-handle fallback used=false; unique executable directory removed=true.";
+            Logger::WriteMessage(message.c_str());
+        }
+
+        TEST_METHOD (LaunchInJob_NestedJob_TerminatesParentAndDescendant)
+        {
+            nonthrowing_temp_directory tempDirectory;
+            static std::atomic_uint64_t invocation{};
+            const auto uniqueName =
+                L"nested_containment_cmd_" +
+                std::to_wstring(GetCurrentProcessId()) +
+                L"_" +
+                std::to_wstring(GetTickCount64()) +
+                L"_" +
+                std::to_wstring(invocation.fetch_add(1)) +
+                L".exe";
+            const auto isolatedCmd = tempDirectory.path() / uniqueName;
+            std::filesystem::copy_file(get_cmd_path(), isolatedCmd);
+
+            const auto helper =
+                get_test_module_path().parent_path() /
+                L"ThumbnailProviderTestHelper.exe";
+            const auto resultPath = tempDirectory.path() / L"nested-job-result.bin";
+            const auto pingPath = get_ping_path();
+            Assert::IsTrue(
+                std::filesystem::is_regular_file(helper),
+                L"The nested-job test helper was not built beside the test module.");
+
+            wil::unique_handle outerJob{ CreateJobObjectW(nullptr, nullptr) };
+            Assert::IsNotNull(outerJob.get());
+            JOBOBJECT_EXTENDED_LIMIT_INFORMATION outerJobInformation{};
+            outerJobInformation.BasicLimitInformation.LimitFlags =
+                JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+            Assert::IsTrue(SetInformationJobObject(
+                outerJob.get(),
+                JobObjectExtendedLimitInformation,
+                &outerJobInformation,
+                sizeof(outerJobInformation)));
+
+            auto commandLine =
+                quote_argument(helper) +
+                L" " +
+                quote_argument(resultPath) +
+                L" " +
+                quote_argument(isolatedCmd) +
+                L" " +
+                quote_argument(pingPath);
+            std::vector<wchar_t> mutableCommandLine(
+                commandLine.begin(),
+                commandLine.end());
+            mutableCommandLine.push_back(L'\0');
+
+            STARTUPINFOW startupInformation{ sizeof(startupInformation) };
+            PROCESS_INFORMATION processInformation{};
+            Assert::IsTrue(CreateProcessW(
+                helper.c_str(),
+                mutableCommandLine.data(),
+                nullptr,
+                nullptr,
+                FALSE,
+                CREATE_NO_WINDOW | CREATE_SUSPENDED,
+                nullptr,
+                nullptr,
+                &startupInformation,
+                &processInformation));
+
+            wil::unique_handle helperProcess{ processInformation.hProcess };
+            wil::unique_handle helperThread{ processInformation.hThread };
+            Assert::IsTrue(
+                AssignProcessToJobObject(outerJob.get(), helperProcess.get()),
+                L"Could not assign the test helper to its outer job.");
+            Assert::AreNotEqual<DWORD>(
+                static_cast<DWORD>(-1),
+                ResumeThread(helperThread.get()));
+
+            std::optional<contained_processes> processes;
+            TestHelpers::WaitFor(
+                [&] {
+                    processes = find_contained_processes(uniqueName, L"ping.exe");
+                    return processes.has_value();
+                },
+                std::chrono::seconds{ 4 });
+
+            wil::unique_handle parentProcess;
+            wil::unique_handle descendantProcess;
+            if (processes)
+            {
+                parentProcess.reset(OpenProcess(
+                    SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_TERMINATE,
+                    FALSE,
+                    processes->parent_id));
+                descendantProcess.reset(OpenProcess(
+                    SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_TERMINATE,
+                    FALSE,
+                    processes->descendant_id));
+            }
+
+            Assert::AreEqual<DWORD>(
+                WAIT_OBJECT_0,
+                WaitForSingleObject(helperProcess.get(), 12'000),
+                L"The nested-job test helper did not finish.");
+            DWORD helperExitCode = STILL_ACTIVE;
+            Assert::IsTrue(GetExitCodeProcess(helperProcess.get(), &helperExitCode));
+
+            nested_job_probe_result probeResult;
+            std::ifstream resultFile(resultPath, std::ios::binary);
+            resultFile.read(
+                reinterpret_cast<char*>(&probeResult),
+                sizeof(probeResult));
+            const auto resultReadSucceeded = resultFile.good();
+            resultFile.close();
+
+            const auto parentObservation =
+                observe_process_termination(parentProcess.get());
+            const auto descendantObservation =
+                observe_process_termination(descendantProcess.get());
+            parentProcess.reset();
+            descendantProcess.reset();
+            helperProcess.reset();
+            helperThread.reset();
+            outerJob.reset();
+            const auto cleanupSucceeded = tempDirectory.cleanup();
+
+            Assert::IsTrue(
+                processes.has_value(),
+                L"Did not observe the nested isolated cmd.exe -> ping.exe process tree.");
+            Assert::IsTrue(resultReadSucceeded, L"The nested-job helper result was incomplete.");
+            Assert::AreEqual<DWORD>(1, probeResult.version);
+            Assert::AreEqual<DWORD>(TRUE, probeResult.process_in_outer_job);
+            Assert::AreEqual<DWORD>(
+                static_cast<DWORD>(thumbnail_provider::launch_status::timed_out),
+                probeResult.launch_status);
+            Assert::AreEqual<DWORD>(ERROR_TIMEOUT, probeResult.error);
+            Assert::AreEqual<DWORD>(processes->parent_id, probeResult.process_id);
+            Assert::AreEqual<DWORD>(ERROR_SUCCESS, helperExitCode);
+            Assert::AreEqual<DWORD>(WAIT_OBJECT_0, parentObservation.initial_wait);
+            Assert::AreEqual<DWORD>(WAIT_OBJECT_0, descendantObservation.initial_wait);
+            Assert::IsFalse(parentObservation.fallback_termination_used);
+            Assert::IsFalse(descendantObservation.fallback_termination_used);
+            Assert::IsTrue(parentObservation.exit_code_read);
+            Assert::IsTrue(descendantObservation.exit_code_read);
+            Assert::AreNotEqual<DWORD>(STILL_ACTIVE, parentObservation.exit_code);
+            Assert::AreNotEqual<DWORD>(STILL_ACTIVE, descendantObservation.exit_code);
+            Assert::IsTrue(cleanupSucceeded);
+
+            Logger::WriteMessage(
+                L"Nested-job compatibility verified: helper remained in its outer job while "
+                L"the inner timeout job terminated the isolated cmd.exe and ping.exe process tree.");
+        }
+    };
+}

--- a/src/common/UnitTests-CommonUtils/ThumbnailProviderTestHelper.cpp
+++ b/src/common/UnitTests-CommonUtils/ThumbnailProviderTestHelper.cpp
@@ -1,0 +1,49 @@
+#include "ThumbnailProviderTestProtocol.h"
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include <thumbnail_provider.h>
+
+int wmain(int argc, wchar_t* argv[])
+{
+    if (argc != 4)
+    {
+        return ERROR_BAD_ARGUMENTS;
+    }
+
+    BOOL processInOuterJob = FALSE;
+    if (!IsProcessInJob(GetCurrentProcess(), nullptr, &processInOuterJob))
+    {
+        return static_cast<int>(GetLastError());
+    }
+
+    const std::filesystem::path resultPath{ argv[1] };
+    const std::filesystem::path application{ argv[2] };
+    const std::filesystem::path pingPath{ argv[3] };
+    const auto arguments =
+        L"/d /s /c \"\"" + pingPath.wstring() + L"\" -n 120 127.0.0.1 >nul\"";
+    const auto launch = thumbnail_provider::launch_in_job(application, arguments, 5'000);
+
+    const nested_job_probe_result result{
+        .process_in_outer_job = static_cast<DWORD>(processInOuterJob),
+        .launch_status = static_cast<DWORD>(launch.status),
+        .error = launch.error,
+        .exit_code = launch.exit_code,
+        .process_id = launch.process_id,
+    };
+
+    std::ofstream output(resultPath, std::ios::binary | std::ios::trunc);
+    output.write(reinterpret_cast<const char*>(&result), sizeof(result));
+    if (!output.good())
+    {
+        return ERROR_WRITE_FAULT;
+    }
+
+    return processInOuterJob &&
+                   launch.status == thumbnail_provider::launch_status::timed_out &&
+                   launch.error == ERROR_TIMEOUT ?
+               ERROR_SUCCESS :
+               ERROR_PROCESS_ABORTED;
+}

--- a/src/common/UnitTests-CommonUtils/ThumbnailProviderTestHelper.vcxproj
+++ b/src/common/UnitTests-CommonUtils/ThumbnailProviderTestHelper.vcxproj
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <ProjectGuid>{F82A86E7-7C58-48C1-A923-5D735E17D5AB}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>ThumbnailProviderTestHelper</RootNamespace>
+    <ProjectName>ThumbnailProviderTestHelper</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>Unicode</CharacterSet>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\tests\UnitTestsCommonUtils\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\utils;..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.260126.7\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp23</LanguageStandard>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="ThumbnailProviderTestHelper.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="ThumbnailProviderTestProtocol.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/src/common/UnitTests-CommonUtils/ThumbnailProviderTestHelper.vcxproj
+++ b/src/common/UnitTests-CommonUtils/ThumbnailProviderTestHelper.vcxproj
@@ -38,6 +38,7 @@
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
+    <VcpkgEnabled>false</VcpkgEnabled>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\tests\UnitTestsCommonUtils\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
   </PropertyGroup>

--- a/src/common/UnitTests-CommonUtils/ThumbnailProviderTestProtocol.h
+++ b/src/common/UnitTests-CommonUtils/ThumbnailProviderTestProtocol.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <Windows.h>
+
+struct nested_job_probe_result
+{
+    DWORD version = 1;
+    DWORD process_in_outer_job = FALSE;
+    DWORD launch_status = 0;
+    DWORD error = ERROR_SUCCESS;
+    DWORD exit_code = 0;
+    DWORD process_id = 0;
+};

--- a/src/common/UnitTests-CommonUtils/UnitTests-CommonUtils.vcxproj
+++ b/src/common/UnitTests-CommonUtils/UnitTests-CommonUtils.vcxproj
@@ -69,6 +69,7 @@
     <ClCompile Include="Package.Tests.cpp" />
     <ClCompile Include="ProcessApi.Tests.cpp" />
     <ClCompile Include="ProcessWaiter.Tests.cpp" />
+    <ClCompile Include="ThumbnailProvider.Tests.cpp" />
     <ClCompile Include="Registry.Tests.cpp" />
     <ClCompile Include="Resources.Tests.cpp" />
     <ClCompile Include="TestStubs.cpp" />
@@ -82,6 +83,12 @@
     <ClInclude Include="pch.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="TestHelpers.h" />
+    <ClInclude Include="ThumbnailProviderTestProtocol.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="ThumbnailProviderTestHelper.vcxproj">
+      <Project>{F82A86E7-7C58-48C1-A923-5D735E17D5AB}</Project>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="UnitTests-CommonUtils.rc" />

--- a/src/common/UnitTests-CommonUtils/UnitTests-CommonUtils.vcxproj.filters
+++ b/src/common/UnitTests-CommonUtils/UnitTests-CommonUtils.vcxproj.filters
@@ -72,6 +72,9 @@
     <ClCompile Include="ProcessApi.Tests.cpp">
       <Filter>Source Files\Process</Filter>
     </ClCompile>
+    <ClCompile Include="ThumbnailProvider.Tests.cpp">
+      <Filter>Source Files\Process</Filter>
+    </ClCompile>
     <ClCompile Include="Window.Tests.cpp">
       <Filter>Source Files\Process</Filter>
     </ClCompile>
@@ -132,6 +135,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="TestHelpers.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ThumbnailProviderTestProtocol.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/common/utils/thumbnail_provider.h
+++ b/src/common/utils/thumbnail_provider.h
@@ -1,0 +1,236 @@
+#pragma once
+
+#include <Windows.h>
+#include <objidl.h>
+
+#include <cerrno>
+#include <cwchar>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <wil/resource.h>
+
+namespace thumbnail_provider
+{
+    // This is a coarse shell-extension safety ceiling, not a startup target. The executable
+    // cold-start test covers every supported thumbnail provider under this default budget.
+    constexpr DWORD default_timeout_ms = 30'000;
+    constexpr DWORD minimum_timeout_ms = 1'000;
+    constexpr DWORD maximum_timeout_ms = 300'000;
+    constexpr wchar_t timeout_environment_variable[] = L"POWERTOYS_THUMBNAIL_PROVIDER_TIMEOUT_MS";
+
+    inline DWORD parse_timeout(std::wstring_view value)
+    {
+        if (value.empty())
+        {
+            return default_timeout_ms;
+        }
+
+        std::wstring nullTerminatedValue{ value };
+        wchar_t* end = nullptr;
+        errno = 0;
+        const auto parsed = std::wcstoul(nullTerminatedValue.c_str(), &end, 10);
+        if (errno == ERANGE ||
+            end == nullTerminatedValue.c_str() ||
+            *end != L'\0' ||
+            parsed < minimum_timeout_ms ||
+            parsed > maximum_timeout_ms)
+        {
+            return default_timeout_ms;
+        }
+
+        return static_cast<DWORD>(parsed);
+    }
+
+    inline DWORD get_timeout_ms()
+    {
+        wchar_t value[32]{};
+        const auto length = GetEnvironmentVariableW(timeout_environment_variable, value, ARRAYSIZE(value));
+        if (length == 0 || length >= ARRAYSIZE(value))
+        {
+            return default_timeout_ms;
+        }
+
+        return parse_timeout(value);
+    }
+
+    inline void release_stream(IStream*& stream) noexcept
+    {
+        if (stream)
+        {
+            stream->Release();
+            stream = nullptr;
+        }
+    }
+
+    inline HRESULT copy_stream_to_file(IStream* stream, const std::filesystem::path& destination) noexcept
+    {
+        if (!stream)
+        {
+            return E_INVALIDARG;
+        }
+
+        try
+        {
+            std::ofstream file(destination, std::ios_base::out | std::ios_base::binary | std::ios_base::trunc);
+            if (!file.is_open())
+            {
+                return HRESULT_FROM_WIN32(ERROR_OPEN_FAILED);
+            }
+
+            char buffer[4096];
+            while (true)
+            {
+                ULONG bytesRead = 0;
+                const auto result = stream->Read(buffer, ARRAYSIZE(buffer), &bytesRead);
+                if (FAILED(result))
+                {
+                    return result;
+                }
+
+                if (bytesRead != 0)
+                {
+                    file.write(buffer, bytesRead);
+                    if (!file.good())
+                    {
+                        return STG_E_WRITEFAULT;
+                    }
+                }
+
+                if (result == S_FALSE)
+                {
+                    return S_OK;
+                }
+
+                if (bytesRead == 0)
+                {
+                    return HRESULT_FROM_WIN32(ERROR_READ_FAULT);
+                }
+            }
+        }
+        catch (...)
+        {
+            return E_FAIL;
+        }
+    }
+
+    enum class launch_status
+    {
+        completed,
+        timed_out,
+        failed,
+    };
+
+    struct launch_result
+    {
+        launch_status status = launch_status::failed;
+        DWORD error = ERROR_SUCCESS;
+        DWORD exit_code = 0;
+        DWORD process_id = 0;
+    };
+
+    inline launch_result launch_in_job(
+        const std::filesystem::path& application,
+        const std::wstring& arguments,
+        DWORD timeoutMs = get_timeout_ms())
+    {
+        launch_result result;
+
+        wil::unique_handle job{ CreateJobObjectW(nullptr, nullptr) };
+        if (!job)
+        {
+            result.error = GetLastError();
+            return result;
+        }
+
+        JOBOBJECT_EXTENDED_LIMIT_INFORMATION jobInformation{};
+        jobInformation.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        if (!SetInformationJobObject(
+                job.get(),
+                JobObjectExtendedLimitInformation,
+                &jobInformation,
+                sizeof(jobInformation)))
+        {
+            result.error = GetLastError();
+            return result;
+        }
+
+        std::wstring commandLine = L"\"" + application.wstring() + L"\"";
+        if (!arguments.empty())
+        {
+            commandLine += L" ";
+            commandLine += arguments;
+        }
+
+        std::vector<wchar_t> mutableCommandLine(commandLine.begin(), commandLine.end());
+        mutableCommandLine.push_back(L'\0');
+
+        STARTUPINFOW startupInformation{ sizeof(startupInformation) };
+        PROCESS_INFORMATION processInformation{};
+        if (!CreateProcessW(
+                application.c_str(),
+                mutableCommandLine.data(),
+                nullptr,
+                nullptr,
+                FALSE,
+                CREATE_NO_WINDOW | CREATE_SUSPENDED,
+                nullptr,
+                nullptr,
+                &startupInformation,
+                &processInformation))
+        {
+            result.error = GetLastError();
+            return result;
+        }
+
+        wil::unique_handle process{ processInformation.hProcess };
+        wil::unique_handle thread{ processInformation.hThread };
+        result.process_id = processInformation.dwProcessId;
+
+        if (!AssignProcessToJobObject(job.get(), process.get()))
+        {
+            result.error = GetLastError();
+            TerminateProcess(process.get(), result.error);
+            WaitForSingleObject(process.get(), 5'000);
+            return result;
+        }
+
+        if (ResumeThread(thread.get()) == static_cast<DWORD>(-1))
+        {
+            result.error = GetLastError();
+            TerminateJobObject(job.get(), result.error);
+            WaitForSingleObject(process.get(), 5'000);
+            return result;
+        }
+
+        const auto waitResult = WaitForSingleObject(process.get(), timeoutMs);
+        if (waitResult == WAIT_OBJECT_0)
+        {
+            if (!GetExitCodeProcess(process.get(), &result.exit_code))
+            {
+                result.error = GetLastError();
+                return result;
+            }
+
+            result.status = launch_status::completed;
+            return result;
+        }
+
+        if (waitResult == WAIT_TIMEOUT)
+        {
+            result.status = launch_status::timed_out;
+            result.error = ERROR_TIMEOUT;
+        }
+        else
+        {
+            result.error = GetLastError();
+        }
+
+        TerminateJobObject(job.get(), result.error);
+        WaitForSingleObject(process.get(), 5'000);
+        return result;
+    }
+}

--- a/src/modules/previewpane/BgcodeThumbnailProviderCpp/BgcodeThumbnailProvider.cpp
+++ b/src/modules/previewpane/BgcodeThumbnailProviderCpp/BgcodeThumbnailProvider.cpp
@@ -2,8 +2,6 @@
 #include "BgcodeThumbnailProvider.h"
 
 #include <filesystem>
-#include <fstream>
-#include <shellapi.h>
 #include <Shlwapi.h>
 #include <string>
 
@@ -14,12 +12,13 @@
 #include <common/logger/logger.h>
 #include <common/SettingsAPI/settings_helpers.h>
 #include <common/utils/process_path.h>
+#include <common/utils/thumbnail_provider.h>
 
 extern HINSTANCE g_hInst;
 extern long g_cDllRef;
 
 BgcodeThumbnailProvider::BgcodeThumbnailProvider() :
-    m_cRef(1), m_pStream(NULL), m_process(NULL)
+    m_cRef(1), m_pStream(NULL)
 {
     std::filesystem::path logFilePath(PTSettingsHelper::get_local_low_folder_location());
     logFilePath.append(LogSettings::bgcodeThumbLogPath);
@@ -30,6 +29,7 @@ BgcodeThumbnailProvider::BgcodeThumbnailProvider() :
 
 BgcodeThumbnailProvider::~BgcodeThumbnailProvider()
 {
+    thumbnail_provider::release_stream(m_pStream);
     InterlockedDecrement(&g_cDllRef);
 }
 
@@ -73,11 +73,7 @@ IFACEMETHODIMP BgcodeThumbnailProvider::Initialize(IStream* pStream, DWORD grfMo
     {
         // Initialize can be called more than once, so release existing valid
         // m_pStream.
-        if (m_pStream)
-        {
-            m_pStream->Release();
-            m_pStream = NULL;
-        }
+        thumbnail_provider::release_stream(m_pStream);
 
         m_pStream = pStream;
         m_pStream->AddRef();
@@ -92,10 +88,6 @@ IFACEMETHODIMP BgcodeThumbnailProvider::Initialize(IStream* pStream, DWORD grfMo
 
 IFACEMETHODIMP BgcodeThumbnailProvider::GetThumbnail(UINT cx, HBITMAP* phbmp, WTS_ALPHATYPE* pdwAlpha)
 {
-    // Read stream into the buffer
-    char buffer[4096];
-    ULONG cbRead;
-
     Logger::trace(L"Begin");
 
     GUID guid;
@@ -115,54 +107,48 @@ IFACEMETHODIMP BgcodeThumbnailProvider::GetThumbnail(UINT cx, HBITMAP* phbmp, WT
             }
 
             std::wstring fileName = filePath + guid + L".bgcode";
-            
-            // Write data to tmp file
-            std::fstream file;
-            file.open(fileName, std::ios_base::out | std::ios_base::binary);
+            std::wstring fileNameBmp = filePath + guid + L".bmp";
 
-            if (!file.is_open())
+            const auto copyResult = thumbnail_provider::copy_stream_to_file(m_pStream, fileName);
+            thumbnail_provider::release_stream(m_pStream);
+
+            if (FAILED(copyResult))
             {
-                return 0;
+                std::error_code error;
+                std::filesystem::remove(fileName, error);
+                return copyResult;
             }
-
-            while (true)
-            {
-                auto result = m_pStream->Read(buffer, 4096, &cbRead);
-
-                file.write(buffer, cbRead);
-                if (result == S_FALSE)
-                {               
-                    break;
-                }
-            }
-            file.close();
-
-            m_pStream->Release();
-            m_pStream = NULL;
 
             try
             {
                 Logger::info(L"Start BgcodeThumbnailProvider.exe");
 
-                STARTUPINFO info = { sizeof(info) };
                 std::wstring cmdLine{ L"\"" + fileName + L"\"" };
                 cmdLine += L" ";
                 cmdLine += std::to_wstring(cx);
 
                 std::wstring appPath = get_module_folderpath(g_hInst) + L"\\PowerToys.BgcodeThumbnailProvider.exe";
+                const auto timeoutMs = thumbnail_provider::get_timeout_ms();
+                const auto launchResult = thumbnail_provider::launch_in_job(appPath, cmdLine, timeoutMs);
 
-                SHELLEXECUTEINFO sei{ sizeof(sei) };
-                sei.fMask = { SEE_MASK_NOCLOSEPROCESS | SEE_MASK_FLAG_NO_UI };
-                sei.lpFile = appPath.c_str();
-                sei.lpParameters = cmdLine.c_str();
-                sei.nShow = SW_SHOWDEFAULT;
-                ShellExecuteEx(&sei);
-                m_process = sei.hProcess;
-                WaitForSingleObject(m_process, INFINITE);
-                std::filesystem::remove(fileName);
+                std::error_code error;
+                std::filesystem::remove(fileName, error);
 
+                if (launchResult.status != thumbnail_provider::launch_status::completed)
+                {
+                    if (launchResult.status == thumbnail_provider::launch_status::timed_out)
+                    {
+                        Logger::error(L"Bgcode thumbnail provider timed out after {} ms.", timeoutMs);
+                    }
+                    else
+                    {
+                        Logger::error(L"Failed to launch Bgcode thumbnail provider. Error: {}", launchResult.error);
+                    }
 
-                std::wstring fileNameBmp = filePath + guid + L".bmp";
+                    std::filesystem::remove(fileNameBmp, error);
+                    return HRESULT_FROM_WIN32(launchResult.error == ERROR_SUCCESS ? ERROR_PROCESS_ABORTED : launchResult.error);
+                }
+
                 if (std::filesystem::exists(fileNameBmp))
                 {
                     *phbmp = static_cast<HBITMAP>(LoadImage(NULL, fileNameBmp.c_str(), IMAGE_BITMAP, 0, 0, LR_LOADFROMFILE));
@@ -179,20 +165,18 @@ IFACEMETHODIMP BgcodeThumbnailProvider::GetThumbnail(UINT cx, HBITMAP* phbmp, WT
             {
                 std::wstring errorMessage = std::wstring{ winrt::to_hstring(e.what()) };
                 Logger::error(L"Failed to start BgcodeThumbnailProvider.exe. Error: {}", errorMessage);
+                std::error_code error;
+                std::filesystem::remove(fileName, error);
+                std::filesystem::remove(fileNameBmp, error);
             }
         }
     }
 
     // ensure releasing the stream (not all if branches contain it)
-    if (m_pStream)
-    {
-        m_pStream->Release();
-        m_pStream = NULL;
-    }
+    thumbnail_provider::release_stream(m_pStream);
 
     return S_OK;
 }
-
 
 #pragma endregion
 

--- a/src/modules/previewpane/BgcodeThumbnailProviderCpp/BgcodeThumbnailProvider.h
+++ b/src/modules/previewpane/BgcodeThumbnailProviderCpp/BgcodeThumbnailProvider.h
@@ -32,6 +32,4 @@ private:
 
     // Provided during initialization.
     IStream* m_pStream;
-
-    HANDLE m_process;
 };

--- a/src/modules/previewpane/GcodeThumbnailProviderCpp/GcodeThumbnailProvider.cpp
+++ b/src/modules/previewpane/GcodeThumbnailProviderCpp/GcodeThumbnailProvider.cpp
@@ -2,8 +2,6 @@
 #include "GcodeThumbnailProvider.h"
 
 #include <filesystem>
-#include <fstream>
-#include <shellapi.h>
 #include <Shlwapi.h>
 #include <string>
 
@@ -14,12 +12,13 @@
 #include <common/logger/logger.h>
 #include <common/SettingsAPI/settings_helpers.h>
 #include <common/utils/process_path.h>
+#include <common/utils/thumbnail_provider.h>
 
 extern HINSTANCE g_hInst;
 extern long g_cDllRef;
 
 GcodeThumbnailProvider::GcodeThumbnailProvider() :
-    m_cRef(1), m_pStream(NULL), m_process(NULL)
+    m_cRef(1), m_pStream(NULL)
 {
     std::filesystem::path logFilePath(PTSettingsHelper::get_local_low_folder_location());
     logFilePath.append(LogSettings::gcodeThumbLogPath);
@@ -30,6 +29,7 @@ GcodeThumbnailProvider::GcodeThumbnailProvider() :
 
 GcodeThumbnailProvider::~GcodeThumbnailProvider()
 {
+    thumbnail_provider::release_stream(m_pStream);
     InterlockedDecrement(&g_cDllRef);
 }
 
@@ -73,11 +73,7 @@ IFACEMETHODIMP GcodeThumbnailProvider::Initialize(IStream* pStream, DWORD grfMod
     {
         // Initialize can be called more than once, so release existing valid
         // m_pStream.
-        if (m_pStream)
-        {
-            m_pStream->Release();
-            m_pStream = NULL;
-        }
+        thumbnail_provider::release_stream(m_pStream);
 
         m_pStream = pStream;
         m_pStream->AddRef();
@@ -92,10 +88,6 @@ IFACEMETHODIMP GcodeThumbnailProvider::Initialize(IStream* pStream, DWORD grfMod
 
 IFACEMETHODIMP GcodeThumbnailProvider::GetThumbnail(UINT cx, HBITMAP* phbmp, WTS_ALPHATYPE* pdwAlpha)
 {
-    // Read stream into the buffer
-    char buffer[4096];
-    ULONG cbRead;
-
     Logger::trace(L"Begin");
 
     GUID guid;
@@ -115,54 +107,48 @@ IFACEMETHODIMP GcodeThumbnailProvider::GetThumbnail(UINT cx, HBITMAP* phbmp, WTS
             }
 
             std::wstring fileName = filePath + guid + L".gcode";
-            
-            // Write data to tmp file
-            std::fstream file;
-            file.open(fileName, std::ios_base::out | std::ios_base::binary);
+            std::wstring fileNameBmp = filePath + guid + L".bmp";
 
-            if (!file.is_open())
+            const auto copyResult = thumbnail_provider::copy_stream_to_file(m_pStream, fileName);
+            thumbnail_provider::release_stream(m_pStream);
+
+            if (FAILED(copyResult))
             {
-                return 0;
+                std::error_code error;
+                std::filesystem::remove(fileName, error);
+                return copyResult;
             }
-
-            while (true)
-            {
-                auto result = m_pStream->Read(buffer, 4096, &cbRead);
-
-                file.write(buffer, cbRead);
-                if (result == S_FALSE)
-                {               
-                    break;
-                }
-            }
-            file.close();
-
-            m_pStream->Release();
-            m_pStream = NULL;
 
             try
             {
                 Logger::info(L"Start GcodeThumbnailProvider.exe");
 
-                STARTUPINFO info = { sizeof(info) };
                 std::wstring cmdLine{ L"\"" + fileName + L"\"" };
                 cmdLine += L" ";
                 cmdLine += std::to_wstring(cx);
 
                 std::wstring appPath = get_module_folderpath(g_hInst) + L"\\PowerToys.GcodeThumbnailProvider.exe";
+                const auto timeoutMs = thumbnail_provider::get_timeout_ms();
+                const auto launchResult = thumbnail_provider::launch_in_job(appPath, cmdLine, timeoutMs);
 
-                SHELLEXECUTEINFO sei{ sizeof(sei) };
-                sei.fMask = { SEE_MASK_NOCLOSEPROCESS | SEE_MASK_FLAG_NO_UI };
-                sei.lpFile = appPath.c_str();
-                sei.lpParameters = cmdLine.c_str();
-                sei.nShow = SW_SHOWDEFAULT;
-                ShellExecuteEx(&sei);
-                m_process = sei.hProcess;
-                WaitForSingleObject(m_process, INFINITE);
-                std::filesystem::remove(fileName);
+                std::error_code error;
+                std::filesystem::remove(fileName, error);
 
+                if (launchResult.status != thumbnail_provider::launch_status::completed)
+                {
+                    if (launchResult.status == thumbnail_provider::launch_status::timed_out)
+                    {
+                        Logger::error(L"Gcode thumbnail provider timed out after {} ms.", timeoutMs);
+                    }
+                    else
+                    {
+                        Logger::error(L"Failed to launch Gcode thumbnail provider. Error: {}", launchResult.error);
+                    }
 
-                std::wstring fileNameBmp = filePath + guid + L".bmp";
+                    std::filesystem::remove(fileNameBmp, error);
+                    return HRESULT_FROM_WIN32(launchResult.error == ERROR_SUCCESS ? ERROR_PROCESS_ABORTED : launchResult.error);
+                }
+
                 if (std::filesystem::exists(fileNameBmp))
                 {
                     *phbmp = static_cast<HBITMAP>(LoadImage(NULL, fileNameBmp.c_str(), IMAGE_BITMAP, 0, 0, LR_LOADFROMFILE));
@@ -179,20 +165,18 @@ IFACEMETHODIMP GcodeThumbnailProvider::GetThumbnail(UINT cx, HBITMAP* phbmp, WTS
             {
                 std::wstring errorMessage = std::wstring{ winrt::to_hstring(e.what()) };
                 Logger::error(L"Failed to start GcodeThumbnailProvider.exe. Error: {}", errorMessage);
+                std::error_code error;
+                std::filesystem::remove(fileName, error);
+                std::filesystem::remove(fileNameBmp, error);
             }
         }
     }
 
     // ensure releasing the stream (not all if branches contain it)
-    if (m_pStream)
-    {
-        m_pStream->Release();
-        m_pStream = NULL;
-    }
+    thumbnail_provider::release_stream(m_pStream);
 
     return S_OK;
 }
-
 
 #pragma endregion
 

--- a/src/modules/previewpane/GcodeThumbnailProviderCpp/GcodeThumbnailProvider.h
+++ b/src/modules/previewpane/GcodeThumbnailProviderCpp/GcodeThumbnailProvider.h
@@ -32,6 +32,4 @@ private:
 
     // Provided during initialization.
     IStream* m_pStream;
-
-    HANDLE m_process;
 };

--- a/src/modules/previewpane/PdfThumbnailProviderCpp/PdfThumbnailProvider.cpp
+++ b/src/modules/previewpane/PdfThumbnailProviderCpp/PdfThumbnailProvider.cpp
@@ -2,8 +2,6 @@
 #include "PdfThumbnailProvider.h"
 
 #include <filesystem>
-#include <fstream>
-#include <shellapi.h>
 #include <Shlwapi.h>
 #include <string>
 
@@ -13,12 +11,13 @@
 #include <common/logger/logger.h>
 #include <common/SettingsAPI/settings_helpers.h>
 #include <common/utils/process_path.h>
+#include <common/utils/thumbnail_provider.h>
 
 extern HINSTANCE g_hInst;
 extern long g_cDllRef;
 
 PdfThumbnailProvider::PdfThumbnailProvider() :
-    m_cRef(1), m_pStream(NULL), m_process(NULL)
+    m_cRef(1), m_pStream(NULL)
 {
     std::filesystem::path logFilePath(PTSettingsHelper::get_local_low_folder_location());
     logFilePath.append(LogSettings::pdfThumbLogPath);
@@ -29,6 +28,7 @@ PdfThumbnailProvider::PdfThumbnailProvider() :
 
 PdfThumbnailProvider::~PdfThumbnailProvider()
 {
+    thumbnail_provider::release_stream(m_pStream);
     InterlockedDecrement(&g_cDllRef);
 }
 
@@ -72,11 +72,7 @@ IFACEMETHODIMP PdfThumbnailProvider::Initialize(IStream* pStream, DWORD grfMode)
     {
         // Initialize can be called more than once, so release existing valid
         // m_pStream.
-        if (m_pStream)
-        {
-            m_pStream->Release();
-            m_pStream = NULL;
-        }
+        thumbnail_provider::release_stream(m_pStream);
 
         m_pStream = pStream;
         m_pStream->AddRef();
@@ -91,10 +87,6 @@ IFACEMETHODIMP PdfThumbnailProvider::Initialize(IStream* pStream, DWORD grfMode)
 
 IFACEMETHODIMP PdfThumbnailProvider::GetThumbnail(UINT cx, HBITMAP* phbmp, WTS_ALPHATYPE* pdwAlpha)
 {
-    // Read stream into the buffer
-    char buffer[4096];
-    ULONG cbRead;
-
     Logger::trace(L"Begin");
 
     GUID guid;
@@ -114,53 +106,48 @@ IFACEMETHODIMP PdfThumbnailProvider::GetThumbnail(UINT cx, HBITMAP* phbmp, WTS_A
             }
 
             std::wstring fileName = filePath + guid + L".pdf";
+            std::wstring fileNameBmp = filePath + guid + L".bmp";
 
-            // Write data to tmp file
-            std::fstream file;
-            file.open(fileName, std::ios_base::out | std::ios_base::binary);
+            const auto copyResult = thumbnail_provider::copy_stream_to_file(m_pStream, fileName);
+            thumbnail_provider::release_stream(m_pStream);
 
-            if (!file.is_open())
+            if (FAILED(copyResult))
             {
-                return 0;
+                std::error_code error;
+                std::filesystem::remove(fileName, error);
+                return copyResult;
             }
-
-            while (true)
-            {
-                auto result = m_pStream->Read(buffer, 4096, &cbRead);
-
-                file.write(buffer, cbRead);
-                if (result == S_FALSE)
-                {
-                    break;
-                }
-            }
-            file.close();
-
-            m_pStream->Release();
-            m_pStream = NULL;
 
             try
             {
                 Logger::info(L"Start PdfThumbnailProvider.exe");
 
-                STARTUPINFO info = { sizeof(info) };
                 std::wstring cmdLine{ L"\"" + fileName + L"\"" };
                 cmdLine += L" ";
                 cmdLine += std::to_wstring(cx);
 
                 std::wstring appPath = get_module_folderpath(g_hInst) + L"\\PowerToys.PdfThumbnailProvider.exe";
+                const auto timeoutMs = thumbnail_provider::get_timeout_ms();
+                const auto launchResult = thumbnail_provider::launch_in_job(appPath, cmdLine, timeoutMs);
 
-                SHELLEXECUTEINFO sei{ sizeof(sei) };
-                sei.fMask = { SEE_MASK_NOCLOSEPROCESS | SEE_MASK_FLAG_NO_UI };
-                sei.lpFile = appPath.c_str();
-                sei.lpParameters = cmdLine.c_str();
-                sei.nShow = SW_SHOWDEFAULT;
-                ShellExecuteEx(&sei);
-                m_process = sei.hProcess;
-                WaitForSingleObject(m_process, INFINITE);
-                std::filesystem::remove(fileName);
+                std::error_code error;
+                std::filesystem::remove(fileName, error);
 
-                std::wstring fileNameBmp = filePath + guid + L".bmp";
+                if (launchResult.status != thumbnail_provider::launch_status::completed)
+                {
+                    if (launchResult.status == thumbnail_provider::launch_status::timed_out)
+                    {
+                        Logger::error(L"Pdf thumbnail provider timed out after {} ms.", timeoutMs);
+                    }
+                    else
+                    {
+                        Logger::error(L"Failed to launch Pdf thumbnail provider. Error: {}", launchResult.error);
+                    }
+
+                    std::filesystem::remove(fileNameBmp, error);
+                    return HRESULT_FROM_WIN32(launchResult.error == ERROR_SUCCESS ? ERROR_PROCESS_ABORTED : launchResult.error);
+                }
+
                 if (std::filesystem::exists(fileNameBmp))
                 {
                     *phbmp = static_cast<HBITMAP>(LoadImage(NULL, fileNameBmp.c_str(), IMAGE_BITMAP, 0, 0, LR_LOADFROMFILE));
@@ -172,22 +159,20 @@ IFACEMETHODIMP PdfThumbnailProvider::GetThumbnail(UINT cx, HBITMAP* phbmp, WTS_A
                     Logger::info(L"Bmp file not generated.");
                     return E_FAIL;
                 }
-
             }
             catch (std::exception& e)
             {
                 std::wstring errorMessage = std::wstring{ winrt::to_hstring(e.what()) };
                 Logger::error(L"Failed to start PdfThumbnailProvider.exe. Error: {}", errorMessage);
+                std::error_code error;
+                std::filesystem::remove(fileName, error);
+                std::filesystem::remove(fileNameBmp, error);
             }
         }
     }
 
     // ensure releasing the stream (not all if branches contain it)
-    if (m_pStream)
-    {
-        m_pStream->Release();
-        m_pStream = NULL;
-    }
+    thumbnail_provider::release_stream(m_pStream);
 
     return S_OK;
 }

--- a/src/modules/previewpane/PdfThumbnailProviderCpp/PdfThumbnailProvider.h
+++ b/src/modules/previewpane/PdfThumbnailProviderCpp/PdfThumbnailProvider.h
@@ -32,6 +32,4 @@ private:
 
     // Provided during initialization.
     IStream* m_pStream;
-
-    HANDLE m_process;
 };

--- a/src/modules/previewpane/QoiThumbnailProviderCpp/QoiThumbnailProvider.cpp
+++ b/src/modules/previewpane/QoiThumbnailProviderCpp/QoiThumbnailProvider.cpp
@@ -2,8 +2,6 @@
 #include "QoiThumbnailProvider.h"
 
 #include <filesystem>
-#include <fstream>
-#include <shellapi.h>
 #include <Shlwapi.h>
 #include <string>
 
@@ -14,12 +12,13 @@
 #include <common/logger/logger.h>
 #include <common/SettingsAPI/settings_helpers.h>
 #include <common/utils/process_path.h>
+#include <common/utils/thumbnail_provider.h>
 
 extern HINSTANCE g_hInst;
 extern long g_cDllRef;
 
 QoiThumbnailProvider::QoiThumbnailProvider() :
-    m_cRef(1), m_pStream(NULL), m_process(NULL)
+    m_cRef(1), m_pStream(NULL)
 {
     std::filesystem::path logFilePath(PTSettingsHelper::get_local_low_folder_location());
     logFilePath.append(LogSettings::qoiThumbLogPath);
@@ -30,6 +29,7 @@ QoiThumbnailProvider::QoiThumbnailProvider() :
 
 QoiThumbnailProvider::~QoiThumbnailProvider()
 {
+    thumbnail_provider::release_stream(m_pStream);
     InterlockedDecrement(&g_cDllRef);
 }
 
@@ -73,11 +73,7 @@ IFACEMETHODIMP QoiThumbnailProvider::Initialize(IStream* pStream, DWORD grfMode)
     {
         // Initialize can be called more than once, so release existing valid
         // m_pStream.
-        if (m_pStream)
-        {
-            m_pStream->Release();
-            m_pStream = NULL;
-        }
+        thumbnail_provider::release_stream(m_pStream);
 
         m_pStream = pStream;
         m_pStream->AddRef();
@@ -92,10 +88,6 @@ IFACEMETHODIMP QoiThumbnailProvider::Initialize(IStream* pStream, DWORD grfMode)
 
 IFACEMETHODIMP QoiThumbnailProvider::GetThumbnail(UINT cx, HBITMAP* phbmp, WTS_ALPHATYPE* pdwAlpha)
 {
-    // Read stream into the buffer
-    char buffer[4096];
-    ULONG cbRead;
-
     Logger::trace(L"Begin");
 
     GUID guid;
@@ -115,54 +107,48 @@ IFACEMETHODIMP QoiThumbnailProvider::GetThumbnail(UINT cx, HBITMAP* phbmp, WTS_A
             }
 
             std::wstring fileName = filePath + guid + L".qoi";
-            
-            // Write data to tmp file
-            std::fstream file;
-            file.open(fileName, std::ios_base::out | std::ios_base::binary);
+            std::wstring fileNameBmp = filePath + guid + L".bmp";
 
-            if (!file.is_open())
+            const auto copyResult = thumbnail_provider::copy_stream_to_file(m_pStream, fileName);
+            thumbnail_provider::release_stream(m_pStream);
+
+            if (FAILED(copyResult))
             {
-                return 0;
+                std::error_code error;
+                std::filesystem::remove(fileName, error);
+                return copyResult;
             }
-
-            while (true)
-            {
-                auto result = m_pStream->Read(buffer, 4096, &cbRead);
-
-                file.write(buffer, cbRead);
-                if (result == S_FALSE)
-                {               
-                    break;
-                }
-            }
-            file.close();
-
-            m_pStream->Release();
-            m_pStream = NULL;
 
             try
             {
                 Logger::info(L"Start QoiThumbnailProvider.exe");
 
-                STARTUPINFO info = { sizeof(info) };
                 std::wstring cmdLine{ L"\"" + fileName + L"\"" };
                 cmdLine += L" ";
                 cmdLine += std::to_wstring(cx);
 
                 std::wstring appPath = get_module_folderpath(g_hInst) + L"\\PowerToys.QoiThumbnailProvider.exe";
+                const auto timeoutMs = thumbnail_provider::get_timeout_ms();
+                const auto launchResult = thumbnail_provider::launch_in_job(appPath, cmdLine, timeoutMs);
 
-                SHELLEXECUTEINFO sei{ sizeof(sei) };
-                sei.fMask = { SEE_MASK_NOCLOSEPROCESS | SEE_MASK_FLAG_NO_UI };
-                sei.lpFile = appPath.c_str();
-                sei.lpParameters = cmdLine.c_str();
-                sei.nShow = SW_SHOWDEFAULT;
-                ShellExecuteEx(&sei);
-                m_process = sei.hProcess;
-                WaitForSingleObject(m_process, INFINITE);
-                std::filesystem::remove(fileName);
+                std::error_code error;
+                std::filesystem::remove(fileName, error);
 
+                if (launchResult.status != thumbnail_provider::launch_status::completed)
+                {
+                    if (launchResult.status == thumbnail_provider::launch_status::timed_out)
+                    {
+                        Logger::error(L"Qoi thumbnail provider timed out after {} ms.", timeoutMs);
+                    }
+                    else
+                    {
+                        Logger::error(L"Failed to launch Qoi thumbnail provider. Error: {}", launchResult.error);
+                    }
 
-                std::wstring fileNameBmp = filePath + guid + L".bmp";
+                    std::filesystem::remove(fileNameBmp, error);
+                    return HRESULT_FROM_WIN32(launchResult.error == ERROR_SUCCESS ? ERROR_PROCESS_ABORTED : launchResult.error);
+                }
+
                 if (std::filesystem::exists(fileNameBmp))
                 {
                     *phbmp = static_cast<HBITMAP>(LoadImage(NULL, fileNameBmp.c_str(), IMAGE_BITMAP, 0, 0, LR_LOADFROMFILE));
@@ -179,20 +165,18 @@ IFACEMETHODIMP QoiThumbnailProvider::GetThumbnail(UINT cx, HBITMAP* phbmp, WTS_A
             {
                 std::wstring errorMessage = std::wstring{ winrt::to_hstring(e.what()) };
                 Logger::error(L"Failed to start QoiThumbnailProvider.exe. Error: {}", errorMessage);
+                std::error_code error;
+                std::filesystem::remove(fileName, error);
+                std::filesystem::remove(fileNameBmp, error);
             }
         }
     }
 
     // ensure releasing the stream (not all if branches contain it)
-    if (m_pStream)
-    {
-        m_pStream->Release();
-        m_pStream = NULL;
-    }
+    thumbnail_provider::release_stream(m_pStream);
 
     return S_OK;
 }
-
 
 #pragma endregion
 

--- a/src/modules/previewpane/QoiThumbnailProviderCpp/QoiThumbnailProvider.h
+++ b/src/modules/previewpane/QoiThumbnailProviderCpp/QoiThumbnailProvider.h
@@ -32,6 +32,4 @@ private:
 
     // Provided during initialization.
     IStream* m_pStream;
-
-    HANDLE m_process;
 };

--- a/src/modules/previewpane/StlThumbnailProvider/StlThumbnailProvider.cs
+++ b/src/modules/previewpane/StlThumbnailProvider/StlThumbnailProvider.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Stl
         /// <returns>A thumbnail rendered from the Stl model.</returns>
         public static Bitmap GetThumbnail(Stream stream, uint cx)
         {
-            if (cx > MaxThumbnailSize || stream == null || stream.Length == 0)
+            if (cx > MaxThumbnailSize || !IsSafeToParse(stream))
             {
                 return null;
             }
@@ -117,6 +117,242 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Stl
             }
 
             return thumbnail;
+        }
+
+        /// <summary>
+        /// Checks that HelixToolkit can safely dispatch the stream to its binary or ASCII STL parser.
+        /// </summary>
+        /// <param name="stream">The STL stream.</param>
+        /// <returns><see langword="true"/> when the selected parser can make bounded forward progress.</returns>
+        public static bool IsSafeToParse(Stream stream)
+        {
+            if (stream == null || !stream.CanRead || !stream.CanSeek || stream.Position < 0 || stream.Position >= stream.Length)
+            {
+                return false;
+            }
+
+            var initialPosition = stream.Position;
+            try
+            {
+                var remainingLength = stream.Length - initialPosition;
+                if (remainingLength < 84)
+                {
+                    return false;
+                }
+
+                stream.Position = initialPosition + 80;
+                Span<byte> triangleCountBytes = stackalloc byte[sizeof(uint)];
+                if (stream.Read(triangleCountBytes) != triangleCountBytes.Length)
+                {
+                    return false;
+                }
+
+                var triangleCount = BitConverter.ToUInt32(triangleCountBytes);
+                var payloadLength = (ulong)(remainingLength - 84);
+
+                // HelixToolkit 2.24 tries binary first and compares the payload length with a
+                // 32-bit triangleCount * 50 expression. Reject an overflow that would make that
+                // check succeed and then drive billions of binary facet reads.
+                var helixPayloadLength = unchecked(triangleCount * 50U);
+                if (payloadLength == helixPayloadLength)
+                {
+                    return payloadLength == 50UL * triangleCount;
+                }
+
+                // A failed binary length check rewinds the stream and dispatches to the ASCII
+                // parser. Validate the line structure that parser relies on for forward progress.
+                return IsSafeAsciiStl(stream, initialPosition);
+            }
+            finally
+            {
+                stream.Position = initialPosition;
+            }
+        }
+
+        private static bool IsSafeAsciiStl(Stream stream, long initialPosition)
+        {
+            stream.Position = initialPosition;
+
+            Span<byte> bom = stackalloc byte[3];
+            if (stream.Read(bom) != bom.Length ||
+                bom[0] != 0xEF ||
+                bom[1] != 0xBB ||
+                bom[2] != 0xBF)
+            {
+                stream.Position = initialPosition;
+            }
+
+            var state = AsciiStlState.OutsideFacet;
+            var sawSolid = false;
+            var sawEndSolid = false;
+            var solidOpen = false;
+            var lineLength = 0;
+            var tokenLength = 0;
+            var tokenComplete = false;
+            var comment = false;
+            var previousLineTerminatorWasCr = false;
+            Span<byte> token = stackalloc byte[16];
+            Span<byte> buffer = stackalloc byte[4096];
+
+            while (true)
+            {
+                var bytesRead = stream.Read(buffer);
+                if (bytesRead == 0)
+                {
+                    break;
+                }
+
+                foreach (var value in buffer[..bytesRead])
+                {
+                    if (value == '\n' && previousLineTerminatorWasCr)
+                    {
+                        previousLineTerminatorWasCr = false;
+                        continue;
+                    }
+
+                    if (value == '\r' || value == '\n')
+                    {
+                        if (!ProcessAsciiLine(token[..tokenLength], comment, ref state, ref sawSolid, ref sawEndSolid, ref solidOpen))
+                        {
+                            return false;
+                        }
+
+                        lineLength = 0;
+                        tokenLength = 0;
+                        tokenComplete = false;
+                        comment = false;
+                        previousLineTerminatorWasCr = value == '\r';
+                        continue;
+                    }
+
+                    previousLineTerminatorWasCr = false;
+
+                    if (++lineLength > 4096)
+                    {
+                        return false;
+                    }
+
+                    if (value == '\t' || value == ' ')
+                    {
+                        tokenComplete |= tokenLength != 0;
+                        continue;
+                    }
+
+                    if (value < 0x20 || value > 0x7E)
+                    {
+                        return false;
+                    }
+
+                    if (tokenLength == 0 && (value == '#' || value == '!' || value == '$'))
+                    {
+                        comment = true;
+                    }
+
+                    if (!tokenComplete && !comment)
+                    {
+                        if (tokenLength == token.Length)
+                        {
+                            tokenComplete = true;
+                        }
+                        else
+                        {
+                            token[tokenLength++] = value >= (byte)'A' && value <= (byte)'Z' ? (byte)(value + 32) : value;
+                        }
+                    }
+                }
+            }
+
+            if (lineLength != 0 &&
+                !ProcessAsciiLine(token[..tokenLength], comment, ref state, ref sawSolid, ref sawEndSolid, ref solidOpen))
+            {
+                return false;
+            }
+
+            return state == AsciiStlState.OutsideFacet && sawSolid && sawEndSolid && !solidOpen;
+        }
+
+        private static bool ProcessAsciiLine(
+            ReadOnlySpan<byte> token,
+            bool comment,
+            ref AsciiStlState state,
+            ref bool sawSolid,
+            ref bool sawEndSolid,
+            ref bool solidOpen)
+        {
+            if (comment || token.IsEmpty)
+            {
+                return true;
+            }
+
+            switch (state)
+            {
+                case AsciiStlState.OutsideFacet:
+                    if (token.SequenceEqual("solid"u8))
+                    {
+                        if (solidOpen)
+                        {
+                            return false;
+                        }
+
+                        sawSolid = true;
+                        solidOpen = true;
+                        return true;
+                    }
+
+                    if (!solidOpen)
+                    {
+                        return false;
+                    }
+
+                    if (token.SequenceEqual("facet"u8))
+                    {
+                        state = AsciiStlState.ExpectOuterLoop;
+                    }
+                    else if (token.SequenceEqual("endsolid"u8))
+                    {
+                        sawEndSolid = true;
+                        solidOpen = false;
+                    }
+
+                    return true;
+
+                case AsciiStlState.ExpectOuterLoop:
+                    if (!token.SequenceEqual("outer"u8))
+                    {
+                        return false;
+                    }
+
+                    state = AsciiStlState.InLoop;
+                    return true;
+
+                case AsciiStlState.InLoop:
+                    if (token.SequenceEqual("endloop"u8))
+                    {
+                        state = AsciiStlState.ExpectEndFacet;
+                    }
+
+                    return true;
+
+                case AsciiStlState.ExpectEndFacet:
+                    if (!token.SequenceEqual("endfacet"u8))
+                    {
+                        return false;
+                    }
+
+                    state = AsciiStlState.OutsideFacet;
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        private enum AsciiStlState
+        {
+            OutsideFacet,
+            ExpectOuterLoop,
+            InLoop,
+            ExpectEndFacet,
         }
 
         /// <summary>

--- a/src/modules/previewpane/StlThumbnailProvider/StlThumbnailProvider.cs
+++ b/src/modules/previewpane/StlThumbnailProvider/StlThumbnailProvider.cs
@@ -120,10 +120,10 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Stl
         }
 
         /// <summary>
-        /// Checks that HelixToolkit can safely dispatch the stream to its binary or ASCII STL parser.
+        /// Checks that HelixToolkit cannot mistake a wrapped binary facet count for a valid payload length.
         /// </summary>
         /// <param name="stream">The STL stream.</param>
-        /// <returns><see langword="true"/> when the selected parser can make bounded forward progress.</returns>
+        /// <returns><see langword="true"/> when the stream can be delegated to HelixToolkit.</returns>
         public static bool IsSafeToParse(Stream stream)
         {
             if (stream == null || !stream.CanRead || !stream.CanSeek || stream.Position < 0 || stream.Position >= stream.Length)
@@ -137,7 +137,7 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Stl
                 var remainingLength = stream.Length - initialPosition;
                 if (remainingLength < 84)
                 {
-                    return false;
+                    return true;
                 }
 
                 stream.Position = initialPosition + 80;
@@ -159,200 +159,14 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Stl
                     return payloadLength == 50UL * triangleCount;
                 }
 
-                // A failed binary length check rewinds the stream and dispatches to the ASCII
-                // parser. Validate the line structure that parser relies on for forward progress.
-                return IsSafeAsciiStl(stream, initialPosition);
+                // HelixToolkit delegates every other stream to its ASCII parser. Do not duplicate
+                // that parser's grammar here, because doing so would reject supported extensions.
+                return true;
             }
             finally
             {
                 stream.Position = initialPosition;
             }
-        }
-
-        private static bool IsSafeAsciiStl(Stream stream, long initialPosition)
-        {
-            stream.Position = initialPosition;
-
-            Span<byte> bom = stackalloc byte[3];
-            if (stream.Read(bom) != bom.Length ||
-                bom[0] != 0xEF ||
-                bom[1] != 0xBB ||
-                bom[2] != 0xBF)
-            {
-                stream.Position = initialPosition;
-            }
-
-            var state = AsciiStlState.OutsideFacet;
-            var sawSolid = false;
-            var sawEndSolid = false;
-            var solidOpen = false;
-            var lineLength = 0;
-            var tokenLength = 0;
-            var tokenComplete = false;
-            var comment = false;
-            var previousLineTerminatorWasCr = false;
-            Span<byte> token = stackalloc byte[16];
-            Span<byte> buffer = stackalloc byte[4096];
-
-            while (true)
-            {
-                var bytesRead = stream.Read(buffer);
-                if (bytesRead == 0)
-                {
-                    break;
-                }
-
-                foreach (var value in buffer[..bytesRead])
-                {
-                    if (value == '\n' && previousLineTerminatorWasCr)
-                    {
-                        previousLineTerminatorWasCr = false;
-                        continue;
-                    }
-
-                    if (value == '\r' || value == '\n')
-                    {
-                        if (!ProcessAsciiLine(token[..tokenLength], comment, ref state, ref sawSolid, ref sawEndSolid, ref solidOpen))
-                        {
-                            return false;
-                        }
-
-                        lineLength = 0;
-                        tokenLength = 0;
-                        tokenComplete = false;
-                        comment = false;
-                        previousLineTerminatorWasCr = value == '\r';
-                        continue;
-                    }
-
-                    previousLineTerminatorWasCr = false;
-
-                    if (++lineLength > 4096)
-                    {
-                        return false;
-                    }
-
-                    if (value == '\t' || value == ' ')
-                    {
-                        tokenComplete |= tokenLength != 0;
-                        continue;
-                    }
-
-                    if (value < 0x20 || value > 0x7E)
-                    {
-                        return false;
-                    }
-
-                    if (tokenLength == 0 && (value == '#' || value == '!' || value == '$'))
-                    {
-                        comment = true;
-                    }
-
-                    if (!tokenComplete && !comment)
-                    {
-                        if (tokenLength == token.Length)
-                        {
-                            tokenComplete = true;
-                        }
-                        else
-                        {
-                            token[tokenLength++] = value >= (byte)'A' && value <= (byte)'Z' ? (byte)(value + 32) : value;
-                        }
-                    }
-                }
-            }
-
-            if (lineLength != 0 &&
-                !ProcessAsciiLine(token[..tokenLength], comment, ref state, ref sawSolid, ref sawEndSolid, ref solidOpen))
-            {
-                return false;
-            }
-
-            return state == AsciiStlState.OutsideFacet && sawSolid && sawEndSolid && !solidOpen;
-        }
-
-        private static bool ProcessAsciiLine(
-            ReadOnlySpan<byte> token,
-            bool comment,
-            ref AsciiStlState state,
-            ref bool sawSolid,
-            ref bool sawEndSolid,
-            ref bool solidOpen)
-        {
-            if (comment || token.IsEmpty)
-            {
-                return true;
-            }
-
-            switch (state)
-            {
-                case AsciiStlState.OutsideFacet:
-                    if (token.SequenceEqual("solid"u8))
-                    {
-                        if (solidOpen)
-                        {
-                            return false;
-                        }
-
-                        sawSolid = true;
-                        solidOpen = true;
-                        return true;
-                    }
-
-                    if (!solidOpen)
-                    {
-                        return false;
-                    }
-
-                    if (token.SequenceEqual("facet"u8))
-                    {
-                        state = AsciiStlState.ExpectOuterLoop;
-                    }
-                    else if (token.SequenceEqual("endsolid"u8))
-                    {
-                        sawEndSolid = true;
-                        solidOpen = false;
-                    }
-
-                    return true;
-
-                case AsciiStlState.ExpectOuterLoop:
-                    if (!token.SequenceEqual("outer"u8))
-                    {
-                        return false;
-                    }
-
-                    state = AsciiStlState.InLoop;
-                    return true;
-
-                case AsciiStlState.InLoop:
-                    if (token.SequenceEqual("endloop"u8))
-                    {
-                        state = AsciiStlState.ExpectEndFacet;
-                    }
-
-                    return true;
-
-                case AsciiStlState.ExpectEndFacet:
-                    if (!token.SequenceEqual("endfacet"u8))
-                    {
-                        return false;
-                    }
-
-                    state = AsciiStlState.OutsideFacet;
-                    return true;
-
-                default:
-                    return false;
-            }
-        }
-
-        private enum AsciiStlState
-        {
-            OutsideFacet,
-            ExpectOuterLoop,
-            InLoop,
-            ExpectEndFacet,
         }
 
         /// <summary>

--- a/src/modules/previewpane/StlThumbnailProviderCpp/StlThumbnailProvider.cpp
+++ b/src/modules/previewpane/StlThumbnailProviderCpp/StlThumbnailProvider.cpp
@@ -2,8 +2,6 @@
 #include "StlThumbnailProvider.h"
 
 #include <filesystem>
-#include <fstream>
-#include <shellapi.h>
 #include <Shlwapi.h>
 #include <string>
 
@@ -13,12 +11,13 @@
 #include <common/logger/logger.h>
 #include <common/SettingsAPI/settings_helpers.h>
 #include <common/utils/process_path.h>
+#include <common/utils/thumbnail_provider.h>
 
 extern HINSTANCE g_hInst;
 extern long g_cDllRef;
 
 StlThumbnailProvider::StlThumbnailProvider() :
-    m_cRef(1), m_pStream(NULL), m_process(NULL)
+    m_cRef(1), m_pStream(NULL)
 {
     std::filesystem::path logFilePath(PTSettingsHelper::get_local_low_folder_location());
     logFilePath.append(LogSettings::stlThumbLogPath);
@@ -29,6 +28,7 @@ StlThumbnailProvider::StlThumbnailProvider() :
 
 StlThumbnailProvider::~StlThumbnailProvider()
 {
+    thumbnail_provider::release_stream(m_pStream);
     InterlockedDecrement(&g_cDllRef);
 }
 
@@ -72,11 +72,7 @@ IFACEMETHODIMP StlThumbnailProvider::Initialize(IStream* pStream, DWORD grfMode)
     {
         // Initialize can be called more than once, so release existing valid
         // m_pStream.
-        if (m_pStream)
-        {
-            m_pStream->Release();
-            m_pStream = NULL;
-        }
+        thumbnail_provider::release_stream(m_pStream);
 
         m_pStream = pStream;
         m_pStream->AddRef();
@@ -91,10 +87,6 @@ IFACEMETHODIMP StlThumbnailProvider::Initialize(IStream* pStream, DWORD grfMode)
 
 IFACEMETHODIMP StlThumbnailProvider::GetThumbnail(UINT cx, HBITMAP* phbmp, WTS_ALPHATYPE* pdwAlpha)
 {
-    // Read stream into the buffer
-    char buffer[4096];
-    ULONG cbRead;
-
     Logger::trace(L"Begin");
 
     GUID guid;
@@ -104,7 +96,7 @@ IFACEMETHODIMP StlThumbnailProvider::GetThumbnail(UINT cx, HBITMAP* phbmp, WTS_A
         if (SUCCEEDED(StringFromCLSID(guid, &guidString)))
         {
             Logger::info(L"Read stream and save to tmp file.");
-            
+
             // {CLSID} -> CLSID
             std::wstring guid = std::wstring(guidString.get()).substr(1, std::wstring(guidString.get()).size() - 2);
             std::wstring filePath = PTSettingsHelper::get_local_low_folder_location() + L"\\StlThumbnail-Temp\\";
@@ -114,53 +106,48 @@ IFACEMETHODIMP StlThumbnailProvider::GetThumbnail(UINT cx, HBITMAP* phbmp, WTS_A
             }
 
             std::wstring fileName = filePath + guid + L".stl";
+            std::wstring fileNameBmp = filePath + guid + L".bmp";
 
-            // Write data to tmp file
-            std::fstream file;
-            file.open(fileName, std::ios_base::out | std::ios_base::binary);
+            const auto copyResult = thumbnail_provider::copy_stream_to_file(m_pStream, fileName);
+            thumbnail_provider::release_stream(m_pStream);
 
-            if (!file.is_open())
+            if (FAILED(copyResult))
             {
-                return 0;
+                std::error_code error;
+                std::filesystem::remove(fileName, error);
+                return copyResult;
             }
-
-            while (true)
-            {
-                auto result = m_pStream->Read(buffer, 4096, &cbRead);
-
-                file.write(buffer, cbRead);
-                if (result == S_FALSE)
-                {
-                    break;
-                }
-            }
-            file.close();
-
-            m_pStream->Release();
-            m_pStream = NULL;
 
             try
             {
                 Logger::info(L"Start StlThumbnailProvider.exe");
-                
-                STARTUPINFO info = { sizeof(info) };
+
                 std::wstring cmdLine{ L"\"" + fileName + L"\"" };
                 cmdLine += L" ";
                 cmdLine += std::to_wstring(cx);
 
                 std::wstring appPath = get_module_folderpath(g_hInst) + L"\\PowerToys.StlThumbnailProvider.exe";
+                const auto timeoutMs = thumbnail_provider::get_timeout_ms();
+                const auto launchResult = thumbnail_provider::launch_in_job(appPath, cmdLine, timeoutMs);
 
-                SHELLEXECUTEINFO sei{ sizeof(sei) };
-                sei.fMask = { SEE_MASK_NOCLOSEPROCESS | SEE_MASK_FLAG_NO_UI };
-                sei.lpFile = appPath.c_str();
-                sei.lpParameters = cmdLine.c_str();
-                sei.nShow = SW_SHOWDEFAULT;
-                ShellExecuteEx(&sei);
-                m_process = sei.hProcess;
-                WaitForSingleObject(m_process, INFINITE);
-                std::filesystem::remove(fileName);
+                std::error_code error;
+                std::filesystem::remove(fileName, error);
 
-                std::wstring fileNameBmp = filePath + guid + L".bmp";
+                if (launchResult.status != thumbnail_provider::launch_status::completed)
+                {
+                    if (launchResult.status == thumbnail_provider::launch_status::timed_out)
+                    {
+                        Logger::error(L"Stl thumbnail provider timed out after {} ms.", timeoutMs);
+                    }
+                    else
+                    {
+                        Logger::error(L"Failed to launch Stl thumbnail provider. Error: {}", launchResult.error);
+                    }
+
+                    std::filesystem::remove(fileNameBmp, error);
+                    return HRESULT_FROM_WIN32(launchResult.error == ERROR_SUCCESS ? ERROR_PROCESS_ABORTED : launchResult.error);
+                }
+
                 if (std::filesystem::exists(fileNameBmp))
                 {
                     *phbmp = static_cast<HBITMAP>(LoadImage(NULL, fileNameBmp.c_str(), IMAGE_BITMAP, 0, 0, LR_LOADFROMFILE));
@@ -177,16 +164,15 @@ IFACEMETHODIMP StlThumbnailProvider::GetThumbnail(UINT cx, HBITMAP* phbmp, WTS_A
             {
                 std::wstring errorMessage = std::wstring{ winrt::to_hstring(e.what()) };
                 Logger::error(L"Failed to start StlThumbnailProvider.exe. Error: {}", errorMessage);
+                std::error_code error;
+                std::filesystem::remove(fileName, error);
+                std::filesystem::remove(fileNameBmp, error);
             }
         }
     }
 
     // ensure releasing the stream (not all if branches contain it)
-    if (m_pStream)
-    {
-        m_pStream->Release();
-        m_pStream = NULL;
-    }
+    thumbnail_provider::release_stream(m_pStream);
 
     return S_OK;
 }

--- a/src/modules/previewpane/StlThumbnailProviderCpp/StlThumbnailProvider.h
+++ b/src/modules/previewpane/StlThumbnailProviderCpp/StlThumbnailProvider.h
@@ -32,6 +32,4 @@ private:
 
     // Provided during initialization.
     IStream* m_pStream;
-
-    HANDLE m_process;
 };

--- a/src/modules/previewpane/SvgThumbnailProviderCpp/SvgThumbnailProvider.cpp
+++ b/src/modules/previewpane/SvgThumbnailProviderCpp/SvgThumbnailProvider.cpp
@@ -2,8 +2,6 @@
 #include "SvgThumbnailProvider.h"
 
 #include <filesystem>
-#include <fstream>
-#include <shellapi.h>
 #include <Shlwapi.h>
 #include <string>
 
@@ -13,12 +11,13 @@
 #include <common/logger/logger.h>
 #include <common/SettingsAPI/settings_helpers.h>
 #include <common/utils/process_path.h>
+#include <common/utils/thumbnail_provider.h>
 
 extern HINSTANCE g_hInst;
 extern long g_cDllRef;
 
 SvgThumbnailProvider::SvgThumbnailProvider() :
-    m_cRef(1), m_pStream(NULL), m_process(NULL)
+    m_cRef(1), m_pStream(NULL)
 {
     std::filesystem::path logFilePath(PTSettingsHelper::get_local_low_folder_location());
     logFilePath.append(LogSettings::svgThumbLogPath);
@@ -29,6 +28,7 @@ SvgThumbnailProvider::SvgThumbnailProvider() :
 
 SvgThumbnailProvider::~SvgThumbnailProvider()
 {
+    thumbnail_provider::release_stream(m_pStream);
     InterlockedDecrement(&g_cDllRef);
 }
 
@@ -72,11 +72,7 @@ IFACEMETHODIMP SvgThumbnailProvider::Initialize(IStream* pStream, DWORD grfMode)
     {
         // Initialize can be called more than once, so release existing valid
         // m_pStream.
-        if (m_pStream)
-        {
-            m_pStream->Release();
-            m_pStream = NULL;
-        }
+        thumbnail_provider::release_stream(m_pStream);
 
         m_pStream = pStream;
         m_pStream->AddRef();
@@ -91,10 +87,6 @@ IFACEMETHODIMP SvgThumbnailProvider::Initialize(IStream* pStream, DWORD grfMode)
 
 IFACEMETHODIMP SvgThumbnailProvider::GetThumbnail(UINT cx, HBITMAP* phbmp, WTS_ALPHATYPE* pdwAlpha)
 {
-    // Read stream into the buffer
-    char buffer[4096];
-    ULONG cbRead;
-
     Logger::trace(L"Begin");
 
     GUID guid;
@@ -114,53 +106,47 @@ IFACEMETHODIMP SvgThumbnailProvider::GetThumbnail(UINT cx, HBITMAP* phbmp, WTS_A
             }
 
             std::wstring fileName = filePath + guid + L".svg";
+            std::wstring fileNameBmp = filePath + guid + L".bmp";
 
-            // Write data to tmp file
-            std::fstream file;
-            file.open(fileName, std::ios_base::out | std::ios_base::binary);
+            const auto copyResult = thumbnail_provider::copy_stream_to_file(m_pStream, fileName);
+            thumbnail_provider::release_stream(m_pStream);
 
-            if (!file.is_open())
+            if (FAILED(copyResult))
             {
-                return 0;
+                std::error_code error;
+                std::filesystem::remove(fileName, error);
+                return copyResult;
             }
-
-            while (true)
-            {
-                auto result = m_pStream->Read(buffer, 4096, &cbRead);
-
-                file.write(buffer, cbRead);
-                if (result == S_FALSE)
-                {
-                    break;
-                }
-            }
-            file.close();
-
-            m_pStream->Release();
-            m_pStream = NULL;
 
             try
             {
                 Logger::info(L"Start SvgThumbnailProvider.exe");
 
-                STARTUPINFO info = { sizeof(info) };
                 std::wstring cmdLine{ L"\"" + fileName + L"\"" };
                 cmdLine += L" ";
                 cmdLine += std::to_wstring(cx);
 
                 std::wstring appPath = get_module_folderpath(g_hInst) + L"\\PowerToys.SvgThumbnailProvider.exe";
+                const auto timeoutMs = thumbnail_provider::get_timeout_ms();
+                const auto launchResult = thumbnail_provider::launch_in_job(appPath, cmdLine, timeoutMs);
 
-                SHELLEXECUTEINFO sei{ sizeof(sei) };
-                sei.fMask = { SEE_MASK_NOCLOSEPROCESS | SEE_MASK_FLAG_NO_UI };
-                sei.lpFile = appPath.c_str();
-                sei.lpParameters = cmdLine.c_str();
-                sei.nShow = SW_SHOWDEFAULT;
-                ShellExecuteEx(&sei);
-                m_process = sei.hProcess;
-                WaitForSingleObject(m_process, INFINITE);
-                std::filesystem::remove(fileName);
+                std::error_code error;
+                std::filesystem::remove(fileName, error);
 
-                std::wstring fileNameBmp = filePath + guid + L".bmp";
+                if (launchResult.status != thumbnail_provider::launch_status::completed)
+                {
+                    if (launchResult.status == thumbnail_provider::launch_status::timed_out)
+                    {
+                        Logger::error(L"Svg thumbnail provider timed out after {} ms.", timeoutMs);
+                    }
+                    else
+                    {
+                        Logger::error(L"Failed to launch Svg thumbnail provider. Error: {}", launchResult.error);
+                    }
+
+                    std::filesystem::remove(fileNameBmp, error);
+                    return HRESULT_FROM_WIN32(launchResult.error == ERROR_SUCCESS ? ERROR_PROCESS_ABORTED : launchResult.error);
+                }
 
                 if (std::filesystem::exists(fileNameBmp))
                 {
@@ -178,16 +164,15 @@ IFACEMETHODIMP SvgThumbnailProvider::GetThumbnail(UINT cx, HBITMAP* phbmp, WTS_A
             {
                 std::wstring errorMessage = std::wstring{ winrt::to_hstring(e.what()) };
                 Logger::error(L"Failed to start SvgThumbnailProvider.exe. Error: {}", errorMessage);
+                std::error_code error;
+                std::filesystem::remove(fileName, error);
+                std::filesystem::remove(fileNameBmp, error);
             }
         }
     }
 
     // ensure releasing the stream (not all if branches contain it)
-    if (m_pStream)
-    {
-        m_pStream->Release();
-        m_pStream = NULL;
-    }
+    thumbnail_provider::release_stream(m_pStream);
 
     return S_OK;
 }

--- a/src/modules/previewpane/SvgThumbnailProviderCpp/SvgThumbnailProvider.h
+++ b/src/modules/previewpane/SvgThumbnailProviderCpp/SvgThumbnailProvider.h
@@ -32,6 +32,4 @@ private:
 
     // Provided during initialization.
     IStream* m_pStream;
-
-    HANDLE m_process;
 };

--- a/src/modules/previewpane/UnitTests-BgcodeThumbnailProvider/BgcodeThumbnailProviderTests.cs
+++ b/src/modules/previewpane/UnitTests-BgcodeThumbnailProvider/BgcodeThumbnailProviderTests.cs
@@ -2,9 +2,13 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Drawing;
 using System.IO;
+using System.IO.Compression;
+using System.Linq;
 
+using Microsoft.PowerToys.FilePreviewCommon;
 using Microsoft.PowerToys.ThumbnailHandler.Bgcode;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -66,6 +70,280 @@ namespace BgcodeThumbnailProviderUnitTests
         {
             Bitmap thumbnail = BgcodeThumbnailProvider.GetThumbnail(null, 256);
             Assert.IsTrue(thumbnail == null);
+        }
+
+        [TestMethod]
+        public void WrappedBlockSizeShouldBeRejected()
+        {
+            using var reader = CreateReader(writer =>
+            {
+                WriteBlockHeader(writer, BgcodeBlockType.ThumbnailBlock, BgcodeCompressionType.NoCompression, uint.MaxValue);
+                writer.Write((ushort)BgcodeThumbnailFormat.PNG);
+                writer.Write((ushort)1);
+                writer.Write((ushort)1);
+            });
+
+            Assert.ThrowsExactly<InvalidDataException>(() => BgcodeHelper.GetBestThumbnail(reader));
+        }
+
+        [TestMethod]
+        public void TruncatedThumbnailBlockShouldBeRejected()
+        {
+            using var reader = CreateReader(writer =>
+            {
+                WriteBlockHeader(writer, BgcodeBlockType.ThumbnailBlock, BgcodeCompressionType.NoCompression, 8);
+                writer.Write((ushort)BgcodeThumbnailFormat.PNG);
+                writer.Write((ushort)1);
+                writer.Write((ushort)1);
+                writer.Write(new byte[] { 1, 2 });
+            });
+
+            Assert.ThrowsExactly<InvalidDataException>(() => BgcodeHelper.GetBestThumbnail(reader));
+        }
+
+        [TestMethod]
+        public void UnsupportedCompressionShouldBeSkippedAndNextBlockParsed()
+        {
+            var expected = new byte[] { 1, 2, 3, 4 };
+            using var reader = CreateReader(writer =>
+            {
+                WriteBlockHeader(
+                    writer,
+                    BgcodeBlockType.ThumbnailBlock,
+                    BgcodeCompressionType.HeatshrinkAlgorithm11,
+                    uncompressedSize: 100,
+                    storedSize: 3);
+                WriteThumbnailMetadata(writer);
+                writer.Write(new byte[] { 9, 8, 7 });
+
+                WriteBlockHeader(
+                    writer,
+                    BgcodeBlockType.ThumbnailBlock,
+                    BgcodeCompressionType.NoCompression,
+                    (uint)expected.Length);
+                WriteThumbnailMetadata(writer);
+                writer.Write(expected);
+            });
+
+            var thumbnails = BgcodeHelper.GetThumbnails(reader).ToList();
+
+            Assert.HasCount(1, thumbnails);
+            CollectionAssert.AreEqual(expected, thumbnails[0].Data);
+        }
+
+        [TestMethod]
+        public void DeflateBlockShouldConsumeOnlyItsStoredPayloadAndMakeForwardProgress()
+        {
+            var expected = new byte[] { 1, 2, 3, 4, 5 };
+            byte[] compressed;
+            using (var compressedStream = new MemoryStream())
+            {
+                using (var deflate = new DeflateStream(compressedStream, CompressionLevel.SmallestSize, leaveOpen: true))
+                {
+                    deflate.Write(expected);
+                }
+
+                compressed = compressedStream.ToArray();
+            }
+
+            using var reader = CreateReader(writer =>
+            {
+                WriteBlockHeader(
+                    writer,
+                    BgcodeBlockType.ThumbnailBlock,
+                    BgcodeCompressionType.DeflateAlgorithm,
+                    (uint)expected.Length,
+                    (uint)compressed.Length);
+                WriteThumbnailMetadata(writer);
+                writer.Write(compressed);
+
+                WriteBlockHeader(writer, BgcodeBlockType.FileMetadataBlock, BgcodeCompressionType.NoCompression, 0);
+                writer.Write((ushort)0);
+            });
+
+            var thumbnails = BgcodeHelper.GetThumbnails(reader).ToList();
+
+            Assert.HasCount(1, thumbnails);
+            CollectionAssert.AreEqual(expected, thumbnails[0].Data);
+            Assert.AreEqual(reader.BaseStream.Length, reader.BaseStream.Position);
+        }
+
+        [TestMethod]
+        public void ValidCrc32FileWithMetadataAndThumbnailShouldParse()
+        {
+            var expected = new byte[] { 1, 2, 3, 4 };
+            using var reader = CreateReader(
+                writer =>
+                {
+                    WriteBlockHeader(writer, BgcodeBlockType.FileMetadataBlock, BgcodeCompressionType.NoCompression, 3);
+                    writer.Write((ushort)0);
+                    writer.Write(new byte[] { 7, 8, 9 });
+                    writer.Write(0x12345678U);
+
+                    WriteBlockHeader(
+                        writer,
+                        BgcodeBlockType.ThumbnailBlock,
+                        BgcodeCompressionType.NoCompression,
+                        (uint)expected.Length);
+                    WriteThumbnailMetadata(writer);
+                    writer.Write(expected);
+                    writer.Write(0x87654321U);
+                },
+                BgcodeChecksumType.CRC32);
+
+            var thumbnails = BgcodeHelper.GetThumbnails(reader).ToList();
+
+            Assert.HasCount(1, thumbnails);
+            CollectionAssert.AreEqual(expected, thumbnails[0].Data);
+            Assert.AreEqual(reader.BaseStream.Length, reader.BaseStream.Position);
+        }
+
+        [TestMethod]
+        public void WrappedMetadataBlockSizeShouldBeRejectedBeforeRepeatedReads()
+        {
+            using var stream = new SparseWrappedMetadataStream();
+            using var reader = new BinaryReader(stream);
+
+            Assert.ThrowsExactly<InvalidDataException>(() => BgcodeHelper.GetBestThumbnail(reader));
+            Assert.IsTrue(stream.ReadCallCount <= 8, $"Parser performed {stream.ReadCallCount} reads.");
+        }
+
+        [TestMethod]
+        public void DeflateThumbnailAboveAllocationLimitShouldBeRejectedBeforeAllocation()
+        {
+            using var reader = CreateReader(writer =>
+            {
+                WriteBlockHeader(
+                    writer,
+                    BgcodeBlockType.ThumbnailBlock,
+                    BgcodeCompressionType.DeflateAlgorithm,
+                    uncompressedSize: (64U * 1024 * 1024) + 1,
+                    storedSize: 0);
+                WriteThumbnailMetadata(writer);
+            });
+
+            var exception = Assert.ThrowsExactly<InvalidDataException>(() => BgcodeHelper.GetBestThumbnail(reader));
+
+            Assert.AreEqual("The BGCODE thumbnail block exceeds the 64 MiB limit.", exception.Message);
+        }
+
+        private static BinaryReader CreateReader(
+            Action<BinaryWriter> writeBlocks,
+            BgcodeChecksumType checksum = BgcodeChecksumType.None)
+        {
+            var stream = new MemoryStream();
+            using (var writer = new BinaryWriter(stream, System.Text.Encoding.UTF8, leaveOpen: true))
+            {
+                writer.Write((byte)'G');
+                writer.Write((byte)'C');
+                writer.Write((byte)'D');
+                writer.Write((byte)'E');
+                writer.Write(1U);
+                writer.Write((ushort)checksum);
+                writeBlocks(writer);
+            }
+
+            stream.Position = 0;
+            return new BinaryReader(stream);
+        }
+
+        private static void WriteBlockHeader(
+            BinaryWriter writer,
+            BgcodeBlockType blockType,
+            BgcodeCompressionType compression,
+            uint uncompressedSize,
+            uint storedSize = 0)
+        {
+            writer.Write((ushort)blockType);
+            writer.Write((ushort)compression);
+            writer.Write(uncompressedSize);
+            if (compression != BgcodeCompressionType.NoCompression)
+            {
+                writer.Write(storedSize);
+            }
+        }
+
+        private static void WriteThumbnailMetadata(BinaryWriter writer)
+        {
+            writer.Write((ushort)BgcodeThumbnailFormat.PNG);
+            writer.Write((ushort)1);
+            writer.Write((ushort)1);
+        }
+
+        private sealed class SparseWrappedMetadataStream : Stream
+        {
+            private const int MaximumReadCalls = 16;
+            private readonly byte[] prefix;
+
+            public SparseWrappedMetadataStream()
+            {
+                using var stream = new MemoryStream();
+                using (var writer = new BinaryWriter(stream, System.Text.Encoding.UTF8, leaveOpen: true))
+                {
+                    writer.Write((byte)'G');
+                    writer.Write((byte)'C');
+                    writer.Write((byte)'D');
+                    writer.Write((byte)'E');
+                    writer.Write(1U);
+                    writer.Write((ushort)BgcodeChecksumType.None);
+                    writer.Write((ushort)BgcodeBlockType.GCodeBlock);
+                    writer.Write((ushort)BgcodeCompressionType.NoCompression);
+                    writer.Write(0xFFFFFFFEU);
+                }
+
+                prefix = stream.ToArray();
+            }
+
+            public int ReadCallCount { get; private set; }
+
+            public override bool CanRead => true;
+
+            public override bool CanSeek => true;
+
+            public override bool CanWrite => false;
+
+            public override long Length => 1L << 31;
+
+            public override long Position { get; set; }
+
+            public override void Flush()
+            {
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                if (++ReadCallCount > MaximumReadCalls)
+                {
+                    throw new InvalidOperationException("The parser exceeded the bounded read count.");
+                }
+
+                var available = (int)Math.Min(count, Length - Position);
+                for (var index = 0; index < available; index++)
+                {
+                    var sourcePosition = Position + index;
+                    buffer[offset + index] = sourcePosition < prefix.Length ? prefix[(int)sourcePosition] : (byte)0;
+                }
+
+                Position += available;
+                return available;
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                Position = origin switch
+                {
+                    SeekOrigin.Begin => offset,
+                    SeekOrigin.Current => Position + offset,
+                    SeekOrigin.End => Length + offset,
+                    _ => throw new ArgumentOutOfRangeException(nameof(origin)),
+                };
+
+                return Position;
+            }
+
+            public override void SetLength(long value) => throw new NotSupportedException();
+
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
         }
     }
 }

--- a/src/modules/previewpane/UnitTests-StlThumbnailProvider/StlThumbnailProviderTests.cs
+++ b/src/modules/previewpane/UnitTests-StlThumbnailProvider/StlThumbnailProviderTests.cs
@@ -2,8 +2,11 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Diagnostics;
 using System.Drawing;
 using System.IO;
+using System.Text;
 
 using Microsoft.PowerToys.ThumbnailHandler.Stl;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -67,6 +70,200 @@ namespace StlThumbnailProviderUnitTests
         {
             Bitmap thumbnail = StlThumbnailProvider.GetThumbnail(null, 256);
             Assert.IsTrue(thumbnail == null);
+        }
+
+        [TestMethod]
+        public void BinaryStlDeclaredFacetPastEofShouldFailPreflight()
+        {
+            using var stream = CreateBinaryStl(triangleCount: 1, facetBytes: 0);
+
+            Assert.IsFalse(StlThumbnailProvider.IsSafeToParse(stream));
+            Assert.IsNull(StlThumbnailProvider.GetThumbnail(stream, 256));
+        }
+
+        [TestMethod]
+        public void BinaryStlWrappedFacetCountShouldFailPreflight()
+        {
+            using var stream = CreateBinaryStl(0x80000000, facetBytes: 0, header: "solid wrapped binary");
+
+            Assert.IsFalse(StlThumbnailProvider.IsSafeToParse(stream));
+            Assert.IsNull(StlThumbnailProvider.GetThumbnail(stream, 256));
+        }
+
+        [TestMethod]
+        public void ValidBinaryStlShouldPassPreflight()
+        {
+            using var stream = File.OpenRead("HelperFiles/sample.stl");
+
+            Assert.IsTrue(StlThumbnailProvider.IsSafeToParse(stream));
+        }
+
+        [DataTestMethod]
+        [DataRow(true, false, false, DisplayName = "Leading CRLF")]
+        [DataRow(false, true, false, DisplayName = "UTF-8 BOM")]
+        [DataRow(false, false, true, DisplayName = "Uppercase SOLID")]
+        public void ValidAsciiStlVariantsShouldPassPreflightAndRender(bool leadingCrLf, bool bom, bool uppercase)
+        {
+            using var stream = CreateAsciiStl(leadingCrLf, bom, uppercase);
+
+            Assert.IsTrue(StlThumbnailProvider.IsSafeToParse(stream));
+            using var thumbnail = StlThumbnailProvider.GetThumbnail(stream, 256);
+            Assert.IsNotNull(thumbnail);
+        }
+
+        [TestMethod]
+        public void ValidCrOnlyAsciiStlShouldPassPreflightAndRender()
+        {
+            using var stream = CreateAsciiStl(leadingCrLf: false, bom: false, uppercase: false, lineEnding: "\r");
+
+            Assert.IsTrue(StlThumbnailProvider.IsSafeToParse(stream));
+            using var thumbnail = StlThumbnailProvider.GetThumbnail(stream, 256);
+            Assert.IsNotNull(thumbnail);
+        }
+
+        [TestMethod]
+        public void ValidAsciiStlWithMultipleFacetsAndBlankLinesShouldRender()
+        {
+            const string content =
+                "\r\n" +
+                "solid unusual\r\n" +
+                "facet normal 0 0 1\r\n" +
+                "outer loop\r\n" +
+                "vertex 0 0 0\r\n" +
+                "vertex 1 0 0\r\n" +
+                "vertex 0 1 0\r\n" +
+                "endloop\r\n" +
+                "endfacet\r\n" +
+                "\r\n" +
+                "facet normal 0 0 1\r\n" +
+                "outer loop\r\n" +
+                "vertex 1 0 0\r\n" +
+                "vertex 1 1 0\r\n" +
+                "vertex 0 1 0\r\n" +
+                "endloop\r\n" +
+                "endfacet\r\n" +
+                "\r\n" +
+                "endsolid unusual\r\n";
+            using var stream = new MemoryStream(Encoding.ASCII.GetBytes(content));
+
+            Assert.IsTrue(StlThumbnailProvider.IsSafeToParse(stream));
+            using var thumbnail = StlThumbnailProvider.GetThumbnail(stream, 256);
+            Assert.IsNotNull(thumbnail);
+        }
+
+        [TestMethod]
+        [Timeout(5000)]
+        public void TruncatedAsciiStlWithUnterminatedFacetShouldFailBoundedly()
+        {
+            const string lineEnding = "\r\n";
+            var content =
+                $"solid truncated{lineEnding}" +
+                $"facet normal 0 0 1{lineEnding}" +
+                $"outer loop{lineEnding}" +
+                $"vertex 0 0 0{lineEnding}" +
+                $"vertex 1 0 0{lineEnding}" +
+                $"vertex 0 1 0{lineEnding}" +
+                $"endloop{lineEnding}";
+            using var stream = new MemoryStream(Encoding.ASCII.GetBytes(content));
+            var stopwatch = Stopwatch.StartNew();
+
+            Assert.IsFalse(StlThumbnailProvider.IsSafeToParse(stream));
+            Assert.IsNull(StlThumbnailProvider.GetThumbnail(stream, 256));
+
+            stopwatch.Stop();
+            Assert.IsTrue(
+                stopwatch.Elapsed < TimeSpan.FromSeconds(1),
+                $"Truncated ASCII facet rejection took {stopwatch.Elapsed}.");
+        }
+
+        [TestMethod]
+        public void ValidBinaryStlWithSolidHeaderShouldUseBinaryLengthValidation()
+        {
+            using var stream = CreateValidBinaryStl("solid binary header");
+
+            Assert.IsTrue(StlThumbnailProvider.IsSafeToParse(stream));
+            using var thumbnail = StlThumbnailProvider.GetThumbnail(stream, 256);
+            Assert.IsNotNull(thumbnail);
+        }
+
+        private static MemoryStream CreateBinaryStl(uint triangleCount, int facetBytes, string header = null)
+        {
+            var stream = new MemoryStream(new byte[84 + facetBytes]);
+            if (header != null)
+            {
+                var headerBytes = Encoding.ASCII.GetBytes(header);
+                stream.Write(headerBytes, 0, Math.Min(headerBytes.Length, 80));
+            }
+
+            stream.Position = 80;
+            using (var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true))
+            {
+                writer.Write(triangleCount);
+            }
+
+            stream.Position = 0;
+            return stream;
+        }
+
+        private static MemoryStream CreateValidBinaryStl(string header)
+        {
+            var stream = CreateBinaryStl(triangleCount: 1, facetBytes: 50, header);
+            stream.Position = 84;
+            using (var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true))
+            {
+                writer.Write(0f);
+                writer.Write(0f);
+                writer.Write(1f);
+                writer.Write(0f);
+                writer.Write(0f);
+                writer.Write(0f);
+                writer.Write(1f);
+                writer.Write(0f);
+                writer.Write(0f);
+                writer.Write(0f);
+                writer.Write(1f);
+                writer.Write(0f);
+                writer.Write((ushort)0);
+            }
+
+            stream.Position = 0;
+            return stream;
+        }
+
+        private static MemoryStream CreateAsciiStl(bool leadingCrLf, bool bom, bool uppercase, string lineEnding = "\r\n")
+        {
+            var content =
+                $"solid sample{lineEnding}" +
+                $"facet normal 0 0 1{lineEnding}" +
+                $"outer loop{lineEnding}" +
+                $"vertex 0 0 0{lineEnding}" +
+                $"vertex 1 0 0{lineEnding}" +
+                $"vertex 0 1 0{lineEnding}" +
+                $"endloop{lineEnding}" +
+                $"endfacet{lineEnding}" +
+                $"endsolid sample{lineEnding}";
+
+            if (uppercase)
+            {
+                content = content.ToUpperInvariant();
+            }
+
+            if (leadingCrLf)
+            {
+                content = "\r\n" + content;
+            }
+
+            var data = Encoding.UTF8.GetBytes(content);
+            if (!bom)
+            {
+                return new MemoryStream(data);
+            }
+
+            var preamble = Encoding.UTF8.GetPreamble();
+            var withPreamble = new byte[preamble.Length + data.Length];
+            preamble.CopyTo(withPreamble, 0);
+            data.CopyTo(withPreamble, preamble.Length);
+            return new MemoryStream(withPreamble);
         }
     }
 }

--- a/src/modules/previewpane/UnitTests-StlThumbnailProvider/StlThumbnailProviderTests.cs
+++ b/src/modules/previewpane/UnitTests-StlThumbnailProvider/StlThumbnailProviderTests.cs
@@ -73,11 +73,11 @@ namespace StlThumbnailProviderUnitTests
         }
 
         [TestMethod]
-        public void BinaryStlDeclaredFacetPastEofShouldFailPreflight()
+        public void BinaryStlDeclaredFacetPastEofShouldBeDelegatedToParser()
         {
             using var stream = CreateBinaryStl(triangleCount: 1, facetBytes: 0);
 
-            Assert.IsFalse(StlThumbnailProvider.IsSafeToParse(stream));
+            Assert.IsTrue(StlThumbnailProvider.IsSafeToParse(stream));
             Assert.IsNull(StlThumbnailProvider.GetThumbnail(stream, 256));
         }
 
@@ -122,6 +122,35 @@ namespace StlThumbnailProviderUnitTests
         }
 
         [TestMethod]
+        public void ValidAsciiStlWithLocalizedNameShouldPassPreflightAndRender()
+        {
+            using var stream = CreateAsciiStl(leadingCrLf: false, bom: false, uppercase: false, solidName: "café");
+
+            Assert.IsTrue(StlThumbnailProvider.IsSafeToParse(stream));
+            using var thumbnail = StlThumbnailProvider.GetThumbnail(stream, 256);
+            Assert.IsNotNull(thumbnail);
+        }
+
+        [TestMethod]
+        public void AsciiStlWithUnknownKeywordShouldBeDelegatedToParser()
+        {
+            const string content =
+                "solid extended\r\n" +
+                "facet normal 0 0 1\r\n" +
+                "future_keyword value\r\n" +
+                "outer loop\r\n" +
+                "vertex 0 0 0\r\n" +
+                "vertex 1 0 0\r\n" +
+                "vertex 0 1 0\r\n" +
+                "endloop\r\n" +
+                "endfacet\r\n" +
+                "endsolid extended\r\n";
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(content));
+
+            Assert.IsTrue(StlThumbnailProvider.IsSafeToParse(stream));
+        }
+
+        [TestMethod]
         public void ValidAsciiStlWithMultipleFacetsAndBlankLinesShouldRender()
         {
             const string content =
@@ -153,7 +182,7 @@ namespace StlThumbnailProviderUnitTests
 
         [TestMethod]
         [Timeout(5000)]
-        public void TruncatedAsciiStlWithUnterminatedFacetShouldFailBoundedly()
+        public void TruncatedAsciiStlWithUnterminatedFacetShouldBeDelegatedAndFailBoundedly()
         {
             const string lineEnding = "\r\n";
             var content =
@@ -167,7 +196,7 @@ namespace StlThumbnailProviderUnitTests
             using var stream = new MemoryStream(Encoding.ASCII.GetBytes(content));
             var stopwatch = Stopwatch.StartNew();
 
-            Assert.IsFalse(StlThumbnailProvider.IsSafeToParse(stream));
+            Assert.IsTrue(StlThumbnailProvider.IsSafeToParse(stream));
             Assert.IsNull(StlThumbnailProvider.GetThumbnail(stream, 256));
 
             stopwatch.Stop();
@@ -230,10 +259,10 @@ namespace StlThumbnailProviderUnitTests
             return stream;
         }
 
-        private static MemoryStream CreateAsciiStl(bool leadingCrLf, bool bom, bool uppercase, string lineEnding = "\r\n")
+        private static MemoryStream CreateAsciiStl(bool leadingCrLf, bool bom, bool uppercase, string lineEnding = "\r\n", string solidName = "sample")
         {
             var content =
-                $"solid sample{lineEnding}" +
+                $"solid {solidName}{lineEnding}" +
                 $"facet normal 0 0 1{lineEnding}" +
                 $"outer loop{lineEnding}" +
                 $"vertex 0 0 0{lineEnding}" +
@@ -241,7 +270,7 @@ namespace StlThumbnailProviderUnitTests
                 $"vertex 0 1 0{lineEnding}" +
                 $"endloop{lineEnding}" +
                 $"endfacet{lineEnding}" +
-                $"endsolid sample{lineEnding}";
+                $"endsolid {solidName}{lineEnding}";
 
             if (uppercase)
             {


### PR DESCRIPTION
## Summary of the Pull Request

Bounds thumbnail generation work and improves malformed-input handling for the BGCODE and STL thumbnail paths. Parser executables now run in kill-on-close jobs with a configurable timeout, and temporary streams/files are cleaned up on failure.

## PR Checklist

- [ ] **Communication:** Not yet confirmed with core contributors
- [x] **Tests:** Added/updated and all targeted tests pass
- [x] **Localization:** N/A; no end-user-facing strings changed
- [x] **Dev docs:** N/A; behavior is covered by code comments and tests

## Detailed Description of the Pull Request / Additional comments

- Adds shared bounded stream-copy, timeout parsing, and job-based process launch helpers in `src/common/utils/thumbnail_provider.h`.
- Updates six File Explorer thumbnail handlers under `src/modules/previewpane/` to use bounded child execution and deterministic cleanup.
- Adds bounded BGCODE block parsing in `src/common/FilePreviewCommon/BgcodeHelper.cs`.
- Adds STL binary/ASCII preflight validation in `src/modules/previewpane/StlThumbnailProvider/StlThumbnailProvider.cs`.
- Adds native and managed coverage for malformed input, timeout handling, descendant cleanup, provider startup, nested-job compatibility, CRC32 BGCODE blocks, and multi-facet ASCII STL files. The new helper executable is test-only and is built through the existing common utility test project.

The timeout and hard process-tree termination are a coarse safety ceiling, not a normal execution target. Slow-process behavior is tested at the native host boundary where the timeout is enforced, rather than through an artificial managed-parser delay.

## Validation Steps Performed

- Release builds passed for x64 and ARM64: all six managed parser executables, all six native thumbnail handlers, BGCODE/STL managed unit-test projects, and `Common.Utils.UnitTests` with its test helper. Filtered solution builds also verified that the helper follows the selected x64/ARM64 configuration and does not invoke unused package integration.
- `Common.Utils.UnitTests`: 9/9 thumbnail provider tests passed, including six executable startup checks, direct timeout process-tree containment, and nested-job process-tree containment.
- `Preview.BgcodeThumbnailProvider.UnitTests`: 12/12 passed.
- `Preview.StlThumbnailProvider.UnitTests`: 15/15 passed.
- Full CI completed the ARM64 matrix. Across the x64 runs, the main build and all nine changed thumbnail tests passed. A Command Palette test failure seen once disappeared on the narrow rerun, while the native test host again did not exit before the job limit after emitting the completed test output; therefore the overall x64 matrix remains incomplete.
- No Explorer registration or real Explorer integration was performed. Real Explorer-host validation remains an external gate for a disposable VM; local tests directly invoked test assemblies and parser executables from build/test-owned paths.