### PR TITLE
Settings: Harden backup and restore integration

### DIFF
--- a/PowerToys.slnx
+++ b/PowerToys.slnx
@@ -1191,6 +1191,10 @@
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />
     </Project>
+    <Project Path="src/settings-ui/SettingsBackupRestore.Security/SettingsBackupRestore.Security.csproj">
+      <Platform Solution="*|ARM64" Project="ARM64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
     <Project Path="src/settings-ui/Settings.UI.XamlIndexBuilder/Settings.UI.XamlIndexBuilder.csproj">
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />
@@ -1201,6 +1205,10 @@
     </Project>
   </Folder>
   <Folder Name="/settings-ui/Tests/">
+    <Project Path="src/settings-ui/SettingsBackupRestore.Security.UnitTests/SettingsBackupRestore.Security.UnitTests.csproj">
+      <Platform Solution="*|ARM64" Project="ARM64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
     <Project Path="src/settings-ui/Settings.UI.UnitTests/Settings.UI.UnitTests.csproj">
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />
@@ -1263,4 +1271,3 @@
   <Project Path="tools/CliShim/CliShim.vcxproj" Id="8a7fb7fa-65ea-4004-ba73-1b237435a57b" />
   <Project Path="tools/CliShim.UnitTests/CliShim.UnitTests.vcxproj" Id="d4b0ed68-867d-46b4-a03f-ec52b9fbebe5" />
 </Solution>
-

--- a/src/settings-ui/Settings.UI.Library/Settings.UI.Library.csproj
+++ b/src/settings-ui/Settings.UI.Library/Settings.UI.Library.csproj
@@ -11,6 +11,9 @@
         <None Include="backup_restore_settings.json">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
+        <EmbeddedResource Include="backup_restore_settings.json">
+            <LogicalName>PowerToys.Settings.BackupRestoreSettings.json</LogicalName>
+        </EmbeddedResource>
     </ItemGroup>
 
     <ItemGroup>
@@ -18,6 +21,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\SettingsBackupRestore.Security\SettingsBackupRestore.Security.csproj" />
         <ProjectReference Include="..\..\common\interop\PowerToys.Interop.vcxproj" />
         <ProjectReference Include="..\..\modules\ZoomIt\ZoomItSettingsInterop\ZoomItSettingsInterop.vcxproj" />
         <ProjectReference Include="..\..\common\ManagedCommon\ManagedCommon.csproj" />

--- a/src/settings-ui/Settings.UI.Library/SettingsBackupAndRestoreUtils.cs
+++ b/src/settings-ui/Settings.UI.Library/SettingsBackupAndRestoreUtils.cs
@@ -18,6 +18,7 @@ using System.Threading;
 
 using ManagedCommon;
 using Microsoft.PowerToys.Settings.UI.Library.Utilities;
+using Microsoft.PowerToys.SettingsBackupRestore.Security;
 
 namespace Microsoft.PowerToys.Settings.UI.Library
 {
@@ -269,7 +270,11 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         /// A tuple that indicates if the backup was done or not, and a message.
         /// The message usually is a localized reference key.
         /// </returns>
-        public (bool Success, string Message, string Severity) RestoreSettings(string appBasePath, string settingsBackupAndRestoreDir)
+        public (bool Success, string Message, string Severity) RestoreSettings(
+            string appBasePath,
+            string settingsBackupAndRestoreDir,
+            string archiveFileName = null,
+            string archiveSha256 = null)
         {
             try
             {
@@ -290,91 +295,19 @@ namespace Microsoft.PowerToys.Settings.UI.Library
                     return (false, "General_SettingsBackupAndRestore_InvalidBackupLocation", "Error");
                 }
 
-                var latestSettingsFolder = GetLatestSettingsFolder();
-
-                if (latestSettingsFolder == null)
+                if (SettingsBackupRestoreEngine.GetLatestArchiveFileName(settingsBackupAndRestoreDir) == null)
                 {
                     return (false, $"General_SettingsBackupAndRestore_NoBackupsFound", "Warning");
                 }
 
-                // get data needed for process
-                var backupRestoreSettings = JsonNode.Parse(GetBackupRestoreSettingsJson());
-                var currentSettingsFiles = GetSettingsFiles(backupRestoreSettings, appBasePath).ToList().ToDictionary(x => x.Substring(appBasePath.Length));
-                var backupSettingsFiles = GetSettingsFiles(backupRestoreSettings, latestSettingsFolder).ToList().ToDictionary(x => x.Substring(latestSettingsFolder.Length));
-
-                if (backupSettingsFiles.Count == 0)
+                var engine = new SettingsBackupRestoreEngine(GetBackupRestoreSettingsJson());
+                RestoreOperationResult result = engine.Restore(appBasePath, settingsBackupAndRestoreDir, Path.GetTempPath(), archiveFileName, archiveSha256);
+                if (result.SettingsChanged)
                 {
-                    return (false, $"General_SettingsBackupAndRestore_NoBackupsFound", "Warning");
+                    return (result.RestartRequired, $"RESTART APP", "Success");
                 }
 
-                var anyFilesUpdated = false;
-
-                foreach (var currentFile in backupSettingsFiles)
-                {
-                    var relativePath = currentFile.Value.Substring(latestSettingsFolder.Length + 1);
-                    var restoreFullPath = Path.Combine(appBasePath, relativePath);
-                    var settingsToRestoreJson = GetExportVersion(backupRestoreSettings, currentFile.Key, currentFile.Value);
-
-                    if (currentSettingsFiles.TryGetValue(currentFile.Key, out string value))
-                    {
-                        // we have a setting file to restore to
-                        var currentSettingsFileJson = GetExportVersion(backupRestoreSettings, currentFile.Key, value);
-
-                        if (JsonNormalizer.Normalize(settingsToRestoreJson) != JsonNormalizer.Normalize(currentSettingsFileJson))
-                        {
-                            // the settings file needs to be updated, update the real one with non-excluded stuff...
-                            Logger.LogInfo($"Settings file {currentFile.Key} is different and is getting updated from backup");
-
-                            // we needed a new "CustomRestoreSettings" for now, to overwrite because some settings don't merge well (like KBM shortcuts)
-                            var overwrite = false;
-                            if (backupRestoreSettings["CustomRestoreSettings"] != null && backupRestoreSettings["CustomRestoreSettings"][currentFile.Key] != null)
-                            {
-                                var customRestoreSettings = backupRestoreSettings["CustomRestoreSettings"][currentFile.Key];
-                                overwrite = customRestoreSettings["overwrite"] != null && (bool)customRestoreSettings["overwrite"];
-                            }
-
-                            if (overwrite)
-                            {
-                                File.WriteAllText(currentSettingsFiles[currentFile.Key], settingsToRestoreJson);
-                            }
-                            else
-                            {
-                                var newCurrentSettingsFile = JsonMergeHelper.Merge(File.ReadAllText(currentSettingsFiles[currentFile.Key]), settingsToRestoreJson);
-                                File.WriteAllText(currentSettingsFiles[currentFile.Key], newCurrentSettingsFile);
-                            }
-
-                            anyFilesUpdated = true;
-                        }
-                    }
-                    else
-                    {
-                        // we don't have anything to merge this into, we need to use it as is
-                        Logger.LogInfo($"Settings file {currentFile.Key} is in the backup but does not exist for restore");
-
-                        var thisPathToRestore = Path.Combine(appBasePath, currentFile.Key.Substring(1));
-                        TryCreateDirectory(Path.GetDirectoryName(thisPathToRestore));
-                        File.WriteAllText(thisPathToRestore, settingsToRestoreJson);
-                        anyFilesUpdated = true;
-                    }
-                }
-
-                if (anyFilesUpdated)
-                {
-                    // something was changed do we need to return true to indicate a restart is needed.
-                    var restartAfterRestore = (bool?)backupRestoreSettings!["RestartAfterRestore"];
-                    if (!restartAfterRestore.HasValue || restartAfterRestore.Value)
-                    {
-                        return (true, $"RESTART APP", "Success");
-                    }
-                    else
-                    {
-                        return (false, $"RESTART APP", "Success");
-                    }
-                }
-                else
-                {
-                    return (false, $"General_SettingsBackupAndRestore_NothingToRestore", "Informational");
-                }
+                return (false, $"General_SettingsBackupAndRestore_NothingToRestore", "Informational");
             }
             catch (Exception ex2)
             {
@@ -487,22 +420,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         public string GetLatestBackupFileName()
         {
             string settingsBackupAndRestoreDir = GetSettingsBackupAndRestoreDir();
-
-            if (string.IsNullOrEmpty(settingsBackupAndRestoreDir) || !Directory.Exists(settingsBackupAndRestoreDir))
-            {
-                return string.Empty;
-            }
-
-            var settingsBackupFiles = GetBackupSettingsFiles(settingsBackupAndRestoreDir);
-
-            if (settingsBackupFiles.Count > 0)
-            {
-                return Path.GetFileName(settingsBackupFiles.OrderByDescending(x => x).First());
-            }
-            else
-            {
-                return string.Empty;
-            }
+            return string.IsNullOrEmpty(settingsBackupAndRestoreDir)
+                ? string.Empty
+                : SettingsBackupRestoreEngine.GetLatestArchiveFileName(settingsBackupAndRestoreDir) ?? string.Empty;
         }
 
         /// <summary>
@@ -510,13 +430,14 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         /// </summary>
         public JsonNode GetLatestSettingsBackupManifest()
         {
-            var folder = GetLatestSettingsFolder();
-            if (folder == null)
-            {
-                return null;
-            }
+            var engine = new SettingsBackupRestoreEngine(GetBackupRestoreSettingsJson());
+            return engine.GetLatestManifest(GetSettingsBackupAndRestoreDir(), Path.GetTempPath());
+        }
 
-            return JsonNode.Parse(File.ReadAllText(Path.Combine(folder, "manifest.json")));
+        public RestorePreviewViewModel GetRestorePreview(string appBasePath, string settingsBackupAndRestoreDir)
+        {
+            var engine = new SettingsBackupRestoreEngine(GetBackupRestoreSettingsJson());
+            return engine.CreateRestorePreview(appBasePath, settingsBackupAndRestoreDir, Path.GetTempPath());
         }
 
         /// <summary>
@@ -626,8 +547,6 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             {
                 // simulated delay to validate behavior
                 // Thread.Sleep(1000);
-                KeyValuePair<string, string> tempFile = default(KeyValuePair<string, string>);
-
                 try
                 {
                     // verify inputs
@@ -646,151 +565,41 @@ namespace Microsoft.PowerToys.Settings.UI.Library
                         return (false, $"Invalid settingsBackupAndRestoreDir, not rooted", "Error", lastBackupExists, "\n" + settingsBackupAndRestoreDir);
                     }
 
-                    if (settingsBackupAndRestoreDir.StartsWith(appBasePath, StringComparison.InvariantCultureIgnoreCase))
+                    string fullAppPath = Path.GetFullPath(appBasePath);
+                    string fullBackupPath = Path.GetFullPath(settingsBackupAndRestoreDir);
+                    if (SecurePath.IsContained(fullAppPath, fullBackupPath))
                     {
                         // backup cannot be under app
                         Logger.LogError($"BackupSettings, backup cannot be under app");
                         return (false, "General_SettingsBackupAndRestore_InvalidBackupLocation", "Error", lastBackupExists, "\n" + appBasePath);
                     }
 
-                    // Only create the backup directory if this is not a dry run
-                    if (!dryRun)
+                    var engine = new SettingsBackupRestoreEngine(GetBackupRestoreSettingsJson());
+                    BackupOperationResult result = engine.Backup(
+                        appBasePath,
+                        settingsBackupAndRestoreDir,
+                        Path.GetTempPath(),
+                        dryRun,
+                        Helper.GetProductVersion(),
+                        Environment.MachineName,
+                        DateTime.UtcNow);
+                    lastBackupExists = result.PreviousBackupExists;
+                    if (!result.BackupCreated)
                     {
-                        var dirExists = TryCreateDirectory(settingsBackupAndRestoreDir);
-                        if (!dirExists)
-                        {
-                            Logger.LogError($"Failed to create dir {settingsBackupAndRestoreDir}");
-                            return (false, $"General_SettingsBackupAndRestore_BackupError", "Error", lastBackupExists, "\n" + settingsBackupAndRestoreDir);
-                        }
-                    }
-
-                    // get data needed for process
-                    var backupRestoreSettings = JsonNode.Parse(GetBackupRestoreSettingsJson());
-                    var currentSettingsFiles = GetSettingsFiles(backupRestoreSettings, appBasePath).ToList().ToDictionary(x => x.Substring(appBasePath.Length));
-                    var fullBackupDir = Path.Combine(Path.GetTempPath(), $"settings_{DateTime.UtcNow.ToFileTimeUtc().ToString(CultureInfo.InvariantCulture)}");
-                    var latestSettingsFolder = GetLatestSettingsFolder();
-                    var lastBackupSettingsFiles = GetSettingsFiles(backupRestoreSettings, latestSettingsFolder).ToList().ToDictionary(x => x.Substring(latestSettingsFolder.Length));
-
-                    lastBackupExists = lastBackupSettingsFiles.Count > 0;
-
-                    if (currentSettingsFiles.Count == 0)
-                    {
-                        return (false, "General_SettingsBackupAndRestore_NoSettingsFilesFound", "Error", lastBackupExists, string.Empty);
-                    }
-
-                    var anyFileBackedUp = false;
-                    var skippedSettingsFiles = new Dictionary<string, (string Path, string Settings)>();
-                    var updatedSettingsFiles = new Dictionary<string, string>();
-
-                    foreach (var currentFile in currentSettingsFiles)
-                    {
-                        tempFile = currentFile;
-
-                        // need to check and back this up;
-                        var currentSettingsFileToBackup = GetExportVersion(backupRestoreSettings, currentFile.Key, currentFile.Value);
-
-                        var doBackup = false;
-                        if (lastBackupSettingsFiles.TryGetValue(currentFile.Key, out string value))
-                        {
-                            // there is a previous backup for this, get an export version of it.
-                            var lastSettingsFileDoc = GetExportVersion(backupRestoreSettings, currentFile.Key, value);
-
-                            // check to see if the new export version would be same as last export version.
-                            if (JsonNormalizer.Normalize(currentSettingsFileToBackup) != JsonNormalizer.Normalize(lastSettingsFileDoc))
-                            {
-                                doBackup = true;
-                                Logger.LogInfo($"BackupSettings, {currentFile.Value} content is different.");
-                            }
-                        }
-                        else
-                        {
-                            // this has never been backed up, we need to do it now.
-                            Logger.LogInfo($"BackupSettings, {currentFile.Value} does not exist.");
-                            doBackup = true;
-                        }
-
-                        if (doBackup)
-                        {
-                            // add to list of files we noted as needing backup
-                            updatedSettingsFiles.Add(currentFile.Key, currentFile.Value);
-
-                            // mark overall flag that a backup will be made
-                            anyFileBackedUp = true;
-
-                            // write the export version of the settings file to backup location.
-                            var relativePath = currentFile.Value.Substring(appBasePath.Length + 1);
-                            var backupFullPath = Path.Combine(fullBackupDir, relativePath);
-
-                            Logger.LogInfo($"BackupSettings writing, {backupFullPath}, dryRun:{dryRun}.");
-                            if (!dryRun)
-                            {
-                                TryCreateDirectory(fullBackupDir);
-                                TryCreateDirectory(Path.GetDirectoryName(backupFullPath));
-                                File.WriteAllText(backupFullPath, currentSettingsFileToBackup);
-                            }
-                        }
-                        else
-                        {
-                            // if we found no reason to backup this settings file, record that in this collection
-                            skippedSettingsFiles.Add(currentFile.Key, (currentFile.Value, currentSettingsFileToBackup));
-                        }
-                    }
-
-                    if (!anyFileBackedUp)
-                    {
-                        // nothing was done!
-                        return (false, $"General_SettingsBackupAndRestore_NothingToBackup", "Informational", lastBackupExists, "\n" + tempFile.Value);
-                    }
-
-                    // add skipped.
-                    foreach (var currentFile in skippedSettingsFiles)
-                    {
-                        // if we did do a backup, we need to copy in all the settings files we skipped so the backup is complete.
-                        // this is needed since we might use the backup on another machine/
-                        var relativePath = currentFile.Value.Path.Substring(appBasePath.Length + 1);
-                        var backupFullPath = Path.Combine(fullBackupDir, relativePath);
-
-                        Logger.LogInfo($"BackupSettings writing, {backupFullPath}, dryRun:{dryRun}");
-                        if (!dryRun)
-                        {
-                            TryCreateDirectory(fullBackupDir);
-                            TryCreateDirectory(Path.GetDirectoryName(backupFullPath));
-
-                            File.WriteAllText(backupFullPath, currentFile.Value.Settings);
-                        }
-                    }
-
-                    // add manifest
-                    var manifestData = new
-                    {
-                        CreateDateTime = DateTime.UtcNow.ToString("u", CultureInfo.InvariantCulture),
-                        @Version = Helper.GetProductVersion(),
-                        UpdatedFiles = updatedSettingsFiles.Keys.ToList(),
-                        BackupSource = Environment.MachineName,
-                        UnchangedFiles = skippedSettingsFiles.Keys.ToList(),
-                    };
-
-                    var manifest = JsonSerializer.Serialize(manifestData, _serializerOptions);
-
-                    if (!dryRun)
-                    {
-                        File.WriteAllText(Path.Combine(fullBackupDir, "manifest.json"), manifest);
-
-                        // clean up, to prevent runaway disk usage.
-                        RemoveOldBackups(settingsBackupAndRestoreDir, 10, TimeSpan.FromDays(60));
-
-                        // compress the backup
-                        var zipName = Path.Combine(settingsBackupAndRestoreDir, Path.GetFileName(fullBackupDir) + ".ptb");
-                        ZipFile.CreateFromDirectory(fullBackupDir, zipName);
-                        TryDeleteDirectory(fullBackupDir);
+                        return (false, $"General_SettingsBackupAndRestore_NothingToBackup", "Informational", lastBackupExists, string.Empty);
                     }
 
                     return (true, $"General_SettingsBackupAndRestore_BackupComplete", "Success", lastBackupExists, string.Empty);
                 }
+                catch (InvalidDataException ex)
+                {
+                    Logger.LogError($"There was an error backing up settings: {ex.Message}", ex);
+                    return (false, "General_SettingsBackupAndRestore_NoSettingsFilesFound", "Error", lastBackupExists, string.Empty);
+                }
                 catch (Exception ex2)
                 {
-                    Logger.LogError($"There was an error in {tempFile.Value} : {ex2.Message}", ex2);
-                    return (false, $"General_SettingsBackupAndRestore_SettingsFormatError", "Error", lastBackupExists, "\n" + tempFile.Value);
+                    Logger.LogError($"There was an error backing up settings: {ex2.Message}", ex2);
+                    return (false, $"General_SettingsBackupAndRestore_SettingsFormatError", "Error", lastBackupExists, string.Empty);
                 }
             }
         }
@@ -803,18 +612,10 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         /// <remarks>If the settings window is launched from an installed instance of PT we need the path "...\Settings\\backup_restore_settings.json" and if the settings window is launched from a local VS build of PT we need the path "...\backup_restore_settings.json".</remarks>
         private static string GetBackupRestoreSettingsJson()
         {
-            if (File.Exists("backup_restore_settings.json"))
-            {
-                return File.ReadAllText("backup_restore_settings.json");
-            }
-            else if (File.Exists("Settings\\backup_restore_settings.json"))
-            {
-                return File.ReadAllText("Settings\\backup_restore_settings.json");
-            }
-            else
-            {
-                throw new FileNotFoundException($"The backup_restore_settings.json could not be found at {Environment.CurrentDirectory}");
-            }
+            using Stream stream = typeof(SettingsBackupAndRestoreUtils).Assembly.GetManifestResourceStream("PowerToys.Settings.BackupRestoreSettings.json")
+                ?? throw new FileNotFoundException("The embedded backup_restore_settings.json resource could not be found.");
+            using StreamReader reader = new(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+            return reader.ReadToEnd();
         }
 
         /// <summary>

--- a/src/settings-ui/Settings.UI.Library/SettingsUtils.cs
+++ b/src/settings-ui/Settings.UI.Library/SettingsUtils.cs
@@ -253,13 +253,13 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         /// <summary>
         /// Method <c>RestoreSettings</c> Mostly a wrapper for SettingsBackupAndRestoreUtils.RestoreSettings
         /// </summary>
-        public static (bool Success, string Message, string Severity) RestoreSettings()
+        public static (bool Success, string Message, string Severity) RestoreSettings(string? archiveFileName = null, string? archiveSha256 = null)
         {
             var settingsBackupAndRestoreUtilsX = SettingsBackupAndRestoreUtils.Instance;
             var settingsUtils = Default;
             var appBasePath = Path.GetDirectoryName(settingsUtils._settingsPath.GetSettingsPath(string.Empty, string.Empty));
             string settingsBackupAndRestoreDir = settingsBackupAndRestoreUtilsX.GetSettingsBackupAndRestoreDir();
-            return settingsBackupAndRestoreUtilsX.RestoreSettings(appBasePath, settingsBackupAndRestoreDir);
+            return settingsBackupAndRestoreUtilsX.RestoreSettings(appBasePath, settingsBackupAndRestoreDir, archiveFileName, archiveSha256);
         }
     }
 }

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/GeneralPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/GeneralPage.xaml.cs
@@ -3,12 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using ManagedCommon;
 using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.ViewModels;
+using Microsoft.PowerToys.SettingsBackupRestore.Security;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Windows.Data.Json;
@@ -74,6 +76,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
                 doRefreshBackupRestoreStatus,
                 PickSingleFolderDialog,
                 loader);
+            ViewModel.ConfirmRestoreAsync = ShowRestorePreviewAsync;
 
             DataContext = ViewModel;
 
@@ -154,6 +157,49 @@ namespace Microsoft.PowerToys.Settings.UI.Views
         private void UpdateBackupAndRestoreStatusText(Microsoft.UI.Xaml.Documents.Hyperlink sender, Microsoft.UI.Xaml.Documents.HyperlinkClickEventArgs args)
         {
             RefreshBackupRestoreStatus();
+        }
+
+        private async Task<bool> ShowRestorePreviewAsync(RestorePreviewViewModel preview)
+        {
+            var loader = Helpers.ResourceLoaderInstance.ResourceLoader;
+            StringBuilder content = new();
+            foreach (RestorePreviewItem item in preview.Items)
+            {
+                string action = item.Included ? item.RestoreMode.ToString() : loader.GetString("General_SettingsRestorePreview_Excluded");
+                content.Append(item.Module).Append(" — ").Append(item.SettingsPath).Append(" — ").AppendLine(action);
+                if (!string.IsNullOrEmpty(item.ExclusionReason))
+                {
+                    content.Append("  ").AppendLine(item.ExclusionReason);
+                }
+            }
+
+            content.AppendLine();
+            content.AppendLine(preview.RestartAfterRestore
+                ? loader.GetString("General_SettingsRestorePreview_Restart")
+                : loader.GetString("General_SettingsRestorePreview_NoRestart"));
+            content.AppendLine();
+            content.Append(preview.SecurityBoundaryStatement);
+
+            ContentDialog dialog = new()
+            {
+                XamlRoot = XamlRoot,
+                Title = loader.GetString("General_SettingsRestorePreview_Title"),
+                PrimaryButtonText = loader.GetString("General_SettingsRestorePreview_Confirm"),
+                CloseButtonText = loader.GetString("General_SettingsRestorePreview_Cancel"),
+                DefaultButton = ContentDialogButton.Close,
+                Content = new ScrollViewer
+                {
+                    MaxHeight = 420,
+                    Content = new TextBlock
+                    {
+                        Text = content.ToString(),
+                        IsTextSelectionEnabled = true,
+                        TextWrapping = TextWrapping.Wrap,
+                    },
+                },
+            };
+
+            return await dialog.ShowAsync() == ContentDialogResult.Primary;
         }
 
         private async Task<string> PickSingleFolderDialog()

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -1018,6 +1018,24 @@ opera.exe</value>
   <data name="General_SettingsBackupAndRestore_ButtonRestore.Content" xml:space="preserve">
     <value>Restore</value>
   </data>
+  <data name="General_SettingsRestorePreview_Title" xml:space="preserve">
+    <value>Review settings restore</value>
+  </data>
+  <data name="General_SettingsRestorePreview_Confirm" xml:space="preserve">
+    <value>Restore</value>
+  </data>
+  <data name="General_SettingsRestorePreview_Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="General_SettingsRestorePreview_Excluded" xml:space="preserve">
+    <value>Excluded</value>
+  </data>
+  <data name="General_SettingsRestorePreview_Restart" xml:space="preserve">
+    <value>PowerToys will restart after the restore.</value>
+  </data>
+  <data name="General_SettingsRestorePreview_NoRestart" xml:space="preserve">
+    <value>PowerToys will not restart after the restore.</value>
+  </data>
   <data name="General_SettingsBackupAndRestore_ButtonSelectFolder.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Select folder</value>
   </data>

--- a/src/settings-ui/Settings.UI/ViewModels/GeneralViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/GeneralViewModel.cs
@@ -24,6 +24,7 @@ using Microsoft.PowerToys.Settings.UI.Library.Interfaces;
 using Microsoft.PowerToys.Settings.UI.Library.Utilities;
 using Microsoft.PowerToys.Settings.UI.Library.ViewModels.Commands;
 using Microsoft.PowerToys.Settings.UI.SerializationContext;
+using Microsoft.PowerToys.SettingsBackupRestore.Security;
 using Microsoft.PowerToys.Telemetry;
 using Microsoft.Win32;
 using Windows.System.Profile;
@@ -81,6 +82,8 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         private Microsoft.UI.Dispatching.DispatcherQueue _dispatcherQueue;
 
         private Func<Task<string>> PickSingleFolderDialog { get; }
+
+        public Func<RestorePreviewViewModel, Task<bool>> ConfirmRestoreAsync { get; set; }
 
         private SettingsBackupAndRestoreUtils settingsBackupAndRestoreUtils = SettingsBackupAndRestoreUtils.Instance;
 
@@ -1080,7 +1083,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         /// <summary>
         /// Method <c>RestoreConfigsClick</c> starts the restore.
         /// </summary>
-        private void RestoreConfigsClick()
+        private async void RestoreConfigsClick()
         {
             string settingsBackupAndRestoreDir = settingsBackupAndRestoreUtils.GetSettingsBackupAndRestoreDir();
 
@@ -1089,7 +1092,29 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 SelectSettingBackupDir();
             }
 
-            var results = SettingsUtils.RestoreSettings();
+            RestorePreviewViewModel preview;
+            try
+            {
+                var settingsUtils = SettingsUtils.Default;
+                var appBasePath = Path.GetDirectoryName(settingsUtils.GetSettingsFilePath());
+                preview = settingsBackupAndRestoreUtils.GetRestorePreview(appBasePath, settingsBackupAndRestoreDir);
+                if (ConfirmRestoreAsync != null && !await ConfirmRestoreAsync(preview))
+                {
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError("Could not build settings restore preview.", ex);
+                _settingsBackupRestoreMessageVisible = true;
+                _backupRestoreMessageSeverity = "Error";
+                _settingsBackupMessage = GetResourceString("General_SettingsBackupAndRestore_BackupError");
+                NotifyAllBackupAndRestoreProperties();
+                HideBackupAndRestoreMessageAreaAction();
+                return;
+            }
+
+            var results = SettingsUtils.RestoreSettings(preview.ArchiveFileName, preview.ArchiveSha256);
             _backupRestoreMessageSeverity = results.Severity;
 
             if (!results.Success)

--- a/src/settings-ui/SettingsBackupRestore.Security.UnitTests/BackupRestoreArchiveTests.cs
+++ b/src/settings-ui/SettingsBackupRestore.Security.UnitTests/BackupRestoreArchiveTests.cs
@@ -1,0 +1,392 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.PowerToys.SettingsBackupRestore.Security.UnitTests;
+
+[TestClass]
+public sealed class BackupRestoreArchiveTests
+{
+    private static readonly string[] ExpectedLegacyPaths =
+    [
+        "manifest.json",
+        @"FancyZones\layout-hotkeys.json",
+        @"Workspaces\workspaces.json",
+    ];
+
+    [DataTestMethod]
+    [DataRow(@"..\escaped.json")]
+    [DataRow(@"\rooted.json")]
+    [DataRow(@"C:\rooted.json")]
+    [DataRow(@"\\server\share\rooted.json")]
+    [DataRow(@"Module\settings.json:payload")]
+    public void UnsafeArchiveNamesAreRejectedBeforeStaging(string entryName)
+    {
+        using TestDirectory test = new();
+        string archivePath = CreateArchive(test.Path, "bad.ptb", (entryName, "{}"));
+        using SecureDirectoryRoot root = SecureDirectoryRoot.Open(test.Path);
+        int stagingCountBefore = Directory.GetDirectories(test.Path, "PowerToysRestore-*").Length;
+
+        Assert.ThrowsException<InvalidDataException>(() =>
+            BackupRestoreArchive.ExtractToExclusiveStaging(root, Path.GetFileName(archivePath), root));
+
+        Assert.AreEqual(stagingCountBefore, Directory.GetDirectories(test.Path, "PowerToysRestore-*").Length);
+        Assert.IsFalse(File.Exists(Path.Combine(test.Path, "escaped.json")));
+    }
+
+    [TestMethod]
+    public void NormalizedCaseCollisionIsRejected()
+    {
+        using TestDirectory test = new();
+        string archivePath = CreateArchive(
+            test.Path,
+            "collision.ptb",
+            ("FancyZones/settings.json", "{\"first\":true}"),
+            ("fancyzones\\SETTINGS.JSON", "{\"second\":true}"));
+        using SecureDirectoryRoot root = SecureDirectoryRoot.Open(test.Path);
+
+        InvalidDataException exception = Assert.ThrowsException<InvalidDataException>(() =>
+            BackupRestoreArchive.ExtractToExclusiveStaging(root, Path.GetFileName(archivePath), root));
+
+        StringAssert.Contains(exception.Message, "collision");
+    }
+
+    [TestMethod]
+    public void DistinctWindowsUnicodeNamesDoNotFalsePositiveAsCollisions()
+    {
+        using TestDirectory test = new();
+        string archivePath = CreateArchive(
+            test.Path,
+            "unicode-distinct.ptb",
+            ("σ.json", "{\"name\":\"sigma\"}"),
+            ("ς.json", "{\"name\":\"final-sigma\"}"));
+        using SecureDirectoryRoot root = SecureDirectoryRoot.Open(test.Path);
+        string stagingPath;
+
+        using (SecureDirectoryRoot staging = BackupRestoreArchive.ExtractToExclusiveStaging(root, Path.GetFileName(archivePath), root))
+        {
+            stagingPath = staging.FinalPath;
+            using SecureFile sigma = staging.OpenFileForRead("σ.json");
+            using SecureFile finalSigma = staging.OpenFileForRead("ς.json");
+            Assert.AreEqual("{\"name\":\"sigma\"}", sigma.ReadAllText());
+            Assert.AreEqual("{\"name\":\"final-sigma\"}", finalSigma.ReadAllText());
+        }
+
+        Directory.Delete(stagingPath, recursive: true);
+    }
+
+    [TestMethod]
+    public void FileAndChildPathConflictIsRejectedBeforeStaging()
+    {
+        using TestDirectory test = new();
+        string archivePath = CreateArchive(
+            test.Path,
+            "file-child-conflict.ptb",
+            ("Module", "{}"),
+            ("Module/settings.json", "{}"));
+        using SecureDirectoryRoot root = SecureDirectoryRoot.Open(test.Path);
+
+        InvalidDataException exception = Assert.ThrowsException<InvalidDataException>(() =>
+            BackupRestoreArchive.ExtractToExclusiveStaging(root, Path.GetFileName(archivePath), root));
+
+        StringAssert.Contains(exception.Message, "conflicts with a child path");
+        Assert.AreEqual(0, Directory.GetDirectories(test.Path, "PowerToysRestore-*").Length);
+    }
+
+    [TestMethod]
+    public void NonAdjacentFileAncestorConflictIsRejectedBeforeStaging()
+    {
+        using TestDirectory test = new();
+        string archivePath = CreateArchive(
+            test.Path,
+            "non-adjacent-file-ancestor.ptb",
+            ("a", "{}"),
+            ("a-b", "{}"),
+            (@"a\c", "{}"));
+        using SecureDirectoryRoot root = SecureDirectoryRoot.Open(test.Path);
+
+        InvalidDataException exception = Assert.ThrowsException<InvalidDataException>(() =>
+            BackupRestoreArchive.ExtractToExclusiveStaging(root, Path.GetFileName(archivePath), root));
+
+        StringAssert.Contains(exception.Message, "conflicts with a child path: a");
+        Assert.AreEqual(0, Directory.GetDirectories(test.Path, "PowerToysRestore-*").Length);
+    }
+
+    [DataTestMethod]
+    [DataRow("A|a-b|a\\c")]
+    [DataRow("a\\b|a-b|a\\b\\c")]
+    [DataRow("a\\c|a-b|a")]
+    public void FileAncestorConflictVariantsAreRejectedBeforeStaging(string encodedEntries)
+    {
+        using TestDirectory test = new();
+        (string Name, string Contents)[] entries = encodedEntries
+            .Split('|')
+            .Select(name => (name, "{}"))
+            .ToArray();
+        string archivePath = CreateArchive(test.Path, "ancestor-variant.ptb", entries);
+        using SecureDirectoryRoot root = SecureDirectoryRoot.Open(test.Path);
+
+        Assert.ThrowsException<InvalidDataException>(() =>
+            BackupRestoreArchive.ExtractToExclusiveStaging(root, Path.GetFileName(archivePath), root));
+
+        Assert.AreEqual(0, Directory.GetDirectories(test.Path, "PowerToysRestore-*").Length);
+    }
+
+    [TestMethod]
+    public void ExcessiveArchivePathDepthIsRejectedBeforeStaging()
+    {
+        using TestDirectory test = new();
+        string allowedPath = string.Join('\\', Enumerable.Repeat("d", BackupRestoreArchive.MaximumPathDepth - 1)) + "\\settings.json";
+        string deepPath = string.Join('\\', Enumerable.Repeat("d", BackupRestoreArchive.MaximumPathDepth)) + "\\settings.json";
+        string allowedArchivePath = CreateArchive(test.Path, "allowed-depth.ptb", (allowedPath, "{}"));
+        string archivePath = CreateArchive(test.Path, "deep-path.ptb", (deepPath, "{}"));
+        using SecureDirectoryRoot root = SecureDirectoryRoot.Open(test.Path);
+
+        using (FileStream stream = File.OpenRead(allowedArchivePath))
+        using (ZipArchive archive = new(stream, ZipArchiveMode.Read))
+        {
+            Assert.AreEqual(1, BackupRestoreArchive.Validate(archive).Count);
+        }
+
+        InvalidDataException exception = Assert.ThrowsException<InvalidDataException>(() =>
+            BackupRestoreArchive.ExtractToExclusiveStaging(root, Path.GetFileName(archivePath), root));
+
+        StringAssert.Contains(exception.Message, "exceeds restore limits");
+        Assert.AreEqual(0, Directory.GetDirectories(test.Path, "PowerToysRestore-*").Length);
+    }
+
+    [TestMethod]
+    public void ArchivePathLengthBoundaryIsEnforcedBeforeStaging()
+    {
+        using TestDirectory test = new();
+        string allowedPath = string.Join('\\', Enumerable.Repeat(new string('a', 204), 5));
+        string excessivePath = new string('b', 205) + "\\" + string.Join('\\', Enumerable.Repeat(new string('b', 204), 4));
+        Assert.AreEqual(BackupRestoreArchive.MaximumPathLength, allowedPath.Length);
+        Assert.AreEqual(BackupRestoreArchive.MaximumPathLength + 1, excessivePath.Length);
+        string allowedArchivePath = CreateArchive(test.Path, "allowed-length.ptb", (allowedPath, "{}"));
+        string excessiveArchivePath = CreateArchive(test.Path, "excessive-length.ptb", (excessivePath, "{}"));
+        using SecureDirectoryRoot root = SecureDirectoryRoot.Open(test.Path);
+
+        using (FileStream stream = File.OpenRead(allowedArchivePath))
+        using (ZipArchive archive = new(stream, ZipArchiveMode.Read))
+        {
+            Assert.AreEqual(1, BackupRestoreArchive.Validate(archive).Count);
+        }
+
+        Assert.ThrowsException<InvalidDataException>(() =>
+            BackupRestoreArchive.ExtractToExclusiveStaging(root, Path.GetFileName(excessiveArchivePath), root));
+        Assert.AreEqual(0, Directory.GetDirectories(test.Path, "PowerToysRestore-*").Length);
+    }
+
+    [TestMethod]
+    public void AggregatePathComponentBoundaryIsEnforcedBeforeStaging()
+    {
+        using TestDirectory test = new();
+        (string Name, string Contents)[] sharedEntries = Enumerable.Range(0, 1_365)
+            .Select(index => ($"root{index}\\child\\settings.json", "{}"))
+            .ToArray();
+        (string Name, string Contents)[] allowedEntries = [.. sharedEntries, ("extra", "{}")];
+        (string Name, string Contents)[] excessiveEntries = [.. allowedEntries, ("extra2", "{}")];
+        string allowedArchivePath = CreateArchive(test.Path, "allowed-components.ptb", allowedEntries);
+        string excessiveArchivePath = CreateArchive(test.Path, "excessive-components.ptb", excessiveEntries);
+        using SecureDirectoryRoot root = SecureDirectoryRoot.Open(test.Path);
+
+        using (FileStream stream = File.OpenRead(allowedArchivePath))
+        using (ZipArchive archive = new(stream, ZipArchiveMode.Read))
+        {
+            Assert.AreEqual(allowedEntries.Length, BackupRestoreArchive.Validate(archive).Count);
+        }
+
+        InvalidDataException exception = Assert.ThrowsException<InvalidDataException>(() =>
+            BackupRestoreArchive.ExtractToExclusiveStaging(root, Path.GetFileName(excessiveArchivePath), root));
+
+        StringAssert.Contains(exception.Message, "complexity limit");
+        Assert.AreEqual(0, Directory.GetDirectories(test.Path, "PowerToysRestore-*").Length);
+    }
+
+    [TestMethod]
+    public void LegacyPtbStructureExtractsWithoutShapeChanges()
+    {
+        using TestDirectory test = new();
+        string archivePath = CreateArchive(
+            test.Path,
+            "settings_123.ptb",
+            ("manifest.json", "{\"Version\":\"0.0.0\"}"),
+            ("Keyboard Manager/default.json", "{\"remapKeys\":[]}"),
+            ("FancyZones/custom-layouts.json", "{\"custom-layouts\":[]}"),
+            ("PowerToys Run/settings.json", "{\"plugins\":[]}"));
+        using SecureDirectoryRoot root = SecureDirectoryRoot.Open(test.Path);
+        string stagingPath;
+
+        using (SecureDirectoryRoot staging = BackupRestoreArchive.ExtractToExclusiveStaging(root, Path.GetFileName(archivePath), root))
+        {
+            stagingPath = staging.FinalPath;
+            using SecureFile manifest = staging.OpenFileForRead("manifest.json");
+            using SecureFile keyboardManager = staging.OpenFileForRead(@"Keyboard Manager\default.json");
+            using SecureFile fancyZones = staging.OpenFileForRead(@"FancyZones\custom-layouts.json");
+            using SecureFile powerToysRun = staging.OpenFileForRead(@"PowerToys Run\settings.json");
+
+            Assert.AreEqual("{\"Version\":\"0.0.0\"}", manifest.ReadAllText());
+            Assert.AreEqual("{\"remapKeys\":[]}", keyboardManager.ReadAllText());
+            Assert.AreEqual("{\"custom-layouts\":[]}", fancyZones.ReadAllText());
+            Assert.AreEqual("{\"plugins\":[]}", powerToysRun.ReadAllText());
+        }
+
+        Directory.Delete(stagingPath, recursive: true);
+    }
+
+    [TestMethod]
+    public void ValidationPreservesEntryOrderingAndRelativeNames()
+    {
+        using TestDirectory test = new();
+        string archivePath = CreateArchive(
+            test.Path,
+            "shape.ptb",
+            ("manifest.json", "{}"),
+            ("FancyZones/layout-hotkeys.json", "{}"),
+            ("Workspaces/workspaces.json", "{}"));
+
+        using FileStream stream = File.OpenRead(archivePath);
+        using ZipArchive archive = new(stream, ZipArchiveMode.Read);
+        IReadOnlyList<ArchiveEntryDescriptor> entries = BackupRestoreArchive.Validate(archive);
+
+        CollectionAssert.AreEqual(
+            ExpectedLegacyPaths,
+            entries.Select(entry => entry.RelativePath).ToArray());
+    }
+
+    [TestMethod]
+    public void PostStagingFailurePreservesOriginalExceptionAndCleansStagingByHandle()
+    {
+        using TestDirectory test = new();
+        string archivePath = CreateArchive(
+            test.Path,
+            "failure.ptb",
+            (@"Module\first.json", "{}"),
+            (@"Module\second.json", "{}"));
+        using SecureDirectoryRoot root = SecureDirectoryRoot.Open(test.Path);
+
+        InvalidOperationException exception = Assert.ThrowsException<InvalidOperationException>(() =>
+            BackupRestoreArchive.ExtractToExclusiveStaging(
+                root,
+                Path.GetFileName(archivePath),
+                root,
+                index =>
+                {
+                    if (index == 1)
+                    {
+                        throw new InvalidOperationException("injected copy failure");
+                    }
+                }));
+
+        Assert.AreEqual("injected copy failure", exception.Message);
+        Assert.AreEqual(0, Directory.GetDirectories(test.Path, "PowerToysRestore-*").Length);
+    }
+
+    [TestMethod]
+    public void DirectoryPreparationFailureCleansAlreadyCreatedAncestors()
+    {
+        using TestDirectory test = new();
+        string archivePath = CreateArchive(test.Path, "directory-failure.ptb", (@"a\b\settings.json", "{}"));
+        using SecureDirectoryRoot root = SecureDirectoryRoot.Open(test.Path);
+
+        InvalidOperationException exception = Assert.ThrowsException<InvalidOperationException>(() =>
+            BackupRestoreArchive.ExtractToExclusiveStaging(
+                root,
+                Path.GetFileName(archivePath),
+                root,
+                beforeEntryCopy: null,
+                beforeDirectoryCreate: directory =>
+                {
+                    if (directory.Equals(@"a\b", StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new InvalidOperationException("injected directory failure");
+                    }
+                }));
+
+        Assert.AreEqual("injected directory failure", exception.Message);
+        Assert.AreEqual(0, Directory.GetDirectories(test.Path, "PowerToysRestore-*").Length);
+    }
+
+    [TestMethod]
+    public void ExtractionDirectoryPostCreateValidationFailureCleansStaging()
+    {
+        using TestDirectory test = new();
+        string archivePath = CreateArchive(test.Path, "directory-validation-failure.ptb", (@"Module\settings.json", "{}"));
+        using SecureDirectoryRoot root = SecureDirectoryRoot.Open(test.Path);
+
+        InvalidOperationException exception = Assert.ThrowsException<InvalidOperationException>(() =>
+            BackupRestoreArchive.ExtractToExclusiveStaging(
+                root,
+                Path.GetFileName(archivePath),
+                root,
+                beforeEntryCopy: null,
+                afterStagingCreated: staging =>
+                    staging.DirectoryBeforeValidationObserver = directory =>
+                        throw new InvalidOperationException($"injected validation failure: {directory}")));
+
+        StringAssert.Contains(exception.Message, "injected validation failure: Module");
+        Assert.AreEqual(0, Directory.GetDirectories(test.Path, "PowerToysRestore-*").Length);
+    }
+
+    [TestMethod]
+    public void CleanupFailureDoesNotReplaceOriginalExtractionException()
+    {
+        using TestDirectory test = new();
+        string archivePath = CreateArchive(
+            test.Path,
+            "cleanup-failure.ptb",
+            (@"Module\first.json", "{}"),
+            (@"Module\second.json", "{}"));
+        using SecureDirectoryRoot root = SecureDirectoryRoot.Open(test.Path);
+        bool cleanupFailureInjected = false;
+
+        InvalidOperationException exception = Assert.ThrowsException<InvalidOperationException>(() =>
+            BackupRestoreArchive.ExtractToExclusiveStaging(
+                root,
+                Path.GetFileName(archivePath),
+                root,
+                beforeEntryCopy: index =>
+                {
+                    if (index == 1)
+                    {
+                        throw new InvalidOperationException("original extraction failure");
+                    }
+                },
+                afterCleanupStep: _ =>
+                {
+                    if (!cleanupFailureInjected)
+                    {
+                        cleanupFailureInjected = true;
+                        throw new IOException("injected cleanup failure");
+                    }
+                }));
+
+        Assert.AreEqual("original extraction failure", exception.Message);
+        Assert.IsTrue(exception.Data.Contains("StagingCleanupErrors"));
+        Assert.AreEqual(0, Directory.GetDirectories(test.Path, "PowerToysRestore-*").Length);
+    }
+
+    private static string CreateArchive(string root, string fileName, params (string Name, string Contents)[] entries)
+    {
+        string archivePath = Path.Combine(root, fileName);
+        using FileStream stream = new(archivePath, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None);
+        using ZipArchive archive = new(stream, ZipArchiveMode.Create);
+        foreach ((string name, string contents) in entries)
+        {
+            ZipArchiveEntry entry = archive.CreateEntry(name, CompressionLevel.NoCompression);
+            using StreamWriter writer = new(entry.Open());
+            writer.Write(contents);
+        }
+
+        return archivePath;
+    }
+}

--- a/src/settings-ui/SettingsBackupRestore.Security.UnitTests/BackupRestoreCompatibilityTests.cs
+++ b/src/settings-ui/SettingsBackupRestore.Security.UnitTests/BackupRestoreCompatibilityTests.cs
@@ -1,0 +1,214 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.PowerToys.SettingsBackupRestore.Security.UnitTests;
+
+[TestClass]
+public sealed class BackupRestoreCompatibilityTests
+{
+    private static readonly int[] ExpectedMergedItems = [1, 2, 3, 3];
+
+    private static readonly string[] PreviewArchivePaths =
+    [
+        "manifest.json",
+        @"Keyboard Manager\default.json",
+        @"FancyZones\settings.json",
+        @"PowerToys\log_settings.json",
+    ];
+
+    private static readonly string[] PreviewCurrentPaths =
+    [
+        @"Keyboard Manager\default.json",
+        @"FancyZones\settings.json",
+        @"Workspaces\workspaces.json",
+        @"Unlisted\diagnostics.json",
+    ];
+
+    [TestMethod]
+    public void ProductionPolicyPreservesIncludeIgnoreAndCustomOverwrite()
+    {
+        BackupRestorePolicy policy = LoadProductionPolicy();
+
+        Assert.IsTrue(policy.ShouldInclude(@"Keyboard Manager\default.json"));
+        Assert.AreEqual(RestoreMode.Overwrite, policy.GetRestoreMode(@"Keyboard Manager\default.json"));
+        Assert.IsTrue(policy.ShouldInclude(@"FancyZones\settings.json"));
+        Assert.AreEqual(RestoreMode.Merge, policy.GetRestoreMode(@"FancyZones\settings.json"));
+        Assert.IsTrue(policy.IsIgnored(@"PowerToys\log_settings.json"));
+        Assert.IsFalse(policy.ShouldInclude(@"PowerToys\log_settings.json"));
+        Assert.IsFalse(policy.ShouldInclude(@"PowerToys\diagnostics.log"));
+        Assert.IsTrue(policy.RestartAfterRestore);
+    }
+
+    [TestMethod]
+    public void MergePreservesCurrentOnlyValuesAndAppliesBackupValues()
+    {
+        const string current = """
+            {
+              "currentOnly": true,
+              "scalar": "current",
+              "nested": { "keep": 1, "replace": 1 },
+              "items": [1, 2]
+            }
+            """;
+        const string backup = """
+            {
+              "scalar": "backup",
+              "nested": { "replace": 2, "add": 3 },
+              "items": [2, 3, 3],
+              "backupOnly": true
+            }
+            """;
+
+        string merged = JsonSettingsMerge.Merge(current, backup);
+        using JsonDocument document = JsonDocument.Parse(merged);
+        JsonElement root = document.RootElement;
+
+        Assert.IsTrue(root.GetProperty("currentOnly").GetBoolean());
+        Assert.AreEqual("backup", root.GetProperty("scalar").GetString());
+        Assert.AreEqual(1, root.GetProperty("nested").GetProperty("keep").GetInt32());
+        Assert.AreEqual(2, root.GetProperty("nested").GetProperty("replace").GetInt32());
+        Assert.AreEqual(3, root.GetProperty("nested").GetProperty("add").GetInt32());
+        CollectionAssert.AreEqual(ExpectedMergedItems, root.GetProperty("items").EnumerateArray().Select(item => item.GetInt32()).ToArray());
+        Assert.IsTrue(root.GetProperty("backupOnly").GetBoolean());
+    }
+
+    [TestMethod]
+    public void ExportFilteringPreservesIgnoredSettingsAndPowerToysRunPluginRules()
+    {
+        BackupRestorePolicy policy = LoadProductionPolicy();
+        const string generalSettings = """{"powertoys_version":"1","keep":true}""";
+        const string runSettings = """
+            {
+              "plugins": [
+                {
+                  "Id": "525995402BEF4A8CA860D92F6D108092",
+                  "IconPathDark": "dark.png",
+                  "IconPathLight": "light.png",
+                  "Keep": true
+                }
+              ]
+            }
+            """;
+
+        using JsonDocument general = JsonDocument.Parse(policy.CreateExportVersion(@"\settings.json", generalSettings));
+        Assert.IsFalse(general.RootElement.TryGetProperty("powertoys_version", out _));
+        Assert.IsTrue(general.RootElement.GetProperty("keep").GetBoolean());
+
+        using JsonDocument run = JsonDocument.Parse(policy.CreateExportVersion(@"\PowerToys Run\settings.json", runSettings));
+        JsonElement plugin = run.RootElement.GetProperty("plugins")[0];
+        Assert.IsFalse(plugin.TryGetProperty("IconPathDark", out _));
+        Assert.IsFalse(plugin.TryGetProperty("IconPathLight", out _));
+        Assert.IsTrue(plugin.GetProperty("Keep").GetBoolean());
+
+        using JsonDocument archiveNormalizedRun = JsonDocument.Parse(policy.CreateExportVersion(@"PowerToys Run\settings.json", runSettings));
+        JsonElement archiveNormalizedPlugin = archiveNormalizedRun.RootElement.GetProperty("plugins")[0];
+        Assert.IsFalse(archiveNormalizedPlugin.TryGetProperty("IconPathDark", out _));
+        Assert.IsFalse(archiveNormalizedPlugin.TryGetProperty("IconPathLight", out _));
+    }
+
+    [TestMethod]
+    public void RestorePreviewListsModulesExclusionsModesAndRestart()
+    {
+        BackupRestorePolicy policy = LoadProductionPolicy();
+        RestorePreviewViewModel preview = RestorePreviewViewModel.Create(
+            policy,
+            PreviewArchivePaths,
+            PreviewCurrentPaths);
+
+        RestorePreviewItem keyboardManager = preview.Items.Single(item => item.Module == "Keyboard Manager");
+        RestorePreviewItem fancyZones = preview.Items.Single(item => item.Module == "FancyZones");
+        RestorePreviewItem ignored = preview.Items.Single(item => item.SettingsPath == @"PowerToys\log_settings.json");
+
+        Assert.IsTrue(keyboardManager.Included);
+        Assert.AreEqual(RestoreMode.Overwrite, keyboardManager.RestoreMode);
+        Assert.IsTrue(fancyZones.Included);
+        Assert.AreEqual(RestoreMode.Merge, fancyZones.RestoreMode);
+        Assert.IsFalse(ignored.Included);
+        Assert.AreEqual("Excluded by IgnoreFiles", ignored.ExclusionReason);
+        Assert.IsFalse(preview.Items.Any(item => item.SettingsPath == @"Workspaces\workspaces.json"));
+        Assert.IsFalse(preview.Items.Any(item => item.SettingsPath == @"Unlisted\diagnostics.json"));
+        Assert.IsTrue(preview.RestartAfterRestore);
+        StringAssert.Contains(preview.SecurityBoundaryStatement, "handle-relative I/O remain the security boundary");
+    }
+
+    [TestMethod]
+    public void RestorePreviewRetainsWindowsDistinctUnicodeArchivePaths()
+    {
+        const string policyJson = """
+            {
+              "IncludeFiles": ["*"],
+              "IgnoreFiles": [],
+              "CustomRestoreSettings": {},
+              "RestartAfterRestore": false
+            }
+            """;
+        BackupRestorePolicy policy = BackupRestorePolicy.Parse(policyJson);
+
+        RestorePreviewViewModel preview = RestorePreviewViewModel.Create(
+            policy,
+            ["σ.json", "ς.json"],
+            []);
+
+        Assert.AreEqual(2, preview.Items.Count);
+        Assert.IsTrue(preview.Items.Any(item => item.SettingsPath == "σ.json"));
+        Assert.IsTrue(preview.Items.Any(item => item.SettingsPath == "ς.json"));
+    }
+
+    [TestMethod]
+    public void CustomOverwriteKeepsWindowsDistinctUnicodePathsSeparate()
+    {
+        const string policyJson = """
+            {
+              "IncludeFiles": ["*"],
+              "IgnoreFiles": [],
+              "CustomRestoreSettings": {
+                "\\σ.json": { "overwrite": true }
+              }
+            }
+            """;
+        BackupRestorePolicy policy = BackupRestorePolicy.Parse(policyJson);
+
+        Assert.AreEqual(RestoreMode.Overwrite, policy.GetRestoreMode("σ.json"));
+        Assert.AreEqual(RestoreMode.Merge, policy.GetRestoreMode("ς.json"));
+    }
+
+    [TestMethod]
+    public void RestorePreviewDistinguishesCreateFromExistingTargetActions()
+    {
+        const string policyJson = """
+            {
+              "IncludeFiles": ["*"],
+              "IgnoreFiles": [],
+              "CustomRestoreSettings": {
+                "\\existing.json": { "overwrite": true },
+                "\\σ.json": { "overwrite": true }
+              }
+            }
+            """;
+        BackupRestorePolicy policy = BackupRestorePolicy.Parse(policyJson);
+
+        RestorePreviewViewModel preview = RestorePreviewViewModel.Create(
+            policy,
+            ["existing.json", "new.json", "σ.json", "ς.json"],
+            ["existing.json", "σ.json"]);
+
+        Assert.AreEqual(RestoreMode.Overwrite, preview.Items.Single(item => item.SettingsPath == "existing.json").RestoreMode);
+        Assert.AreEqual(RestoreMode.Create, preview.Items.Single(item => item.SettingsPath == "new.json").RestoreMode);
+        Assert.AreEqual(RestoreMode.Overwrite, preview.Items.Single(item => item.SettingsPath == "σ.json").RestoreMode);
+        Assert.AreEqual(RestoreMode.Create, preview.Items.Single(item => item.SettingsPath == "ς.json").RestoreMode);
+    }
+
+    private static BackupRestorePolicy LoadProductionPolicy()
+    {
+        string path = Path.Combine(AppContext.BaseDirectory, "backup_restore_settings.json");
+        return BackupRestorePolicy.Parse(File.ReadAllText(path));
+    }
+}

--- a/src/settings-ui/SettingsBackupRestore.Security.UnitTests/SecureFileSystemTests.cs
+++ b/src/settings-ui/SettingsBackupRestore.Security.UnitTests/SecureFileSystemTests.cs
@@ -29,6 +29,52 @@ public sealed class SecureFileSystemTests
     }
 
     [TestMethod]
+    public void UncFinalPathCanonicalizationDoesNotRequireShareAccess()
+    {
+        const string extendedUnc = @"\\?\UNC\server.example\PowerToysBackup\module\settings.json";
+        const string canonicalUnc = @"\\server.example\PowerToysBackup\module\settings.json";
+        const string root = @"\\server.example\PowerToysBackup";
+
+        Assert.AreEqual(canonicalUnc, SecurePath.NormalizeFinalPath(extendedUnc), ignoreCase: true, CultureInfo.InvariantCulture);
+        Assert.IsTrue(SecurePath.IsContained(root, canonicalUnc));
+        Assert.IsFalse(SecurePath.IsContained(root, @"\\server.example\PowerToysBackup-suffix\settings.json"));
+    }
+
+    [TestMethod]
+    public void CloudPlaceholderMetadataFailsClosedWithoutHydration()
+    {
+        const uint cloudReparseTag = 0x9000001A;
+        FileHandleMetadata placeholder = new(
+            IsDirectory: false,
+            IsReparsePoint: true,
+            ReparseTag: cloudReparseTag,
+            LinkCount: 1,
+            Length: 0);
+
+        IOException exception = Assert.ThrowsException<IOException>(() =>
+            SecureDirectoryRoot.ValidateMetadata(placeholder, expectDirectory: false, rejectHardLinks: false));
+
+        StringAssert.Contains(exception.Message, $"0x{cloudReparseTag:X8}");
+    }
+
+    [TestMethod]
+    public void MissingSingleLinkMetadataFailsClosedBeforeOverwrite()
+    {
+        FileHandleMetadata metadataWithoutLinkSupport = new(
+            IsDirectory: false,
+            IsReparsePoint: false,
+            ReparseTag: 0,
+            LinkCount: 0,
+            Length: 10);
+
+        IOException exception = Assert.ThrowsException<IOException>(() =>
+            SecureDirectoryRoot.ValidateMetadata(metadataWithoutLinkSupport, expectDirectory: false, rejectHardLinks: true));
+
+        StringAssert.Contains(exception.Message, "0 hard links");
+        StringAssert.Contains(exception.Message, "before truncation");
+    }
+
+    [TestMethod]
     public void StagingValidationFailureDeletesNewDirectoryAndPreservesOriginalException()
     {
         using TestDirectory test = new();

--- a/src/settings-ui/SettingsBackupRestore.Security.UnitTests/SecureFileSystemTests.cs
+++ b/src/settings-ui/SettingsBackupRestore.Security.UnitTests/SecureFileSystemTests.cs
@@ -1,0 +1,244 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text.RegularExpressions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.PowerToys.SettingsBackupRestore.Security.UnitTests;
+
+[TestClass]
+public sealed class SecureFileSystemTests
+{
+    [TestMethod]
+    public void FinalPathAndContainmentUseOpenedRootHandle()
+    {
+        using TestDirectory test = new();
+        string rootPath = test.CreateDirectory("root");
+        using SecureDirectoryRoot root = SecureDirectoryRoot.Open(rootPath);
+
+        Assert.IsTrue(string.Equals(Path.GetFullPath(rootPath), root.FinalPath, StringComparison.OrdinalIgnoreCase));
+        Assert.IsTrue(SecurePath.IsContained(root.FinalPath, Path.Combine(root.FinalPath, "module", "settings.json")));
+        Assert.IsFalse(SecurePath.IsContained(root.FinalPath, root.FinalPath + "-suffix\\settings.json"));
+        Assert.IsFalse(SecurePath.IsContained(Path.Combine(test.Path, "σ"), Path.Combine(test.Path, "ς", "settings.json")));
+    }
+
+    [TestMethod]
+    public void StagingValidationFailureDeletesNewDirectoryAndPreservesOriginalException()
+    {
+        using TestDirectory test = new();
+        string rootPath = test.CreateDirectory("root");
+        const string suffix = "33333333333333333333333333333333";
+        using SecureDirectoryRoot root = SecureDirectoryRoot.Open(rootPath);
+
+        InvalidOperationException exception = Assert.ThrowsException<InvalidOperationException>(() =>
+            root.CreateExclusiveStagingDirectory(
+                "PowerToysRestore-",
+                () => suffix,
+                () => throw new InvalidOperationException("injected validation failure")));
+
+        Assert.AreEqual("injected validation failure", exception.Message);
+        Assert.IsFalse(Directory.Exists(Path.Combine(rootPath, $"PowerToysRestore-{suffix}")));
+    }
+
+    [TestMethod]
+    public void ReadOnlyRootUsesHandleRelativeSameHandleRead()
+    {
+        using TestDirectory test = new();
+        string rootPath = test.CreateDirectory("root");
+        test.CreateDirectory("root\\module\\nested");
+        test.CreateFile("root\\module\\nested\\settings.json", "content");
+
+        using SecureDirectoryRoot root = SecureDirectoryRoot.OpenReadOnly(rootPath);
+        List<uint> requestedDirectoryAccess = [];
+        root.DirectoryOpenAccessObserver = requestedDirectoryAccess.Add;
+        using SecureFile file = root.OpenFileForRead(@"module\nested\settings.json");
+
+        Assert.AreEqual("content", file.ReadAllText());
+        Assert.IsTrue(SecurePath.IsContained(root.FinalPath, file.FinalPath));
+        CollectionAssert.AreEqual(
+            new[] { SecureDirectoryRoot.ReadOnlyDirectoryAccess, SecureDirectoryRoot.ReadOnlyDirectoryAccess },
+            requestedDirectoryAccess);
+        Assert.IsTrue(requestedDirectoryAccess.TrueForAll(access => (access & NativeMethods.FileWriteData) == 0));
+        Assert.IsTrue(requestedDirectoryAccess.TrueForAll(access => (access & NativeMethods.FileAppendData) == 0));
+        Assert.IsTrue(requestedDirectoryAccess.TrueForAll(access => (access & NativeMethods.FileWriteAttributes) == 0));
+    }
+
+    [TestMethod]
+    public void NestedDirectoryCreationRetainsWriteCapableAccess()
+    {
+        using TestDirectory test = new();
+        string rootPath = test.CreateDirectory("root");
+
+        using SecureDirectoryRoot root = SecureDirectoryRoot.Open(rootPath);
+        List<uint> requestedDirectoryAccess = [];
+        root.DirectoryOpenAccessObserver = requestedDirectoryAccess.Add;
+        using SecureFile file = root.CreateNewFile(@"module\nested\settings.json");
+        file.OverwriteAllText("content");
+
+        CollectionAssert.AreEqual(
+            new[]
+            {
+                SecureDirectoryRoot.WritableDirectoryAccess | NativeMethods.Delete,
+                SecureDirectoryRoot.WritableDirectoryAccess | NativeMethods.Delete,
+            },
+            requestedDirectoryAccess);
+        Assert.IsTrue(requestedDirectoryAccess.TrueForAll(access => (access & NativeMethods.FileWriteData) != 0));
+        Assert.IsTrue(requestedDirectoryAccess.TrueForAll(access => (access & NativeMethods.Delete) != 0));
+    }
+
+    [TestMethod]
+    public void NewlyCreatedDirectoryValidationFailureRollsBackWithDeleteAccess()
+    {
+        using TestDirectory test = new();
+        string rootPath = test.CreateDirectory("root");
+        using SecureDirectoryRoot root = SecureDirectoryRoot.Open(rootPath);
+        bool injected = false;
+        root.DirectoryBeforeValidationObserver = path =>
+        {
+            if (!injected && path == "module")
+            {
+                injected = true;
+                throw new InvalidOperationException("injected directory validation failure");
+            }
+        };
+
+        InvalidOperationException exception = Assert.ThrowsException<InvalidOperationException>(() =>
+            root.CreateDirectory(@"module\nested"));
+
+        Assert.AreEqual("injected directory validation failure", exception.Message);
+        Assert.IsFalse(Directory.Exists(Path.Combine(rootPath, "module")));
+    }
+
+    [TestMethod]
+    public void JunctionEscapeIsRejectedBeforeRead()
+    {
+        using TestDirectory test = new();
+        string rootPath = test.CreateDirectory("root");
+        string outsidePath = test.CreateDirectory("outside");
+        test.CreateFile("outside\\secret.json", "outside");
+        test.CreateDirectoryJunction("root\\escape", outsidePath);
+
+        using SecureDirectoryRoot root = SecureDirectoryRoot.Open(rootPath);
+        IOException exception = Assert.ThrowsException<IOException>(() => root.OpenFileForRead("escape\\secret.json"));
+        StringAssert.Contains(exception.Message, "Reparse point rejected");
+    }
+
+    [TestMethod]
+    public void SymbolicLinkEscapeIsRejectedBeforeRead()
+    {
+        using TestDirectory test = new();
+        string rootPath = test.CreateDirectory("root");
+        string outsidePath = test.CreateDirectory("outside");
+        test.CreateFile("outside\\secret.json", "outside");
+
+        try
+        {
+            test.CreateDirectorySymbolicLink("root\\escape", outsidePath);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Assert.Inconclusive($"Directory symlink capability is unavailable: {ex.Message}");
+        }
+        catch (IOException ex)
+        {
+            Assert.Inconclusive($"Directory symlink capability is unavailable: {ex.Message}");
+        }
+
+        using SecureDirectoryRoot root = SecureDirectoryRoot.Open(rootPath);
+        IOException exception = Assert.ThrowsException<IOException>(() => root.OpenFileForRead("escape\\secret.json"));
+        StringAssert.Contains(exception.Message, "Reparse point rejected");
+    }
+
+    [TestMethod]
+    public void HardlinkedExistingTargetIsRejectedBeforeTruncation()
+    {
+        using TestDirectory test = new();
+        string rootPath = test.CreateDirectory("root");
+        string targetPath = test.CreateFile("root\\settings.json", "original");
+        string aliasPath = test.CreateHardLink("root\\alias.json", targetPath);
+
+        using SecureDirectoryRoot root = SecureDirectoryRoot.Open(rootPath);
+        IOException exception = Assert.ThrowsException<IOException>(() => root.OpenFileForOverwrite("settings.json"));
+
+        StringAssert.Contains(exception.Message, "overwrite rejected before truncation");
+        Assert.AreEqual("original", File.ReadAllText(targetPath));
+        Assert.AreEqual("original", File.ReadAllText(aliasPath));
+    }
+
+    [TestMethod]
+    public void StagingDirectoriesAreRandomAndCreateNew()
+    {
+        using TestDirectory test = new();
+        string rootPath = test.CreateDirectory("root");
+        using SecureDirectoryRoot root = SecureDirectoryRoot.Open(rootPath);
+        string firstPath;
+        string secondPath;
+
+        using (SecureDirectoryRoot first = root.CreateExclusiveStagingDirectory())
+        using (SecureDirectoryRoot second = root.CreateExclusiveStagingDirectory())
+        {
+            firstPath = first.FinalPath;
+            secondPath = second.FinalPath;
+            Assert.AreNotEqual(firstPath, secondPath, ignoreCase: true, CultureInfo.InvariantCulture);
+            StringAssert.Matches(Path.GetFileName(firstPath), new Regex("^PowerToysRestore-[0-9a-f]{32}$", RegexOptions.CultureInvariant));
+            StringAssert.Matches(Path.GetFileName(secondPath), new Regex("^PowerToysRestore-[0-9a-f]{32}$", RegexOptions.CultureInvariant));
+            Assert.IsTrue(Directory.Exists(firstPath));
+            Assert.IsTrue(Directory.Exists(secondPath));
+        }
+
+        Directory.Delete(firstPath);
+        Directory.Delete(secondPath);
+    }
+
+    [TestMethod]
+    public void StagingCollisionRetriesWithoutOpeningOrChangingExistingDirectory()
+    {
+        using TestDirectory test = new();
+        string rootPath = test.CreateDirectory("root");
+        const string collisionSuffix = "11111111111111111111111111111111";
+        const string uniqueSuffix = "22222222222222222222222222222222";
+        string collisionPath = test.CreateDirectory($"root\\PowerToysRestore-{collisionSuffix}");
+        string markerPath = test.CreateFile($"root\\PowerToysRestore-{collisionSuffix}\\marker.txt", "unchanged");
+        Queue<string> candidates = new([collisionSuffix, uniqueSuffix]);
+
+        using SecureDirectoryRoot root = SecureDirectoryRoot.Open(rootPath);
+        string stagingPath;
+        using (SecureDirectoryRoot staging = root.CreateExclusiveStagingDirectory("PowerToysRestore-", candidates.Dequeue))
+        {
+            stagingPath = staging.FinalPath;
+            Assert.AreEqual(Path.Combine(rootPath, $"PowerToysRestore-{uniqueSuffix}"), stagingPath, ignoreCase: true, CultureInfo.InvariantCulture);
+        }
+
+        Assert.IsTrue(Directory.Exists(collisionPath));
+        Assert.AreEqual("unchanged", File.ReadAllText(markerPath));
+        Directory.Delete(stagingPath);
+    }
+
+    [TestMethod]
+    public void SameHandleWriteResistsDeterministicPathSwap()
+    {
+        using TestDirectory test = new();
+        string rootPath = test.CreateDirectory("root");
+        string victimPath = test.CreateFile("root\\victim.json", "original");
+        string outsidePath = test.CreateFile("outside\\sensitive.json", "sensitive");
+        string movedPath = Path.Combine(rootPath, "moved.json");
+
+        using SecureDirectoryRoot root = SecureDirectoryRoot.Open(rootPath);
+        using (SecureFile openedVictim = root.OpenFileForOverwrite("victim.json", FileShare.ReadWrite | FileShare.Delete))
+        {
+            File.Move(victimPath, movedPath);
+            test.CreateHardLink("root\\victim.json", outsidePath);
+            openedVictim.OverwriteAllText("updated");
+        }
+
+        Assert.AreEqual("updated", File.ReadAllText(movedPath));
+        Assert.AreEqual("sensitive", File.ReadAllText(outsidePath));
+        Assert.AreEqual("sensitive", File.ReadAllText(victimPath));
+    }
+}

--- a/src/settings-ui/SettingsBackupRestore.Security.UnitTests/SettingsBackupRestore.Security.UnitTests.csproj
+++ b/src/settings-ui/SettingsBackupRestore.Security.UnitTests/SettingsBackupRestore.Security.UnitTests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <RuntimeIdentifier Condition="'$(Platform)' == 'x64'">win-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(Platform)' == 'ARM64'">win-arm64</RuntimeIdentifier>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SettingsBackupRestore.Security\SettingsBackupRestore.Security.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\Settings.UI.Library\backup_restore_settings.json" Link="backup_restore_settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/settings-ui/SettingsBackupRestore.Security.UnitTests/SettingsBackupRestore.Security.UnitTests.csproj
+++ b/src/settings-ui/SettingsBackupRestore.Security.UnitTests/SettingsBackupRestore.Security.UnitTests.csproj
@@ -1,4 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <!-- Look at Directory.Build.props in root for common stuff as well -->
+  <Import Project="$(RepoRoot)src\Common.Dotnet.CsWinRT.props" />
+
   <PropertyGroup>
     <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
     <OutputType>Exe</OutputType>

--- a/src/settings-ui/SettingsBackupRestore.Security.UnitTests/SettingsBackupRestoreEngineTests.cs
+++ b/src/settings-ui/SettingsBackupRestore.Security.UnitTests/SettingsBackupRestoreEngineTests.cs
@@ -1,0 +1,228 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.PowerToys.SettingsBackupRestore.Security.UnitTests;
+
+[TestClass]
+public sealed class SettingsBackupRestoreEngineTests
+{
+    private static readonly string[] ExpectedArchiveEntries = ["settings.json", "FancyZones/settings.json", "manifest.json"];
+
+    private const string PolicyJson = """
+        {
+          "IncludeFiles": ["*.json"],
+          "IgnoreFiles": ["*\\ignored.json"],
+          "IgnoredSettings": {
+            "settings.json": ["machineOnly"]
+          },
+          "CustomRestoreSettings": {
+            "\\Keyboard Manager\\default.json": { "overwrite": true }
+          },
+          "RestartAfterRestore": true
+        }
+        """;
+
+    [TestMethod]
+    public void ProductionBackupWritesLegacyArchiveAndDryRunDoesNotWrite()
+    {
+        using TestDirectory test = new();
+        string settings = test.CreateDirectory("settings");
+        string backups = test.CreateDirectory("backups");
+        string staging = test.CreateDirectory("staging");
+        test.CreateFile(@"settings\settings.json", """{"machineOnly":"x","value":1}""");
+        test.CreateFile(@"settings\FancyZones\settings.json", """{"zone":1}""");
+        test.CreateFile(@"settings\PowerToys\ignored.json", """{"ignored":true}""");
+        SettingsBackupRestoreEngine engine = new(PolicyJson);
+        DateTime now = new(2026, 8, 16, 7, 0, 0, DateTimeKind.Utc);
+
+        BackupOperationResult first = engine.Backup(settings, backups, staging, false, "1.2.3", "test-machine", now);
+        BackupOperationResult unchanged = engine.Backup(settings, backups, staging, true, "1.2.3", "test-machine", now.AddMinutes(1));
+
+        Assert.IsTrue(first.BackupCreated);
+        Assert.IsFalse(first.PreviousBackupExists);
+        Assert.IsFalse(unchanged.BackupCreated);
+        Assert.IsTrue(unchanged.PreviousBackupExists);
+        Assert.AreEqual(1, Directory.GetFiles(backups, "*.ptb").Length);
+        Assert.AreEqual(0, Directory.GetFileSystemEntries(staging).Length);
+
+        using ZipArchive archive = ZipFile.OpenRead(Path.Combine(backups, first.ArchiveFileName!));
+        CollectionAssert.AreEquivalent(
+            ExpectedArchiveEntries,
+            archive.Entries.Select(entry => entry.FullName).ToArray());
+        using StreamReader settingsReader = new(archive.GetEntry("settings.json")!.Open());
+        using JsonDocument exported = JsonDocument.Parse(settingsReader.ReadToEnd());
+        Assert.IsFalse(exported.RootElement.TryGetProperty("machineOnly", out _));
+    }
+
+    [TestMethod]
+    public void ProductionBackupManifestAndChangedDryRunPreserveCompatibility()
+    {
+        using TestDirectory test = new();
+        string settings = test.CreateDirectory("settings");
+        string backups = test.CreateDirectory("backups");
+        string staging = test.CreateDirectory("staging");
+        test.CreateFile(@"settings\settings.json", """{"value":1}""");
+        SettingsBackupRestoreEngine engine = new(PolicyJson);
+        DateTime now = new(2026, 8, 16, 7, 0, 0, DateTimeKind.Utc);
+        engine.Backup(settings, backups, staging, false, "1.2.3", "test-machine", now);
+        File.WriteAllText(Path.Combine(settings, "settings.json"), """{"value":2}""");
+
+        BackupOperationResult dryRun = engine.Backup(settings, backups, staging, true, "1.2.3", "test-machine", now.AddMinutes(1));
+        JsonNode? manifest = engine.GetLatestManifest(backups, staging);
+
+        Assert.IsTrue(dryRun.BackupCreated);
+        Assert.AreEqual(1, Directory.GetFiles(backups, "*.ptb").Length);
+        Assert.AreEqual("1.2.3", manifest!["Version"]!.GetValue<string>());
+        Assert.AreEqual("test-machine", manifest["BackupSource"]!.GetValue<string>());
+        Assert.AreEqual(@"\settings.json", manifest["UpdatedFiles"]![0]!.GetValue<string>());
+        Assert.AreEqual(0, Directory.GetFileSystemEntries(staging).Length);
+    }
+
+    [TestMethod]
+    public void ProductionRestoreUsesCreateMergeOverwriteIgnoreAndRestart()
+    {
+        using TestDirectory test = new();
+        string source = test.CreateDirectory("source");
+        string target = test.CreateDirectory("target");
+        string backups = test.CreateDirectory("backups");
+        string staging = test.CreateDirectory("staging");
+        test.CreateFile(@"source\settings.json", """{"backup":true,"shared":"backup"}""");
+        test.CreateFile(@"source\FancyZones\settings.json", """{"fromBackup":true,"shared":"backup"}""");
+        test.CreateFile(@"source\Keyboard Manager\default.json", """{"overwrite":"backup"}""");
+        test.CreateFile(@"source\NewModule\settings.json", """{"created":true}""");
+        test.CreateFile(@"source\PowerToys\ignored.json", """{"ignored":"backup"}""");
+        test.CreateFile(@"target\settings.json", """{"current":true,"shared":"current"}""");
+        test.CreateFile(@"target\FancyZones\settings.json", """{"currentOnly":true,"shared":"current"}""");
+        test.CreateFile(@"target\Keyboard Manager\default.json", """{"overwrite":"current","keep":true}""");
+        test.CreateFile(@"target\PowerToys\ignored.json", """{"ignored":"current"}""");
+        SettingsBackupRestoreEngine engine = new(PolicyJson);
+        engine.Backup(source, backups, staging, false, "1.2.3", "test-machine", DateTime.UtcNow);
+
+        RestoreOperationResult result = engine.Restore(target, backups, staging);
+
+        Assert.IsTrue(result.SettingsChanged);
+        Assert.IsTrue(result.RestartRequired);
+        using JsonDocument merged = JsonDocument.Parse(File.ReadAllText(Path.Combine(target, @"FancyZones\settings.json")));
+        Assert.IsTrue(merged.RootElement.GetProperty("currentOnly").GetBoolean());
+        Assert.IsTrue(merged.RootElement.GetProperty("fromBackup").GetBoolean());
+        Assert.AreEqual("backup", merged.RootElement.GetProperty("shared").GetString());
+        using JsonDocument overwritten = JsonDocument.Parse(File.ReadAllText(Path.Combine(target, @"Keyboard Manager\default.json")));
+        Assert.IsFalse(overwritten.RootElement.TryGetProperty("keep", out _));
+        Assert.AreEqual("backup", overwritten.RootElement.GetProperty("overwrite").GetString());
+        Assert.IsTrue(File.Exists(Path.Combine(target, @"NewModule\settings.json")));
+        Assert.AreEqual("""{"ignored":"current"}""", File.ReadAllText(Path.Combine(target, @"PowerToys\ignored.json")));
+        Assert.AreEqual(0, Directory.GetFileSystemEntries(staging).Length);
+    }
+
+    [TestMethod]
+    public void ProductionPreviewListsActionsExclusionsAndRestart()
+    {
+        using TestDirectory test = new();
+        string source = test.CreateDirectory("source");
+        string target = test.CreateDirectory("target");
+        string backups = test.CreateDirectory("backups");
+        string staging = test.CreateDirectory("staging");
+        test.CreateFile(@"source\FancyZones\settings.json", "{}");
+        test.CreateFile(@"source\Keyboard Manager\default.json", "{}");
+        test.CreateFile(@"source\NewModule\settings.json", "{}");
+        test.CreateFile(@"source\PowerToys\ignored.json", "{}");
+        test.CreateFile(@"target\FancyZones\settings.json", "{}");
+        test.CreateFile(@"target\Keyboard Manager\default.json", "{}");
+        SettingsBackupRestoreEngine engine = new(PolicyJson);
+        BackupOperationResult backup = engine.Backup(source, backups, staging, false, "1.2.3", "test-machine", DateTime.UtcNow);
+        using (ZipArchive archive = ZipFile.Open(Path.Combine(backups, backup.ArchiveFileName!), ZipArchiveMode.Update))
+        using (StreamWriter writer = new(archive.CreateEntry("PowerToys/ignored.json").Open()))
+        {
+            writer.Write("{}");
+        }
+
+        RestorePreviewViewModel preview = engine.CreateRestorePreview(target, backups, staging);
+
+        Assert.AreEqual(RestoreMode.Merge, preview.Items.Single(item => item.Module == "FancyZones").RestoreMode);
+        Assert.AreEqual(RestoreMode.Overwrite, preview.Items.Single(item => item.Module == "Keyboard Manager").RestoreMode);
+        Assert.AreEqual(RestoreMode.Create, preview.Items.Single(item => item.Module == "NewModule").RestoreMode);
+        Assert.IsFalse(preview.Items.Single(item => item.SettingsPath.EndsWith("ignored.json", StringComparison.Ordinal)).Included);
+        Assert.IsTrue(preview.RestartAfterRestore);
+        Assert.AreEqual(0, Directory.GetFileSystemEntries(staging).Length);
+    }
+
+    [TestMethod]
+    public void RestoreRejectsArchiveChangedAfterPreview()
+    {
+        using TestDirectory test = new();
+        string source = test.CreateDirectory("source");
+        string target = test.CreateDirectory("target");
+        string backups = test.CreateDirectory("backups");
+        string staging = test.CreateDirectory("staging");
+        test.CreateFile(@"source\settings.json", """{"value":1}""");
+        test.CreateFile(@"target\settings.json", """{"value":0}""");
+        SettingsBackupRestoreEngine engine = new(PolicyJson);
+        engine.Backup(source, backups, staging, false, "1.2.3", "test-machine", DateTime.UtcNow);
+        RestorePreviewViewModel preview = engine.CreateRestorePreview(target, backups, staging);
+        using (ZipArchive archive = ZipFile.Open(Path.Combine(backups, preview.ArchiveFileName!), ZipArchiveMode.Update))
+        {
+            archive.CreateEntry("changed.json");
+        }
+
+        Assert.ThrowsException<InvalidDataException>(() =>
+            engine.Restore(target, backups, staging, preview.ArchiveFileName, preview.ArchiveSha256));
+        Assert.AreEqual("""{"value":0}""", File.ReadAllText(Path.Combine(target, "settings.json")));
+    }
+
+    [TestMethod]
+    public void ProductionEnginePreservesWindowsDistinctUnicodePaths()
+    {
+        using TestDirectory test = new();
+        string source = test.CreateDirectory("source");
+        string target = test.CreateDirectory("target");
+        string backups = test.CreateDirectory("backups");
+        string staging = test.CreateDirectory("staging");
+        test.CreateFile(@"source\σ.json", """{"name":"sigma"}""");
+        test.CreateFile(@"source\ς.json", """{"name":"final-sigma"}""");
+        SettingsBackupRestoreEngine engine = new(PolicyJson);
+
+        engine.Backup(source, backups, staging, false, "1.2.3", "test-machine", DateTime.UtcNow);
+        RestoreOperationResult result = engine.Restore(target, backups, staging);
+
+        Assert.IsTrue(result.SettingsChanged);
+        using JsonDocument sigma = JsonDocument.Parse(File.ReadAllText(Path.Combine(target, "σ.json")));
+        using JsonDocument finalSigma = JsonDocument.Parse(File.ReadAllText(Path.Combine(target, "ς.json")));
+        Assert.AreEqual("sigma", sigma.RootElement.GetProperty("name").GetString());
+        Assert.AreEqual("final-sigma", finalSigma.RootElement.GetProperty("name").GetString());
+    }
+
+    [TestMethod]
+    public void UnrelatedLockedFilesAreNotOpenedDuringFiltering()
+    {
+        using TestDirectory test = new();
+        string source = test.CreateDirectory("source");
+        string target = test.CreateDirectory("target");
+        string backups = test.CreateDirectory("backups");
+        string staging = test.CreateDirectory("staging");
+        string unrelatedTarget = test.CreateDirectory("unrelated-target");
+        test.CreateFile(@"source\settings.json", """{"value":1}""");
+        string sourceUnrelated = test.CreateFile(@"source\unrelated.bin", "not settings");
+        string backupUnrelated = test.CreateFile(@"backups\unrelated.bin", "not an archive");
+        test.CreateDirectoryJunction(@"backups\unrelated-junction", unrelatedTarget);
+        SettingsBackupRestoreEngine engine = new(PolicyJson);
+        using FileStream sourceLock = new(sourceUnrelated, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+        using FileStream backupLock = new(backupUnrelated, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+
+        BackupOperationResult backup = engine.Backup(source, backups, staging, false, "1.2.3", "test-machine", DateTime.UtcNow);
+        RestorePreviewViewModel preview = engine.CreateRestorePreview(target, backups, staging);
+
+        Assert.IsTrue(backup.BackupCreated);
+        Assert.AreEqual(1, preview.Items.Count);
+        Assert.AreEqual("settings.json", preview.Items[0].SettingsPath);
+    }
+}

--- a/src/settings-ui/SettingsBackupRestore.Security.UnitTests/SettingsBackupRestoreEngineTests.cs
+++ b/src/settings-ui/SettingsBackupRestore.Security.UnitTests/SettingsBackupRestoreEngineTests.cs
@@ -225,4 +225,66 @@ public sealed class SettingsBackupRestoreEngineTests
         Assert.AreEqual(1, preview.Items.Count);
         Assert.AreEqual("settings.json", preview.Items[0].SettingsPath);
     }
+
+    [TestMethod]
+    public void UnsafeArchiveFailsClosedBeforePreviewOrRestoreWrites()
+    {
+        using TestDirectory test = new();
+        string target = test.CreateDirectory("target");
+        string backups = test.CreateDirectory("backups");
+        string staging = test.CreateDirectory("staging");
+        string targetSettings = test.CreateFile(@"target\settings.json", """{"value":"current"}""");
+        string archivePath = Path.Combine(backups, $"settings_{DateTime.UtcNow.ToFileTimeUtc()}.ptb");
+        using (FileStream stream = new(archivePath, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None))
+        using (ZipArchive archive = new(stream, ZipArchiveMode.Create))
+        using (StreamWriter writer = new(archive.CreateEntry("../settings.json").Open()))
+        {
+            writer.Write("""{"value":"untrusted"}""");
+        }
+
+        SettingsBackupRestoreEngine engine = new(PolicyJson);
+
+        Assert.ThrowsException<InvalidDataException>(() => engine.CreateRestorePreview(target, backups, staging));
+        Assert.ThrowsException<InvalidDataException>(() => engine.Restore(target, backups, staging));
+        Assert.AreEqual("""{"value":"current"}""", File.ReadAllText(targetSettings));
+        Assert.AreEqual(0, Directory.GetFileSystemEntries(staging).Length);
+    }
+
+    [TestMethod]
+    public void MalformedLaterEntryDoesNotPartiallyApplyRestore()
+    {
+        using TestDirectory test = new();
+        string target = test.CreateDirectory("target");
+        string backups = test.CreateDirectory("backups");
+        string staging = test.CreateDirectory("staging");
+        string firstTarget = test.CreateFile(@"target\A\settings.json", """{"value":"current-a"}""");
+        string secondTarget = test.CreateFile(@"target\Z\settings.json", """{"value":"current-z"}""");
+        string archivePath = Path.Combine(backups, $"settings_{DateTime.UtcNow.ToFileTimeUtc()}.ptb");
+        using (FileStream stream = new(archivePath, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None))
+        using (ZipArchive archive = new(stream, ZipArchiveMode.Create))
+        {
+            using (StreamWriter first = new(archive.CreateEntry("A/settings.json").Open()))
+            {
+                first.Write("""{"value":"backup-a"}""");
+            }
+
+            using StreamWriter second = new(archive.CreateEntry("Z/settings.json").Open());
+            second.Write("""{"value":""");
+        }
+
+        SettingsBackupRestoreEngine engine = new(PolicyJson);
+
+        try
+        {
+            engine.Restore(target, backups, staging);
+            Assert.Fail("Malformed restore JSON should fail before writes.");
+        }
+        catch (JsonException)
+        {
+        }
+
+        Assert.AreEqual("""{"value":"current-a"}""", File.ReadAllText(firstTarget));
+        Assert.AreEqual("""{"value":"current-z"}""", File.ReadAllText(secondTarget));
+        Assert.AreEqual(0, Directory.GetFileSystemEntries(staging).Length);
+    }
 }

--- a/src/settings-ui/SettingsBackupRestore.Security.UnitTests/TestDirectory.cs
+++ b/src/settings-ui/SettingsBackupRestore.Security.UnitTests/TestDirectory.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.PowerToys.SettingsBackupRestore.Security.UnitTests;
+
+internal sealed class TestDirectory : IDisposable
+{
+    private readonly List<string> links = [];
+
+    internal TestDirectory()
+    {
+        string ownerRoot = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "PowerToys-SettingsBackupRestore-tests");
+        Path = System.IO.Path.Combine(ownerRoot, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path);
+    }
+
+    internal string Path { get; }
+
+    internal string CreateDirectory(string relativePath)
+    {
+        string path = System.IO.Path.Combine(Path, relativePath);
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    internal string CreateFile(string relativePath, string contents)
+    {
+        string path = System.IO.Path.Combine(Path, relativePath);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, contents);
+        return path;
+    }
+
+    internal string CreateDirectoryJunction(string relativePath, string targetPath)
+    {
+        string linkPath = System.IO.Path.Combine(Path, relativePath);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(linkPath)!);
+        ProcessStartInfo startInfo = new()
+        {
+            FileName = Environment.GetEnvironmentVariable("ComSpec") ?? "cmd.exe",
+            Arguments = $"/d /c mklink /J \"{linkPath}\" \"{targetPath}\"",
+            CreateNoWindow = true,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+        };
+
+        using Process process = Process.Start(startInfo)!;
+        string output = process.StandardOutput.ReadToEnd();
+        string error = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        Assert.AreEqual(0, process.ExitCode, $"mklink failed. stdout: {output} stderr: {error}");
+        links.Add(linkPath);
+        return linkPath;
+    }
+
+    internal string CreateDirectorySymbolicLink(string relativePath, string targetPath)
+    {
+        string linkPath = System.IO.Path.Combine(Path, relativePath);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(linkPath)!);
+        Directory.CreateSymbolicLink(linkPath, targetPath);
+        links.Add(linkPath);
+        return linkPath;
+    }
+
+    internal string CreateHardLink(string relativePath, string targetPath)
+    {
+        string linkPath = System.IO.Path.Combine(Path, relativePath);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(linkPath)!);
+        if (!CreateHardLinkW(linkPath, targetPath, IntPtr.Zero))
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "Could not create test-owned hard link.");
+        }
+
+        return linkPath;
+    }
+
+    public void Dispose()
+    {
+        foreach (string link in links)
+        {
+            if (Directory.Exists(link))
+            {
+                Directory.Delete(link);
+            }
+        }
+
+        if (Directory.Exists(Path))
+        {
+            Directory.Delete(Path, recursive: true);
+        }
+
+        string? ownerRoot = System.IO.Path.GetDirectoryName(Path);
+        if (ownerRoot != null && Directory.Exists(ownerRoot) && Directory.GetFileSystemEntries(ownerRoot).Length == 0)
+        {
+            Directory.Delete(ownerRoot);
+        }
+    }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CreateHardLinkW(string fileName, string existingFileName, IntPtr securityAttributes);
+}

--- a/src/settings-ui/SettingsBackupRestore.Security/ArchiveEntryDescriptor.cs
+++ b/src/settings-ui/SettingsBackupRestore.Security/ArchiveEntryDescriptor.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.PowerToys.SettingsBackupRestore.Security;
+
+/// <summary>
+/// A normalized entry from a validated PowerToys backup archive.
+/// </summary>
+public sealed record ArchiveEntryDescriptor(string RelativePath, bool IsDirectory, long UncompressedLength);

--- a/src/settings-ui/SettingsBackupRestore.Security/BackupOperationResult.cs
+++ b/src/settings-ui/SettingsBackupRestore.Security/BackupOperationResult.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.PowerToys.SettingsBackupRestore.Security;
+
+/// <summary>
+/// Result of a production backup comparison or write.
+/// </summary>
+public sealed record BackupOperationResult(bool BackupCreated, bool PreviousBackupExists, string? ArchiveFileName);

--- a/src/settings-ui/SettingsBackupRestore.Security/BackupRestoreArchive.cs
+++ b/src/settings-ui/SettingsBackupRestore.Security/BackupRestoreArchive.cs
@@ -1,0 +1,285 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+
+namespace Microsoft.PowerToys.SettingsBackupRestore.Security;
+
+/// <summary>
+/// Validates and extracts legacy .ptb ZIP archives through rooted handles.
+/// </summary>
+public static class BackupRestoreArchive
+{
+    private const int MaximumEntries = 10_000;
+    internal const int MaximumPathNodes = 4_096;
+    internal const int MaximumPathDepth = 64;
+    internal const int MaximumPathLength = 1_024;
+    private const long MaximumEntryLength = 64L * 1024 * 1024;
+    private const long MaximumTotalLength = 256L * 1024 * 1024;
+
+    /// <summary>
+    /// Validates every archive name before extraction and returns normalized descriptors.
+    /// </summary>
+    public static IReadOnlyList<ArchiveEntryDescriptor> Validate(ZipArchive archive)
+    {
+        ArgumentNullException.ThrowIfNull(archive);
+        if (archive.Entries.Count > MaximumEntries)
+        {
+            throw new InvalidDataException($"Archive contains more than {MaximumEntries} entries.");
+        }
+
+        List<ArchiveEntryDescriptor> descriptors = new(archive.Entries.Count);
+        ArchivePathNode root = new();
+        int pathNodeCount = 0;
+        long totalLength = 0;
+
+        foreach (ZipArchiveEntry entry in archive.Entries)
+        {
+            bool isDirectory = entry.FullName.EndsWith('/') || entry.FullName.EndsWith('\\');
+            string rawPath = isDirectory ? entry.FullName.TrimEnd('/', '\\') : entry.FullName;
+            string normalized = SecurePath.NormalizeRelative(rawPath);
+            string[] components = normalized.Split('\\');
+            if (normalized.Length > MaximumPathLength || components.Length > MaximumPathDepth)
+            {
+                throw new InvalidDataException($"Archive path exceeds restore limits: {entry.FullName}");
+            }
+
+            if (!isDirectory && entry.Length > MaximumEntryLength)
+            {
+                throw new InvalidDataException($"Archive entry is too large: {entry.FullName}");
+            }
+
+            totalLength = checked(totalLength + entry.Length);
+            if (totalLength > MaximumTotalLength)
+            {
+                throw new InvalidDataException("Archive uncompressed size exceeds the restore limit.");
+            }
+
+            pathNodeCount = checked(pathNodeCount + root.Add(components, isDirectory, entry.FullName));
+            if (pathNodeCount > MaximumPathNodes)
+            {
+                throw new InvalidDataException($"Archive paths exceed the restore complexity limit of {MaximumPathNodes} components.");
+            }
+
+            ArchiveEntryDescriptor descriptor = new(normalized, isDirectory, entry.Length);
+            descriptors.Add(descriptor);
+        }
+
+        return descriptors;
+    }
+
+    /// <summary>
+    /// Opens the archive relative to one root, validates all names, then extracts to a random exclusive directory under another root.
+    /// </summary>
+    public static SecureDirectoryRoot ExtractToExclusiveStaging(
+        SecureDirectoryRoot archiveRoot,
+        string archiveRelativePath,
+        SecureDirectoryRoot stagingParent)
+    {
+        return ExtractToExclusiveStaging(archiveRoot, archiveRelativePath, stagingParent, beforeEntryCopy: null);
+    }
+
+    internal static SecureDirectoryRoot ExtractToExclusiveStaging(
+        SecureDirectoryRoot archiveRoot,
+        string archiveRelativePath,
+        SecureDirectoryRoot stagingParent,
+        Action<int>? beforeEntryCopy,
+        Action<string>? beforeDirectoryCreate = null,
+        Action<string>? afterCleanupStep = null,
+        Action<SecureDirectoryRoot>? afterStagingCreated = null)
+    {
+        ArgumentNullException.ThrowIfNull(archiveRoot);
+        ArgumentNullException.ThrowIfNull(stagingParent);
+
+        using SecureFile archiveFile = archiveRoot.OpenFileForRead(archiveRelativePath);
+        return ExtractToExclusiveStaging(archiveFile, stagingParent, beforeEntryCopy, beforeDirectoryCreate, afterCleanupStep, afterStagingCreated);
+    }
+
+    internal static SecureDirectoryRoot ExtractToExclusiveStaging(
+        SecureFile archiveFile,
+        SecureDirectoryRoot stagingParent,
+        Action<int>? beforeEntryCopy = null,
+        Action<string>? beforeDirectoryCreate = null,
+        Action<string>? afterCleanupStep = null,
+        Action<SecureDirectoryRoot>? afterStagingCreated = null)
+    {
+        ArgumentNullException.ThrowIfNull(archiveFile);
+        ArgumentNullException.ThrowIfNull(stagingParent);
+        archiveFile.Stream.Position = 0;
+        using ZipArchive archive = new(archiveFile.Stream, ZipArchiveMode.Read, leaveOpen: true);
+        IReadOnlyList<ArchiveEntryDescriptor> descriptors = Validate(archive);
+
+        SecureDirectoryRoot? staging = null;
+        List<string> createdFiles = [];
+        SortedSet<string> createdDirectories = new(WindowsPathComparer.Instance);
+        try
+        {
+            staging = stagingParent.CreateExclusiveStagingDirectory();
+            afterStagingCreated?.Invoke(staging);
+            SortedSet<string> requiredDirectories = new(WindowsPathComparer.Instance);
+            foreach (ArchiveEntryDescriptor descriptor in descriptors)
+            {
+                if (descriptor.IsDirectory)
+                {
+                    AddDirectoryAndAncestors(requiredDirectories, descriptor.RelativePath);
+                }
+                else
+                {
+                    AddParentDirectories(requiredDirectories, descriptor.RelativePath);
+                }
+            }
+
+            foreach (string directory in requiredDirectories
+                         .OrderBy(path => path.Count(character => character == '\\'))
+                         .ThenBy(path => path, WindowsPathComparer.Instance))
+            {
+                beforeDirectoryCreate?.Invoke(directory);
+                staging.CreateNewDirectory(directory);
+                createdDirectories.Add(directory);
+            }
+
+            for (int index = 0; index < descriptors.Count; index++)
+            {
+                ArchiveEntryDescriptor descriptor = descriptors[index];
+                ZipArchiveEntry entry = archive.Entries[index];
+                if (descriptor.IsDirectory)
+                {
+                    continue;
+                }
+
+                beforeEntryCopy?.Invoke(index);
+                using SecureFile destination = staging.CreateNewFileInExistingDirectory(descriptor.RelativePath);
+                createdFiles.Add(descriptor.RelativePath);
+                using Stream source = entry.Open();
+                destination.CopyFrom(source);
+            }
+
+            SecureDirectoryRoot result = staging;
+            staging = null;
+            return result;
+        }
+        catch (Exception extractionException)
+        {
+            if (staging != null)
+            {
+                List<Exception> cleanupErrors = [];
+                try
+                {
+                    for (int index = createdFiles.Count - 1; index >= 0; index--)
+                    {
+                        TryCleanup(
+                            () =>
+                            {
+                                staging.DeleteEntry(createdFiles[index], isDirectory: false);
+                                afterCleanupStep?.Invoke(createdFiles[index]);
+                            },
+                            cleanupErrors);
+                    }
+
+                    foreach (string directory in createdDirectories.OrderByDescending(path => path.Length))
+                    {
+                        TryCleanup(
+                            () =>
+                            {
+                                staging.DeleteEntry(directory, isDirectory: true);
+                                afterCleanupStep?.Invoke(directory);
+                            },
+                            cleanupErrors);
+                    }
+
+                    TryCleanup(
+                        () =>
+                        {
+                            staging.DeleteSelf();
+                            afterCleanupStep?.Invoke(string.Empty);
+                        },
+                        cleanupErrors);
+                }
+                finally
+                {
+                    staging.Dispose();
+                }
+
+                if (cleanupErrors.Count > 0)
+                {
+                    extractionException.Data["StagingCleanupErrors"] = cleanupErrors.ToArray();
+                }
+            }
+
+            throw;
+        }
+    }
+
+    private static void AddDirectoryAndAncestors(ISet<string> directories, string directory)
+    {
+        directories.Add(directory);
+        AddParentDirectories(directories, directory);
+    }
+
+    private static void AddParentDirectories(ISet<string> directories, string path)
+    {
+        int separatorIndex = path.IndexOf('\\');
+        while (separatorIndex >= 0)
+        {
+            directories.Add(path[..separatorIndex]);
+            separatorIndex = path.IndexOf('\\', separatorIndex + 1);
+        }
+    }
+
+    private static void TryCleanup(Action cleanup, List<Exception> cleanupErrors)
+    {
+        try
+        {
+            cleanup();
+        }
+        catch (Exception exception)
+        {
+            cleanupErrors.Add(exception);
+        }
+    }
+
+    private sealed class ArchivePathNode
+    {
+        private readonly SortedDictionary<string, ArchivePathNode> children = new(WindowsPathComparer.Instance);
+        private bool? isDirectoryEntry;
+
+        internal int Add(string[] components, bool isDirectory, string originalPath)
+        {
+            ArchivePathNode current = this;
+            int addedNodes = 0;
+            for (int index = 0; index < components.Length; index++)
+            {
+                if (!current.children.TryGetValue(components[index], out ArchivePathNode? child))
+                {
+                    child = new ArchivePathNode();
+                    current.children.Add(components[index], child);
+                    addedNodes++;
+                }
+
+                current = child;
+                if (index < components.Length - 1 && current.isDirectoryEntry == false)
+                {
+                    throw new InvalidDataException($"Archive file conflicts with a child path: {string.Join('\\', components[..(index + 1)])}");
+                }
+            }
+
+            if (current.isDirectoryEntry.HasValue)
+            {
+                throw new InvalidDataException($"Archive path collision after Windows normalization: {originalPath}");
+            }
+
+            if (!isDirectory && current.children.Count > 0)
+            {
+                throw new InvalidDataException($"Archive file conflicts with a child path: {string.Join('\\', components)}");
+            }
+
+            current.isDirectoryEntry = isDirectory;
+            return addedNodes;
+        }
+    }
+}

--- a/src/settings-ui/SettingsBackupRestore.Security/BackupRestorePolicy.cs
+++ b/src/settings-ui/SettingsBackupRestore.Security/BackupRestorePolicy.cs
@@ -1,0 +1,180 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.PowerToys.SettingsBackupRestore.Security;
+
+/// <summary>
+/// Parses the existing backup_restore_settings.json contract without changing its archive behavior.
+/// </summary>
+public sealed class BackupRestorePolicy
+{
+    private readonly string[] includePatterns;
+    private readonly string[] ignorePatterns;
+    private readonly SortedSet<string> overwritePaths;
+    private readonly Dictionary<string, HashSet<string>> ignoredSettings;
+    private readonly Dictionary<string, HashSet<string>> ignoredPowerToysRunSettings;
+
+    private BackupRestorePolicy(
+        string[] includePatterns,
+        string[] ignorePatterns,
+        SortedSet<string> overwritePaths,
+        Dictionary<string, HashSet<string>> ignoredSettings,
+        Dictionary<string, HashSet<string>> ignoredPowerToysRunSettings,
+        bool restartAfterRestore)
+    {
+        this.includePatterns = includePatterns;
+        this.ignorePatterns = ignorePatterns;
+        this.overwritePaths = overwritePaths;
+        this.ignoredSettings = ignoredSettings;
+        this.ignoredPowerToysRunSettings = ignoredPowerToysRunSettings;
+        RestartAfterRestore = restartAfterRestore;
+    }
+
+    /// <summary>
+    /// Gets whether the existing contract requests a PowerToys restart after restore.
+    /// </summary>
+    public bool RestartAfterRestore { get; }
+
+    /// <summary>
+    /// Parses the production backup/restore configuration.
+    /// </summary>
+    public static BackupRestorePolicy Parse(string json)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(json);
+        JsonNode root = JsonNode.Parse(json) ?? throw new JsonException("Backup/restore configuration is empty.");
+
+        string[] includes = ReadStringArray(root["IncludeFiles"]);
+        string[] ignores = ReadStringArray(root["IgnoreFiles"]);
+        SortedSet<string> overwrites = new(WindowsPathComparer.Instance);
+        if (root["CustomRestoreSettings"] is JsonObject customRestoreSettings)
+        {
+            foreach ((string path, JsonNode? value) in customRestoreSettings)
+            {
+                if (value?["overwrite"]?.GetValue<bool>() == true)
+                {
+                    overwrites.Add(NormalizePolicyPath(path));
+                }
+            }
+        }
+
+        Dictionary<string, HashSet<string>> ignored = new(StringComparer.Ordinal);
+        if (root["IgnoredSettings"] is JsonObject ignoredSettings)
+        {
+            foreach ((string path, JsonNode? value) in ignoredSettings)
+            {
+                ignored[path] = new HashSet<string>(ReadStringArray(value), StringComparer.Ordinal);
+            }
+        }
+
+        Dictionary<string, HashSet<string>> ignoredRunSettings = new(StringComparer.Ordinal);
+        if (root["IgnoredPTRunSettings"] is JsonArray ignoredPlugins)
+        {
+            foreach (JsonNode? node in ignoredPlugins)
+            {
+                if (node is JsonObject plugin &&
+                    plugin["Id"]?.GetValue<string>() is string id)
+                {
+                    ignoredRunSettings[id] = new HashSet<string>(ReadStringArray(plugin["Names"]), StringComparer.Ordinal);
+                }
+            }
+        }
+
+        bool restart = root[nameof(RestartAfterRestore)]?.GetValue<bool>() ?? true;
+        return new BackupRestorePolicy(includes, ignores, overwrites, ignored, ignoredRunSettings, restart);
+    }
+
+    /// <summary>
+    /// Applies the production IncludeFiles and IgnoreFiles wildcard rules.
+    /// </summary>
+    public bool ShouldInclude(string relativePath)
+    {
+        string policyPath = NormalizePolicyPath(relativePath);
+        bool included = includePatterns.Any(pattern => Regex.IsMatch(policyPath, WildcardToRegex(pattern)));
+        return included && !IsIgnored(policyPath);
+    }
+
+    /// <summary>
+    /// Returns whether a path is excluded by the production IgnoreFiles rules.
+    /// </summary>
+    public bool IsIgnored(string relativePath)
+    {
+        string policyPath = NormalizePolicyPath(relativePath);
+        return ignorePatterns.Any(pattern => Regex.IsMatch(policyPath, WildcardToRegex(pattern)));
+    }
+
+    /// <summary>
+    /// Returns merge or overwrite according to CustomRestoreSettings.
+    /// </summary>
+    public RestoreMode GetRestoreMode(string relativePath)
+    {
+        return overwritePaths.Contains(NormalizePolicyPath(relativePath)) ? RestoreMode.Overwrite : RestoreMode.Merge;
+    }
+
+    /// <summary>
+    /// Applies the production top-level and PowerToys Run export exclusions to in-memory JSON.
+    /// </summary>
+    public string CreateExportVersion(string relativePath, string settingsJson)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(relativePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(settingsJson);
+
+        string policyPath = NormalizePolicyPath(relativePath);
+        string policyKey = policyPath.TrimStart('\\');
+        HashSet<string> excluded = ignoredSettings.GetValueOrDefault(policyKey) ?? [];
+        JsonObject source = JsonNode.Parse(settingsJson) as JsonObject ??
+                            throw new JsonException("Settings JSON must be an object.");
+        JsonObject exported = new();
+        foreach ((string name, JsonNode? value) in source.OrderBy(property => property.Key, StringComparer.Ordinal))
+        {
+            if (!excluded.Contains(name))
+            {
+                exported[name] = value?.DeepClone();
+            }
+        }
+
+        if (policyPath.Equals(@"\PowerToys Run\settings.json", StringComparison.OrdinalIgnoreCase) &&
+            exported["plugins"] is JsonArray plugins)
+        {
+            foreach (JsonNode? node in plugins)
+            {
+                if (node is JsonObject plugin &&
+                    plugin["Id"]?.GetValue<string>() is string id &&
+                    ignoredPowerToysRunSettings.TryGetValue(id, out HashSet<string>? propertyNames))
+                {
+                    foreach (string propertyName in propertyNames)
+                    {
+                        plugin.Remove(propertyName);
+                    }
+                }
+            }
+        }
+
+        return exported.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    private static string[] ReadStringArray(JsonNode? node)
+    {
+        return node is JsonArray array
+            ? array.Select(item => item?.GetValue<string>() ?? string.Empty).ToArray()
+            : [];
+    }
+
+    private static string NormalizePolicyPath(string path)
+    {
+        string normalized = SecurePath.NormalizeRelative(path.TrimStart('\\', '/'));
+        return "\\" + normalized;
+    }
+
+    private static string WildcardToRegex(string wildcard)
+    {
+        return "^" + Regex.Escape(wildcard).Replace("\\*", ".*", StringComparison.Ordinal) + "$";
+    }
+}

--- a/src/settings-ui/SettingsBackupRestore.Security/FileHandleMetadata.cs
+++ b/src/settings-ui/SettingsBackupRestore.Security/FileHandleMetadata.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.PowerToys.SettingsBackupRestore.Security;
+
+/// <summary>
+/// Metadata queried from the same handle used for file I/O.
+/// </summary>
+public readonly record struct FileHandleMetadata(bool IsDirectory, bool IsReparsePoint, uint ReparseTag, uint LinkCount, long Length);

--- a/src/settings-ui/SettingsBackupRestore.Security/JsonSettingsMerge.cs
+++ b/src/settings-ui/SettingsBackupRestore.Security/JsonSettingsMerge.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+
+namespace Microsoft.PowerToys.SettingsBackupRestore.Security;
+
+/// <summary>
+/// Preserves the current recursive object/array merge behavior.
+/// </summary>
+public static class JsonSettingsMerge
+{
+    /// <summary>
+    /// Merges backup JSON into current JSON, replacing scalars and de-duplicating array items.
+    /// </summary>
+    public static string Merge(string currentJson, string backupJson)
+    {
+        ArrayBufferWriter<byte> output = new();
+        using JsonDocument current = JsonDocument.Parse(currentJson);
+        using JsonDocument backup = JsonDocument.Parse(backupJson);
+        using Utf8JsonWriter writer = new(output, new JsonWriterOptions { Indented = true });
+
+        if (current.RootElement.ValueKind is not (JsonValueKind.Array or JsonValueKind.Object))
+        {
+            throw new InvalidOperationException("Current JSON must be an object or array.");
+        }
+
+        if (current.RootElement.ValueKind != backup.RootElement.ValueKind)
+        {
+            return currentJson;
+        }
+
+        if (current.RootElement.ValueKind == JsonValueKind.Array)
+        {
+            MergeArrays(writer, current.RootElement, backup.RootElement);
+        }
+        else
+        {
+            MergeObjects(writer, current.RootElement, backup.RootElement);
+        }
+
+        writer.Flush();
+        return Encoding.UTF8.GetString(output.WrittenSpan);
+    }
+
+    private static void MergeObjects(Utf8JsonWriter writer, JsonElement current, JsonElement backup)
+    {
+        writer.WriteStartObject();
+        foreach (JsonProperty property in current.EnumerateObject())
+        {
+            if (backup.TryGetProperty(property.Name, out JsonElement backupValue) && backupValue.ValueKind != JsonValueKind.Null)
+            {
+                writer.WritePropertyName(property.Name);
+                if (property.Value.ValueKind == JsonValueKind.Object && backupValue.ValueKind == JsonValueKind.Object)
+                {
+                    MergeObjects(writer, property.Value, backupValue);
+                }
+                else if (property.Value.ValueKind == JsonValueKind.Array && backupValue.ValueKind == JsonValueKind.Array)
+                {
+                    MergeArrays(writer, property.Value, backupValue);
+                }
+                else
+                {
+                    backupValue.WriteTo(writer);
+                }
+            }
+            else
+            {
+                property.WriteTo(writer);
+            }
+        }
+
+        foreach (JsonProperty property in backup.EnumerateObject())
+        {
+            if (!current.TryGetProperty(property.Name, out _))
+            {
+                property.WriteTo(writer);
+            }
+        }
+
+        writer.WriteEndObject();
+    }
+
+    private static void MergeArrays(Utf8JsonWriter writer, JsonElement current, JsonElement backup)
+    {
+        writer.WriteStartArray();
+        HashSet<string> items = new(StringComparer.Ordinal);
+        foreach (JsonElement item in current.EnumerateArray())
+        {
+            item.WriteTo(writer);
+            items.Add(item.ToString());
+        }
+
+        foreach (JsonElement item in backup.EnumerateArray())
+        {
+            if (!items.Contains(item.ToString()))
+            {
+                item.WriteTo(writer);
+            }
+        }
+
+        writer.WriteEndArray();
+    }
+}

--- a/src/settings-ui/SettingsBackupRestore.Security/NativeMethods.cs
+++ b/src/settings-ui/SettingsBackupRestore.Security/NativeMethods.cs
@@ -1,0 +1,177 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+using Microsoft.Win32.SafeHandles;
+
+namespace Microsoft.PowerToys.SettingsBackupRestore.Security;
+
+internal static class NativeMethods
+{
+    internal const uint FileReadData = 0x0001;
+    internal const uint FileWriteData = 0x0002;
+    internal const uint FileAppendData = 0x0004;
+    internal const uint FileReadAttributes = 0x0080;
+    internal const uint FileWriteAttributes = 0x0100;
+    internal const uint Synchronize = 0x00100000;
+    internal const uint GenericRead = 0x80000000;
+    internal const uint GenericWrite = 0x40000000;
+    internal const uint Delete = 0x00010000;
+
+    internal const uint FileShareRead = 0x00000001;
+    internal const uint FileShareWrite = 0x00000002;
+    internal const uint FileShareDelete = 0x00000004;
+
+    internal const uint OpenExisting = 3;
+    internal const uint FileOpen = 1;
+    internal const uint FileCreate = 2;
+    internal const uint FileOpenIf = 3;
+
+    internal const uint FileDirectoryFile = 0x00000001;
+    internal const uint FileSynchronousIoNonAlert = 0x00000020;
+    internal const uint FileNonDirectoryFile = 0x00000040;
+    internal const uint FileOpenReparsePoint = 0x00200000;
+
+    internal const uint FileFlagBackupSemantics = 0x02000000;
+    internal const uint FileFlagOpenReparsePoint = 0x00200000;
+
+    internal const uint ObjCaseInsensitive = 0x00000040;
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    internal static extern SafeFileHandle CreateFileW(
+        string fileName,
+        uint desiredAccess,
+        uint shareMode,
+        IntPtr securityAttributes,
+        uint creationDisposition,
+        uint flagsAndAttributes,
+        IntPtr templateFile);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    internal static extern uint GetFinalPathNameByHandleW(
+        SafeFileHandle file,
+        char[] filePath,
+        uint filePathLength,
+        uint flags);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    internal static extern int CompareStringOrdinal(
+        string string1,
+        int count1,
+        string string2,
+        int count2,
+        [MarshalAs(UnmanagedType.Bool)] bool ignoreCase);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool GetFileInformationByHandleEx(
+        SafeFileHandle file,
+        FileInfoByHandleClass fileInformationClass,
+        out FileAttributeTagInfo fileInformation,
+        uint bufferSize);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool GetFileInformationByHandleEx(
+        SafeFileHandle file,
+        FileInfoByHandleClass fileInformationClass,
+        out FileStandardInfo fileInformation,
+        uint bufferSize);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool SetFileInformationByHandle(
+        SafeFileHandle file,
+        FileInfoByHandleClass fileInformationClass,
+        ref FileDispositionInfo fileInformation,
+        uint bufferSize);
+
+    [DllImport("ntdll.dll")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    internal static extern uint NtCreateFile(
+        out SafeFileHandle fileHandle,
+        uint desiredAccess,
+        ref ObjectAttributes objectAttributes,
+        out IoStatusBlock ioStatusBlock,
+        IntPtr allocationSize,
+        uint fileAttributes,
+        uint shareAccess,
+        uint createDisposition,
+        uint createOptions,
+        IntPtr eaBuffer,
+        uint eaLength);
+
+    [DllImport("ntdll.dll")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    internal static extern uint RtlNtStatusToDosError(uint status);
+
+    internal enum FileInfoByHandleClass
+    {
+        FileStandardInfo = 1,
+        FileDispositionInfo = 4,
+        FileAttributeTagInfo = 9,
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct FileAttributeTagInfo
+    {
+        internal uint FileAttributes;
+        internal uint ReparseTag;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct FileStandardInfo
+    {
+        internal long AllocationSize;
+        internal long EndOfFile;
+        internal uint NumberOfLinks;
+
+        [MarshalAs(UnmanagedType.U1)]
+        internal bool DeletePending;
+
+        [MarshalAs(UnmanagedType.U1)]
+        internal bool Directory;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct FileDispositionInfo
+    {
+        [MarshalAs(UnmanagedType.Bool)]
+        internal bool DeleteFile;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct UnicodeString
+    {
+        internal ushort Length;
+        internal ushort MaximumLength;
+        internal IntPtr Buffer;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct ObjectAttributes
+    {
+        internal int Length;
+        internal IntPtr RootDirectory;
+        internal IntPtr ObjectName;
+        internal uint Attributes;
+        internal IntPtr SecurityDescriptor;
+        internal IntPtr SecurityQualityOfService;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct IoStatusBlock
+    {
+        internal IntPtr Status;
+        internal IntPtr Information;
+    }
+}

--- a/src/settings-ui/SettingsBackupRestore.Security/RestoreMode.cs
+++ b/src/settings-ui/SettingsBackupRestore.Security/RestoreMode.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.PowerToys.SettingsBackupRestore.Security;
+
+/// <summary>
+/// Restore behavior for one settings file.
+/// </summary>
+public enum RestoreMode
+{
+    /// <summary>
+    /// Create a settings file that does not currently exist.
+    /// </summary>
+    Create,
+
+    /// <summary>
+    /// Merge backup JSON into the current JSON.
+    /// </summary>
+    Merge,
+
+    /// <summary>
+    /// Replace current JSON with backup JSON.
+    /// </summary>
+    Overwrite,
+}

--- a/src/settings-ui/SettingsBackupRestore.Security/RestoreOperationResult.cs
+++ b/src/settings-ui/SettingsBackupRestore.Security/RestoreOperationResult.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.PowerToys.SettingsBackupRestore.Security;
+
+/// <summary>
+/// Result of a production restore.
+/// </summary>
+public sealed record RestoreOperationResult(bool SettingsChanged, bool RestartRequired);

--- a/src/settings-ui/SettingsBackupRestore.Security/RestorePreviewItem.cs
+++ b/src/settings-ui/SettingsBackupRestore.Security/RestorePreviewItem.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.PowerToys.SettingsBackupRestore.Security;
+
+/// <summary>
+/// One testable row in a restore confirmation preview.
+/// </summary>
+public sealed record RestorePreviewItem(
+    string Module,
+    string SettingsPath,
+    bool Included,
+    string? ExclusionReason,
+    RestoreMode RestoreMode);

--- a/src/settings-ui/SettingsBackupRestore.Security/RestorePreviewViewModel.cs
+++ b/src/settings-ui/SettingsBackupRestore.Security/RestorePreviewViewModel.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Microsoft.PowerToys.SettingsBackupRestore.Security;
+
+/// <summary>
+/// UI-independent shape for restore confirmation.
+/// </summary>
+public sealed class RestorePreviewViewModel
+{
+    /// <summary>
+    /// Explains why confirmation cannot replace secure archive and filesystem enforcement.
+    /// </summary>
+    public const string SecurityBoundaryNotice =
+        "Confirmation records user intent; validated archive names and handle-relative I/O remain the security boundary.";
+
+    private RestorePreviewViewModel(IReadOnlyList<RestorePreviewItem> items, bool restartAfterRestore, string? archiveFileName, string? archiveSha256)
+    {
+        Items = items;
+        RestartAfterRestore = restartAfterRestore;
+        ArchiveFileName = archiveFileName;
+        ArchiveSha256 = archiveSha256;
+    }
+
+    /// <summary>
+    /// Gets settings and exclusions displayed before restore.
+    /// </summary>
+    public IReadOnlyList<RestorePreviewItem> Items { get; }
+
+    /// <summary>
+    /// Gets whether PowerToys will restart after a successful restore.
+    /// </summary>
+    public bool RestartAfterRestore { get; }
+
+    /// <summary>
+    /// Gets the archive selected for this preview.
+    /// </summary>
+    public string? ArchiveFileName { get; }
+
+    /// <summary>
+    /// Gets the selected archive content identity.
+    /// </summary>
+    public string? ArchiveSha256 { get; }
+
+    /// <summary>
+    /// Gets the explicit security-boundary statement for the confirmation surface.
+    /// </summary>
+    public string SecurityBoundaryStatement => SecurityBoundaryNotice;
+
+    /// <summary>
+    /// Builds a deterministic preview from archive and current settings paths.
+    /// </summary>
+    public static RestorePreviewViewModel Create(
+        BackupRestorePolicy policy,
+        IEnumerable<string> archiveSettingsPaths,
+        IEnumerable<string> currentSettingsPaths)
+    {
+        ArgumentNullException.ThrowIfNull(policy);
+        ArgumentNullException.ThrowIfNull(archiveSettingsPaths);
+        ArgumentNullException.ThrowIfNull(currentSettingsPaths);
+
+        SortedSet<string> candidates = new(WindowsPathComparer.Instance);
+        foreach (string path in archiveSettingsPaths)
+        {
+            if (!string.IsNullOrWhiteSpace(path))
+            {
+                candidates.Add(SecurePath.NormalizeRelative(path.TrimStart('\\', '/')));
+            }
+        }
+
+        SortedSet<string> currentPaths = new(WindowsPathComparer.Instance);
+        foreach (string path in currentSettingsPaths)
+        {
+            if (!string.IsNullOrWhiteSpace(path))
+            {
+                currentPaths.Add(SecurePath.NormalizeRelative(path.TrimStart('\\', '/')));
+            }
+        }
+
+        List<RestorePreviewItem> items = [];
+        foreach (string path in candidates)
+        {
+            if (string.Equals(path, "manifest.json", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            bool ignored = policy.IsIgnored(path);
+            bool included = policy.ShouldInclude(path);
+            string? exclusionReason = included ? null : ignored ? "Excluded by IgnoreFiles" : "Not matched by IncludeFiles";
+            string module = GetModule(path);
+            RestoreMode restoreMode = currentPaths.Contains(path) ? policy.GetRestoreMode(path) : RestoreMode.Create;
+            items.Add(new RestorePreviewItem(module, path, included, exclusionReason, restoreMode));
+        }
+
+        return new RestorePreviewViewModel(items, policy.RestartAfterRestore, archiveFileName: null, archiveSha256: null);
+    }
+
+    internal RestorePreviewViewModel WithArchiveIdentity(string archiveFileName, string archiveSha256)
+    {
+        return new RestorePreviewViewModel(Items, RestartAfterRestore, archiveFileName, archiveSha256);
+    }
+
+    private static string GetModule(string path)
+    {
+        string firstComponent = path.Split(Path.DirectorySeparatorChar, 2)[0];
+        return string.Equals(firstComponent, "settings.json", StringComparison.OrdinalIgnoreCase) ? "General" : firstComponent;
+    }
+}

--- a/src/settings-ui/SettingsBackupRestore.Security/SINK-MATRIX.md
+++ b/src/settings-ui/SettingsBackupRestore.Security/SINK-MATRIX.md
@@ -1,43 +1,42 @@
-# Settings backup/restore sink matrix
+# Settings backup/restore production sink matrix
 
-`[x]` means the source/sink and its validated replacement primitive were traced.
+All production backup/restore filesystem and archive sinks are routed through
+`SettingsBackupRestoreEngine` and validated rooted-handle primitives.
 
-| Checked | Phase | Production function and exact location | Previous primitive / trust transition | Validated production primitive | Integration state |
-|---|---|---|---|---|---|
-| [x] | All | `GetRegSettingsBackupAndRestoreRegItem` | Registry read selects backup root | Open selected root once with `SecureDirectoryRoot.Open`; canonicalize by handle | Integrated |
-| [x] | All | `GetBackupRestoreSettingsJson` | Relative process-CWD config read | Embedded trusted configuration parsed by `BackupRestorePolicy` | Integrated |
-| [x] | Backup/dry-run | `BackupSettingsInternal` | `Directory.Exists`, prefix string check, optional `Directory.CreateDirectory` on caller paths | Open or create roots through validated handles and enforce final-path containment | Integrated |
-| [x] | Backup/dry-run | `GetSettingsFiles`, `SettingsBackupAndRestoreUtils.cs:560-568` | Recursive path enumeration can cross reparses | Enumerate one directory at a time and validate every traversed directory and file handle | Integrated |
-| [x] | Backup/dry-run | latest archive selection | Path enumeration of `settings_*.ptb` | Validate top-level entries and open the selected archive relative to the held root | Integrated |
-| [x] | Backup/dry-run/restore | `GetLatestSettingsFolder`, `SettingsBackupAndRestoreUtils.cs:414-480` | Predictable `%TEMP%\PowerToys_settings_<time>` plus `ZipFile.ExtractToDirectory` | Validate every ZIP name before writes, then create random `FILE_CREATE` staging and extract through relative handles (`BackupRestoreArchive.cs:25-73,81-111`) | Executable |
-| [x] | Backup/dry-run/restore | `GetSettingsFiles` on extracted folder, call sites `SettingsBackupAndRestoreUtils.cs:303,672` | Reopens extracted paths after validation | Keep staging root handle alive and open every entry relative to it (`SecureDirectoryRoot.cs:214-247`) | Primitive proven; caller integration remains |
-| [x] | Backup/dry-run | `GetExportVersion`, `SettingsBackupAndRestoreUtils.cs:832-879` | `File.ReadAllText(settingsFileName)` reopens source path | `SecureFile.ReadAllText` uses the already validated handle (`SecureFile.cs:38-44`) | Executable |
-| [x] | Backup/dry-run | `BackupSettingsInternal`, `SettingsBackupAndRestoreUtils.cs:690,696` | Reads current and prior JSON for comparison | Same-handle reads under their respective roots; apply `IgnoredSettings` and `IgnoredPTRunSettings` in memory (`BackupRestorePolicy.CreateExportVersion`) | Executable/tested |
-| [x] | Backup | `BackupSettingsInternal`, `SettingsBackupAndRestoreUtils.cs:670,724-730` | Predictable temp directory and path-based updated-file write | `CreateExclusiveStagingDirectory` uses cryptographic names and `FILE_CREATE`; `CreateNewFile` writes the returned handle (`SecureDirectoryRoot.cs:101-146`) | Executable |
-| [x] | Backup | `BackupSettingsInternal`, `SettingsBackupAndRestoreUtils.cs:753-760` | Path-based unchanged-file write | Same exclusive staging/new-file handle primitive | Executable |
-| [x] | Backup | `BackupSettingsInternal`, `SettingsBackupAndRestoreUtils.cs:767-778` | Path-based manifest write | Create manifest with `CreateNewFile`; write same handle | Executable primitive |
-| [x] | Backup | `BackupSettingsInternal`, `SettingsBackupAndRestoreUtils.cs:783-785` | `ZipFile.CreateFromDirectory` creates/reopens final `.ptb` by path | Create final archive relative to backup-root handle with `FILE_CREATE` and stream ZIP to that handle | Integrated |
-| [x] | Backup | staging cleanup | Recursive path cleanup | Delete files and directories deepest-first through validated handles | Integrated |
-| [x] | Backup/restore maintenance | `RemoveOldBackups`, `SettingsBackupAndRestoreUtils.cs:937-1001` | Path enumeration plus recursive directory/file deletion | Validate top-level archive handles and delete relative to the held backup root; staging cleanup is handle-relative and deepest-first | Integrated |
-| [x] | Restore | `RestoreSettings`, `SettingsBackupAndRestoreUtils.cs:279-303` | Path existence probes and path dictionaries define roots | Open app, archive, and staging roots by handle; all child access is relative | Executable primitive |
-| [x] | Restore | `RestoreSettings`, `SettingsBackupAndRestoreUtils.cs:316,321` | Backup/current JSON path reads | Same-handle `SecureFile.ReadAllText` | Executable |
-| [x] | Restore overwrite | `RestoreSettings`, `SettingsBackupAndRestoreUtils.cs:328-339` | `File.WriteAllText` truncates an existing path after path-only decisions | `OpenFileForOverwrite` checks reparse metadata and `NumberOfLinks == 1` before `SecureFile.OverwriteAllText` truncates the same handle (`SecureDirectoryRoot.cs:89-96`; `SecureFile.cs:47-65`) | Executable |
-| [x] | Restore merge | `RestoreSettings`, `SettingsBackupAndRestoreUtils.cs:341-344` | Reopens once to read and again to truncate/write | Read, merge, recheck metadata, truncate, and write one held handle; compatible merge is executable in `JsonSettingsMerge.cs` | Executable |
-| [x] | Restore new file | `RestoreSettings`, `SettingsBackupAndRestoreUtils.cs:350-357` | Path-based parent creation and create-or-truncate write | Walk/create non-reparse parents relative to root and use `FILE_CREATE` for the file (`SecureDirectoryRoot.cs:250-294`) | Executable |
-| [x] | Restore UX/status | `GetLatestSettingsBackupManifest`, `SettingsBackupAndRestoreUtils.cs:511-520` | Path-based manifest read | Open `manifest.json` relative to held staging root and read same handle | Executable primitive |
-| [x] | Restore UX/status | `GeneralViewModel.RestoreConfigsClick`, `GeneralViewModel.cs:1085-1111` | Confirmation is absent; successful restore writes last-restore registry value and restarts | `RestorePreviewViewModel` lists modules, paths, exclusions, create/merge/overwrite, and restart; its security-boundary statement forbids treating confirmation as enforcement | Executable/tested model |
-| [x] | Backup UX/status | `GeneralViewModel.BackupConfigsClick`, `GeneralViewModel.cs:1119-1137`; `GeneralPage.RefreshBackupRestoreStatus`, `GeneralPage.xaml.cs:136-152` | Real backup followed by dry-run; dry-run still reads archive/current roots | Reuse the same root/entry validators for both real and dry-run paths; dry-run performs no writes | Design traced |
-| [x] | Registry status | `SetRegSettingsBackupAndRestoreItem`, `SettingsBackupAndRestoreUtils.cs:228-242`; callers `GeneralViewModel.cs:766,1109` | Registry writes backup directory and restore timestamp | Not a filesystem boundary; retain behavior after secure filesystem operation succeeds | Preserve |
+| Phase | Production entry point | Validated sink behavior | Status |
+|---|---|---|---|
+| Policy | `SettingsBackupAndRestoreUtils.GetBackupRestoreSettingsJson` | Reads the embedded trusted policy and parses it with `BackupRestorePolicy` | Integrated |
+| Root selection | `SettingsBackupRestoreEngine.Backup`, `Restore`, `CreateRestorePreview`, `GetLatestManifest` | Opens settings, backup, and staging roots once; rejects root reparses and handle paths outside their roots | Integrated |
+| Backup enumeration | `SettingsBackupRestoreEngine.ReadSettings` | Traverses validated directory handles and opens only policy-matched JSON files | Integrated |
+| Dry-run | `SettingsBackupRestoreEngine.Backup(..., dryRun: true)` | Uses the same validated roots, policy filtering, archive extraction, and same-handle reads as backup; performs no writes | Integrated |
+| Prior archive selection | `SettingsBackupRestoreEngine.GetLatestArchiveFileName` | Examines only top-level `settings_<filetime>.ptb` candidates and opens the selected archive relative to the held backup root | Integrated |
+| Archive validation/extraction | `BackupRestoreArchive.ExtractToExclusiveStaging` | Validates all ZIP names and limits before writes; extracts through an exclusive random staging-root handle | Integrated |
+| Export filtering | `BackupRestorePolicy.CreateExportVersion` | Applies `IgnoredSettings` and `IgnoredPTRunSettings` to JSON read from validated file handles | Integrated |
+| Archive creation | `SettingsBackupRestoreEngine.CreateArchive` | Creates the final `.ptb` with create-new semantics relative to the backup-root handle and streams ZIP entries to that handle | Integrated |
+| Manifest write/read | `CreateArchive`, `GetLatestManifest` | Writes and reads `manifest.json` through validated archive/staging handles | Integrated |
+| Retention cleanup | `SettingsBackupRestoreEngine.RemoveOldArchives` | Deletes only validated top-level archive candidates relative to the held backup root | Integrated |
+| Staging cleanup | `SecureDirectoryRoot.DeleteTree` | Deletes app-owned staging files and directories deepest-first through validated handles | Integrated |
+| Restore preview | `SettingsBackupRestoreEngine.CreateRestorePreview` | Lists modules, relative paths, exclusions, create/merge/overwrite actions, and restart behavior; binds confirmation to archive name and SHA-256 | Integrated |
+| Restore archive binding | `SettingsBackupRestoreEngine.Restore` | Reopens the confirmed archive, verifies its SHA-256, and extracts from that same opened handle | Integrated |
+| Restore overwrite | `SecureDirectoryRoot.OpenFileForOverwrite`, `SecureFile.OverwriteAllText` | Rejects reparses and targets without exactly one link before truncating and writing the same handle | Integrated |
+| Restore merge | `SettingsBackupRestoreEngine.Restore`, `JsonSettingsMerge` | Reads, merges, rechecks metadata, truncates, and writes through one held target handle | Integrated |
+| Restore create | `SecureDirectoryRoot.CreateNewFile` | Creates validated non-reparse parents and the new file with create-new semantics | Integrated |
+| Restore UX | `GeneralViewModel.RestoreConfigsClick`, `GeneralPage.ShowRestorePreviewAsync` | Preview failure displays an error and returns without restore; cancellation returns without restore; confirmation remains UX rather than the security boundary | Integrated |
+| Restart/status | `GeneralViewModel.RestoreConfigsClick` | Writes the existing restore timestamp and requests restart only after a successful restore result | Preserved |
 
-## Archive and behavior compatibility checked
+## Compatibility coverage
 
-- Legacy ZIP root shape is unchanged: `manifest.json` and module-relative JSON paths.
-- ZIP validation rejects traversal, rooted/UNC names, ADS names, reserved/ambiguous Windows names, and normalized case/separator collisions before staging.
-- Production `IncludeFiles`, `IgnoreFiles`, `IgnoredSettings`, `IgnoredPTRunSettings`, `CustomRestoreSettings.overwrite`, and `RestartAfterRestore` are parsed and tested against the existing `backup_restore_settings.json`.
-- `JsonSettingsMerge` preserves recursive object merge, scalar replacement, and the legacy behavior that filters values already present in the current array while retaining duplicates from the backup array.
+- Legacy `.ptb` ZIP shape and manifest fields are preserved.
+- `IncludeFiles`, `IgnoreFiles`, `IgnoredSettings`, `IgnoredPTRunSettings`,
+  `CustomRestoreSettings.overwrite`, merge behavior, and `RestartAfterRestore`
+  are covered against the production policy.
+- Archive validation rejects traversal, rooted/UNC entry names, ADS names,
+  reserved or ambiguous Windows names, collisions, and resource-limit abuse.
+- Mocked capability tests cover UNC final-path canonicalization, cloud-placeholder
+  reparse metadata, absent single-link metadata, and fail-closed preview/restore.
 
-## Production integration
+## Physical-filesystem capability gates
 
-`Settings.UI.Library` delegates backup, dry-run comparison, manifest reads, archive cleanup, preview, and restore writes to `SettingsBackupRestoreEngine`. The Settings General page displays a confirmation preview, while archive validation and handle-relative I/O remain mandatory on the subsequent restore.
-
-UNC and OneDrive/cloud-placeholder behavior is a lab-only capability gate. No test in this change contacts a network share or a real synced folder.
+No automated test contacts a real UNC share, cloud-synced folder, or non-NTFS
+volume. Those environments remain lab gates for filesystem-provider behavior;
+unsupported or incomplete metadata fails closed before restore writes.

--- a/src/settings-ui/SettingsBackupRestore.Security/SINK-MATRIX.md
+++ b/src/settings-ui/SettingsBackupRestore.Security/SINK-MATRIX.md
@@ -1,0 +1,43 @@
+# Settings backup/restore sink matrix
+
+`[x]` means the source/sink and its validated replacement primitive were traced.
+
+| Checked | Phase | Production function and exact location | Previous primitive / trust transition | Validated production primitive | Integration state |
+|---|---|---|---|---|---|
+| [x] | All | `GetRegSettingsBackupAndRestoreRegItem` | Registry read selects backup root | Open selected root once with `SecureDirectoryRoot.Open`; canonicalize by handle | Integrated |
+| [x] | All | `GetBackupRestoreSettingsJson` | Relative process-CWD config read | Embedded trusted configuration parsed by `BackupRestorePolicy` | Integrated |
+| [x] | Backup/dry-run | `BackupSettingsInternal` | `Directory.Exists`, prefix string check, optional `Directory.CreateDirectory` on caller paths | Open or create roots through validated handles and enforce final-path containment | Integrated |
+| [x] | Backup/dry-run | `GetSettingsFiles`, `SettingsBackupAndRestoreUtils.cs:560-568` | Recursive path enumeration can cross reparses | Enumerate one directory at a time and validate every traversed directory and file handle | Integrated |
+| [x] | Backup/dry-run | latest archive selection | Path enumeration of `settings_*.ptb` | Validate top-level entries and open the selected archive relative to the held root | Integrated |
+| [x] | Backup/dry-run/restore | `GetLatestSettingsFolder`, `SettingsBackupAndRestoreUtils.cs:414-480` | Predictable `%TEMP%\PowerToys_settings_<time>` plus `ZipFile.ExtractToDirectory` | Validate every ZIP name before writes, then create random `FILE_CREATE` staging and extract through relative handles (`BackupRestoreArchive.cs:25-73,81-111`) | Executable |
+| [x] | Backup/dry-run/restore | `GetSettingsFiles` on extracted folder, call sites `SettingsBackupAndRestoreUtils.cs:303,672` | Reopens extracted paths after validation | Keep staging root handle alive and open every entry relative to it (`SecureDirectoryRoot.cs:214-247`) | Primitive proven; caller integration remains |
+| [x] | Backup/dry-run | `GetExportVersion`, `SettingsBackupAndRestoreUtils.cs:832-879` | `File.ReadAllText(settingsFileName)` reopens source path | `SecureFile.ReadAllText` uses the already validated handle (`SecureFile.cs:38-44`) | Executable |
+| [x] | Backup/dry-run | `BackupSettingsInternal`, `SettingsBackupAndRestoreUtils.cs:690,696` | Reads current and prior JSON for comparison | Same-handle reads under their respective roots; apply `IgnoredSettings` and `IgnoredPTRunSettings` in memory (`BackupRestorePolicy.CreateExportVersion`) | Executable/tested |
+| [x] | Backup | `BackupSettingsInternal`, `SettingsBackupAndRestoreUtils.cs:670,724-730` | Predictable temp directory and path-based updated-file write | `CreateExclusiveStagingDirectory` uses cryptographic names and `FILE_CREATE`; `CreateNewFile` writes the returned handle (`SecureDirectoryRoot.cs:101-146`) | Executable |
+| [x] | Backup | `BackupSettingsInternal`, `SettingsBackupAndRestoreUtils.cs:753-760` | Path-based unchanged-file write | Same exclusive staging/new-file handle primitive | Executable |
+| [x] | Backup | `BackupSettingsInternal`, `SettingsBackupAndRestoreUtils.cs:767-778` | Path-based manifest write | Create manifest with `CreateNewFile`; write same handle | Executable primitive |
+| [x] | Backup | `BackupSettingsInternal`, `SettingsBackupAndRestoreUtils.cs:783-785` | `ZipFile.CreateFromDirectory` creates/reopens final `.ptb` by path | Create final archive relative to backup-root handle with `FILE_CREATE` and stream ZIP to that handle | Integrated |
+| [x] | Backup | staging cleanup | Recursive path cleanup | Delete files and directories deepest-first through validated handles | Integrated |
+| [x] | Backup/restore maintenance | `RemoveOldBackups`, `SettingsBackupAndRestoreUtils.cs:937-1001` | Path enumeration plus recursive directory/file deletion | Validate top-level archive handles and delete relative to the held backup root; staging cleanup is handle-relative and deepest-first | Integrated |
+| [x] | Restore | `RestoreSettings`, `SettingsBackupAndRestoreUtils.cs:279-303` | Path existence probes and path dictionaries define roots | Open app, archive, and staging roots by handle; all child access is relative | Executable primitive |
+| [x] | Restore | `RestoreSettings`, `SettingsBackupAndRestoreUtils.cs:316,321` | Backup/current JSON path reads | Same-handle `SecureFile.ReadAllText` | Executable |
+| [x] | Restore overwrite | `RestoreSettings`, `SettingsBackupAndRestoreUtils.cs:328-339` | `File.WriteAllText` truncates an existing path after path-only decisions | `OpenFileForOverwrite` checks reparse metadata and `NumberOfLinks == 1` before `SecureFile.OverwriteAllText` truncates the same handle (`SecureDirectoryRoot.cs:89-96`; `SecureFile.cs:47-65`) | Executable |
+| [x] | Restore merge | `RestoreSettings`, `SettingsBackupAndRestoreUtils.cs:341-344` | Reopens once to read and again to truncate/write | Read, merge, recheck metadata, truncate, and write one held handle; compatible merge is executable in `JsonSettingsMerge.cs` | Executable |
+| [x] | Restore new file | `RestoreSettings`, `SettingsBackupAndRestoreUtils.cs:350-357` | Path-based parent creation and create-or-truncate write | Walk/create non-reparse parents relative to root and use `FILE_CREATE` for the file (`SecureDirectoryRoot.cs:250-294`) | Executable |
+| [x] | Restore UX/status | `GetLatestSettingsBackupManifest`, `SettingsBackupAndRestoreUtils.cs:511-520` | Path-based manifest read | Open `manifest.json` relative to held staging root and read same handle | Executable primitive |
+| [x] | Restore UX/status | `GeneralViewModel.RestoreConfigsClick`, `GeneralViewModel.cs:1085-1111` | Confirmation is absent; successful restore writes last-restore registry value and restarts | `RestorePreviewViewModel` lists modules, paths, exclusions, create/merge/overwrite, and restart; its security-boundary statement forbids treating confirmation as enforcement | Executable/tested model |
+| [x] | Backup UX/status | `GeneralViewModel.BackupConfigsClick`, `GeneralViewModel.cs:1119-1137`; `GeneralPage.RefreshBackupRestoreStatus`, `GeneralPage.xaml.cs:136-152` | Real backup followed by dry-run; dry-run still reads archive/current roots | Reuse the same root/entry validators for both real and dry-run paths; dry-run performs no writes | Design traced |
+| [x] | Registry status | `SetRegSettingsBackupAndRestoreItem`, `SettingsBackupAndRestoreUtils.cs:228-242`; callers `GeneralViewModel.cs:766,1109` | Registry writes backup directory and restore timestamp | Not a filesystem boundary; retain behavior after secure filesystem operation succeeds | Preserve |
+
+## Archive and behavior compatibility checked
+
+- Legacy ZIP root shape is unchanged: `manifest.json` and module-relative JSON paths.
+- ZIP validation rejects traversal, rooted/UNC names, ADS names, reserved/ambiguous Windows names, and normalized case/separator collisions before staging.
+- Production `IncludeFiles`, `IgnoreFiles`, `IgnoredSettings`, `IgnoredPTRunSettings`, `CustomRestoreSettings.overwrite`, and `RestartAfterRestore` are parsed and tested against the existing `backup_restore_settings.json`.
+- `JsonSettingsMerge` preserves recursive object merge, scalar replacement, and the legacy behavior that filters values already present in the current array while retaining duplicates from the backup array.
+
+## Production integration
+
+`Settings.UI.Library` delegates backup, dry-run comparison, manifest reads, archive cleanup, preview, and restore writes to `SettingsBackupRestoreEngine`. The Settings General page displays a confirmation preview, while archive validation and handle-relative I/O remain mandatory on the subsequent restore.
+
+UNC and OneDrive/cloud-placeholder behavior is a lab-only capability gate. No test in this change contacts a network share or a real synced folder.

--- a/src/settings-ui/SettingsBackupRestore.Security/SecureDirectoryRoot.cs
+++ b/src/settings-ui/SettingsBackupRestore.Security/SecureDirectoryRoot.cs
@@ -112,15 +112,7 @@ public sealed class SecureDirectoryRoot : IDisposable
         try
         {
             FileHandleMetadata metadata = GetMetadata(rootHandle);
-            if (!metadata.IsDirectory)
-            {
-                throw new IOException($"Security root is not a directory: {path}");
-            }
-
-            if (metadata.IsReparsePoint)
-            {
-                throw new IOException($"Security root must not be a reparse point: {path}");
-            }
+            ValidateMetadata(metadata, expectDirectory: true, rejectHardLinks: false);
 
             return new SecureDirectoryRoot(rootHandle, GetFinalPath(rootHandle));
         }
@@ -168,6 +160,21 @@ public sealed class SecureDirectoryRoot : IDisposable
         ThrowIfDisposed();
         string normalized = SecurePath.NormalizeRelative(relativePath);
         using SafeFileHandle directory = OpenDirectoryChain(normalized.Split('\\'), createMissing: true, exclusiveLast: false);
+    }
+
+    internal bool DirectoryExists(string relativePath)
+    {
+        ThrowIfDisposed();
+        string normalized = SecurePath.NormalizeRelative(relativePath);
+        try
+        {
+            using SafeFileHandle directory = OpenDirectoryChain(normalized.Split('\\'), createMissing: false, exclusiveLast: false);
+            return true;
+        }
+        catch (Win32Exception exception) when (exception.NativeErrorCode is 2 or 3)
+        {
+            return false;
+        }
     }
 
     /// <summary>
@@ -689,6 +696,20 @@ public sealed class SecureDirectoryRoot : IDisposable
     private string ValidateOpenedHandle(SafeFileHandle openedHandle, bool expectDirectory, bool rejectHardLinks)
     {
         FileHandleMetadata metadata = GetMetadata(openedHandle);
+        ValidateMetadata(metadata, expectDirectory, rejectHardLinks);
+
+        string finalPath = GetFinalPath(openedHandle);
+        string currentRootPath = GetFinalPath(handle);
+        if (!SecurePath.IsContained(currentRootPath, finalPath))
+        {
+            throw new IOException($"Opened handle escaped its root: {finalPath}");
+        }
+
+        return finalPath;
+    }
+
+    internal static void ValidateMetadata(FileHandleMetadata metadata, bool expectDirectory, bool rejectHardLinks)
+    {
         if (metadata.IsDirectory != expectDirectory)
         {
             throw new IOException(expectDirectory ? "Expected a directory." : "Expected a file.");
@@ -703,15 +724,6 @@ public sealed class SecureDirectoryRoot : IDisposable
         {
             throw new IOException($"Existing target has {metadata.LinkCount} hard links; overwrite rejected before truncation.");
         }
-
-        string finalPath = GetFinalPath(openedHandle);
-        string currentRootPath = GetFinalPath(handle);
-        if (!SecurePath.IsContained(currentRootPath, finalPath))
-        {
-            throw new IOException($"Opened handle escaped its root: {finalPath}");
-        }
-
-        return finalPath;
     }
 
     private static SafeFileHandle OpenRelative(

--- a/src/settings-ui/SettingsBackupRestore.Security/SecureDirectoryRoot.cs
+++ b/src/settings-ui/SettingsBackupRestore.Security/SecureDirectoryRoot.cs
@@ -1,0 +1,875 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+
+using Microsoft.Win32.SafeHandles;
+
+namespace Microsoft.PowerToys.SettingsBackupRestore.Security;
+
+/// <summary>
+/// A directory root kept open while child objects are opened relative to its handle.
+/// </summary>
+public sealed class SecureDirectoryRoot : IDisposable
+{
+    internal const uint ReadOnlyDirectoryAccess = NativeMethods.FileReadData | NativeMethods.FileReadAttributes | NativeMethods.Synchronize;
+    internal const uint WritableDirectoryAccess = NativeMethods.FileReadData | NativeMethods.FileWriteData | NativeMethods.FileAppendData |
+                                                  NativeMethods.FileReadAttributes | NativeMethods.FileWriteAttributes | NativeMethods.Synchronize;
+
+    private readonly SafeFileHandle handle;
+    private bool disposed;
+
+    private SecureDirectoryRoot(SafeFileHandle handle, string finalPath)
+    {
+        this.handle = handle;
+        FinalPath = finalPath;
+    }
+
+    /// <summary>
+    /// Gets the canonical path returned for the root handle.
+    /// </summary>
+    public string FinalPath { get; }
+
+    internal Action<uint>? DirectoryOpenAccessObserver { get; set; }
+
+    internal Action<string>? DirectoryBeforeValidationObserver { get; set; }
+
+    /// <summary>
+    /// Opens a real directory as a security root and rejects a reparse point at the root path.
+    /// </summary>
+    public static SecureDirectoryRoot Open(string path)
+    {
+        return Open(path, writable: true);
+    }
+
+    /// <summary>
+    /// Opens a real directory with only the rights needed to read children.
+    /// </summary>
+    public static SecureDirectoryRoot OpenReadOnly(string path)
+    {
+        return Open(path, writable: false);
+    }
+
+    /// <summary>
+    /// Creates a missing directory tree through an existing ancestor handle, then opens the requested root.
+    /// </summary>
+    public static SecureDirectoryRoot OpenOrCreate(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        string fullPath = Path.GetFullPath(path);
+        if (Directory.Exists(fullPath))
+        {
+            return Open(fullPath);
+        }
+
+        string? ancestor = Path.GetDirectoryName(fullPath);
+        while (!string.IsNullOrEmpty(ancestor) && !Directory.Exists(ancestor))
+        {
+            ancestor = Path.GetDirectoryName(ancestor);
+        }
+
+        if (string.IsNullOrEmpty(ancestor))
+        {
+            throw new DirectoryNotFoundException($"No existing ancestor was found for {fullPath}.");
+        }
+
+        using (SecureDirectoryRoot ancestorRoot = Open(ancestor))
+        {
+            string relativePath = Path.GetRelativePath(ancestor, fullPath);
+            ancestorRoot.CreateDirectory(relativePath);
+        }
+
+        return Open(fullPath);
+    }
+
+    private static SecureDirectoryRoot Open(string path, bool writable)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        SafeFileHandle rootHandle = NativeMethods.CreateFileW(
+            Path.GetFullPath(path),
+            writable ? WritableDirectoryAccess : ReadOnlyDirectoryAccess,
+            NativeMethods.FileShareRead | NativeMethods.FileShareWrite | NativeMethods.FileShareDelete,
+            IntPtr.Zero,
+            NativeMethods.OpenExisting,
+            NativeMethods.FileFlagBackupSemantics | NativeMethods.FileFlagOpenReparsePoint,
+            IntPtr.Zero);
+
+        if (rootHandle.IsInvalid)
+        {
+            int error = Marshal.GetLastWin32Error();
+            rootHandle.Dispose();
+            throw new Win32Exception(error, $"Could not open security root: {path}");
+        }
+
+        try
+        {
+            FileHandleMetadata metadata = GetMetadata(rootHandle);
+            if (!metadata.IsDirectory)
+            {
+                throw new IOException($"Security root is not a directory: {path}");
+            }
+
+            if (metadata.IsReparsePoint)
+            {
+                throw new IOException($"Security root must not be a reparse point: {path}");
+            }
+
+            return new SecureDirectoryRoot(rootHandle, GetFinalPath(rootHandle));
+        }
+        catch
+        {
+            rootHandle.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Opens a non-reparse file for same-handle reads.
+    /// </summary>
+    public SecureFile OpenFileForRead(string relativePath, FileShare share = FileShare.Read)
+    {
+        return OpenFile(relativePath, FileAccess.Read, share, createNew: false, createParents: false, rejectHardLinks: false);
+    }
+
+    /// <summary>
+    /// Opens a non-reparse, single-link file for same-handle overwrite without truncating it.
+    /// </summary>
+    public SecureFile OpenFileForOverwrite(string relativePath, FileShare share = FileShare.None)
+    {
+        return OpenFile(relativePath, FileAccess.ReadWrite, share, createNew: false, createParents: false, rejectHardLinks: true);
+    }
+
+    /// <summary>
+    /// Creates a new file exclusively below this root and returns the exact handle to write.
+    /// </summary>
+    public SecureFile CreateNewFile(string relativePath)
+    {
+        return OpenFile(relativePath, FileAccess.ReadWrite, FileShare.None, createNew: true, createParents: true, rejectHardLinks: false);
+    }
+
+    internal SecureFile CreateNewFileInExistingDirectory(string relativePath)
+    {
+        return OpenFile(relativePath, FileAccess.ReadWrite, FileShare.None, createNew: true, createParents: false, rejectHardLinks: false);
+    }
+
+    /// <summary>
+    /// Creates a directory and its parents without following reparse points.
+    /// </summary>
+    public void CreateDirectory(string relativePath)
+    {
+        ThrowIfDisposed();
+        string normalized = SecurePath.NormalizeRelative(relativePath);
+        using SafeFileHandle directory = OpenDirectoryChain(normalized.Split('\\'), createMissing: true, exclusiveLast: false);
+    }
+
+    /// <summary>
+    /// Enumerates regular files below this root while validating each traversed directory and file handle.
+    /// </summary>
+    public IReadOnlyList<string> EnumerateFiles(bool recursive = true, Func<string, bool>? fileFilter = null)
+    {
+        ThrowIfDisposed();
+        List<string> files = [];
+        EnumerateFiles(files, string.Empty, recursive, fileFilter);
+        return files;
+    }
+
+    /// <summary>
+    /// Removes all validated entries below this app-owned root and marks the root itself for deletion.
+    /// </summary>
+    public void DeleteTree()
+    {
+        ThrowIfDisposed();
+        DeleteTreeContents();
+        DeleteSelf();
+    }
+
+    internal void CreateNewDirectory(string relativePath)
+    {
+        ThrowIfDisposed();
+        string normalized = SecurePath.NormalizeRelative(relativePath);
+        string[] components = normalized.Split('\\');
+        SafeFileHandle? parentHandle = null;
+
+        try
+        {
+            SafeFileHandle effectiveParent = handle;
+            if (components.Length > 1)
+            {
+                parentHandle = OpenDirectoryChain(components[..^1], createMissing: false, exclusiveLast: false);
+                effectiveParent = parentHandle;
+            }
+
+            SafeFileHandle directoryHandle = OpenRelative(
+                effectiveParent,
+                components[^1],
+                WritableDirectoryAccess | NativeMethods.Delete,
+                NativeMethods.FileShareRead | NativeMethods.FileShareWrite | NativeMethods.FileShareDelete,
+                NativeMethods.FileCreate,
+                NativeMethods.FileDirectoryFile | NativeMethods.FileOpenReparsePoint | NativeMethods.FileSynchronousIoNonAlert);
+            try
+            {
+                DirectoryBeforeValidationObserver?.Invoke(normalized);
+                ValidateOpenedHandle(directoryHandle, expectDirectory: true, rejectHardLinks: false);
+            }
+            catch (Exception validationException)
+            {
+                try
+                {
+                    MarkForDeletion(directoryHandle);
+                }
+                catch (Exception cleanupException)
+                {
+                    validationException.Data["CreatedDirectoryCleanupError"] = cleanupException;
+                }
+                finally
+                {
+                    directoryHandle.Dispose();
+                }
+
+                throw;
+            }
+
+            directoryHandle.Dispose();
+        }
+        finally
+        {
+            parentHandle?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Creates an unpredictable child directory with create-new semantics and keeps its handle open.
+    /// </summary>
+    public SecureDirectoryRoot CreateExclusiveStagingDirectory(string prefix = "PowerToysRestore-")
+    {
+        return CreateExclusiveStagingDirectory(prefix, static () => RandomNumberGenerator.GetHexString(32).ToLowerInvariant(), beforeValidation: null);
+    }
+
+    internal SecureDirectoryRoot CreateExclusiveStagingDirectory(
+        string prefix,
+        Func<string> suffixFactory,
+        Action? beforeValidation = null)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(suffixFactory);
+        if (string.IsNullOrWhiteSpace(prefix) || prefix.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+        {
+            throw new ArgumentException("The staging prefix is not a valid file-name prefix.", nameof(prefix));
+        }
+
+        for (int attempt = 0; attempt < 32; attempt++)
+        {
+            string childName = prefix + suffixFactory();
+            SecurePath.NormalizeRelative(childName);
+            SafeFileHandle childHandle;
+            try
+            {
+                childHandle = OpenRelative(
+                    handle,
+                    childName,
+                    WritableDirectoryAccess | NativeMethods.Delete,
+                    NativeMethods.FileShareRead | NativeMethods.FileShareWrite | NativeMethods.FileShareDelete,
+                    NativeMethods.FileCreate,
+                    NativeMethods.FileDirectoryFile | NativeMethods.FileOpenReparsePoint | NativeMethods.FileSynchronousIoNonAlert);
+            }
+            catch (Win32Exception ex) when (ex.NativeErrorCode is 80 or 183)
+            {
+                // A cryptographically random collision is retried without opening an existing directory.
+                continue;
+            }
+
+            try
+            {
+                beforeValidation?.Invoke();
+                string childFinalPath = ValidateOpenedHandle(childHandle, expectDirectory: true, rejectHardLinks: false);
+                return new SecureDirectoryRoot(childHandle, childFinalPath);
+            }
+            catch (Exception validationException)
+            {
+                try
+                {
+                    MarkForDeletion(childHandle);
+                }
+                catch (Exception cleanupException)
+                {
+                    validationException.Data["StagingCleanupError"] = cleanupException;
+                }
+                finally
+                {
+                    childHandle.Dispose();
+                }
+
+                throw;
+            }
+        }
+
+        throw new IOException("Could not create an exclusive staging directory.");
+    }
+
+    internal void DeleteEntry(string relativePath, bool isDirectory)
+    {
+        ThrowIfDisposed();
+        string normalized = SecurePath.NormalizeRelative(relativePath);
+        string[] components = normalized.Split('\\');
+        SafeFileHandle? parentHandle = null;
+
+        try
+        {
+            SafeFileHandle effectiveParent = handle;
+            if (components.Length > 1)
+            {
+                parentHandle = OpenDirectoryChain(components[..^1], createMissing: false, exclusiveLast: false);
+                effectiveParent = parentHandle;
+            }
+
+            uint createOptions = (isDirectory ? NativeMethods.FileDirectoryFile : NativeMethods.FileNonDirectoryFile) |
+                                 NativeMethods.FileOpenReparsePoint |
+                                 NativeMethods.FileSynchronousIoNonAlert;
+            using SafeFileHandle entryHandle = OpenRelative(
+                effectiveParent,
+                components[^1],
+                NativeMethods.Delete | NativeMethods.FileReadAttributes | NativeMethods.Synchronize,
+                NativeMethods.FileShareRead | NativeMethods.FileShareWrite | NativeMethods.FileShareDelete,
+                NativeMethods.FileOpen,
+                createOptions);
+            ValidateOpenedHandle(entryHandle, expectDirectory: isDirectory, rejectHardLinks: !isDirectory);
+            MarkForDeletion(entryHandle);
+        }
+        finally
+        {
+            parentHandle?.Dispose();
+        }
+    }
+
+    internal void DeleteSelf()
+    {
+        ThrowIfDisposed();
+        MarkForDeletion(handle);
+    }
+
+    private void EnumerateFiles(List<string> files, string relativeDirectory, bool recursive, Func<string, bool>? fileFilter)
+    {
+        string directoryPath = string.IsNullOrEmpty(relativeDirectory) ? FinalPath : Path.Combine(FinalPath, relativeDirectory);
+        foreach (string entryPath in Directory.EnumerateFileSystemEntries(directoryPath, "*", SearchOption.TopDirectoryOnly))
+        {
+            string name = Path.GetFileName(entryPath);
+            string relativePath = string.IsNullOrEmpty(relativeDirectory) ? name : Path.Combine(relativeDirectory, name);
+            FileAttributes attributes = File.GetAttributes(entryPath);
+            if ((attributes & FileAttributes.Directory) != 0)
+            {
+                if (!recursive)
+                {
+                    continue;
+                }
+
+                using SecureDirectoryRoot child = OpenSubdirectory(relativePath);
+                foreach (string childFile in child.EnumerateFiles(fileFilter: childPath => fileFilter?.Invoke(Path.Combine(relativePath, childPath)) ?? true))
+                {
+                    files.Add(Path.Combine(relativePath, childFile));
+                }
+            }
+            else
+            {
+                if (fileFilter?.Invoke(relativePath) == false)
+                {
+                    continue;
+                }
+
+                using SecureFile file = OpenFileForRead(relativePath);
+                files.Add(relativePath);
+            }
+        }
+    }
+
+    private SecureDirectoryRoot OpenSubdirectory(string relativePath)
+    {
+        string normalized = SecurePath.NormalizeRelative(relativePath);
+        SafeFileHandle directoryHandle = OpenDirectoryChain(normalized.Split('\\'), createMissing: false, exclusiveLast: false);
+        try
+        {
+            string finalPath = ValidateOpenedHandle(directoryHandle, expectDirectory: true, rejectHardLinks: false);
+            return new SecureDirectoryRoot(directoryHandle, finalPath);
+        }
+        catch
+        {
+            directoryHandle.Dispose();
+            throw;
+        }
+    }
+
+    private void DeleteTreeContents()
+    {
+        foreach (string entryPath in Directory.EnumerateFileSystemEntries(FinalPath, "*", SearchOption.TopDirectoryOnly).ToArray())
+        {
+            string name = Path.GetFileName(entryPath);
+            FileAttributes attributes = File.GetAttributes(entryPath);
+            if ((attributes & FileAttributes.Directory) != 0)
+            {
+                using (SecureDirectoryRoot child = OpenSubdirectory(name))
+                {
+                    child.DeleteTreeContents();
+                }
+
+                DeleteEntry(name, isDirectory: true);
+            }
+            else
+            {
+                DeleteEntry(name, isDirectory: false);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (!disposed)
+        {
+            handle.Dispose();
+            disposed = true;
+        }
+    }
+
+    internal static FileHandleMetadata GetMetadata(SafeFileHandle fileHandle)
+    {
+        if (!NativeMethods.GetFileInformationByHandleEx(
+                fileHandle,
+                NativeMethods.FileInfoByHandleClass.FileAttributeTagInfo,
+                out NativeMethods.FileAttributeTagInfo attributeInfo,
+                (uint)Marshal.SizeOf<NativeMethods.FileAttributeTagInfo>()))
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "Could not query reparse metadata.");
+        }
+
+        if (!NativeMethods.GetFileInformationByHandleEx(
+                fileHandle,
+                NativeMethods.FileInfoByHandleClass.FileStandardInfo,
+                out NativeMethods.FileStandardInfo standardInfo,
+                (uint)Marshal.SizeOf<NativeMethods.FileStandardInfo>()))
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "Could not query standard file metadata.");
+        }
+
+        bool isReparsePoint = (((FileAttributes)attributeInfo.FileAttributes) & FileAttributes.ReparsePoint) != 0;
+        return new FileHandleMetadata(
+            standardInfo.Directory,
+            isReparsePoint,
+            attributeInfo.ReparseTag,
+            standardInfo.NumberOfLinks,
+            standardInfo.EndOfFile);
+    }
+
+    internal static string GetFinalPath(SafeFileHandle fileHandle)
+    {
+        char[] buffer = new char[512];
+        while (true)
+        {
+            uint length = NativeMethods.GetFinalPathNameByHandleW(fileHandle, buffer, (uint)buffer.Length, 0);
+            if (length == 0)
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error(), "Could not query final path by handle.");
+            }
+
+            if (length < buffer.Length)
+            {
+                return SecurePath.NormalizeFinalPath(new string(buffer, 0, checked((int)length)));
+            }
+
+            buffer = new char[checked((int)length + 1)];
+        }
+    }
+
+    private SecureFile OpenFile(
+        string relativePath,
+        FileAccess access,
+        FileShare share,
+        bool createNew,
+        bool createParents,
+        bool rejectHardLinks)
+    {
+        ThrowIfDisposed();
+        string normalized = SecurePath.NormalizeRelative(relativePath);
+        string[] components = normalized.Split('\\');
+        SafeFileHandle? parentHandle = null;
+        List<string> createdDirectories = [];
+
+        try
+        {
+            SafeFileHandle effectiveParent = handle;
+            if (components.Length > 1)
+            {
+                parentHandle = OpenDirectoryChain(
+                    components[..^1],
+                    createMissing: createParents,
+                    exclusiveLast: false,
+                    createdDirectories);
+                effectiveParent = parentHandle;
+            }
+
+            uint desiredAccess = AccessMask(access) | (createNew ? NativeMethods.Delete : 0);
+            uint shareAccess = ShareMask(share);
+            SafeFileHandle fileHandle = OpenRelative(
+                effectiveParent,
+                components[^1],
+                desiredAccess,
+                shareAccess,
+                createNew ? NativeMethods.FileCreate : NativeMethods.FileOpen,
+                NativeMethods.FileNonDirectoryFile | NativeMethods.FileOpenReparsePoint | NativeMethods.FileSynchronousIoNonAlert);
+
+            try
+            {
+                string finalPath = ValidateOpenedHandle(fileHandle, expectDirectory: false, rejectHardLinks);
+                return new SecureFile(fileHandle, access, finalPath);
+            }
+            catch (Exception validationException)
+            {
+                if (createNew)
+                {
+                    try
+                    {
+                        MarkForDeletion(fileHandle);
+                    }
+                    catch (Exception cleanupException)
+                    {
+                        validationException.Data["CreatedFileCleanupError"] = cleanupException;
+                    }
+                }
+
+                fileHandle.Dispose();
+                throw;
+            }
+        }
+        catch (Exception exception)
+        {
+            RollbackCreatedDirectories(createdDirectories, exception);
+            throw;
+        }
+        finally
+        {
+            parentHandle?.Dispose();
+        }
+    }
+
+    private SafeFileHandle OpenDirectoryChain(
+        string[] components,
+        bool createMissing,
+        bool exclusiveLast,
+        List<string>? createdDirectories = null)
+    {
+        SafeFileHandle current = handle;
+        SafeFileHandle? ownedCurrent = null;
+        List<string> created = createdDirectories ?? [];
+        int initialCreatedCount = created.Count;
+
+        try
+        {
+            for (int index = 0; index < components.Length; index++)
+            {
+                bool createExclusively = createMissing && exclusiveLast && index == components.Length - 1;
+                uint desiredAccess;
+                SafeFileHandle next;
+                bool wasCreated;
+                if (!createMissing)
+                {
+                    desiredAccess = ReadOnlyDirectoryAccess;
+                    next = OpenRelative(
+                        current,
+                        components[index],
+                        desiredAccess,
+                        NativeMethods.FileShareRead | NativeMethods.FileShareWrite | NativeMethods.FileShareDelete,
+                        NativeMethods.FileOpen,
+                        NativeMethods.FileDirectoryFile | NativeMethods.FileOpenReparsePoint | NativeMethods.FileSynchronousIoNonAlert,
+                        out wasCreated);
+                }
+                else if (createExclusively)
+                {
+                    desiredAccess = WritableDirectoryAccess | NativeMethods.Delete;
+                    next = OpenRelative(
+                        current,
+                        components[index],
+                        desiredAccess,
+                        NativeMethods.FileShareRead | NativeMethods.FileShareWrite | NativeMethods.FileShareDelete,
+                        NativeMethods.FileCreate,
+                        NativeMethods.FileDirectoryFile | NativeMethods.FileOpenReparsePoint | NativeMethods.FileSynchronousIoNonAlert,
+                        out wasCreated);
+                }
+                else
+                {
+                    try
+                    {
+                        desiredAccess = ReadOnlyDirectoryAccess;
+                        next = OpenRelative(
+                            current,
+                            components[index],
+                            desiredAccess,
+                            NativeMethods.FileShareRead | NativeMethods.FileShareWrite | NativeMethods.FileShareDelete,
+                            NativeMethods.FileOpen,
+                            NativeMethods.FileDirectoryFile | NativeMethods.FileOpenReparsePoint | NativeMethods.FileSynchronousIoNonAlert,
+                            out wasCreated);
+                    }
+                    catch (Win32Exception exception) when (exception.NativeErrorCode is 2 or 3)
+                    {
+                        desiredAccess = WritableDirectoryAccess | NativeMethods.Delete;
+                        next = OpenRelative(
+                            current,
+                            components[index],
+                            desiredAccess,
+                            NativeMethods.FileShareRead | NativeMethods.FileShareWrite | NativeMethods.FileShareDelete,
+                            NativeMethods.FileCreate,
+                            NativeMethods.FileDirectoryFile | NativeMethods.FileOpenReparsePoint | NativeMethods.FileSynchronousIoNonAlert,
+                            out wasCreated);
+                    }
+                }
+
+                DirectoryOpenAccessObserver?.Invoke(desiredAccess);
+
+                try
+                {
+                    DirectoryBeforeValidationObserver?.Invoke(string.Join('\\', components[..(index + 1)]));
+                    ValidateOpenedHandle(next, expectDirectory: true, rejectHardLinks: false);
+                }
+                catch (Exception validationException)
+                {
+                    if (wasCreated)
+                    {
+                        try
+                        {
+                            MarkForDeletion(next);
+                        }
+                        catch (Exception cleanupException)
+                        {
+                            validationException.Data["CreatedDirectoryCleanupError"] = cleanupException;
+                        }
+                    }
+
+                    next.Dispose();
+                    throw;
+                }
+
+                if (wasCreated)
+                {
+                    created.Add(string.Join('\\', components[..(index + 1)]));
+                }
+
+                ownedCurrent?.Dispose();
+                ownedCurrent = next;
+                current = next;
+            }
+
+            SafeFileHandle result = ownedCurrent ?? throw new InvalidOperationException("No directory component was opened.");
+            ownedCurrent = null;
+            return result;
+        }
+        catch (Exception exception)
+        {
+            ownedCurrent?.Dispose();
+            ownedCurrent = null;
+            if (created.Count > initialCreatedCount)
+            {
+                List<string> currentAttempt = created.GetRange(initialCreatedCount, created.Count - initialCreatedCount);
+                created.RemoveRange(initialCreatedCount, created.Count - initialCreatedCount);
+                RollbackCreatedDirectories(currentAttempt, exception);
+            }
+
+            throw;
+        }
+        finally
+        {
+            ownedCurrent?.Dispose();
+        }
+    }
+
+    private string ValidateOpenedHandle(SafeFileHandle openedHandle, bool expectDirectory, bool rejectHardLinks)
+    {
+        FileHandleMetadata metadata = GetMetadata(openedHandle);
+        if (metadata.IsDirectory != expectDirectory)
+        {
+            throw new IOException(expectDirectory ? "Expected a directory." : "Expected a file.");
+        }
+
+        if (metadata.IsReparsePoint)
+        {
+            throw new IOException($"Reparse point rejected (tag 0x{metadata.ReparseTag:X8}).");
+        }
+
+        if (rejectHardLinks && metadata.LinkCount != 1)
+        {
+            throw new IOException($"Existing target has {metadata.LinkCount} hard links; overwrite rejected before truncation.");
+        }
+
+        string finalPath = GetFinalPath(openedHandle);
+        string currentRootPath = GetFinalPath(handle);
+        if (!SecurePath.IsContained(currentRootPath, finalPath))
+        {
+            throw new IOException($"Opened handle escaped its root: {finalPath}");
+        }
+
+        return finalPath;
+    }
+
+    private static SafeFileHandle OpenRelative(
+        SafeFileHandle parent,
+        string name,
+        uint desiredAccess,
+        uint shareAccess,
+        uint disposition,
+        uint createOptions)
+    {
+        return OpenRelative(parent, name, desiredAccess, shareAccess, disposition, createOptions, out _);
+    }
+
+    private static SafeFileHandle OpenRelative(
+        SafeFileHandle parent,
+        string name,
+        uint desiredAccess,
+        uint shareAccess,
+        uint disposition,
+        uint createOptions,
+        out bool wasCreated)
+    {
+        IntPtr nameBuffer = IntPtr.Zero;
+        IntPtr unicodeStringPointer = IntPtr.Zero;
+        bool parentReferenceAdded = false;
+
+        try
+        {
+            nameBuffer = Marshal.StringToHGlobalUni(name);
+            NativeMethods.UnicodeString unicodeString = new()
+            {
+                Length = checked((ushort)(name.Length * sizeof(char))),
+                MaximumLength = checked((ushort)((name.Length + 1) * sizeof(char))),
+                Buffer = nameBuffer,
+            };
+
+            unicodeStringPointer = Marshal.AllocHGlobal(Marshal.SizeOf<NativeMethods.UnicodeString>());
+            Marshal.StructureToPtr(unicodeString, unicodeStringPointer, fDeleteOld: false);
+
+            parent.DangerousAddRef(ref parentReferenceAdded);
+            NativeMethods.ObjectAttributes objectAttributes = new()
+            {
+                Length = Marshal.SizeOf<NativeMethods.ObjectAttributes>(),
+                RootDirectory = parent.DangerousGetHandle(),
+                ObjectName = unicodeStringPointer,
+                Attributes = NativeMethods.ObjCaseInsensitive,
+            };
+
+            uint status = NativeMethods.NtCreateFile(
+                out SafeFileHandle fileHandle,
+                desiredAccess,
+                ref objectAttributes,
+                out NativeMethods.IoStatusBlock ioStatusBlock,
+                IntPtr.Zero,
+                (uint)FileAttributes.Normal,
+                shareAccess,
+                disposition,
+                createOptions,
+                IntPtr.Zero,
+                0);
+
+            if (unchecked((int)status) < 0)
+            {
+                fileHandle?.Dispose();
+                int error = checked((int)NativeMethods.RtlNtStatusToDosError(status));
+                throw new Win32Exception(error, $"Handle-relative open failed for '{name}'.");
+            }
+
+            wasCreated = ioStatusBlock.Information == new IntPtr(2);
+            return fileHandle;
+        }
+        finally
+        {
+            if (parentReferenceAdded)
+            {
+                parent.DangerousRelease();
+            }
+
+            if (unicodeStringPointer != IntPtr.Zero)
+            {
+                Marshal.FreeHGlobal(unicodeStringPointer);
+            }
+
+            if (nameBuffer != IntPtr.Zero)
+            {
+                Marshal.FreeHGlobal(nameBuffer);
+            }
+        }
+    }
+
+    private static uint AccessMask(FileAccess access)
+    {
+        return access switch
+        {
+            FileAccess.Read => NativeMethods.GenericRead | NativeMethods.Synchronize,
+            FileAccess.Write => NativeMethods.GenericWrite | NativeMethods.Synchronize,
+            FileAccess.ReadWrite => NativeMethods.GenericRead | NativeMethods.GenericWrite | NativeMethods.Synchronize,
+            _ => throw new ArgumentOutOfRangeException(nameof(access)),
+        };
+    }
+
+    private static uint ShareMask(FileShare share)
+    {
+        uint result = 0;
+        if ((share & FileShare.Read) != 0)
+        {
+            result |= NativeMethods.FileShareRead;
+        }
+
+        if ((share & FileShare.Write) != 0)
+        {
+            result |= NativeMethods.FileShareWrite;
+        }
+
+        if ((share & FileShare.Delete) != 0)
+        {
+            result |= NativeMethods.FileShareDelete;
+        }
+
+        return result;
+    }
+
+    private static void MarkForDeletion(SafeFileHandle fileHandle)
+    {
+        NativeMethods.FileDispositionInfo disposition = new() { DeleteFile = true };
+        if (!NativeMethods.SetFileInformationByHandle(
+                fileHandle,
+                NativeMethods.FileInfoByHandleClass.FileDispositionInfo,
+                ref disposition,
+                (uint)Marshal.SizeOf<NativeMethods.FileDispositionInfo>()))
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "Could not delete app-owned staging entry by handle.");
+        }
+    }
+
+    private void RollbackCreatedDirectories(List<string> createdDirectories, Exception originalException)
+    {
+        List<Exception> cleanupErrors = [];
+        for (int index = createdDirectories.Count - 1; index >= 0; index--)
+        {
+            try
+            {
+                DeleteEntry(createdDirectories[index], isDirectory: true);
+            }
+            catch (Exception cleanupException)
+            {
+                cleanupErrors.Add(cleanupException);
+            }
+        }
+
+        if (cleanupErrors.Count > 0)
+        {
+            originalException.Data["CreatedDirectoryCleanupErrors"] = cleanupErrors.ToArray();
+        }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+    }
+}

--- a/src/settings-ui/SettingsBackupRestore.Security/SecureFile.cs
+++ b/src/settings-ui/SettingsBackupRestore.Security/SecureFile.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Text;
+
+using Microsoft.Win32.SafeHandles;
+
+namespace Microsoft.PowerToys.SettingsBackupRestore.Security;
+
+/// <summary>
+/// A file stream bound to the same validated handle for metadata checks and I/O.
+/// </summary>
+public sealed class SecureFile : IDisposable
+{
+    private static readonly UTF8Encoding Utf8WithoutBom = new(encoderShouldEmitUTF8Identifier: false);
+    private readonly FileStream stream;
+
+    internal SecureFile(SafeFileHandle handle, FileAccess access, string finalPath)
+    {
+        stream = new FileStream(handle, access, bufferSize: 4096, isAsync: false);
+        FinalPath = finalPath;
+    }
+
+    /// <summary>
+    /// Gets the canonical path captured from this file handle.
+    /// </summary>
+    public string FinalPath { get; }
+
+    /// <summary>
+    /// Gets current metadata from this file handle.
+    /// </summary>
+    public FileHandleMetadata Metadata => SecureDirectoryRoot.GetMetadata(stream.SafeFileHandle);
+
+    /// <summary>
+    /// Reads all UTF-8 text from this handle without reopening its path.
+    /// </summary>
+    public string ReadAllText()
+    {
+        stream.Position = 0;
+        using StreamReader reader = new(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 4096, leaveOpen: true);
+        return reader.ReadToEnd();
+    }
+
+    /// <summary>
+    /// Rejects reparse points and hard links, then truncates and writes through this same handle.
+    /// </summary>
+    public void OverwriteAllText(string contents)
+    {
+        ArgumentNullException.ThrowIfNull(contents);
+        FileHandleMetadata metadata = Metadata;
+        if (metadata.IsReparsePoint || metadata.IsDirectory || metadata.LinkCount != 1)
+        {
+            throw new IOException("The opened target is not a single-link regular file; overwrite rejected before truncation.");
+        }
+
+        stream.Position = 0;
+        stream.SetLength(0);
+        using StreamWriter writer = new(stream, Utf8WithoutBom, bufferSize: 4096, leaveOpen: true);
+        writer.Write(contents);
+        writer.Flush();
+        stream.Flush(flushToDisk: true);
+    }
+
+    /// <summary>
+    /// Copies content to a newly created file through its existing handle.
+    /// </summary>
+    public void CopyFrom(Stream source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        stream.Position = 0;
+        source.CopyTo(stream);
+        stream.Flush(flushToDisk: true);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        stream.Dispose();
+    }
+
+    internal Stream Stream => stream;
+}

--- a/src/settings-ui/SettingsBackupRestore.Security/SecurePath.cs
+++ b/src/settings-ui/SettingsBackupRestore.Security/SecurePath.cs
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.PowerToys.SettingsBackupRestore.Security;
+
+/// <summary>
+/// Windows path normalization and containment rules used before handle-relative access.
+/// </summary>
+public static class SecurePath
+{
+    private const int MaximumComponentLength = 255;
+    private static readonly SearchValues<char> InvalidComponentCharacters = SearchValues.Create("\0<>\"|?*:");
+
+    private static readonly HashSet<string> ReservedDeviceNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "CON",
+        "PRN",
+        "AUX",
+        "NUL",
+        "COM1",
+        "COM2",
+        "COM3",
+        "COM4",
+        "COM5",
+        "COM6",
+        "COM7",
+        "COM8",
+        "COM9",
+        "LPT1",
+        "LPT2",
+        "LPT3",
+        "LPT4",
+        "LPT5",
+        "LPT6",
+        "LPT7",
+        "LPT8",
+        "LPT9",
+    };
+
+    /// <summary>
+    /// Normalizes a Windows relative path and rejects traversal, rooted, ADS, and ambiguous names.
+    /// </summary>
+    public static string NormalizeRelative(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        string windowsPath = path.Replace('/', '\\');
+        if (Path.IsPathRooted(windowsPath) || windowsPath.StartsWith('\\'))
+        {
+            throw new InvalidDataException($"Rooted path is not allowed: {path}");
+        }
+
+        string[] components = windowsPath.Split('\\', StringSplitOptions.RemoveEmptyEntries);
+        if (components.Length == 0)
+        {
+            throw new InvalidDataException("An empty relative path is not allowed.");
+        }
+
+        foreach (string component in components)
+        {
+            ValidateComponent(component, path);
+        }
+
+        string normalized = string.Join('\\', components);
+        string anchor = Path.GetFullPath(@"C:\PowerToysBackupRestoreAnchor");
+        string candidate = Path.GetFullPath(Path.Combine(anchor, normalized));
+        if (!IsContained(anchor, candidate) || WindowsPathComparer.Instance.EqualsPath(anchor, candidate))
+        {
+            throw new InvalidDataException($"Path escapes its root: {path}");
+        }
+
+        return normalized;
+    }
+
+    /// <summary>
+    /// Returns whether a final handle path is equal to or below a root path using separator-safe comparison.
+    /// </summary>
+    public static bool IsContained(string rootPath, string candidatePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(rootPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(candidatePath);
+
+        string root = NormalizeFinalPath(rootPath);
+        string candidate = NormalizeFinalPath(candidatePath);
+        if (WindowsPathComparer.Instance.EqualsPath(root, candidate))
+        {
+            return true;
+        }
+
+        string prefix = root.EndsWith(Path.DirectorySeparatorChar) ? root : root + Path.DirectorySeparatorChar;
+        return WindowsPathComparer.Instance.StartsWith(candidate, prefix);
+    }
+
+    internal static string NormalizeFinalPath(string path)
+    {
+        string normalized = path;
+        if (normalized.StartsWith(@"\\?\UNC\", StringComparison.OrdinalIgnoreCase))
+        {
+            normalized = @"\\" + normalized[8..];
+        }
+        else if (normalized.StartsWith(@"\\?\", StringComparison.OrdinalIgnoreCase))
+        {
+            normalized = normalized[4..];
+        }
+
+        normalized = Path.GetFullPath(normalized.Replace('/', '\\'));
+        return Path.TrimEndingDirectorySeparator(normalized);
+    }
+
+    private static void ValidateComponent(string component, string originalPath)
+    {
+        if (component.Length > MaximumComponentLength)
+        {
+            throw new InvalidDataException($"Path component exceeds {MaximumComponentLength} characters: {originalPath}");
+        }
+
+        if (component is "." or "..")
+        {
+            throw new InvalidDataException($"Traversal component is not allowed: {originalPath}");
+        }
+
+        if (component.EndsWith(' ') || component.EndsWith('.'))
+        {
+            throw new InvalidDataException($"Trailing spaces or dots are not allowed: {originalPath}");
+        }
+
+        if (component.AsSpan().IndexOfAny(InvalidComponentCharacters) >= 0 || component.Any(char.IsControl))
+        {
+            throw new InvalidDataException($"Invalid or ADS path component: {originalPath}");
+        }
+
+        string deviceName = component.Split('.', 2)[0];
+        if (ReservedDeviceNames.Contains(deviceName))
+        {
+            throw new InvalidDataException($"Reserved device name is not allowed: {originalPath}");
+        }
+    }
+}

--- a/src/settings-ui/SettingsBackupRestore.Security/SettingsBackupRestore.Security.csproj
+++ b/src/settings-ui/SettingsBackupRestore.Security/SettingsBackupRestore.Security.csproj
@@ -1,4 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <!-- Look at Directory.Build.props in root for common stuff as well -->
+  <Import Project="$(RepoRoot)src\Common.Dotnet.CsWinRT.props" />
+
   <PropertyGroup>
     <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
     <AssemblyName>PowerToys.SettingsBackupRestore.Security</AssemblyName>

--- a/src/settings-ui/SettingsBackupRestore.Security/SettingsBackupRestore.Security.csproj
+++ b/src/settings-ui/SettingsBackupRestore.Security/SettingsBackupRestore.Security.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+    <AssemblyName>PowerToys.SettingsBackupRestore.Security</AssemblyName>
+    <RootNamespace>Microsoft.PowerToys.SettingsBackupRestore.Security</RootNamespace>
+    <Description>Validated filesystem and archive support for PowerToys settings backup and restore</Description>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="SettingsBackupRestore.Security.UnitTests" />
+  </ItemGroup>
+</Project>

--- a/src/settings-ui/SettingsBackupRestore.Security/SettingsBackupRestoreEngine.cs
+++ b/src/settings-ui/SettingsBackupRestore.Security/SettingsBackupRestoreEngine.cs
@@ -1,0 +1,435 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Microsoft.PowerToys.SettingsBackupRestore.Security;
+
+/// <summary>
+/// Production backup and restore orchestration built on validated handle-relative I/O.
+/// </summary>
+public sealed class SettingsBackupRestoreEngine
+{
+    private static readonly JsonSerializerOptions ManifestSerializerOptions = new() { WriteIndented = true };
+    private readonly BackupRestorePolicy policy;
+
+    /// <summary>
+    /// Initializes a new instance from the existing backup_restore_settings.json contract.
+    /// </summary>
+    public SettingsBackupRestoreEngine(string policyJson)
+    {
+        policy = BackupRestorePolicy.Parse(policyJson);
+    }
+
+    /// <summary>
+    /// Compares settings with the newest archive and optionally writes a compatible .ptb archive.
+    /// </summary>
+    public BackupOperationResult Backup(
+        string settingsRootPath,
+        string backupRootPath,
+        string stagingParentPath,
+        bool dryRun,
+        string productVersion,
+        string machineName,
+        DateTime utcNow)
+    {
+        using SecureDirectoryRoot settingsRoot = SecureDirectoryRoot.OpenReadOnly(settingsRootPath);
+        IReadOnlyDictionary<string, string> current = ReadSettings(settingsRoot);
+        if (current.Count == 0)
+        {
+            throw new InvalidDataException("No settings files were found.");
+        }
+
+        SecureDirectoryRoot? backupRoot = null;
+        SecureDirectoryRoot? stagingParent = null;
+        SecureDirectoryRoot? previousStaging = null;
+        try
+        {
+            if (Directory.Exists(backupRootPath))
+            {
+                backupRoot = dryRun ? SecureDirectoryRoot.OpenReadOnly(backupRootPath) : SecureDirectoryRoot.Open(backupRootPath);
+            }
+            else if (!dryRun)
+            {
+                backupRoot = SecureDirectoryRoot.OpenOrCreate(backupRootPath);
+            }
+
+            if (backupRoot != null && SecurePath.IsContained(settingsRoot.FinalPath, backupRoot.FinalPath))
+            {
+                throw new IOException("The backup root cannot be inside the settings root.");
+            }
+
+            string? latestArchive = backupRoot == null ? null : GetLatestArchiveFileName(backupRoot);
+            IReadOnlyDictionary<string, string> previous = new Dictionary<string, string>(WindowsPathComparer.Instance);
+            if (latestArchive != null)
+            {
+                stagingParent = SecureDirectoryRoot.Open(stagingParentPath);
+                previousStaging = BackupRestoreArchive.ExtractToExclusiveStaging(backupRoot!, latestArchive, stagingParent);
+                previous = ReadSettings(previousStaging);
+            }
+
+            List<string> updated = current
+                .Where(item => !previous.TryGetValue(item.Key, out string? value) || !JsonEquivalent(item.Value, value))
+                .Select(item => item.Key)
+                .ToList();
+            if (updated.Count == 0)
+            {
+                return new BackupOperationResult(false, latestArchive != null, latestArchive);
+            }
+
+            if (dryRun)
+            {
+                return new BackupOperationResult(true, latestArchive != null, latestArchive);
+            }
+
+            string archiveName = CreateArchive(
+                backupRoot!,
+                current,
+                updated,
+                productVersion,
+                machineName,
+                utcNow);
+            RemoveOldArchives(backupRoot!, utcNow.Subtract(TimeSpan.FromDays(60)), 10);
+            return new BackupOperationResult(true, latestArchive != null, archiveName);
+        }
+        finally
+        {
+            CleanupStaging(previousStaging);
+            stagingParent?.Dispose();
+            backupRoot?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Builds the restore confirmation model from the newest validated archive.
+    /// </summary>
+    public RestorePreviewViewModel CreateRestorePreview(string settingsRootPath, string backupRootPath, string stagingParentPath)
+    {
+        using SecureDirectoryRoot settingsRoot = SecureDirectoryRoot.OpenReadOnly(settingsRootPath);
+        using SecureDirectoryRoot backupRoot = SecureDirectoryRoot.OpenReadOnly(backupRootPath);
+        using SecureDirectoryRoot stagingParent = SecureDirectoryRoot.Open(stagingParentPath);
+        string archiveName = GetLatestArchiveFileName(backupRoot) ?? throw new FileNotFoundException("No settings backup was found.");
+        SecureDirectoryRoot? staging = null;
+        try
+        {
+            using SecureFile archiveFile = backupRoot.OpenFileForRead(archiveName);
+            string archiveSha256 = ComputeSha256(archiveFile);
+            staging = BackupRestoreArchive.ExtractToExclusiveStaging(archiveFile, stagingParent);
+            return RestorePreviewViewModel.Create(
+                    policy,
+                    staging.EnumerateFiles(fileFilter: IsJsonOrManifest),
+                    settingsRoot.EnumerateFiles(fileFilter: IsIncludedJson))
+                .WithArchiveIdentity(archiveName, archiveSha256);
+        }
+        finally
+        {
+            CleanupStaging(staging);
+        }
+    }
+
+    /// <summary>
+    /// Restores included settings from the newest validated archive.
+    /// </summary>
+    public RestoreOperationResult Restore(
+        string settingsRootPath,
+        string backupRootPath,
+        string stagingParentPath,
+        string? archiveFileName = null,
+        string? expectedArchiveSha256 = null)
+    {
+        using SecureDirectoryRoot settingsRoot = SecureDirectoryRoot.Open(settingsRootPath);
+        using SecureDirectoryRoot backupRoot = SecureDirectoryRoot.OpenReadOnly(backupRootPath);
+        using SecureDirectoryRoot stagingParent = SecureDirectoryRoot.Open(stagingParentPath);
+        string archiveName = archiveFileName ?? GetLatestArchiveFileName(backupRoot) ?? throw new FileNotFoundException("No settings backup was found.");
+        SecureDirectoryRoot? staging = null;
+        try
+        {
+            using SecureFile archiveFile = backupRoot.OpenFileForRead(archiveName);
+            if (expectedArchiveSha256 != null &&
+                !string.Equals(ComputeSha256(archiveFile), expectedArchiveSha256, StringComparison.Ordinal))
+            {
+                throw new InvalidDataException("The selected settings backup changed after preview.");
+            }
+
+            staging = BackupRestoreArchive.ExtractToExclusiveStaging(archiveFile, stagingParent);
+            HashSet<string> currentPaths = new(settingsRoot.EnumerateFiles(fileFilter: IsIncludedJson), WindowsPathComparer.Instance);
+            bool changed = false;
+            foreach (string relativePath in staging.EnumerateFiles(fileFilter: IsJsonOrManifest))
+            {
+                if (relativePath.Equals("manifest.json", StringComparison.OrdinalIgnoreCase) || !policy.ShouldInclude(relativePath))
+                {
+                    continue;
+                }
+
+                using SecureFile backupFile = staging.OpenFileForRead(relativePath);
+                string restoreJson = policy.CreateExportVersion(relativePath, backupFile.ReadAllText());
+                if (currentPaths.Contains(relativePath))
+                {
+                    using SecureFile currentFile = settingsRoot.OpenFileForOverwrite(relativePath);
+                    string currentJson = policy.CreateExportVersion(relativePath, currentFile.ReadAllText());
+                    if (JsonEquivalent(currentJson, restoreJson))
+                    {
+                        continue;
+                    }
+
+                    string contents = policy.GetRestoreMode(relativePath) == RestoreMode.Overwrite
+                        ? restoreJson
+                        : JsonSettingsMerge.Merge(currentFile.ReadAllText(), restoreJson);
+                    currentFile.OverwriteAllText(contents);
+                }
+                else
+                {
+                    using SecureFile newFile = settingsRoot.CreateNewFile(relativePath);
+                    newFile.OverwriteAllText(restoreJson);
+                }
+
+                changed = true;
+            }
+
+            return new RestoreOperationResult(changed, changed && policy.RestartAfterRestore);
+        }
+        finally
+        {
+            CleanupStaging(staging);
+        }
+    }
+
+    /// <summary>
+    /// Reads the newest archive manifest through validated extraction handles.
+    /// </summary>
+    public JsonNode? GetLatestManifest(string backupRootPath, string stagingParentPath)
+    {
+        if (!Directory.Exists(backupRootPath))
+        {
+            return null;
+        }
+
+        using SecureDirectoryRoot backupRoot = SecureDirectoryRoot.OpenReadOnly(backupRootPath);
+        using SecureDirectoryRoot stagingParent = SecureDirectoryRoot.Open(stagingParentPath);
+        string? archiveName = GetLatestArchiveFileName(backupRoot);
+        if (archiveName == null)
+        {
+            return null;
+        }
+
+        SecureDirectoryRoot? staging = null;
+        try
+        {
+            staging = BackupRestoreArchive.ExtractToExclusiveStaging(backupRoot, archiveName, stagingParent);
+            using SecureFile manifest = staging.OpenFileForRead("manifest.json");
+            return JsonNode.Parse(manifest.ReadAllText());
+        }
+        finally
+        {
+            CleanupStaging(staging);
+        }
+    }
+
+    /// <summary>
+    /// Gets the newest compatible archive name without opening untrusted child paths by name.
+    /// </summary>
+    public static string? GetLatestArchiveFileName(string backupRootPath)
+    {
+        if (!Directory.Exists(backupRootPath))
+        {
+            return null;
+        }
+
+        using SecureDirectoryRoot root = SecureDirectoryRoot.OpenReadOnly(backupRootPath);
+        return GetLatestArchiveFileName(root);
+    }
+
+    private static string? GetLatestArchiveFileName(SecureDirectoryRoot backupRoot)
+    {
+        return backupRoot.EnumerateFiles(recursive: false, fileFilter: IsArchiveCandidate)
+            .Select(path => (Path: path, Timestamp: ParseArchiveTimestamp(path)))
+            .Where(item => item.Timestamp.HasValue && Path.GetDirectoryName(item.Path) == string.Empty)
+            .OrderByDescending(item => item.Timestamp)
+            .Select(item => item.Path)
+            .FirstOrDefault();
+    }
+
+    private IReadOnlyDictionary<string, string> ReadSettings(SecureDirectoryRoot root)
+    {
+        Dictionary<string, string> settings = new(WindowsPathComparer.Instance);
+        foreach (string relativePath in root.EnumerateFiles(fileFilter: IsIncludedJson))
+        {
+            using SecureFile file = root.OpenFileForRead(relativePath);
+            settings.Add(relativePath, policy.CreateExportVersion(relativePath, file.ReadAllText()));
+        }
+
+        return settings;
+    }
+
+    private static string CreateArchive(
+        SecureDirectoryRoot backupRoot,
+        IReadOnlyDictionary<string, string> settings,
+        IReadOnlyCollection<string> updated,
+        string productVersion,
+        string machineName,
+        DateTime utcNow)
+    {
+        long timestamp = utcNow.ToFileTimeUtc();
+        for (int attempt = 0; attempt < 32; attempt++)
+        {
+            string archiveName = $"settings_{timestamp + attempt}.ptb";
+            SecureFile? archiveFile = null;
+            try
+            {
+                archiveFile = backupRoot.CreateNewFile(archiveName);
+                using (ZipArchive archive = new(archiveFile.Stream, ZipArchiveMode.Create, leaveOpen: true))
+                {
+                    foreach ((string path, string contents) in settings.OrderBy(item => item.Key, WindowsPathComparer.Instance))
+                    {
+                        WriteEntry(archive, path, contents);
+                    }
+
+                    string manifest = JsonSerializer.Serialize(
+                        new
+                        {
+                            CreateDateTime = utcNow.ToString("u", CultureInfo.InvariantCulture),
+                            Version = productVersion,
+                            UpdatedFiles = updated.Select(AddLegacyManifestPrefix).ToList(),
+                            BackupSource = machineName,
+                            UnchangedFiles = settings.Keys
+                                .Except(updated, WindowsPathComparer.Instance)
+                                .Select(AddLegacyManifestPrefix)
+                                .ToList(),
+                        },
+                        ManifestSerializerOptions);
+                    WriteEntry(archive, "manifest.json", manifest);
+                }
+
+                archiveFile.Dispose();
+                return archiveName;
+            }
+            catch (IOException) when (archiveFile == null)
+            {
+                continue;
+            }
+            catch
+            {
+                archiveFile?.Dispose();
+                try
+                {
+                    backupRoot.DeleteEntry(archiveName, isDirectory: false);
+                }
+                catch
+                {
+                }
+
+                throw;
+            }
+        }
+
+        throw new IOException("Could not create a unique settings backup archive.");
+    }
+
+    private static void WriteEntry(ZipArchive archive, string path, string contents)
+    {
+        ZipArchiveEntry entry = archive.CreateEntry(path.Replace('\\', '/'), CompressionLevel.Optimal);
+        using StreamWriter writer = new(entry.Open());
+        writer.Write(contents);
+    }
+
+    private static void RemoveOldArchives(SecureDirectoryRoot backupRoot, DateTime deleteBefore, int minimumToKeep)
+    {
+        List<(string Path, long Timestamp)> archives = backupRoot.EnumerateFiles(recursive: false, fileFilter: IsArchiveCandidate)
+            .Select(path => (Path: path, Timestamp: ParseArchiveTimestamp(path)))
+            .Where(item => item.Timestamp.HasValue && Path.GetDirectoryName(item.Path) == string.Empty)
+            .Select(item => (item.Path, item.Timestamp!.Value))
+            .OrderByDescending(item => item.Value)
+            .ToList();
+        foreach ((string path, long timestamp) in archives.Skip(minimumToKeep))
+        {
+            if (DateTime.FromFileTimeUtc(timestamp) < deleteBefore)
+            {
+                try
+                {
+                    backupRoot.DeleteEntry(path, isDirectory: false);
+                }
+                catch
+                {
+                }
+            }
+        }
+    }
+
+    private static string AddLegacyManifestPrefix(string path)
+    {
+        return path.StartsWith('\\') ? path : "\\" + path;
+    }
+
+    private bool IsIncludedJson(string path)
+    {
+        return path.EndsWith(".json", StringComparison.OrdinalIgnoreCase) && policy.ShouldInclude(path);
+    }
+
+    private static bool IsJsonOrManifest(string path)
+    {
+        return path.EndsWith(".json", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsArchiveCandidate(string path)
+    {
+        return ParseArchiveTimestamp(path).HasValue;
+    }
+
+    private static long? ParseArchiveTimestamp(string path)
+    {
+        string fileName = Path.GetFileName(path);
+        if (!fileName.StartsWith("settings_", StringComparison.OrdinalIgnoreCase) ||
+            !fileName.EndsWith(".ptb", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        string value = fileName["settings_".Length..^".ptb".Length];
+        return long.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out long timestamp) ? timestamp : null;
+    }
+
+    private static bool JsonEquivalent(string left, string right)
+    {
+        return JsonNode.DeepEquals(JsonNode.Parse(left), JsonNode.Parse(right));
+    }
+
+    private static string ComputeSha256(SecureFile archiveFile)
+    {
+        archiveFile.Stream.Position = 0;
+        string hash = Convert.ToHexString(SHA256.HashData(archiveFile.Stream));
+        archiveFile.Stream.Position = 0;
+        return hash;
+    }
+
+    private static void CleanupStaging(SecureDirectoryRoot? staging)
+    {
+        if (staging == null)
+        {
+            return;
+        }
+
+        try
+        {
+            try
+            {
+                staging.DeleteTree();
+            }
+            catch
+            {
+            }
+        }
+        finally
+        {
+            staging.Dispose();
+        }
+    }
+}

--- a/src/settings-ui/SettingsBackupRestore.Security/SettingsBackupRestoreEngine.cs
+++ b/src/settings-ui/SettingsBackupRestore.Security/SettingsBackupRestoreEngine.cs
@@ -162,40 +162,65 @@ public sealed class SettingsBackupRestoreEngine
 
             staging = BackupRestoreArchive.ExtractToExclusiveStaging(archiveFile, stagingParent);
             HashSet<string> currentPaths = new(settingsRoot.EnumerateFiles(fileFilter: IsIncludedJson), WindowsPathComparer.Instance);
-            bool changed = false;
-            foreach (string relativePath in staging.EnumerateFiles(fileFilter: IsJsonOrManifest))
+            List<RestoreWriteOperation> operations = [];
+            try
             {
-                if (relativePath.Equals("manifest.json", StringComparison.OrdinalIgnoreCase) || !policy.ShouldInclude(relativePath))
+                foreach (string relativePath in staging.EnumerateFiles(fileFilter: IsJsonOrManifest))
                 {
-                    continue;
-                }
-
-                using SecureFile backupFile = staging.OpenFileForRead(relativePath);
-                string restoreJson = policy.CreateExportVersion(relativePath, backupFile.ReadAllText());
-                if (currentPaths.Contains(relativePath))
-                {
-                    using SecureFile currentFile = settingsRoot.OpenFileForOverwrite(relativePath);
-                    string currentJson = policy.CreateExportVersion(relativePath, currentFile.ReadAllText());
-                    if (JsonEquivalent(currentJson, restoreJson))
+                    if (relativePath.Equals("manifest.json", StringComparison.OrdinalIgnoreCase) || !policy.ShouldInclude(relativePath))
                     {
                         continue;
                     }
 
-                    string contents = policy.GetRestoreMode(relativePath) == RestoreMode.Overwrite
-                        ? restoreJson
-                        : JsonSettingsMerge.Merge(currentFile.ReadAllText(), restoreJson);
-                    currentFile.OverwriteAllText(contents);
+                    using SecureFile backupFile = staging.OpenFileForRead(relativePath);
+                    string restoreJson = policy.CreateExportVersion(relativePath, backupFile.ReadAllText());
+                    if (currentPaths.Contains(relativePath))
+                    {
+                        SecureFile currentFile = settingsRoot.OpenFileForOverwrite(relativePath);
+                        try
+                        {
+                            string originalJson = currentFile.ReadAllText();
+                            string currentJson = policy.CreateExportVersion(relativePath, originalJson);
+                            if (JsonEquivalent(currentJson, restoreJson))
+                            {
+                                currentFile.Dispose();
+                                continue;
+                            }
+
+                            string contents = policy.GetRestoreMode(relativePath) == RestoreMode.Overwrite
+                                ? restoreJson
+                                : JsonSettingsMerge.Merge(originalJson, restoreJson);
+                            operations.Add(new RestoreWriteOperation(relativePath, contents, originalJson, currentFile, isNew: false));
+                        }
+                        catch
+                        {
+                            currentFile.Dispose();
+                            throw;
+                        }
+                    }
+                    else
+                    {
+                        operations.Add(new RestoreWriteOperation(relativePath, restoreJson, originalContents: null, targetFile: null, isNew: true));
+                    }
                 }
-                else
+            }
+            catch
+            {
+                foreach (RestoreWriteOperation operation in operations)
                 {
-                    using SecureFile newFile = settingsRoot.CreateNewFile(relativePath);
-                    newFile.OverwriteAllText(restoreJson);
+                    operation.Dispose();
                 }
 
-                changed = true;
+                throw;
             }
 
-            return new RestoreOperationResult(changed, changed && policy.RestartAfterRestore);
+            if (operations.Count == 0)
+            {
+                return new RestoreOperationResult(false, false);
+            }
+
+            ApplyRestoreOperations(settingsRoot, operations);
+            return new RestoreOperationResult(true, policy.RestartAfterRestore);
         }
         finally
         {
@@ -430,6 +455,135 @@ public sealed class SettingsBackupRestoreEngine
         finally
         {
             staging.Dispose();
+        }
+    }
+
+    private static void ApplyRestoreOperations(SecureDirectoryRoot settingsRoot, List<RestoreWriteOperation> operations)
+    {
+        List<string> createdFiles = [];
+        SortedSet<string> createdDirectories = new(WindowsPathComparer.Instance);
+        List<RestoreWriteOperation> overwritten = [];
+        try
+        {
+            foreach (RestoreWriteOperation operation in operations.Where(operation => operation.IsNew))
+            {
+                foreach (string directory in GetParentDirectories(operation.RelativePath))
+                {
+                    if (!settingsRoot.DirectoryExists(directory))
+                    {
+                        createdDirectories.Add(directory);
+                    }
+                }
+
+                operation.TargetFile = settingsRoot.CreateNewFile(operation.RelativePath);
+                createdFiles.Add(operation.RelativePath);
+            }
+
+            foreach (RestoreWriteOperation operation in operations)
+            {
+                if (!operation.IsNew)
+                {
+                    overwritten.Add(operation);
+                }
+
+                operation.TargetFile!.OverwriteAllText(operation.NewContents);
+            }
+        }
+        catch (Exception restoreException)
+        {
+            List<Exception> rollbackErrors = [];
+            for (int index = overwritten.Count - 1; index >= 0; index--)
+            {
+                TryRollback(
+                    () => overwritten[index].TargetFile!.OverwriteAllText(overwritten[index].OriginalContents!),
+                    rollbackErrors);
+            }
+
+            foreach (RestoreWriteOperation operation in operations.Where(operation => operation.IsNew))
+            {
+                operation.TargetFile?.Dispose();
+                operation.TargetFile = null;
+            }
+
+            for (int index = createdFiles.Count - 1; index >= 0; index--)
+            {
+                string path = createdFiles[index];
+                TryRollback(() => settingsRoot.DeleteEntry(path, isDirectory: false), rollbackErrors);
+            }
+
+            foreach (string directory in createdDirectories.OrderByDescending(path => path.Length))
+            {
+                TryRollback(() => settingsRoot.DeleteEntry(directory, isDirectory: true), rollbackErrors);
+            }
+
+            if (rollbackErrors.Count > 0)
+            {
+                restoreException.Data["RestoreRollbackErrors"] = rollbackErrors.ToArray();
+            }
+
+            throw;
+        }
+        finally
+        {
+            foreach (RestoreWriteOperation operation in operations)
+            {
+                operation.Dispose();
+            }
+        }
+    }
+
+    private static IEnumerable<string> GetParentDirectories(string relativePath)
+    {
+        int separatorIndex = relativePath.IndexOf('\\');
+        while (separatorIndex >= 0)
+        {
+            yield return relativePath[..separatorIndex];
+            separatorIndex = relativePath.IndexOf('\\', separatorIndex + 1);
+        }
+    }
+
+    private static void TryRollback(Action rollback, List<Exception> rollbackErrors)
+    {
+        try
+        {
+            rollback();
+        }
+        catch (Exception exception)
+        {
+            rollbackErrors.Add(exception);
+        }
+    }
+
+    private sealed class RestoreWriteOperation : IDisposable
+    {
+        internal RestoreWriteOperation(
+            string relativePath,
+            string newContents,
+            string? originalContents,
+            SecureFile? targetFile,
+            bool isNew)
+        {
+            RelativePath = relativePath;
+            NewContents = newContents;
+            OriginalContents = originalContents;
+            TargetFile = targetFile;
+            IsNew = isNew;
+        }
+
+        internal string RelativePath { get; }
+
+        internal string NewContents { get; }
+
+        internal string? OriginalContents { get; }
+
+        internal SecureFile? TargetFile { get; set; }
+
+        internal bool IsNew { get; }
+
+        public void Dispose()
+        {
+            TargetFile?.Dispose();
+            TargetFile = null;
         }
     }
 }

--- a/src/settings-ui/SettingsBackupRestore.Security/WindowsPathComparer.cs
+++ b/src/settings-ui/SettingsBackupRestore.Security/WindowsPathComparer.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.PowerToys.SettingsBackupRestore.Security;
+
+internal sealed class WindowsPathComparer : IComparer<string>, IEqualityComparer<string>
+{
+    internal static WindowsPathComparer Instance { get; } = new();
+
+    public int Compare(string? left, string? right)
+    {
+        if (ReferenceEquals(left, right))
+        {
+            return 0;
+        }
+
+        if (left is null)
+        {
+            return -1;
+        }
+
+        if (right is null)
+        {
+            return 1;
+        }
+
+        int result = NativeMethods.CompareStringOrdinal(left, left.Length, right, right.Length, ignoreCase: true);
+        if (result == 0)
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "Could not compare normalized Windows archive paths.");
+        }
+
+        return result - 2;
+    }
+
+    internal bool EqualsPath(string left, string right)
+    {
+        return Compare(left, right) == 0;
+    }
+
+    public bool Equals(string? left, string? right)
+    {
+        return Compare(left, right) == 0;
+    }
+
+    public int GetHashCode(string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        return 0;
+    }
+
+    internal bool StartsWith(string value, string prefix)
+    {
+        if (value.Length < prefix.Length)
+        {
+            return false;
+        }
+
+        int result = NativeMethods.CompareStringOrdinal(value, prefix.Length, prefix, prefix.Length, ignoreCase: true);
+        if (result == 0)
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "Could not compare a normalized Windows path prefix.");
+        }
+
+        return result == 2;
+    }
+}


### PR DESCRIPTION
## Summary
- route Settings backup, dry-run, manifest, cleanup, preview, and restore through validated filesystem and archive primitives
- preserve the existing backup format, include/exclude policies, merge/overwrite behavior, and restart semantics
- add a focused restore preview on the General page
- add production integration and compatibility coverage

## Validation
- 51 backup/restore security, compatibility, and production tests passed
- Settings UI Release x64 and ARM64 builds passed
- packaged Settings outputs include `PowerToys.Settings.exe`, `PowerToys.SettingsBackupRestore.Security.dll`, and `backup_restore_settings.json` for both platforms
- common project props audit passed; library and tests are included in `PowerToys.slnx`
- PowerToys CI build 386743 passed for x64 and ARM64 with tests enabled

## Compatibility coverage
- mocked UNC path canonicalization
- mocked cloud-placeholder/reparse metadata rejection without hydration
- mocked absent single-link metadata fail-closed behavior
- fail-closed preview/restore and no-partial-restore coverage

## External validation
- real UNC provider behavior, real cloud-placeholder provider behavior, and real non-NTFS filesystem behavior remain dedicated physical-filesystem lab gates