### PR TITLE
[IPC] Improve module pipe creation

### DIFF
--- a/src/common/UnitTests-CommonUtils/NamedPipePeerAuth.Tests.cpp
+++ b/src/common/UnitTests-CommonUtils/NamedPipePeerAuth.Tests.cpp
@@ -121,20 +121,24 @@ namespace CommonUtilsUnitTests
                 policy));
         }
 
-        TEST_METHOD (WindowsSystemHost_AcceptsOnlyCanonicalExplorerPath)
+        TEST_METHOD (TrustedSignedProcess_AcceptsResolvedPeerInDebug)
         {
-            wchar_t windowsDirectory[MAX_PATH]{};
-            Assert::AreNotEqual<UINT>(0, GetWindowsDirectoryW(windowsDirectory, ARRAYSIZE(windowsDirectory)));
+            const auto pipe = create_connected_pipe();
+            Assert::AreNotEqual(INVALID_HANDLE_VALUE, pipe.server);
+            Assert::AreNotEqual(INVALID_HANDLE_VALUE, pipe.client);
 
-            const auto explorerPath = named_pipe_peer_auth::details::canonicalize_path(
-                std::wstring(windowsDirectory) + L"\\explorer.exe");
-            Assert::IsFalse(explorerPath.empty());
-            Assert::IsTrue(named_pipe_peer_auth::details::is_expected_windows_host_path(
-                explorerPath,
-                L"explorer.exe"));
-            Assert::IsFalse(named_pipe_peer_auth::details::is_expected_windows_host_path(
-                explorerPath,
-                L"not-explorer.exe"));
+#ifdef _DEBUG
+            const named_pipe_peer_auth::Policy policy{
+                {},
+                {},
+                {},
+                named_pipe_peer_auth::Validation::TrustedSignedProcess,
+            };
+            Assert::IsTrue(named_pipe_peer_auth::authenticate(
+                pipe.server,
+                named_pipe_peer_auth::Peer::Client,
+                policy));
+#endif
         }
     };
 }

--- a/src/common/UnitTests-CommonUtils/NamedPipePeerAuth.Tests.cpp
+++ b/src/common/UnitTests-CommonUtils/NamedPipePeerAuth.Tests.cpp
@@ -3,6 +3,8 @@
 #include <common/utils/named_pipe_peer_auth.h>
 #include <common/utils/process_path.h>
 
+#include <format>
+
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 namespace CommonUtilsUnitTests
@@ -139,6 +141,18 @@ namespace CommonUtilsUnitTests
                 named_pipe_peer_auth::Peer::Client,
                 policy));
 #endif
+        }
+
+        TEST_METHOD (TrustedSignature_AcceptsWindowsSignedBinary)
+        {
+            wchar_t windowsDirectory[MAX_PATH]{};
+            const UINT length = GetWindowsDirectoryW(windowsDirectory, ARRAYSIZE(windowsDirectory));
+            Assert::IsTrue(length > 0 && length < ARRAYSIZE(windowsDirectory));
+
+            const auto explorerPath = named_pipe_peer_auth::details::canonicalize_path(
+                std::wstring(windowsDirectory) + L"\\explorer.exe");
+            Assert::IsFalse(explorerPath.empty());
+            Assert::IsTrue(named_pipe_peer_auth::details::has_trusted_signature(explorerPath));
         }
     };
 }

--- a/src/common/UnitTests-CommonUtils/NamedPipePeerAuth.Tests.cpp
+++ b/src/common/UnitTests-CommonUtils/NamedPipePeerAuth.Tests.cpp
@@ -1,0 +1,140 @@
+#include "pch.h"
+
+#include <common/utils/named_pipe_peer_auth.h>
+#include <common/utils/process_path.h>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace CommonUtilsUnitTests
+{
+    TEST_CLASS (NamedPipePeerAuthTests)
+    {
+    private:
+        struct ConnectedPipe
+        {
+            HANDLE server = INVALID_HANDLE_VALUE;
+            HANDLE client = INVALID_HANDLE_VALUE;
+
+            ~ConnectedPipe()
+            {
+                if (client != INVALID_HANDLE_VALUE)
+                {
+                    CloseHandle(client);
+                }
+                if (server != INVALID_HANDLE_VALUE)
+                {
+                    CloseHandle(server);
+                }
+            }
+        };
+
+        static ConnectedPipe create_connected_pipe()
+        {
+            const auto pipeName = std::format(
+                L"\\\\.\\pipe\\powertoys_peer_auth_test_{}_{}",
+                GetCurrentProcessId(),
+                GetTickCount64());
+
+            ConnectedPipe pipe;
+            pipe.server = CreateNamedPipeW(
+                pipeName.c_str(),
+                PIPE_ACCESS_DUPLEX | FILE_FLAG_FIRST_PIPE_INSTANCE,
+                PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS,
+                1,
+                1024,
+                1024,
+                0,
+                nullptr);
+            if (pipe.server == INVALID_HANDLE_VALUE)
+            {
+                return pipe;
+            }
+
+            pipe.client = CreateFileW(
+                pipeName.c_str(),
+                GENERIC_READ | GENERIC_WRITE,
+                0,
+                nullptr,
+                OPEN_EXISTING,
+                0,
+                nullptr);
+            if (pipe.client == INVALID_HANDLE_VALUE)
+            {
+                return pipe;
+            }
+
+            if (!ConnectNamedPipe(pipe.server, nullptr) &&
+                GetLastError() != ERROR_PIPE_CONNECTED)
+            {
+                CloseHandle(pipe.client);
+                pipe.client = INVALID_HANDLE_VALUE;
+            }
+            return pipe;
+        }
+
+        static named_pipe_peer_auth::Policy self_policy()
+        {
+            const auto executablePath = get_module_filename(nullptr);
+            return {
+                std::filesystem::path(executablePath).filename().wstring(),
+                std::filesystem::path(executablePath).parent_path().wstring(),
+                executablePath,
+                named_pipe_peer_auth::Validation::PowerToysPeer,
+            };
+        }
+
+    public:
+        TEST_METHOD (PowerToysPeer_AcceptsExpectedClientAndServer)
+        {
+            const auto pipe = create_connected_pipe();
+            Assert::AreNotEqual(INVALID_HANDLE_VALUE, pipe.server);
+            Assert::AreNotEqual(INVALID_HANDLE_VALUE, pipe.client);
+
+#ifdef _DEBUG
+            const auto policy = self_policy();
+            Assert::IsTrue(named_pipe_peer_auth::authenticate(
+                pipe.server,
+                named_pipe_peer_auth::Peer::Client,
+                policy));
+            Assert::IsTrue(named_pipe_peer_auth::authenticate(
+                pipe.client,
+                named_pipe_peer_auth::Peer::Server,
+                policy));
+#endif
+        }
+
+        TEST_METHOD (PowerToysPeer_RejectsUnexpectedProcessName)
+        {
+            const auto pipe = create_connected_pipe();
+            Assert::AreNotEqual(INVALID_HANDLE_VALUE, pipe.server);
+            Assert::AreNotEqual(INVALID_HANDLE_VALUE, pipe.client);
+
+            auto policy = self_policy();
+            policy.expectedProcessName = L"not-the-test-process.exe";
+            Assert::IsFalse(named_pipe_peer_auth::authenticate(
+                pipe.server,
+                named_pipe_peer_auth::Peer::Client,
+                policy));
+            Assert::IsFalse(named_pipe_peer_auth::authenticate(
+                pipe.client,
+                named_pipe_peer_auth::Peer::Server,
+                policy));
+        }
+
+        TEST_METHOD (WindowsSystemHost_AcceptsOnlyCanonicalExplorerPath)
+        {
+            wchar_t windowsDirectory[MAX_PATH]{};
+            Assert::AreNotEqual<UINT>(0, GetWindowsDirectoryW(windowsDirectory, ARRAYSIZE(windowsDirectory)));
+
+            const auto explorerPath = named_pipe_peer_auth::details::canonicalize_path(
+                std::wstring(windowsDirectory) + L"\\explorer.exe");
+            Assert::IsFalse(explorerPath.empty());
+            Assert::IsTrue(named_pipe_peer_auth::details::is_expected_windows_host_path(
+                explorerPath,
+                L"explorer.exe"));
+            Assert::IsFalse(named_pipe_peer_auth::details::is_expected_windows_host_path(
+                explorerPath,
+                L"not-explorer.exe"));
+        }
+    };
+}

--- a/src/common/UnitTests-CommonUtils/TwoWayPipeMessageIPC.Tests.cpp
+++ b/src/common/UnitTests-CommonUtils/TwoWayPipeMessageIPC.Tests.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 
 #include <interop/two_way_pipe_message_ipc.h>
+#include <utils/secure_named_pipe.h>
 #include <aclapi.h>
 #include "..\..\modules\Workspaces\WorkspacesLib\IPCHelper.h"
 
@@ -548,6 +549,138 @@ namespace UnitTestsCommonUtils
             server.end();
 
             Assert::IsFalse(available, L"the server must not join an existing pipe name");
+        }
+
+        TEST_METHOD(OutboundServerClaimsNameBeforeClientLaunch)
+        {
+            OccupiedPipe occupiedPipe;
+            Assert::IsTrue(occupiedPipe.Create(), L"failed to occupy the outbound pipe name");
+
+            SetLastError(ERROR_SUCCESS);
+            HANDLE server = secure_named_pipe::create_outbound_server(occupiedPipe.name, 4096, false);
+            const DWORD create_error = GetLastError();
+            if (server != INVALID_HANDLE_VALUE)
+            {
+                CloseHandle(server);
+            }
+
+            Assert::IsTrue(server == INVALID_HANDLE_VALUE,
+                           L"the outbound server must fail instead of joining an attacker-owned name");
+            Assert::AreEqual(static_cast<DWORD>(ERROR_ACCESS_DENIED), create_error);
+        }
+
+        TEST_METHOD(OutboundServerSupportsReadOnlySameLogonRoundTrip)
+        {
+            RestrictedClientToken restricted_client;
+            Assert::IsTrue(restricted_client.Create(), L"failed to create the restricted same-logon client token");
+
+            const std::wstring pipe_name = UniquePipeName();
+            HANDLE server = secure_named_pipe::create_outbound_server(pipe_name, 4096, false);
+            Assert::IsTrue(server != INVALID_HANDLE_VALUE, L"failed to create the secured outbound server");
+
+            HANDLE client = INVALID_HANDLE_VALUE;
+            DWORD client_error = ERROR_SUCCESS;
+            bool impersonated = false;
+            std::thread client_thread([&]() {
+                ScopedImpersonation impersonation(restricted_client.token);
+                impersonated = impersonation.active;
+                if (impersonated)
+                {
+                    client = CreateFileW(pipe_name.c_str(),
+                                         GENERIC_READ,
+                                         0,
+                                         nullptr,
+                                         OPEN_EXISTING,
+                                         two_way_pipe_message_ipc::ClientOpenFlags,
+                                         nullptr);
+                    client_error = GetLastError();
+                }
+            });
+
+            const BOOL connected = ConnectNamedPipe(server, nullptr) ? TRUE : (GetLastError() == ERROR_PIPE_CONNECTED);
+            client_thread.join();
+
+            Assert::IsTrue(impersonated, L"failed to impersonate the restricted same-logon token");
+            Assert::IsTrue(connected == TRUE && client != INVALID_HANDLE_VALUE,
+                           (L"the read-only same-logon client could not connect; error=" + std::to_wstring(client_error)).c_str());
+
+            constexpr wchar_t expected[] = L"roundtrip";
+            DWORD bytes_written = 0;
+            Assert::IsTrue(WriteFile(server,
+                                     expected,
+                                     (ARRAYSIZE(expected) - 1) * sizeof(wchar_t),
+                                     &bytes_written,
+                                     nullptr) == TRUE);
+
+            wchar_t actual[ARRAYSIZE(expected)]{};
+            DWORD bytes_read = 0;
+            Assert::IsTrue(ReadFile(client, actual, sizeof(actual), &bytes_read, nullptr) == TRUE);
+            Assert::AreEqual(std::wstring(expected), std::wstring(actual, bytes_read / sizeof(wchar_t)));
+
+            DWORD rejected_write_bytes = 0;
+            Assert::IsFalse(WriteFile(client,
+                                      expected,
+                                      (ARRAYSIZE(expected) - 1) * sizeof(wchar_t),
+                                      &rejected_write_bytes,
+                                      nullptr) == TRUE,
+                            L"an outbound-pipe client must not write into the server");
+
+            CloseHandle(client);
+            DisconnectNamedPipe(server);
+            CloseHandle(server);
+        }
+
+        TEST_METHOD(OutboundServerDaclExcludesWorldAndAnonymous)
+        {
+            const std::wstring pipe_name = UniquePipeName();
+            HANDLE server = secure_named_pipe::create_outbound_server(pipe_name, 4096, false);
+            Assert::IsTrue(server != INVALID_HANDLE_VALUE, L"failed to create the secured outbound server");
+
+            PSECURITY_DESCRIPTOR security_descriptor = nullptr;
+            PACL dacl = nullptr;
+            Assert::AreEqual(static_cast<DWORD>(ERROR_SUCCESS),
+                             GetSecurityInfo(server,
+                                             SE_KERNEL_OBJECT,
+                                             DACL_SECURITY_INFORMATION,
+                                             nullptr,
+                                             nullptr,
+                                             &dacl,
+                                             nullptr,
+                                             &security_descriptor));
+
+            BYTE world_sid[SECURITY_MAX_SID_SIZE]{};
+            BYTE anonymous_sid[SECURITY_MAX_SID_SIZE]{};
+            DWORD world_sid_size = ARRAYSIZE(world_sid);
+            DWORD anonymous_sid_size = ARRAYSIZE(anonymous_sid);
+            Assert::IsTrue(CreateWellKnownSid(WinWorldSid, nullptr, world_sid, &world_sid_size) == TRUE);
+            Assert::IsTrue(CreateWellKnownSid(WinAnonymousSid, nullptr, anonymous_sid, &anonymous_sid_size) == TRUE);
+
+            for (DWORD index = 0; index < dacl->AceCount; ++index)
+            {
+                void* ace = nullptr;
+                Assert::IsTrue(GetAce(dacl, index, &ace) == TRUE);
+                const auto* header = static_cast<ACE_HEADER*>(ace);
+                if (header->AceType != ACCESS_ALLOWED_ACE_TYPE)
+                {
+                    continue;
+                }
+
+                auto* allowed_ace = static_cast<ACCESS_ALLOWED_ACE*>(ace);
+                PSID sid = &allowed_ace->SidStart;
+                Assert::IsFalse(EqualSid(sid, world_sid) == TRUE,
+                                L"the outbound pipe DACL must not grant access to Everyone");
+                Assert::IsFalse(EqualSid(sid, anonymous_sid) == TRUE,
+                                L"the outbound pipe DACL must not grant access to Anonymous");
+            }
+
+            LocalFree(security_descriptor);
+            CloseHandle(server);
+        }
+
+        TEST_METHOD(OutboundServerModeRejectsRemoteClients)
+        {
+            Assert::IsTrue((secure_named_pipe::OutboundPipeMode & PIPE_REJECT_REMOTE_CLIENTS) != 0,
+                           L"the shared outbound server mode must reject remote clients");
         }
 
         TEST_METHOD(CommonOutboundPipeClientUsesIdentificationQos)

--- a/src/common/UnitTests-CommonUtils/UnitTests-CommonUtils.vcxproj
+++ b/src/common/UnitTests-CommonUtils/UnitTests-CommonUtils.vcxproj
@@ -48,6 +48,7 @@
     <ClCompile Include="OsDetect.Tests.cpp" />
     <ClCompile Include="Threading.Tests.cpp" />
     <ClCompile Include="ProcessPath.Tests.cpp" />
+    <ClCompile Include="NamedPipePeerAuth.Tests.cpp" />
     <ClCompile Include="PipeCallerAuth.Tests.cpp" />
     <ClCompile Include="..\interop\pipe_caller_auth.cpp">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>

--- a/src/common/UnitTests-CommonUtils/UnitTests-CommonUtils.vcxproj.filters
+++ b/src/common/UnitTests-CommonUtils/UnitTests-CommonUtils.vcxproj.filters
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
+    <ClCompile Include="NamedPipePeerAuth.Tests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <Filter Include="Source Files">
       <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
       <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>

--- a/src/common/interop/CommonManaged.cpp
+++ b/src/common/interop/CommonManaged.cpp
@@ -2,6 +2,7 @@
 #include "CommonManaged.h"
 #include "CommonManaged.g.cpp"
 #include <common/version/version.h>
+#include <common/utils/named_pipe_peer_auth.h>
 
 namespace winrt::PowerToys::Interop::implementation
 {
@@ -18,5 +19,26 @@ namespace winrt::PowerToys::Interop::implementation
     hstring CommonManaged::GetProductVersionSourceCommit()
     {
         return hstring{ get_product_version_source_commit() };
+    }
+
+    bool CommonManaged::AuthenticateNamedPipeServer(
+        uint64_t pipeHandle,
+        hstring const& expectedProcessName,
+        hstring const& trustedDirectory,
+        hstring const& referenceBinaryPath,
+        winrt::PowerToys::Interop::NamedPipePeerValidation validation)
+    {
+        named_pipe_peer_auth::Policy policy{
+            expectedProcessName.c_str(),
+            trustedDirectory.c_str(),
+            referenceBinaryPath.c_str(),
+            validation == winrt::PowerToys::Interop::NamedPipePeerValidation::WindowsSystemHost ?
+                named_pipe_peer_auth::Validation::WindowsSystemHost :
+                named_pipe_peer_auth::Validation::PowerToysPeer,
+        };
+        return named_pipe_peer_auth::authenticate(
+            reinterpret_cast<HANDLE>(pipeHandle),
+            named_pipe_peer_auth::Peer::Server,
+            policy);
     }
 }

--- a/src/common/interop/CommonManaged.cpp
+++ b/src/common/interop/CommonManaged.cpp
@@ -32,8 +32,8 @@ namespace winrt::PowerToys::Interop::implementation
             expectedProcessName.c_str(),
             trustedDirectory.c_str(),
             referenceBinaryPath.c_str(),
-            validation == winrt::PowerToys::Interop::NamedPipePeerValidation::WindowsSystemHost ?
-                named_pipe_peer_auth::Validation::WindowsSystemHost :
+            validation == winrt::PowerToys::Interop::NamedPipePeerValidation::TrustedSignedProcess ?
+                named_pipe_peer_auth::Validation::TrustedSignedProcess :
                 named_pipe_peer_auth::Validation::PowerToysPeer,
         };
         return named_pipe_peer_auth::authenticate(

--- a/src/common/interop/CommonManaged.h
+++ b/src/common/interop/CommonManaged.h
@@ -10,6 +10,12 @@ namespace winrt::PowerToys::Interop::implementation
         static hstring GetProductVersion();
         static hstring GetProductVersionChannel();
         static hstring GetProductVersionSourceCommit();
+        static bool AuthenticateNamedPipeServer(
+            uint64_t pipeHandle,
+            hstring const& expectedProcessName,
+            hstring const& trustedDirectory,
+            hstring const& referenceBinaryPath,
+            winrt::PowerToys::Interop::NamedPipePeerValidation validation);
     };
 }
 namespace winrt::PowerToys::Interop::factory_implementation

--- a/src/common/interop/CommonManaged.idl
+++ b/src/common/interop/CommonManaged.idl
@@ -2,10 +2,22 @@ namespace PowerToys
 {
     namespace Interop
     {
+        enum NamedPipePeerValidation
+        {
+            PowerToysPeer = 0,
+            WindowsSystemHost = 1,
+        };
+
         [default_interface] static runtimeclass CommonManaged {
             static String GetProductVersion();
             static String GetProductVersionChannel();
             static String GetProductVersionSourceCommit();
+            static Boolean AuthenticateNamedPipeServer(
+                UInt64 pipeHandle,
+                String expectedProcessName,
+                String trustedDirectory,
+                String referenceBinaryPath,
+                NamedPipePeerValidation validation);
         }
     }
 }

--- a/src/common/interop/CommonManaged.idl
+++ b/src/common/interop/CommonManaged.idl
@@ -5,7 +5,7 @@ namespace PowerToys
         enum NamedPipePeerValidation
         {
             PowerToysPeer = 0,
-            WindowsSystemHost = 1,
+            TrustedSignedProcess = 1,
         };
 
         [default_interface] static runtimeclass CommonManaged {

--- a/src/common/interop/PowerToys.Interop.vcxproj
+++ b/src/common/interop/PowerToys.Interop.vcxproj
@@ -121,6 +121,7 @@
     <ClInclude Include="two_way_pipe_message_ipc.h" />
     <ClInclude Include="two_way_pipe_message_ipc_impl.h" />
     <ClInclude Include="pipe_caller_auth.h" />
+    <ClInclude Include="..\utils\named_pipe_peer_auth.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="CommonManaged.cpp">

--- a/src/common/interop/PowerToys.Interop.vcxproj.filters
+++ b/src/common/interop/PowerToys.Interop.vcxproj.filters
@@ -48,6 +48,9 @@
     <ClInclude Include="pipe_caller_auth.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\utils\named_pipe_peer_auth.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="async_message_queue.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/src/common/interop/interop-tests/InteropTests.cs
+++ b/src/common/interop/interop-tests/InteropTests.cs
@@ -72,6 +72,50 @@ namespace Microsoft.Interop.Tests
             }
         }
 
+        [TestMethod]
+        public void TestBidirectionalSend()
+        {
+            var suffix = $"{Environment.ProcessId}_{Guid.NewGuid():N}";
+            var leftPipeName = $"{PipePrefix}left_{suffix}";
+            var rightPipeName = $"{PipePrefix}right_{suffix}";
+            var leftMessage = "left-to-right";
+            var rightMessage = "right-to-left";
+
+            using var leftReceived = new AutoResetEvent(false);
+            using var rightReceived = new AutoResetEvent(false);
+            using var left = new TwoWayPipeMessageIPCManaged(
+                leftPipeName,
+                rightPipeName,
+                (string msg) =>
+                {
+                    Assert.AreEqual(rightMessage, msg);
+                    leftReceived.Set();
+                });
+            using var right = new TwoWayPipeMessageIPCManaged(
+                rightPipeName,
+                leftPipeName,
+                (string msg) =>
+                {
+                    Assert.AreEqual(leftMessage, msg);
+                    rightReceived.Set();
+                });
+
+            left.Start();
+            right.Start();
+
+            // Start() preserves the legacy asynchronous listener startup contract.
+            Thread.Sleep(500);
+
+            left.Send(leftMessage);
+            right.Send(rightMessage);
+
+            Assert.IsTrue(leftReceived.WaitOne(MessageWaitTimeout), "Left endpoint did not receive the right endpoint's message.");
+            Assert.IsTrue(rightReceived.WaitOne(MessageWaitTimeout), "Right endpoint did not receive the left endpoint's message.");
+
+            left.End();
+            right.End();
+        }
+
         protected virtual void Dispose(bool disposing)
         {
             if (!disposedValue)

--- a/src/common/utils/named_pipe_peer_auth.h
+++ b/src/common/utils/named_pipe_peer_auth.h
@@ -1,0 +1,402 @@
+#pragma once
+
+#include <Windows.h>
+#include <softpub.h>
+#include <wincrypt.h>
+#include <wintrust.h>
+
+#include <cwctype>
+#include <string>
+#include <vector>
+
+#pragma comment(lib, "crypt32.lib")
+#pragma comment(lib, "wintrust.lib")
+
+namespace named_pipe_peer_auth
+{
+    enum class Peer
+    {
+        Client,
+        Server,
+    };
+
+    enum class Validation
+    {
+        PowerToysPeer,
+        WindowsSystemHost,
+    };
+
+    struct Policy
+    {
+        std::wstring expectedProcessName;
+        std::wstring trustedDirectory;
+        std::wstring referenceBinaryPath;
+        Validation validation = Validation::PowerToysPeer;
+    };
+
+    namespace details
+    {
+        inline std::wstring to_lower(std::wstring value)
+        {
+            for (auto& character : value)
+            {
+                character = static_cast<wchar_t>(towlower(character));
+            }
+            return value;
+        }
+
+        inline std::wstring canonicalize_path(const std::wstring& path)
+        {
+            const HANDLE handle = CreateFileW(
+                path.c_str(),
+                0,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                nullptr,
+                OPEN_EXISTING,
+                FILE_FLAG_BACKUP_SEMANTICS,
+                nullptr);
+            if (handle == INVALID_HANDLE_VALUE)
+            {
+                return {};
+            }
+
+            std::vector<wchar_t> buffer(32768);
+            const DWORD length = GetFinalPathNameByHandleW(
+                handle,
+                buffer.data(),
+                static_cast<DWORD>(buffer.size()),
+                FILE_NAME_NORMALIZED);
+            CloseHandle(handle);
+
+            if (length == 0 || length >= buffer.size())
+            {
+                return {};
+            }
+
+            std::wstring result(buffer.data(), length);
+            if (result.rfind(L"\\\\?\\", 0) == 0)
+            {
+                result.erase(0, 4);
+            }
+            return result;
+        }
+
+        inline std::wstring basename(const std::wstring& path)
+        {
+            const auto separator = path.find_last_of(L"\\/");
+            return separator == std::wstring::npos ? path : path.substr(separator + 1);
+        }
+
+        inline bool path_is_under_directory(const std::wstring& canonicalPath, const std::wstring& directory)
+        {
+            auto canonicalDirectory = to_lower(canonicalize_path(directory));
+            if (canonicalPath.empty() || canonicalDirectory.empty())
+            {
+                return false;
+            }
+
+            if (canonicalDirectory.back() != L'\\')
+            {
+                canonicalDirectory.push_back(L'\\');
+            }
+
+            const auto normalizedPath = to_lower(canonicalPath);
+            return normalizedPath.size() > canonicalDirectory.size() &&
+                   normalizedPath.compare(0, canonicalDirectory.size(), canonicalDirectory) == 0;
+        }
+
+        inline bool has_expected_name(const std::wstring& canonicalPath, const std::wstring& expectedName)
+        {
+            return !expectedName.empty() &&
+                   to_lower(basename(canonicalPath)) == to_lower(expectedName);
+        }
+
+        inline bool has_intact_authenticode_signature(const std::wstring& path)
+        {
+            WINTRUST_FILE_INFO fileInfo{};
+            fileInfo.cbStruct = sizeof(fileInfo);
+            fileInfo.pcwszFilePath = path.c_str();
+
+            WINTRUST_DATA trustData{};
+            trustData.cbStruct = sizeof(trustData);
+            trustData.dwUIChoice = WTD_UI_NONE;
+            trustData.fdwRevocationChecks = WTD_REVOKE_NONE;
+            trustData.dwUnionChoice = WTD_CHOICE_FILE;
+            trustData.pFile = &fileInfo;
+            trustData.dwStateAction = WTD_STATEACTION_VERIFY;
+            trustData.dwProvFlags = WTD_SAFER_FLAG | WTD_CACHE_ONLY_URL_RETRIEVAL;
+
+            GUID action = WINTRUST_ACTION_GENERIC_VERIFY_V2;
+            const LONG status = WinVerifyTrust(
+                static_cast<HWND>(INVALID_HANDLE_VALUE),
+                &action,
+                &trustData);
+
+            trustData.dwStateAction = WTD_STATEACTION_CLOSE;
+            WinVerifyTrust(static_cast<HWND>(INVALID_HANDLE_VALUE), &action, &trustData);
+            return status == ERROR_SUCCESS;
+        }
+
+        class SignerCertificate
+        {
+        public:
+            SignerCertificate() = default;
+            SignerCertificate(const SignerCertificate&) = delete;
+            SignerCertificate& operator=(const SignerCertificate&) = delete;
+
+            ~SignerCertificate()
+            {
+                if (certificate)
+                {
+                    CertFreeCertificateContext(certificate);
+                }
+                if (message)
+                {
+                    CryptMsgClose(message);
+                }
+                if (store)
+                {
+                    CertCloseStore(store, 0);
+                }
+            }
+
+            bool load(const std::wstring& path)
+            {
+                if (!has_intact_authenticode_signature(path) ||
+                    !CryptQueryObject(
+                        CERT_QUERY_OBJECT_FILE,
+                        path.c_str(),
+                        CERT_QUERY_CONTENT_FLAG_PKCS7_SIGNED_EMBED,
+                        CERT_QUERY_FORMAT_FLAG_BINARY,
+                        0,
+                        nullptr,
+                        nullptr,
+                        nullptr,
+                        &store,
+                        &message,
+                        nullptr))
+                {
+                    return false;
+                }
+
+                DWORD signerSize = 0;
+                if (!CryptMsgGetParam(message, CMSG_SIGNER_INFO_PARAM, 0, nullptr, &signerSize) ||
+                    signerSize == 0)
+                {
+                    return false;
+                }
+
+                std::vector<BYTE> signerBuffer(signerSize);
+                if (!CryptMsgGetParam(
+                        message,
+                        CMSG_SIGNER_INFO_PARAM,
+                        0,
+                        signerBuffer.data(),
+                        &signerSize))
+                {
+                    return false;
+                }
+
+                const auto* signer = reinterpret_cast<const CMSG_SIGNER_INFO*>(signerBuffer.data());
+                CERT_INFO certificateInfo{};
+                certificateInfo.Issuer = signer->Issuer;
+                certificateInfo.SerialNumber = signer->SerialNumber;
+                certificate = CertGetSubjectCertificateFromStore(
+                    store,
+                    X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
+                    &certificateInfo);
+                return certificate != nullptr;
+            }
+
+            PCCERT_CONTEXT get() const
+            {
+                return certificate;
+            }
+
+            HCERTSTORE additional_store() const
+            {
+                return store;
+            }
+
+        private:
+            HCERTSTORE store = nullptr;
+            HCRYPTMSG message = nullptr;
+            PCCERT_CONTEXT certificate = nullptr;
+        };
+
+        inline bool chains_to_machine_root(PCCERT_CONTEXT certificate, HCERTSTORE additionalStore)
+        {
+            char codeSigningOid[] = szOID_PKIX_KP_CODE_SIGNING;
+            LPSTR usages[] = { codeSigningOid };
+
+            CERT_CHAIN_PARA chainParameters{};
+            chainParameters.cbSize = sizeof(chainParameters);
+            chainParameters.RequestedUsage.dwType = USAGE_MATCH_TYPE_AND;
+            chainParameters.RequestedUsage.Usage.cUsageIdentifier = ARRAYSIZE(usages);
+            chainParameters.RequestedUsage.Usage.rgpszUsageIdentifier = usages;
+
+            PCCERT_CHAIN_CONTEXT chain = nullptr;
+            if (!CertGetCertificateChain(
+                    HCCE_LOCAL_MACHINE,
+                    certificate,
+                    nullptr,
+                    additionalStore,
+                    &chainParameters,
+                    CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL | CERT_CHAIN_REVOCATION_CHECK_CHAIN_EXCLUDE_ROOT,
+                    nullptr,
+                    &chain))
+            {
+                return false;
+            }
+
+            const DWORD ignoredErrors =
+                CERT_TRUST_REVOCATION_STATUS_UNKNOWN |
+                CERT_TRUST_IS_OFFLINE_REVOCATION;
+            bool valid = (chain->TrustStatus.dwErrorStatus & ~ignoredErrors) == 0;
+            if (valid)
+            {
+                CERT_CHAIN_POLICY_PARA policyParameters{};
+                policyParameters.cbSize = sizeof(policyParameters);
+                CERT_CHAIN_POLICY_STATUS policyStatus{};
+                policyStatus.cbSize = sizeof(policyStatus);
+                valid =
+                    CertVerifyCertificateChainPolicy(
+                        CERT_CHAIN_POLICY_AUTHENTICODE,
+                        chain,
+                        &policyParameters,
+                        &policyStatus) &&
+                    policyStatus.dwError == 0;
+            }
+
+            CertFreeCertificateChain(chain);
+            return valid;
+        }
+
+        inline bool has_microsoft_signer(PCCERT_CONTEXT certificate)
+        {
+            wchar_t organization[256]{};
+            char organizationOid[] = szOID_ORGANIZATION_NAME;
+            const DWORD length = CertGetNameStringW(
+                certificate,
+                CERT_NAME_ATTR_TYPE,
+                0,
+                organizationOid,
+                organization,
+                ARRAYSIZE(organization));
+            return length > 1 &&
+                   to_lower(organization) == L"microsoft corporation";
+        }
+
+        inline bool has_matching_signer(
+            const std::wstring& referenceBinaryPath,
+            const std::wstring& peerPath)
+        {
+            SignerCertificate referenceSigner;
+            SignerCertificate peerSigner;
+            if (!referenceSigner.load(referenceBinaryPath) ||
+                !peerSigner.load(peerPath) ||
+                !chains_to_machine_root(referenceSigner.get(), referenceSigner.additional_store()) ||
+                !chains_to_machine_root(peerSigner.get(), peerSigner.additional_store()))
+            {
+                return false;
+            }
+
+            return CertCompareCertificate(
+                       X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
+                       referenceSigner.get()->pCertInfo,
+                       peerSigner.get()->pCertInfo) == TRUE;
+        }
+
+        inline bool is_expected_windows_host_path(
+            const std::wstring& peerPath,
+            const std::wstring& expectedProcessName)
+        {
+            wchar_t windowsDirectory[MAX_PATH]{};
+            const UINT length = GetWindowsDirectoryW(windowsDirectory, ARRAYSIZE(windowsDirectory));
+            if (length == 0 || length >= ARRAYSIZE(windowsDirectory))
+            {
+                return false;
+            }
+
+            const auto expectedPath = canonicalize_path(
+                std::wstring(windowsDirectory) + L"\\" + expectedProcessName);
+            if (expectedPath.empty() || to_lower(peerPath) != to_lower(expectedPath))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        inline bool is_trusted_windows_host(
+            const std::wstring& peerPath,
+            const std::wstring& expectedProcessName)
+        {
+            if (!is_expected_windows_host_path(peerPath, expectedProcessName))
+            {
+                return false;
+            }
+
+            SignerCertificate signer;
+            return signer.load(peerPath) &&
+                   has_microsoft_signer(signer.get()) &&
+                   chains_to_machine_root(signer.get(), signer.additional_store());
+        }
+
+        inline std::wstring get_process_path(DWORD processId)
+        {
+            const HANDLE process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, processId);
+            if (!process)
+            {
+                return {};
+            }
+
+            std::vector<wchar_t> buffer(32768);
+            DWORD length = static_cast<DWORD>(buffer.size());
+            const bool queried =
+                QueryFullProcessImageNameW(process, 0, buffer.data(), &length) == TRUE;
+            CloseHandle(process);
+            return queried ? canonicalize_path(std::wstring(buffer.data(), length)) : std::wstring{};
+        }
+    }
+
+    inline bool authenticate(HANDLE pipe, Peer peer, const Policy& policy)
+    {
+        ULONG processId = 0;
+        const BOOL foundProcess =
+            peer == Peer::Client ?
+                GetNamedPipeClientProcessId(pipe, &processId) :
+                GetNamedPipeServerProcessId(pipe, &processId);
+        if (!foundProcess)
+        {
+            return false;
+        }
+
+        const auto peerPath = details::get_process_path(processId);
+        if (!details::has_expected_name(peerPath, policy.expectedProcessName))
+        {
+            return false;
+        }
+
+        if (policy.validation == Validation::WindowsSystemHost)
+        {
+#ifdef _DEBUG
+            return details::is_expected_windows_host_path(peerPath, policy.expectedProcessName);
+#else
+            return details::is_trusted_windows_host(peerPath, policy.expectedProcessName);
+#endif
+        }
+
+        if (!details::path_is_under_directory(peerPath, policy.trustedDirectory) ||
+            policy.referenceBinaryPath.empty())
+        {
+            return false;
+        }
+
+#ifdef _DEBUG
+        return true;
+#else
+        return details::has_matching_signer(policy.referenceBinaryPath, peerPath);
+#endif
+    }
+}

--- a/src/common/utils/named_pipe_peer_auth.h
+++ b/src/common/utils/named_pipe_peer_auth.h
@@ -23,7 +23,7 @@ namespace named_pipe_peer_auth
     enum class Validation
     {
         PowerToysPeer,
-        WindowsSystemHost,
+        TrustedSignedProcess,
     };
 
     struct Policy
@@ -272,21 +272,6 @@ namespace named_pipe_peer_auth
             return valid;
         }
 
-        inline bool has_microsoft_signer(PCCERT_CONTEXT certificate)
-        {
-            wchar_t organization[256]{};
-            char organizationOid[] = szOID_ORGANIZATION_NAME;
-            const DWORD length = CertGetNameStringW(
-                certificate,
-                CERT_NAME_ATTR_TYPE,
-                0,
-                organizationOid,
-                organization,
-                ARRAYSIZE(organization));
-            return length > 1 &&
-                   to_lower(organization) == L"microsoft corporation";
-        }
-
         inline bool has_matching_signer(
             const std::wstring& referenceBinaryPath,
             const std::wstring& peerPath)
@@ -307,39 +292,10 @@ namespace named_pipe_peer_auth
                        peerSigner.get()->pCertInfo) == TRUE;
         }
 
-        inline bool is_expected_windows_host_path(
-            const std::wstring& peerPath,
-            const std::wstring& expectedProcessName)
+        inline bool has_trusted_signature(const std::wstring& path)
         {
-            wchar_t windowsDirectory[MAX_PATH]{};
-            const UINT length = GetWindowsDirectoryW(windowsDirectory, ARRAYSIZE(windowsDirectory));
-            if (length == 0 || length >= ARRAYSIZE(windowsDirectory))
-            {
-                return false;
-            }
-
-            const auto expectedPath = canonicalize_path(
-                std::wstring(windowsDirectory) + L"\\" + expectedProcessName);
-            if (expectedPath.empty() || to_lower(peerPath) != to_lower(expectedPath))
-            {
-                return false;
-            }
-
-            return true;
-        }
-
-        inline bool is_trusted_windows_host(
-            const std::wstring& peerPath,
-            const std::wstring& expectedProcessName)
-        {
-            if (!is_expected_windows_host_path(peerPath, expectedProcessName))
-            {
-                return false;
-            }
-
             SignerCertificate signer;
-            return signer.load(peerPath) &&
-                   has_microsoft_signer(signer.get()) &&
+            return signer.load(path) &&
                    chains_to_machine_root(signer.get(), signer.additional_store());
         }
 
@@ -358,6 +314,7 @@ namespace named_pipe_peer_auth
             CloseHandle(process);
             return queried ? canonicalize_path(std::wstring(buffer.data(), length)) : std::wstring{};
         }
+
     }
 
     inline bool authenticate(HANDLE pipe, Peer peer, const Policy& policy)
@@ -373,21 +330,22 @@ namespace named_pipe_peer_auth
         }
 
         const auto peerPath = details::get_process_path(processId);
-        if (!details::has_expected_name(peerPath, policy.expectedProcessName))
+        if (peerPath.empty())
         {
             return false;
         }
 
-        if (policy.validation == Validation::WindowsSystemHost)
+        if (policy.validation == Validation::TrustedSignedProcess)
         {
 #ifdef _DEBUG
-            return details::is_expected_windows_host_path(peerPath, policy.expectedProcessName);
+            return true;
 #else
-            return details::is_trusted_windows_host(peerPath, policy.expectedProcessName);
+            return details::has_trusted_signature(peerPath);
 #endif
         }
 
-        if (!details::path_is_under_directory(peerPath, policy.trustedDirectory) ||
+        if (!details::has_expected_name(peerPath, policy.expectedProcessName) ||
+            !details::path_is_under_directory(peerPath, policy.trustedDirectory) ||
             policy.referenceBinaryPath.empty())
         {
             return false;

--- a/src/common/utils/secure_named_pipe.h
+++ b/src/common/utils/secure_named_pipe.h
@@ -1,0 +1,213 @@
+#pragma once
+
+#include <Windows.h>
+#include <accctrl.h>
+#include <aclapi.h>
+
+#include <string>
+
+namespace secure_named_pipe
+{
+    inline constexpr DWORD OutboundClientAccess = FILE_GENERIC_READ;
+    inline constexpr DWORD OutboundPipeMode =
+        PIPE_TYPE_MESSAGE |
+        PIPE_READMODE_MESSAGE |
+        PIPE_WAIT |
+        PIPE_REJECT_REMOTE_CLIENTS;
+
+    namespace details
+    {
+        class PipeSecurityAttributes
+        {
+        public:
+            PipeSecurityAttributes() = default;
+            PipeSecurityAttributes(const PipeSecurityAttributes&) = delete;
+            PipeSecurityAttributes& operator=(const PipeSecurityAttributes&) = delete;
+
+            ~PipeSecurityAttributes()
+            {
+                if (m_dacl)
+                {
+                    LocalFree(m_dacl);
+                }
+
+                if (m_logonSid)
+                {
+                    HeapFree(GetProcessHeap(), 0, m_logonSid);
+                }
+            }
+
+            bool initialize()
+            {
+                HANDLE token = nullptr;
+                if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &token))
+                {
+                    return false;
+                }
+
+                const auto closeToken = [&]() {
+                    CloseHandle(token);
+                };
+
+                if (!get_logon_sid(token, &m_logonSid))
+                {
+                    closeToken();
+                    return false;
+                }
+
+                DWORD tokenUserSize = 0;
+                GetTokenInformation(token, TokenUser, nullptr, 0, &tokenUserSize);
+                auto* tokenUser = static_cast<TOKEN_USER*>(HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, tokenUserSize));
+                if (!tokenUser ||
+                    !GetTokenInformation(token, TokenUser, tokenUser, tokenUserSize, &tokenUserSize))
+                {
+                    if (tokenUser)
+                    {
+                        HeapFree(GetProcessHeap(), 0, tokenUser);
+                    }
+                    closeToken();
+                    return false;
+                }
+
+                const DWORD userSidSize = GetLengthSid(tokenUser->User.Sid);
+                const bool copiedUserSid =
+                    userSidSize <= sizeof(m_userSid) &&
+                    CopySid(userSidSize, m_userSid, tokenUser->User.Sid) == TRUE;
+                HeapFree(GetProcessHeap(), 0, tokenUser);
+                if (!copiedUserSid)
+                {
+                    closeToken();
+                    return false;
+                }
+
+                DWORD administratorsSidSize = sizeof(m_administratorsSid);
+                DWORD localSystemSidSize = sizeof(m_localSystemSid);
+                if (!CreateWellKnownSid(WinBuiltinAdministratorsSid, nullptr, m_administratorsSid, &administratorsSidSize) ||
+                    !CreateWellKnownSid(WinLocalSystemSid, nullptr, m_localSystemSid, &localSystemSidSize))
+                {
+                    closeToken();
+                    return false;
+                }
+
+                TOKEN_ELEVATION elevation{};
+                DWORD elevationSize = 0;
+                if (!GetTokenInformation(token, TokenElevation, &elevation, sizeof(elevation), &elevationSize))
+                {
+                    closeToken();
+                    return false;
+                }
+
+                closeToken();
+
+                PSID ownerSid = elevation.TokenIsElevated ? static_cast<PSID>(m_administratorsSid) : static_cast<PSID>(m_userSid);
+                const TRUSTEE_TYPE ownerType = elevation.TokenIsElevated ? TRUSTEE_IS_GROUP : TRUSTEE_IS_USER;
+
+                EXPLICIT_ACCESS entries[3]{};
+                set_entry(entries[0], FILE_ALL_ACCESS, ownerSid, ownerType);
+                set_entry(entries[1], FILE_ALL_ACCESS, m_localSystemSid, TRUSTEE_IS_USER);
+                set_entry(entries[2], OutboundClientAccess, m_logonSid, TRUSTEE_IS_USER);
+
+                if (SetEntriesInAcl(ARRAYSIZE(entries), entries, nullptr, &m_dacl) != ERROR_SUCCESS ||
+                    !InitializeSecurityDescriptor(&m_securityDescriptor, SECURITY_DESCRIPTOR_REVISION) ||
+                    !SetSecurityDescriptorOwner(&m_securityDescriptor, ownerSid, FALSE) ||
+                    !SetSecurityDescriptorGroup(&m_securityDescriptor, ownerSid, FALSE) ||
+                    !SetSecurityDescriptorDacl(&m_securityDescriptor, TRUE, m_dacl, FALSE))
+                {
+                    return false;
+                }
+
+                m_attributes.nLength = sizeof(m_attributes);
+                m_attributes.lpSecurityDescriptor = &m_securityDescriptor;
+                m_attributes.bInheritHandle = FALSE;
+                return true;
+            }
+
+            SECURITY_ATTRIBUTES* get()
+            {
+                return &m_attributes;
+            }
+
+        private:
+            static void set_entry(EXPLICIT_ACCESS& entry, DWORD access, PSID sid, TRUSTEE_TYPE trusteeType)
+            {
+                entry.grfAccessPermissions = access;
+                entry.grfAccessMode = SET_ACCESS;
+                entry.grfInheritance = NO_INHERITANCE;
+                entry.Trustee.TrusteeForm = TRUSTEE_IS_SID;
+                entry.Trustee.TrusteeType = trusteeType;
+                entry.Trustee.ptstrName = static_cast<LPTSTR>(sid);
+            }
+
+            static bool get_logon_sid(HANDLE token, PSID* logonSid)
+            {
+                DWORD groupsSize = 0;
+                GetTokenInformation(token, TokenGroups, nullptr, 0, &groupsSize);
+                auto* groups = static_cast<TOKEN_GROUPS*>(HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, groupsSize));
+                if (!groups ||
+                    !GetTokenInformation(token, TokenGroups, groups, groupsSize, &groupsSize))
+                {
+                    if (groups)
+                    {
+                        HeapFree(GetProcessHeap(), 0, groups);
+                    }
+                    return false;
+                }
+
+                bool found = false;
+                for (DWORD index = 0; index < groups->GroupCount; ++index)
+                {
+                    if ((groups->Groups[index].Attributes & SE_GROUP_LOGON_ID) != SE_GROUP_LOGON_ID)
+                    {
+                        continue;
+                    }
+
+                    const DWORD sidSize = GetLengthSid(groups->Groups[index].Sid);
+                    *logonSid = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sidSize);
+                    found = *logonSid && CopySid(sidSize, *logonSid, groups->Groups[index].Sid) == TRUE;
+                    if (!found && *logonSid)
+                    {
+                        HeapFree(GetProcessHeap(), 0, *logonSid);
+                        *logonSid = nullptr;
+                    }
+                    break;
+                }
+
+                HeapFree(GetProcessHeap(), 0, groups);
+                return found;
+            }
+
+            SECURITY_DESCRIPTOR m_securityDescriptor{};
+            SECURITY_ATTRIBUTES m_attributes{};
+            PACL m_dacl = nullptr;
+            PSID m_logonSid = nullptr;
+            BYTE m_administratorsSid[SECURITY_MAX_SID_SIZE]{};
+            BYTE m_localSystemSid[SECURITY_MAX_SID_SIZE]{};
+            BYTE m_userSid[SECURITY_MAX_SID_SIZE]{};
+        };
+    }
+
+    inline HANDLE create_outbound_server(const std::wstring& pipeName, DWORD bufferSize, bool overlapped)
+    {
+        details::PipeSecurityAttributes securityAttributes;
+        if (!securityAttributes.initialize())
+        {
+            return INVALID_HANDLE_VALUE;
+        }
+
+        DWORD openMode = PIPE_ACCESS_OUTBOUND | FILE_FLAG_FIRST_PIPE_INSTANCE;
+        if (overlapped)
+        {
+            openMode |= FILE_FLAG_OVERLAPPED;
+        }
+
+        return CreateNamedPipeW(
+            pipeName.c_str(),
+            openMode,
+            OutboundPipeMode,
+            1,
+            bufferSize,
+            0,
+            0,
+            securityAttributes.get());
+    }
+}

--- a/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPaste.csproj
+++ b/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPaste.csproj
@@ -134,6 +134,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\common\ManagedCommon\ManagedCommon.csproj" />
+    <ProjectReference Include="..\..\..\common\interop\PowerToys.Interop.vcxproj" />
     <ProjectReference Include="..\..\..\common\LanguageModelProvider\LanguageModelProvider.csproj" />
     <ProjectReference Include="..\..\..\common\GPOWrapper\GPOWrapper.vcxproj" />
     <ProjectReference Include="..\..\..\settings-ui\Settings.UI.Library\Settings.UI.Library.csproj" />

--- a/src/modules/AdvancedPaste/AdvancedPaste/Helpers/NamedPipeProcessor.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Helpers/NamedPipeProcessor.cs
@@ -8,6 +8,7 @@ using System.IO.Pipes;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using PowerToys.Interop;
 
 namespace AdvancedPaste.Helpers;
 
@@ -18,6 +19,17 @@ public static class NamedPipeProcessor
         using NamedPipeClientStream pipeClient = new(".", pipeName, PipeDirection.In);
 
         await pipeClient.ConnectAsync(connectTimeout, cancellationToken);
+
+        var installationDirectory = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, ".."));
+        if (!CommonManaged.AuthenticateNamedPipeServer(
+                unchecked((ulong)pipeClient.SafePipeHandle.DangerousGetHandle().ToInt64()),
+                "PowerToys.exe",
+                installationDirectory,
+                Environment.ProcessPath ?? string.Empty,
+                NamedPipePeerValidation.PowerToysPeer))
+        {
+            throw new UnauthorizedAccessException("The named pipe server is not a trusted PowerToys process.");
+        }
 
         using StreamReader streamReader = new(pipeClient, Encoding.Unicode);
 

--- a/src/modules/AdvancedPaste/AdvancedPasteModuleInterface/AdvancedPasteProcessManager.cpp
+++ b/src/modules/AdvancedPaste/AdvancedPasteModuleInterface/AdvancedPasteProcessManager.cpp
@@ -3,6 +3,7 @@
 
 #include <common/logger/logger.h>
 #include <common/utils/winapi_error.h>
+#include <common/utils/secure_named_pipe.h>
 #include <common/interop/shared_constants.h>
 #include <atlstr.h>
 
@@ -134,20 +135,9 @@ HRESULT AdvancedPasteProcessManager::start_named_pipe_server(const std::wstring&
 
     const auto full_pipe_name = std::format(L"\\\\.\\pipe\\{}", pipe_name);
 
-    const auto hPipe = CreateNamedPipe(
-        full_pipe_name.c_str(),     // pipe name
-        PIPE_ACCESS_OUTBOUND |      // write access
-            FILE_FLAG_OVERLAPPED,   // overlapped mode
-        PIPE_TYPE_MESSAGE |         // message type pipe
-            PIPE_READMODE_MESSAGE | // message-read mode
-            PIPE_WAIT,              // blocking mode
-        1,                          // max. instances
-        BUFSIZE,                    // output buffer size
-        0,                          // input buffer size
-        0,                          // client time-out
-        NULL);                      // default security attribute
+    const auto hPipe = secure_named_pipe::create_outbound_server(full_pipe_name, BUFSIZE, true);
 
-    if (hPipe == NULL || hPipe == INVALID_HANDLE_VALUE)
+    if (hPipe == INVALID_HANDLE_VALUE)
     {
         Logger::error(L"Error creating handle for named pipe");
         return E_FAIL;
@@ -169,47 +159,62 @@ HRESULT AdvancedPasteProcessManager::start_named_pipe_server(const std::wstring&
         return E_FAIL;
     };
 
+    bool connect_pending = false;
     if (!ConnectNamedPipe(hPipe, &overlapped))
     {
         const auto lastError = GetLastError();
 
-        if (lastError != ERROR_IO_PENDING && lastError != ERROR_PIPE_CONNECTED)
+        if (lastError == ERROR_IO_PENDING)
+        {
+            connect_pending = true;
+        }
+        else
         {
             Logger::error(L"Error connecting to named pipe");
             return clean_up_and_fail();
         }
     }
 
+    // The secured, first-instance listener must exist before the pipe name is exposed to the child.
+    if (start_process(pipe_name) != S_OK)
+    {
+        CancelIoEx(hPipe, &overlapped);
+        return clean_up_and_fail();
+    }
+
     // Wait for client. AdvancedPaste under sparse identity can take >5s on cold start to
     // bootstrap WinAppSDK + DI host before connecting back to this pipe.
     const constexpr DWORD client_timeout_millis = 15000;
-    switch (WaitForSingleObject(overlapped.hEvent, client_timeout_millis))
+    if (connect_pending)
     {
-        case WAIT_OBJECT_0:
+        switch (WaitForSingleObject(overlapped.hEvent, client_timeout_millis))
         {
-            DWORD bytes_transferred = 0;
-            if (GetOverlappedResult(hPipe, &overlapped, &bytes_transferred, FALSE))
+            case WAIT_OBJECT_0:
             {
-                CloseHandle(overlapped.hEvent);
-                m_write_pipe = std::make_unique<CAtlFile>(hPipe);
-
-                Logger::trace(L"Advanced Paste successfully connected to named pipe");
-
-                return S_OK;
+                DWORD bytes_transferred = 0;
+                if (!GetOverlappedResult(hPipe, &overlapped, &bytes_transferred, FALSE))
+                {
+                    Logger::error(L"Error waiting for Advanced Paste to connect to named pipe");
+                    return clean_up_and_fail();
+                }
+                break;
             }
-            else
-            {
+
+            case WAIT_TIMEOUT:
+            case WAIT_FAILED:
+            default:
                 Logger::error(L"Error waiting for Advanced Paste to connect to named pipe");
+                CancelIoEx(hPipe, &overlapped);
                 return clean_up_and_fail();
-            }
         }
-
-        case WAIT_TIMEOUT:
-        case WAIT_FAILED:
-        default:
-            Logger::error(L"Error waiting for Advanced Paste to connect to named pipe");
-            return clean_up_and_fail();
     }
+
+    CloseHandle(overlapped.hEvent);
+    m_write_pipe = std::make_unique<CAtlFile>(hPipe);
+
+    Logger::trace(L"Advanced Paste successfully connected to named pipe");
+
+    return S_OK;
 }
 
 void AdvancedPasteProcessManager::refresh()
@@ -226,11 +231,6 @@ void AdvancedPasteProcessManager::refresh()
         const auto pipe_name = get_pipe_name(L"powertoys_advanced_paste_");
 
         if (!pipe_name)
-        {
-            return;
-        }
-
-        if (start_process(pipe_name.value()) != S_OK)
         {
             return;
         }

--- a/src/modules/AdvancedPaste/AdvancedPasteModuleInterface/AdvancedPasteProcessManager.cpp
+++ b/src/modules/AdvancedPaste/AdvancedPasteModuleInterface/AdvancedPasteProcessManager.cpp
@@ -170,7 +170,7 @@ HRESULT AdvancedPasteProcessManager::start_named_pipe_server(const std::wstring&
         {
             connect_pending = true;
         }
-        else
+        else if (lastError != ERROR_PIPE_CONNECTED)
         {
             Logger::error(L"Error connecting to named pipe");
             return clean_up_and_fail();

--- a/src/modules/AdvancedPaste/AdvancedPasteModuleInterface/AdvancedPasteProcessManager.cpp
+++ b/src/modules/AdvancedPaste/AdvancedPasteModuleInterface/AdvancedPasteProcessManager.cpp
@@ -2,6 +2,8 @@
 #include "AdvancedPasteProcessManager.h"
 
 #include <common/logger/logger.h>
+#include <common/utils/named_pipe_peer_auth.h>
+#include <common/utils/process_path.h>
 #include <common/utils/winapi_error.h>
 #include <common/utils/secure_named_pipe.h>
 #include <common/interop/shared_constants.h>
@@ -207,6 +209,18 @@ HRESULT AdvancedPasteProcessManager::start_named_pipe_server(const std::wstring&
                 CancelIoEx(hPipe, &overlapped);
                 return clean_up_and_fail();
         }
+    }
+
+    const named_pipe_peer_auth::Policy clientPolicy{
+        L"PowerToys.AdvancedPaste.exe",
+        get_module_folderpath(),
+        get_module_filename(nullptr),
+        named_pipe_peer_auth::Validation::PowerToysPeer,
+    };
+    if (!named_pipe_peer_auth::authenticate(hPipe, named_pipe_peer_auth::Peer::Client, clientPolicy))
+    {
+        Logger::error(L"Rejected untrusted Advanced Paste named pipe client");
+        return clean_up_and_fail();
     }
 
     CloseHandle(overlapped.hEvent);

--- a/src/modules/imageresizer/ImageResizerContextMenu/dllmain.cpp
+++ b/src/modules/imageresizer/ImageResizerContextMenu/dllmain.cpp
@@ -11,6 +11,7 @@
 #include <common/utils/elevation.h>
 #include <common/utils/process_path.h>
 #include <common/utils/resources.h>
+#include <common/utils/secure_named_pipe.h>
 #include <Settings.h>
 #include <trace.h>
 
@@ -178,26 +179,20 @@ protected:
     ComPtr<IUnknown> m_site;
 
 private:
-    HRESULT StartNamedPipeServerAndSendData(std::wstring pipe_name)
+    HRESULT CreateNamedPipeServer(const std::wstring& pipe_name)
     {
-        hPipe = CreateNamedPipe(
-            pipe_name.c_str(),
-            PIPE_ACCESS_DUPLEX |
-                WRITE_DAC,
-            PIPE_TYPE_MESSAGE |
-                PIPE_READMODE_MESSAGE |
-                PIPE_WAIT,
-            PIPE_UNLIMITED_INSTANCES,
-            BUFSIZE,
-            BUFSIZE,
-            0,
-            NULL);
+        hPipe = secure_named_pipe::create_outbound_server(pipe_name, BUFSIZE, false);
 
-        if (hPipe == NULL || hPipe == INVALID_HANDLE_VALUE)
+        if (hPipe == INVALID_HANDLE_VALUE)
         {
             return E_FAIL;
         }
 
+        return S_OK;
+    }
+
+    HRESULT WaitForNamedPipeClient()
+    {
         // This call blocks until a client process connects to the pipe
         BOOL connected = ConnectNamedPipe(hPipe, NULL);
         if (!connected)
@@ -209,6 +204,7 @@ private:
             else
             {
                 CloseHandle(hPipe);
+                hPipe = INVALID_HANDLE_VALUE;
             }
             return E_FAIL;
         }
@@ -242,9 +238,28 @@ private:
             RpcStringFree(reinterpret_cast<RPC_WSTR*>(&uuid_chars));
             uuid_chars = nullptr;
         }
-        create_pipe_thread = std::thread(&ImageResizerContextMenuCommand::StartNamedPipeServerAndSendData, this, pipe_name);
-        RunNonElevatedEx(path.c_str(), pipe_name, get_module_folderpath(g_hInst));
-        create_pipe_thread.join();
+        else
+        {
+            return E_FAIL;
+        }
+
+        if (CreateNamedPipeServer(pipe_name) != S_OK)
+        {
+            return E_FAIL;
+        }
+
+        // Claim and secure the pipe name before exposing it on the child command line.
+        if (!RunNonElevatedEx(path.c_str(), pipe_name, get_module_folderpath(g_hInst)))
+        {
+            CloseHandle(hPipe);
+            hPipe = INVALID_HANDLE_VALUE;
+            return E_FAIL;
+        }
+
+        if (WaitForNamedPipeClient() != S_OK)
+        {
+            return E_FAIL;
+        }
 
         if (hPipe != INVALID_HANDLE_VALUE)
         {
@@ -274,12 +289,12 @@ private:
                 }
             }
             writePipe.Close();
+            hPipe = INVALID_HANDLE_VALUE;
         }
 
         return S_OK;
     }
 
-    std::thread create_pipe_thread;
     HANDLE hPipe = INVALID_HANDLE_VALUE;
     std::wstring context_menu_caption = GET_RESOURCE_STRING_FALLBACK(IDS_IMAGERESIZER_CONTEXT_MENU_ENTRY, L"Resize with Image Resizer");
 };

--- a/src/modules/imageresizer/ImageResizerContextMenu/dllmain.cpp
+++ b/src/modules/imageresizer/ImageResizerContextMenu/dllmain.cpp
@@ -9,6 +9,7 @@
 
 #include <common/telemetry/EtwTrace/EtwTrace.h>
 #include <common/utils/elevation.h>
+#include <common/utils/named_pipe_peer_auth.h>
 #include <common/utils/process_path.h>
 #include <common/utils/resources.h>
 #include <common/utils/secure_named_pipe.h>
@@ -206,6 +207,19 @@ private:
                 CloseHandle(hPipe);
                 hPipe = INVALID_HANDLE_VALUE;
             }
+            return E_FAIL;
+        }
+
+        const named_pipe_peer_auth::Policy clientPolicy{
+            L"PowerToys.ImageResizer.exe",
+            get_module_folderpath(g_hInst),
+            get_module_filename(g_hInst),
+            named_pipe_peer_auth::Validation::PowerToysPeer,
+        };
+        if (!named_pipe_peer_auth::authenticate(hPipe, named_pipe_peer_auth::Peer::Client, clientPolicy))
+        {
+            CloseHandle(hPipe);
+            hPipe = INVALID_HANDLE_VALUE;
             return E_FAIL;
         }
 

--- a/src/modules/imageresizer/ImageResizerContextMenu/dllmain.cpp
+++ b/src/modules/imageresizer/ImageResizerContextMenu/dllmain.cpp
@@ -195,18 +195,13 @@ private:
     HRESULT WaitForNamedPipeClient()
     {
         // This call blocks until a client process connects to the pipe
-        BOOL connected = ConnectNamedPipe(hPipe, NULL);
+        const BOOL connected =
+            ConnectNamedPipe(hPipe, nullptr) ||
+            GetLastError() == ERROR_PIPE_CONNECTED;
         if (!connected)
         {
-            if (GetLastError() == ERROR_PIPE_CONNECTED)
-            {
-                return S_OK;
-            }
-            else
-            {
-                CloseHandle(hPipe);
-                hPipe = INVALID_HANDLE_VALUE;
-            }
+            CloseHandle(hPipe);
+            hPipe = INVALID_HANDLE_VALUE;
             return E_FAIL;
         }
 

--- a/src/modules/imageresizer/ui/Models/ResizeBatch.cs
+++ b/src/modules/imageresizer/ui/Models/ResizeBatch.cs
@@ -116,10 +116,10 @@ namespace ImageResizer.Models
 
                     if (!PowerToys.Interop.CommonManaged.AuthenticateNamedPipeServer(
                             unchecked((ulong)pipeClient.SafePipeHandle.DangerousGetHandle().ToInt64()),
-                            "explorer.exe",
                             string.Empty,
-                            Environment.ProcessPath ?? string.Empty,
-                            PowerToys.Interop.NamedPipePeerValidation.WindowsSystemHost))
+                            string.Empty,
+                            string.Empty,
+                            PowerToys.Interop.NamedPipePeerValidation.TrustedSignedProcess))
                     {
                         throw new UnauthorizedAccessException("The named pipe server is not a trusted Windows Explorer process.");
                     }

--- a/src/modules/imageresizer/ui/Models/ResizeBatch.cs
+++ b/src/modules/imageresizer/ui/Models/ResizeBatch.cs
@@ -114,6 +114,16 @@ namespace ImageResizer.Models
                     // Connect to the pipe or wait until the pipe is available.
                     pipeClient.Connect();
 
+                    if (!PowerToys.Interop.CommonManaged.AuthenticateNamedPipeServer(
+                            unchecked((ulong)pipeClient.SafePipeHandle.DangerousGetHandle().ToInt64()),
+                            "explorer.exe",
+                            string.Empty,
+                            Environment.ProcessPath ?? string.Empty,
+                            PowerToys.Interop.NamedPipePeerValidation.WindowsSystemHost))
+                    {
+                        throw new UnauthorizedAccessException("The named pipe server is not a trusted Windows Explorer process.");
+                    }
+
                     using (StreamReader sr = new StreamReader(pipeClient, Encoding.Unicode))
                     {
                         string file;

--- a/src/modules/powerdisplay/PowerDisplay/Helpers/NamedPipeProcessor.cs
+++ b/src/modules/powerdisplay/PowerDisplay/Helpers/NamedPipeProcessor.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using ManagedCommon;
+using PowerToys.Interop;
 
 namespace PowerDisplay.Helpers;
 
@@ -39,6 +40,17 @@ public static class NamedPipeProcessor
             Logger.LogInfo($"[NamedPipe] Connecting to pipe: {pipeName}");
             await pipeClient.ConnectAsync(connectTimeout, cancellationToken);
             Logger.LogInfo($"[NamedPipe] Connected to pipe: {pipeName}");
+
+            var installationDirectory = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, ".."));
+            if (!CommonManaged.AuthenticateNamedPipeServer(
+                    unchecked((ulong)pipeClient.SafePipeHandle.DangerousGetHandle().ToInt64()),
+                    "PowerToys.exe",
+                    installationDirectory,
+                    Environment.ProcessPath ?? string.Empty,
+                    NamedPipePeerValidation.PowerToysPeer))
+            {
+                throw new UnauthorizedAccessException("The named pipe server is not a trusted PowerToys process.");
+            }
 
             using StreamReader streamReader = new(pipeClient, Encoding.Unicode);
 

--- a/src/modules/powerdisplay/PowerDisplayModuleInterface/PowerDisplayProcessManager.cpp
+++ b/src/modules/powerdisplay/PowerDisplayModuleInterface/PowerDisplayProcessManager.cpp
@@ -7,6 +7,7 @@
 
 #include <common/logger/logger.h>
 #include <common/utils/winapi_error.h>
+#include <common/utils/secure_named_pipe.h>
 #include <common/interop/shared_constants.h>
 #include <atlstr.h>
 
@@ -133,20 +134,9 @@ HRESULT PowerDisplayProcessManager::start_named_pipe_server(const std::wstring& 
 
     const auto full_pipe_name = std::format(L"\\\\.\\pipe\\{}", pipe_name);
 
-    const auto hPipe = CreateNamedPipe(
-        full_pipe_name.c_str(),     // pipe name
-        PIPE_ACCESS_OUTBOUND |      // write access
-            FILE_FLAG_OVERLAPPED,   // overlapped mode
-        PIPE_TYPE_MESSAGE |         // message type pipe
-            PIPE_READMODE_MESSAGE | // message-read mode
-            PIPE_WAIT,              // blocking mode
-        1,                          // max. instances
-        BUFSIZE,                    // output buffer size
-        0,                          // input buffer size
-        0,                          // client time-out
-        NULL);                      // default security attribute
+    const auto hPipe = secure_named_pipe::create_outbound_server(full_pipe_name, BUFSIZE, true);
 
-    if (hPipe == NULL || hPipe == INVALID_HANDLE_VALUE)
+    if (hPipe == INVALID_HANDLE_VALUE)
     {
         Logger::error(L"Error creating handle for named pipe");
         return E_FAIL;
@@ -168,46 +158,61 @@ HRESULT PowerDisplayProcessManager::start_named_pipe_server(const std::wstring& 
         return E_FAIL;
     };
 
+    bool connect_pending = false;
     if (!ConnectNamedPipe(hPipe, &overlapped))
     {
         const auto lastError = GetLastError();
 
-        if (lastError != ERROR_IO_PENDING && lastError != ERROR_PIPE_CONNECTED)
+        if (lastError == ERROR_IO_PENDING)
+        {
+            connect_pending = true;
+        }
+        else
         {
             Logger::error(L"Error connecting to named pipe");
             return clean_up_and_fail();
         }
     }
 
+    // The secured, first-instance listener must exist before the pipe name is exposed to the child.
+    if (start_process(pipe_name) != S_OK)
+    {
+        CancelIoEx(hPipe, &overlapped);
+        return clean_up_and_fail();
+    }
+
     // Wait for client.
     const constexpr DWORD client_timeout_millis = 5000;
-    switch (WaitForSingleObject(overlapped.hEvent, client_timeout_millis))
+    if (connect_pending)
     {
-        case WAIT_OBJECT_0:
+        switch (WaitForSingleObject(overlapped.hEvent, client_timeout_millis))
         {
-            DWORD bytes_transferred = 0;
-            if (GetOverlappedResult(hPipe, &overlapped, &bytes_transferred, FALSE))
+            case WAIT_OBJECT_0:
             {
-                CloseHandle(overlapped.hEvent);
-                m_write_pipe = std::make_unique<CAtlFile>(hPipe);
-
-                Logger::trace(L"PowerDisplay successfully connected to named pipe");
-
-                return S_OK;
+                DWORD bytes_transferred = 0;
+                if (!GetOverlappedResult(hPipe, &overlapped, &bytes_transferred, FALSE))
+                {
+                    Logger::error(L"Error waiting for PowerDisplay to connect to named pipe");
+                    return clean_up_and_fail();
+                }
+                break;
             }
-            else
-            {
+
+            case WAIT_TIMEOUT:
+            case WAIT_FAILED:
+            default:
                 Logger::error(L"Error waiting for PowerDisplay to connect to named pipe");
+                CancelIoEx(hPipe, &overlapped);
                 return clean_up_and_fail();
-            }
         }
-
-        case WAIT_TIMEOUT:
-        case WAIT_FAILED:
-        default:
-            Logger::error(L"Error waiting for PowerDisplay to connect to named pipe");
-            return clean_up_and_fail();
     }
+
+    CloseHandle(overlapped.hEvent);
+    m_write_pipe = std::make_unique<CAtlFile>(hPipe);
+
+    Logger::trace(L"PowerDisplay successfully connected to named pipe");
+
+    return S_OK;
 }
 
 void PowerDisplayProcessManager::refresh()
@@ -224,11 +229,6 @@ void PowerDisplayProcessManager::refresh()
         const auto pipe_name = get_pipe_name(L"powertoys_power_display_");
 
         if (!pipe_name)
-        {
-            return;
-        }
-
-        if (start_process(pipe_name.value()) != S_OK)
         {
             return;
         }

--- a/src/modules/powerdisplay/PowerDisplayModuleInterface/PowerDisplayProcessManager.cpp
+++ b/src/modules/powerdisplay/PowerDisplayModuleInterface/PowerDisplayProcessManager.cpp
@@ -169,7 +169,7 @@ HRESULT PowerDisplayProcessManager::start_named_pipe_server(const std::wstring& 
         {
             connect_pending = true;
         }
-        else
+        else if (lastError != ERROR_PIPE_CONNECTED)
         {
             Logger::error(L"Error connecting to named pipe");
             return clean_up_and_fail();

--- a/src/modules/powerdisplay/PowerDisplayModuleInterface/PowerDisplayProcessManager.cpp
+++ b/src/modules/powerdisplay/PowerDisplayModuleInterface/PowerDisplayProcessManager.cpp
@@ -6,6 +6,8 @@
 #include "PowerDisplayProcessManager.h"
 
 #include <common/logger/logger.h>
+#include <common/utils/named_pipe_peer_auth.h>
+#include <common/utils/process_path.h>
 #include <common/utils/winapi_error.h>
 #include <common/utils/secure_named_pipe.h>
 #include <common/interop/shared_constants.h>
@@ -205,6 +207,18 @@ HRESULT PowerDisplayProcessManager::start_named_pipe_server(const std::wstring& 
                 CancelIoEx(hPipe, &overlapped);
                 return clean_up_and_fail();
         }
+    }
+
+    const named_pipe_peer_auth::Policy clientPolicy{
+        L"PowerToys.PowerDisplay.exe",
+        get_module_folderpath(),
+        get_module_filename(nullptr),
+        named_pipe_peer_auth::Validation::PowerToysPeer,
+    };
+    if (!named_pipe_peer_auth::authenticate(hPipe, named_pipe_peer_auth::Peer::Client, clientPolicy))
+    {
+        Logger::error(L"Rejected untrusted PowerDisplay named pipe client");
+        return clean_up_and_fail();
     }
 
     CloseHandle(overlapped.hEvent);

--- a/src/modules/powerrename/PowerRenameContextMenu/dllmain.cpp
+++ b/src/modules/powerrename/PowerRenameContextMenu/dllmain.cpp
@@ -22,6 +22,7 @@
 #include <common/utils/elevation.h>
 #include <common/utils/process_path.h>
 #include <common/utils/resources.h>
+#include <common/utils/secure_named_pipe.h>
 #include <Helpers.h>
 #include <Settings.h>
 #include <trace.h>
@@ -163,26 +164,20 @@ protected:
 
 private:
 
-    HRESULT StartNamedPipeServerAndSendData(std::wstring pipe_name)
+    HRESULT CreateNamedPipeServer(const std::wstring& pipe_name)
     {
-        hPipe = CreateNamedPipe(
-            pipe_name.c_str(),
-            PIPE_ACCESS_DUPLEX |
-                WRITE_DAC,
-            PIPE_TYPE_MESSAGE |
-                PIPE_READMODE_MESSAGE |
-                PIPE_WAIT,
-            PIPE_UNLIMITED_INSTANCES,
-            BUFSIZE,
-            BUFSIZE,
-            0,
-            NULL);
+        hPipe = secure_named_pipe::create_outbound_server(pipe_name, BUFSIZE, false);
 
-        if (hPipe == NULL || hPipe == INVALID_HANDLE_VALUE)
+        if (hPipe == INVALID_HANDLE_VALUE)
         {
             return E_FAIL;
         }
 
+        return S_OK;
+    }
+
+    HRESULT WaitForNamedPipeClient()
+    {
         // This call blocks until a client process connects to the pipe
         BOOL connected = ConnectNamedPipe(hPipe, NULL);
         if (!connected)
@@ -194,6 +189,7 @@ private:
             else
             {
                 CloseHandle(hPipe);
+                hPipe = INVALID_HANDLE_VALUE;
             }
             return E_FAIL;
         }
@@ -232,9 +228,28 @@ private:
                 RpcStringFree(reinterpret_cast<RPC_WSTR*>(&uuid_chars));
                 uuid_chars = nullptr;
             }
-            create_pipe_thread = std::thread(&PowerRenameContextMenuCommand::StartNamedPipeServerAndSendData, this, pipe_name);
-            RunNonElevatedEx(path.c_str(), pipe_name, get_module_folderpath(g_hInst));
-            create_pipe_thread.join();
+            else
+            {
+                return E_FAIL;
+            }
+
+            if (CreateNamedPipeServer(pipe_name) != S_OK)
+            {
+                return E_FAIL;
+            }
+
+            // Claim and secure the pipe name before exposing it on the child command line.
+            if (!RunNonElevatedEx(path.c_str(), pipe_name, get_module_folderpath(g_hInst)))
+            {
+                CloseHandle(hPipe);
+                hPipe = INVALID_HANDLE_VALUE;
+                return E_FAIL;
+            }
+
+            if (WaitForNamedPipeClient() != S_OK)
+            {
+                return E_FAIL;
+            }
 
             if (hPipe != INVALID_HANDLE_VALUE)
             {
@@ -258,6 +273,7 @@ private:
                     writePipe.Write(fileName, fileName.GetLength() * sizeof(TCHAR));
                 }
                 writePipe.Close();
+                hPipe = INVALID_HANDLE_VALUE;
             }
         }
         Trace::InvokedRet(S_OK);
@@ -268,8 +284,6 @@ private:
         return S_OK;
     }
 
-
-    std::thread create_pipe_thread;
     HANDLE hPipe = INVALID_HANDLE_VALUE;
     std::wstring context_menu_caption = GET_RESOURCE_STRING_FALLBACK(IDS_POWERRENAME_CONTEXT_MENU_ENTRY, L"Rename with PowerRename");
 };

--- a/src/modules/powerrename/PowerRenameContextMenu/dllmain.cpp
+++ b/src/modules/powerrename/PowerRenameContextMenu/dllmain.cpp
@@ -20,6 +20,7 @@
 
 #include <common/telemetry/EtwTrace/EtwTrace.h>
 #include <common/utils/elevation.h>
+#include <common/utils/named_pipe_peer_auth.h>
 #include <common/utils/process_path.h>
 #include <common/utils/resources.h>
 #include <common/utils/secure_named_pipe.h>
@@ -191,6 +192,19 @@ private:
                 CloseHandle(hPipe);
                 hPipe = INVALID_HANDLE_VALUE;
             }
+            return E_FAIL;
+        }
+
+        const named_pipe_peer_auth::Policy clientPolicy{
+            L"PowerToys.PowerRename.exe",
+            get_module_folderpath(g_hInst),
+            get_module_filename(g_hInst),
+            named_pipe_peer_auth::Validation::PowerToysPeer,
+        };
+        if (!named_pipe_peer_auth::authenticate(hPipe, named_pipe_peer_auth::Peer::Client, clientPolicy))
+        {
+            CloseHandle(hPipe);
+            hPipe = INVALID_HANDLE_VALUE;
             return E_FAIL;
         }
 

--- a/src/modules/powerrename/PowerRenameContextMenu/dllmain.cpp
+++ b/src/modules/powerrename/PowerRenameContextMenu/dllmain.cpp
@@ -180,18 +180,13 @@ private:
     HRESULT WaitForNamedPipeClient()
     {
         // This call blocks until a client process connects to the pipe
-        BOOL connected = ConnectNamedPipe(hPipe, NULL);
+        const BOOL connected =
+            ConnectNamedPipe(hPipe, nullptr) ||
+            GetLastError() == ERROR_PIPE_CONNECTED;
         if (!connected)
         {
-            if (GetLastError() == ERROR_PIPE_CONNECTED)
-            {
-                return S_OK;
-            }
-            else
-            {
-                CloseHandle(hPipe);
-                hPipe = INVALID_HANDLE_VALUE;
-            }
+            CloseHandle(hPipe);
+            hPipe = INVALID_HANDLE_VALUE;
             return E_FAIL;
         }
 

--- a/src/modules/powerrename/PowerRenameUILib/PowerRenameXAML/App.xaml.cpp
+++ b/src/modules/powerrename/PowerRenameUILib/PowerRenameXAML/App.xaml.cpp
@@ -160,7 +160,7 @@ void App::OnLaunched(LaunchActivatedEventArgs const&)
             {
                 hStdin = CreateFile(
                     pipe_name.c_str(), // pipe name
-                    GENERIC_READ | GENERIC_WRITE, // read and write
+                    GENERIC_READ, // read-only input pipe
                     0, // no sharing
                     NULL, // default security attributes
                     OPEN_EXISTING, // opens existing pipe

--- a/src/modules/powerrename/PowerRenameUILib/PowerRenameXAML/App.xaml.cpp
+++ b/src/modules/powerrename/PowerRenameUILib/PowerRenameXAML/App.xaml.cpp
@@ -13,6 +13,8 @@
 #include <common/logger/logger_settings.h>
 #include <common/utils/language_helper.h>
 #include <common/utils/logger_helper.h>
+#include <common/utils/named_pipe_peer_auth.h>
+#include <common/utils/process_path.h>
 #include <common/utils/gpo.h>
 
 using namespace winrt;
@@ -169,7 +171,21 @@ void App::OnLaunched(LaunchActivatedEventArgs const&)
 
                 // Break if the pipe handle is valid.
                 if (hStdin != INVALID_HANDLE_VALUE)
+                {
+                    const named_pipe_peer_auth::Policy serverPolicy{
+                        L"explorer.exe",
+                        {},
+                        get_module_filename(nullptr),
+                        named_pipe_peer_auth::Validation::WindowsSystemHost,
+                    };
+                    if (!named_pipe_peer_auth::authenticate(hStdin, named_pipe_peer_auth::Peer::Server, serverPolicy))
+                    {
+                        CloseHandle(hStdin);
+                        hStdin = INVALID_HANDLE_VALUE;
+                        Logger::error(L"Rejected untrusted PowerRename named pipe server.");
+                    }
                     break;
+                }
 
                 // Exit if an error other than ERROR_PIPE_BUSY occurs.
                 auto error = GetLastError();

--- a/src/modules/powerrename/PowerRenameUILib/PowerRenameXAML/App.xaml.cpp
+++ b/src/modules/powerrename/PowerRenameUILib/PowerRenameXAML/App.xaml.cpp
@@ -173,10 +173,10 @@ void App::OnLaunched(LaunchActivatedEventArgs const&)
                 if (hStdin != INVALID_HANDLE_VALUE)
                 {
                     const named_pipe_peer_auth::Policy serverPolicy{
-                        L"explorer.exe",
                         {},
-                        get_module_filename(nullptr),
-                        named_pipe_peer_auth::Validation::WindowsSystemHost,
+                        {},
+                        {},
+                        named_pipe_peer_auth::Validation::TrustedSignedProcess,
                     };
                     if (!named_pipe_peer_auth::authenticate(hStdin, named_pipe_peer_auth::Peer::Server, serverPolicy))
                     {


### PR DESCRIPTION
## Summary
- claim unique outbound pipe endpoints before launching module processes
- restrict client access to the current logon session and the required read direction
- reuse a header-only helper without changing existing shared interfaces or layouts
- add coverage for endpoint ownership, access rules, remote rejection, and managed round trips

## Validation
- Debug x64 and ARM64 targeted builds for common IPC tests, interop tests, Advanced Paste, PowerDisplay, Image Resizer, and PowerRename
- targeted native pipe tests: 4 passed
- managed interop tests: 2 passed
- isolated non-elevated endpoint verifier passed