### PR TITLE
[Window Hopper] Add AltBackTic attribution

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/AltWindowCyclePage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/AltWindowCyclePage.xaml
@@ -35,5 +35,8 @@
                 </controls:SettingsGroup>
             </StackPanel>
         </controls:SettingsPageControl.ModuleContent>
+        <controls:SettingsPageControl.SecondaryLinks>
+            <controls:PageLink x:Uid="Attribution_AltWindowCycle" Link="https://github.com/wzhudev" />
+        </controls:SettingsPageControl.SecondaryLinks>
     </controls:SettingsPageControl>
 </local:NavigablePage>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -117,6 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Attribution_AltWindowCycle.Text" xml:space="preserve">
+    <value>Wzhudev's work on AltBackTic</value>
+    <comment>Wzhudev is a person's GitHub username and AltBackTic is a product name. Do not localize either name; localize the attribution wording.</comment>
+  </data>
   <data name="Attribution_Rooler.Text" xml:space="preserve">
     <value>Inspired by Rooler</value>
     <comment>Rooler is a name of the tool.</comment>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -118,8 +118,8 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Attribution_AltWindowCycle.Text" xml:space="preserve">
-    <value>Wzhudev's work on AltBackTic</value>
-    <comment>Wzhudev is a person's GitHub username and AltBackTic is a product name. Do not localize either name; localize the attribution wording.</comment>
+    <value>Wzhudev's work on AltBackTick</value>
+    <comment>Wzhudev is a person's GitHub username and AltBackTick is a product name. Do not localize either name; localize the attribution wording.</comment>
   </data>
   <data name="Attribution_Rooler.Text" xml:space="preserve">
     <value>Inspired by Rooler</value>


### PR DESCRIPTION
## Summary
- add an attribution link to the Window Hopper settings page
- credit Wzhudev's work on AltBackTic and link to their GitHub profile

## Validation
- built `PowerToys.Settings.csproj` for Debug ARM64