### PR TITLE
Fix triage automation state handling

### DIFF
--- a/.github/scripts/issue-triage/README.md
+++ b/.github/scripts/issue-triage/README.md
@@ -10,8 +10,10 @@ combines deterministic preprocessing with one bounded GitHub Copilot pass.
   quality, language, and diagnostic-report requirement before AI runs.
 - Compare the reported version with the latest stable PowerToys release.
   Older versions receive a non-blocking update-and-retest recommendation.
-- Retrieve a bounded set of older candidate issues using product labels,
-  technical identifiers, and focused title/body searches.
+- Retrieve a bounded set of older open candidate issues using product labels,
+  technical identifiers, and focused title/body searches. Search results are
+  also checked defensively so closed issues and pull requests cannot be
+  suggested as canonical duplicates.
 - Ask Copilot only to summarize the issue, judge supplied duplicate candidates,
   interpret sanitized diagnostics, and classify the author-written language.
 - Maintain one marked comment with separate sections for the issue author and
@@ -25,6 +27,9 @@ combines deterministic preprocessing with one bounded GitHub Copilot pass.
   accept or decline it; acceptance closes the issue as a duplicate and links
   it to the selected canonical issue.
 - Never close an issue directly from the model output.
+- The daily dedupe digest re-fetches parsed canonical candidates and keeps only
+  open issues, preserving candidate order so the strongest still-open candidate
+  becomes primary.
 
 ## Reproduction and diagnostics
 

--- a/.github/scripts/issue-triage/issue-context.py
+++ b/.github/scripts/issue-triage/issue-context.py
@@ -459,7 +459,7 @@ def allowed_product_labels(title, body, labels, deterministic_label):
 
 def build_queries(repository, title, body, label):
     technical, concepts = search_terms(title, body)
-    scope = f"repo:{repository} is:issue"
+    scope = f"repo:{repository} is:issue is:open"
     label_scope = f' label:"{label}"' if label != "None" else ""
     queries = []
     for identifier in technical[:2]:
@@ -527,6 +527,7 @@ def retrieve_candidates(api, issue, desired_label):
                 or number == issue.get("number")
                 or number > issue.get("number")
                 or candidate.get("pull_request")
+                or candidate.get("state") != "open"
             ):
                 continue
             candidates[number] = candidate

--- a/.github/scripts/issue-triage/tests/test_issue_context.py
+++ b/.github/scripts/issue-triage/tests/test_issue_context.py
@@ -259,6 +259,7 @@ class IssueContextTests(unittest.TestCase):
             "Product-Keyboard Manager",
         )
         rendered = "\n".join(queries)
+        self.assertIn("is:open", rendered)
         self.assertIn('label:"Product-Keyboard Manager"', rendered)
         self.assertIn('"0x8007007e"', rendered)
         self.assertIn('"example.dll"', rendered)
@@ -599,6 +600,29 @@ class IssueContextTests(unittest.TestCase):
             issue,
             "Product-Keyboard Manager",
         )
+        self.assertEqual([candidate["number"] for candidate in candidates], [3])
+
+    def test_candidate_retrieval_discards_closed_results_defensively(self):
+        issue = {
+            "number": 10,
+            "title": "Keyboard Manager editor exits",
+            "body": "Unable to load Example.dll with 0x8007007E",
+            "labels": [{"name": "Product-Keyboard Manager"}],
+        }
+        open_candidate = {
+            "number": 3,
+            "state": "open",
+            "title": "Keyboard Manager editor exits",
+            "body": "Unable to load Example.dll with 0x8007007E",
+            "labels": [{"name": "Product-Keyboard Manager"}],
+        }
+        closed_candidate = {**open_candidate, "number": 2, "state": "closed"}
+        queries, candidates = CONTEXT.retrieve_candidates(
+            FakeApi(results=[closed_candidate, open_candidate]),
+            issue,
+            "Product-Keyboard Manager",
+        )
+        self.assertTrue(all("is:open" in query for query in queries))
         self.assertEqual([candidate["number"] for candidate in candidates], [3])
 
 

--- a/.github/scripts/issue-triage/tests/test_workflow_contract.py
+++ b/.github/scripts/issue-triage/tests/test_workflow_contract.py
@@ -5,6 +5,8 @@ from pathlib import Path
 GITHUB_DIR = Path(__file__).resolve().parents[3]
 WORKFLOW_SOURCE = GITHUB_DIR / "workflows" / "issue-triage.md"
 WORKFLOW_LOCK = GITHUB_DIR / "workflows" / "issue-triage.lock.yml"
+DEDUPE_DIGEST = GITHUB_DIR / "workflows" / "dedupe-digest.yml"
+MANUAL_DEDUPE = GITHUB_DIR / "workflows" / "manual-batch-issue-deduplication.yml"
 
 
 class WorkflowContractTests(unittest.TestCase):
@@ -42,6 +44,18 @@ class WorkflowContractTests(unittest.TestCase):
             "yq",
         ):
             self.assertIn(f"--deny-tool '\\''shell({command})'\\''", generated)
+
+    def test_dedupe_workflows_restrict_canonical_candidates_to_open_issues(self):
+        digest = DEDUPE_DIGEST.read_text(encoding="utf-8")
+        manual = MANUAL_DEDUPE.read_text(encoding="utf-8")
+
+        self.assertIn("resolveOpenIssueCandidates", digest)
+        self.assertIn("live.pull_request || live.state !== 'open'", digest)
+        self.assertIn(
+            "const candidates = await resolveOpenIssueCandidates(",
+            digest,
+        )
+        self.assertIn("state: open", manual)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/pr-intake/README.md
+++ b/.github/scripts/pr-intake/README.md
@@ -1,19 +1,22 @@
 # Pull request intake
 
 The workflow in `.github/workflows/pr-intake.yml` runs deterministic pull
-request intake checks on non-draft pull requests. It does not call any AI model
-and does not execute any code from the pull request head; the Node script reads
-all pull request data through the GitHub API.
+request intake checks. It does not call any AI model and does not execute any
+code from the pull request head; the Node script reads all pull request data
+through the GitHub API.
 
 ## Flow
 
-1. Read the current PR through the GitHub API. Mergeability is re-fetched a few
+1. Read the current PR and changed files through the GitHub API. Mergeability is re-fetched a few
    times when GitHub still reports it as unknown so a conflicting PR is never
    treated as ready by default.
-2. Deterministically validate closing issue references, merge conflicts, and
+2. Add recognized `Product-*` labels from the historical path mapping. The
+   longest path prefix wins, Settings is suppressed when another product
+   matches, and existing product labels are never removed.
+3. Deterministically validate closing issue references, merge conflicts, and
    whether visual evidence is present.
-3. Require visual evidence only when the changed paths touch product UI files.
-4. Keep a single canonical comment in sync and manage only the
+4. Require visual evidence only when the changed paths touch product UI files.
+5. Keep a single canonical comment in sync and manage only the
    `Ready for review` and `Needs-Author-Feedback` labels.
 
 ## Comment behavior
@@ -26,8 +29,9 @@ all pull request data through the GitHub API.
 
 Missing issue references are advisory. Explicitly invalid references, merge
 conflicts, unknown mergeability, and missing required visual evidence block
-readiness. Draft PR events skip normal intake; conversion to draft runs only
-lifecycle-label cleanup, and marking a draft ready triggers full intake.
+readiness. Draft PR events run deterministic path labeling, remove intake
+lifecycle labels, delete trusted canonical intake comments, and then stop.
+Marking a draft ready triggers full intake.
 
 The existing resource-management policy closes PRs that retain
 `Needs-Author-Feedback` for seven inactive days. PR synchronization is handled

--- a/.github/scripts/pr-intake/pr-intake.mjs
+++ b/.github/scripts/pr-intake/pr-intake.mjs
@@ -44,6 +44,48 @@ const VISUAL_PRODUCT_PREFIXES = [
   'src/settings-ui/',
 ];
 
+export const PRODUCT_PATH_LABEL_MAP = [
+  ['src/modules/MouseUtils/FindMyMouse/', 'Product-Find My Mouse'],
+  ['src/modules/MouseUtils/MouseHighlighter/', 'Product-Mouse Highlighter'],
+  ['src/modules/MouseUtils/MouseJump/', 'Product-Mouse Jump'],
+  ['src/modules/MouseUtils/MousePointerCrosshairs/', 'Product-Mouse Pointer Crosshairs'],
+  ['src/modules/MouseUtils/', 'Product-Mouse Utilities'],
+  ['src/modules/AdvancedPaste/', 'Product-Advanced Paste'],
+  ['src/modules/alwaysontop/', 'Product-Always On Top'],
+  ['src/modules/awake/', 'Product-Awake'],
+  ['src/modules/cmdNotFound/', 'Product-CommandNotFound'],
+  ['src/modules/cmdpal/', 'Product-Command Palette'],
+  ['src/modules/colorPicker/', 'Product-Color Picker'],
+  ['src/modules/CropAndLock/', 'Product-CropAndLock'],
+  ['src/modules/EnvironmentVariables/', 'Product-Environment Variables'],
+  ['src/modules/fancyzones/', 'Product-FancyZones'],
+  ['src/modules/FileLocksmith/', 'Product-File Locksmith'],
+  ['src/modules/GrabAndMove/', 'Product-Grab And Move'],
+  ['src/modules/Hosts/', 'Product-Hosts File Editor'],
+  ['src/modules/imageresizer/', 'Product-Image Resizer'],
+  ['src/modules/keyboardmanager/', 'Product-Keyboard Manager'],
+  ['src/modules/launcher/', 'Product-PowerToys Run'],
+  ['src/modules/LightSwitch/', 'Product-LightSwitch'],
+  ['src/modules/MeasureTool/', 'Product-Screen Ruler'],
+  ['src/modules/MouseWithoutBorders/', 'Product-Mouse Without Borders'],
+  ['src/modules/NewPlus/', 'Product-New+'],
+  ['src/modules/peek/', 'Product-Peek'],
+  ['src/modules/poweraccent/', 'Product-Quick Accent'],
+  ['src/modules/powerdisplay/', 'Product-PowerDisplay'],
+  ['src/modules/PowerOCR/', 'Product-Text Extractor'],
+  ['src/modules/powerrename/', 'Product-PowerRename'],
+  ['src/modules/previewpane/', 'Product-File Explorer'],
+  ['src/modules/registrypreview/', 'Product-Registry Preview'],
+  ['src/modules/ShortcutGuide/', 'Product-Shortcut Guide'],
+  ['src/modules/shortcut_guide/', 'Product-Shortcut Guide'],
+  ['src/modules/Workspaces/', 'Product-Workspaces'],
+  ['src/modules/ZoomIt/', 'Product-ZoomIt'],
+  ['src/settings-ui/', 'Product-Settings'],
+];
+
+const SORTED_PRODUCT_PATH_LABEL_MAP = [...PRODUCT_PATH_LABEL_MAP]
+  .sort((left, right) => right[0].length - left[0].length);
+
 export class ApiError extends Error {
   constructor(message, status, details = '') {
     super(message);
@@ -127,6 +169,39 @@ export function normalizePath(value) {
     .replace(/^\.\//, '')
     .replace(/^\/+/, '')
     .trim();
+}
+
+export function deriveProductLabelsFromPaths(paths, currentLabels = []) {
+  if (!Array.isArray(paths)) {
+    throw new Error('Changed paths must be an array');
+  }
+
+  const labels = new Set();
+  for (const rawPath of paths) {
+    const changedPath = normalizePath(rawPath).toLowerCase();
+    if (!changedPath) {
+      continue;
+    }
+    const match = SORTED_PRODUCT_PATH_LABEL_MAP.find(
+      ([prefix]) => changedPath.startsWith(prefix.toLowerCase()),
+    );
+    if (match) {
+      labels.add(match[1]);
+    }
+  }
+
+  const existingNonSettingsProduct = (Array.isArray(currentLabels) ? currentLabels : [])
+    .map((entry) => typeof entry === 'string' ? entry : entry?.name)
+    .some((label) => typeof label === 'string'
+      && label.startsWith('Product-')
+      && label !== 'Product-Settings');
+  const mappedNonSettingsProduct = [...labels]
+    .some((label) => label.startsWith('Product-') && label !== 'Product-Settings');
+  if (existingNonSettingsProduct || mappedNonSettingsProduct) {
+    labels.delete('Product-Settings');
+  }
+
+  return uniqueSorted([...labels]);
 }
 
 function isTestPath(changedPath) {
@@ -649,6 +724,24 @@ export async function upsertCanonicalComment({
   };
 }
 
+export async function deleteCanonicalComments({
+  api,
+  issueNumber,
+  comments = null,
+}) {
+  const existingComments = Array.isArray(comments)
+    ? comments
+    : await listAllComments(api, issueNumber);
+  const { canonical, extras } = selectCanonicalComment(existingComments);
+  const trustedComments = canonical ? [canonical, ...extras] : [];
+  const deletedCommentIds = [];
+  for (const comment of trustedComments) {
+    await api.deleteIssueComment(comment.id);
+    deletedCommentIds.push(comment.id);
+  }
+  return deletedCommentIds;
+}
+
 export function planManagedLabelChanges(
   currentLabels,
   desiredLabels,
@@ -735,10 +828,14 @@ export async function runPullRequestIntake({ api, event }) {
   const issueNumber = pullNumber;
 
   const issue = await api.getIssue(issueNumber);
+  const currentLabels = parseIssueLabels(issue);
+  const fileDetails = await listAllPullRequestFileDetails(api, issueNumber);
+  const changedPaths = changedPathsFromFileDetails(fileDetails);
+  const pathProductLabels = deriveProductLabelsFromPaths(changedPaths, currentLabels);
   if (pullRequest.draft === true) {
     const labelPlan = planManagedLabelChanges(
-      parseIssueLabels(issue),
-      [],
+      currentLabels,
+      pathProductLabels,
       [
         READY_FOR_REVIEW_LABEL,
         NEEDS_AUTHOR_FEEDBACK_LABEL,
@@ -746,15 +843,20 @@ export async function runPullRequestIntake({ api, event }) {
       ],
     );
     await syncManagedLabels(api, issueNumber, labelPlan);
+    const deletedCanonicalCommentIds = await deleteCanonicalComments({
+      api,
+      issueNumber,
+    });
     return {
       issueNumber,
       skippedDraft: true,
+      changedPathCount: changedPaths.length,
+      pathProductLabels,
       labelPlan,
+      deletedCanonicalCommentIds,
     };
   }
 
-  const fileDetails = await listAllPullRequestFileDetails(api, issueNumber);
-  const changedPaths = changedPathsFromFileDetails(fileDetails);
   const closingReferenceVerification = await verifyClosingIssueReferences({
     api,
     repositoryFullName: event.repository.full_name,
@@ -784,9 +886,10 @@ export async function runPullRequestIntake({ api, event }) {
   const desiredManagedLabels = [
     ...(report.readyForReview ? [READY_FOR_REVIEW_LABEL] : []),
     ...(report.needsAuthorFeedback ? [NEEDS_AUTHOR_FEEDBACK_LABEL] : []),
+    ...pathProductLabels,
   ];
   const labelPlan = planManagedLabelChanges(
-    parseIssueLabels(issue),
+    currentLabels,
     desiredManagedLabels,
     [
       READY_FOR_REVIEW_LABEL,
@@ -827,6 +930,7 @@ export async function runPullRequestIntake({ api, event }) {
   return {
     issueNumber,
     changedPathCount: changedPaths.length,
+    pathProductLabels,
     labelPlan,
     commentResult: {
       operation: commentResult.operation,

--- a/.github/scripts/pr-intake/tests/pr-intake.test.mjs
+++ b/.github/scripts/pr-intake/tests/pr-intake.test.mjs
@@ -11,6 +11,8 @@ import {
   ApiError,
   buildIntakeReport,
   classifyChangedPaths,
+  deleteCanonicalComments,
+  deriveProductLabelsFromPaths,
   deriveVisualAssessment,
   determineFeedbackSince,
   findClosingIssueReferences,
@@ -40,17 +42,17 @@ function botComment(id, body) {
   };
 }
 
-test('workflow skips normal draft intake and handles draft transitions', () => {
+test('workflow runs intake for draft events and handles draft transitions', () => {
   const workflow = fs.readFileSync(
     new URL('../../../workflows/pr-intake.yml', import.meta.url),
     'utf8',
   );
 
   assert.equal(READY_FOR_REVIEW_LABEL, 'Ready for review');
-  assert.match(
-    workflow,
-    /if: \$\{\{ github\.event\.pull_request\.draft == false \|\| github\.event\.action == 'converted_to_draft' \}\}/,
-  );
+  assert.doesNotMatch(workflow, /github\.event\.pull_request\.draft == false/);
+  assert.match(workflow, /- opened/);
+  assert.match(workflow, /- edited/);
+  assert.match(workflow, /- synchronize/);
   assert.match(workflow, /- ready_for_review/);
   assert.match(workflow, /- converted_to_draft/);
 });
@@ -158,6 +160,27 @@ test('docs-only changes do not require visual evidence', () => {
 
   assert.equal(report.requiresVisualEvidence, false);
   assert.deepEqual(report.categories, ['docs']);
+});
+
+test('path product labels use longest prefixes and suppress Settings side effects', () => {
+  assert.deepEqual(
+    deriveProductLabelsFromPaths([
+      'src/modules/MouseUtils/MouseJump/MouseJump.Common/Helpers.cs',
+      'src/settings-ui/Settings.UI/SettingsXAML/Views/MouseJumpPage.xaml',
+    ]),
+    ['Product-Mouse Jump'],
+  );
+  assert.deepEqual(
+    deriveProductLabelsFromPaths(['src/modules/cmdpal/src/App/App.xaml']),
+    ['Product-Command Palette'],
+  );
+  assert.deepEqual(
+    deriveProductLabelsFromPaths(
+      ['src/settings-ui/Settings.UI/SettingsXAML/Views/DashboardPage.xaml'],
+      ['Product-FancyZones'],
+    ),
+    [],
+  );
 });
 
 test('deriveVisualAssessment maps the path hint to a requirement', () => {
@@ -601,6 +624,24 @@ test('canonical upsert updates the oldest trusted comment and deletes extras', a
   assert.equal(api.comments.length, 1);
 });
 
+test('canonical deletion removes only trusted intake comments', async () => {
+  const body = `${CANONICAL_MARKER}\nfirst`;
+  const untrusted = {
+    id: 10,
+    body,
+    user: { login: 'attacker', id: 1, type: 'User' },
+  };
+  const api = new MockApi({
+    comments: [untrusted, botComment(20, body), botComment(40, body)],
+  });
+
+  const deleted = await deleteCanonicalComments({ api, issueNumber: 12 });
+
+  assert.deepEqual(deleted, [20, 40]);
+  assert.deepEqual(api.deleted, [20, 40]);
+  assert.deepEqual(api.comments, [untrusted]);
+});
+
 test('all-clear comment carries the canonical marker', () => {
   const body = renderAllClearComment();
   assert.match(body, /^<!-- powertoys-pr-intake:canonical:v1 -->/);
@@ -643,11 +684,23 @@ test('runPullRequestIntake stays silent on a clean PR with no prior comment', as
   assert.deepEqual(result.labelPlan.add, [READY_FOR_REVIEW_LABEL]);
 });
 
-test('converted draft removes lifecycle labels without running intake', async () => {
+test('draft intake adds path labels, removes lifecycle labels, and deletes canonical comments', async () => {
+  const canonical = botComment(50, `${CANONICAL_MARKER}\n## PR intake`);
+  const untrusted = {
+    id: 51,
+    body: `${CANONICAL_MARKER}\nspoof`,
+    user: { login: 'attacker', id: 1, type: 'User' },
+  };
   const api = new MockApi({
+    comments: [canonical, untrusted],
     issues: [{
       number: 100,
-      labels: [READY_FOR_REVIEW_LABEL, NEEDS_AUTHOR_FEEDBACK_LABEL, 'Product-FancyZones'],
+      labels: [
+        READY_FOR_REVIEW_LABEL,
+        NEEDS_AUTHOR_FEEDBACK_LABEL,
+        'Product-FancyZones',
+        'Area-Setup/Install',
+      ],
       title: 'Draft PR',
     }],
     pullRequests: [{
@@ -659,6 +712,7 @@ test('converted draft removes lifecycle labels without running intake', async ()
       base: { ref: 'main' },
       user: { login: 'alice' },
     }],
+    files: [{ filename: 'src/modules/cmdpal/src/App/AppHost.cs', status: 'modified' }],
   });
 
   const result = await runPullRequestIntake({
@@ -668,12 +722,49 @@ test('converted draft removes lifecycle labels without running intake', async ()
 
   assert.equal(result.skippedDraft, true);
   assert.deepEqual(result.labelPlan, {
-    add: [],
+    add: ['Product-Command Palette'],
     remove: [NEEDS_AUTHOR_FEEDBACK_LABEL, READY_FOR_REVIEW_LABEL],
   });
-  assert.equal(api.listPullRequestFilesCalls, 0);
+  assert.deepEqual(result.pathProductLabels, ['Product-Command Palette']);
+  assert.equal(api.listPullRequestFilesCalls, 1);
+  assert.deepEqual(api.addedLabels, [{
+    issueNumber: 100,
+    labels: ['Product-Command Palette'],
+  }]);
+  assert.deepEqual(api.deleted, [50]);
+  assert.deepEqual(result.deletedCanonicalCommentIds, [50]);
+  assert.deepEqual(api.comments, [untrusted]);
   assert.equal(api.created, 0);
   assert.equal(api.updated, 0);
+});
+
+test('non-draft intake adds deterministic product labels with lifecycle labels', async () => {
+  const api = new MockApi({
+    issues: [{ number: 100, labels: ['Product-FancyZones'], title: 'PR' }],
+    pullRequests: [{
+      number: 100,
+      draft: false,
+      mergeable: true,
+      mergeable_state: 'clean',
+      body: 'Closes #12',
+      base: { ref: 'main' },
+      user: { login: 'alice' },
+    }],
+    files: [{ filename: 'src/modules/cmdpal/src/App/AppHost.cs', status: 'modified' }],
+  });
+  api.issues.push({ number: 12, title: 'Tracked issue' });
+
+  const result = await runPullRequestIntake({ api, event: intakeEvent() });
+
+  assert.deepEqual(result.pathProductLabels, ['Product-Command Palette']);
+  assert.deepEqual(result.labelPlan, {
+    add: ['Product-Command Palette', READY_FOR_REVIEW_LABEL],
+    remove: [],
+  });
+  assert.deepEqual(api.addedLabels, [{
+    issueNumber: 100,
+    labels: ['Product-Command Palette', READY_FOR_REVIEW_LABEL],
+  }]);
 });
 
 test('runPullRequestIntake replaces a stale comment with an all-clear note when the PR is clean', async () => {

--- a/.github/workflows/dedupe-digest.yml
+++ b/.github/workflows/dedupe-digest.yml
@@ -130,6 +130,31 @@ jobs:
                 .sort((a, b) => b.id - a.id)[0] || null;
             };
 
+            const liveCandidateCache = new Map();
+            const resolveOpenIssueCandidates = async (candidates) => {
+              const openCandidates = [];
+              for (const candidate of candidates) {
+                let live = liveCandidateCache.get(candidate.number);
+                if (live === undefined) {
+                  try {
+                    live = (await github.rest.issues.get({
+                      owner, repo, issue_number: candidate.number
+                    })).data;
+                  } catch (e) {
+                    if (e.status !== 404) throw e;
+                    live = null;
+                  }
+                  liveCandidateCache.set(candidate.number, live);
+                }
+                if (!live || live.pull_request || live.state !== 'open') continue;
+                openCandidates.push({
+                  ...candidate,
+                  title: sanitize(live.title, 160)
+                });
+              }
+              return openCandidates;
+            };
+
             // --- 1. Ensure the digest label exists -------------------------------
             try {
               await github.rest.issues.getLabel({ owner, repo, name: LABEL });
@@ -202,7 +227,9 @@ jobs:
 
               const triageComment = await findTriageComment(number);
               if (!triageComment) continue;
-              const candidates = parseDuplicateCandidates(triageComment.body);
+              const candidates = await resolveOpenIssueCandidates(
+                parseDuplicateCandidates(triageComment.body)
+              );
               if (!candidates.length) continue;
 
               flagged.push({

--- a/.github/workflows/manual-batch-issue-deduplication.yml
+++ b/.github/workflows/manual-batch-issue-deduplication.yml
@@ -35,4 +35,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_issue: ${{ matrix.issue }}
           label_as_duplicate: ${{ github.event.inputs.label_as_duplicate }}
-          
+          state: open

--- a/.github/workflows/pr-intake.yml
+++ b/.github/workflows/pr-intake.yml
@@ -32,7 +32,6 @@ concurrency:
 
 jobs:
   pr-intake:
-    if: ${{ github.event.pull_request.draft == false || github.event.action == 'converted_to_draft' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout base ref


### PR DESCRIPTION
## Summary
- restrict duplicate searches and digest canonical candidates to live open issues
- add deterministic additive `Product-*` path labels for draft and non-draft PRs
- clean lifecycle labels and trusted intake comments from draft PRs

## Validation
- `node --test .github\scripts\pr-intake\tests\pr-intake.test.mjs`
- `python -m unittest discover .github\scripts\issue-triage\tests -v`
- parsed all modified workflow YAML files with PyYAML
- `git diff --check`