### PR TITLE
[File Locksmith] Stop terminating the handle-enumeration worker

### DIFF
--- a/src/modules/FileLocksmith/FileLocksmithLibInterop/NtdllExtensions.cpp
+++ b/src/modules/FileLocksmith/FileLocksmithLibInterop/NtdllExtensions.cpp
@@ -3,6 +3,8 @@
 #include "NtdllExtensions.h"
 #include <thread>
 #include <atomic>
+#include <memory>
+#include <mutex>
 
 #define STATUS_INFO_LENGTH_MISMATCH ((LONG)0xC0000004)
 
@@ -160,131 +162,175 @@ std::vector<NtdllExtensions::HandleInfo> NtdllExtensions::handles() noexcept
         return {};
     }
 
-    auto info_ptr = reinterpret_cast<SYSTEM_HANDLE_INFORMATION_EX*>(get_info_result.memory.data());
-
-    std::map<ULONG_PTR, HANDLE> pid_to_handle;
-    std::vector<HandleInfo> result;
-
-    std::vector<BYTE> object_info_buffer(DefaultResultBufferSize);
-
-    std::atomic<ULONG> i = 0;
-    std::atomic<ULONG_PTR> handle_count = info_ptr->NumberOfHandles;
-    std::atomic<HANDLE> process_handle = NULL;
-    std::atomic<HANDLE> handle_copy = NULL;
-    ULONG previous_i;
-
-
-    while (i < handle_count)
+    // A worker blocked inside NtQueryObject cannot be stopped safely, so this function never
+    // terminates one.
+    //
+    // This previously called TerminateThread(offload_function.native_handle(), 1) on a
+    // std::thread that had already been detached. On the MSVC STL detach() clears the internal
+    // handle, so native_handle() returns null and the call fails with ERROR_INVALID_HANDLE:
+    // nothing was terminated, the stuck worker kept running, and the loop started another one
+    // on the same std::map, std::vector and scratch buffer with no synchronization. Had the
+    // terminate landed it would be no better, since killing a thread inside a syscall can
+    // leave the CRT heap lock held or a container half-updated.
+    //
+    // Instead a stuck worker is abandoned. Everything it can still reach is either owned by it
+    // outright or kept alive by this shared_ptr, so it stays harmless whether it eventually
+    // returns or blocks forever.
+    struct SharedState
     {
-        previous_i = i;
+        MemoryLoopResult info;
+        SYSTEM_HANDLE_INFORMATION_EX* info_ptr = nullptr;
+        ULONG_PTR handle_count = 0;
 
-        // The system calls we use in this block were reported to hang on some machines.
-        // We need to offload the cycle to another thread and keep track of progress to terminate and resume when needed.
-        // Unfortunately, there are no alternative APIs to what we're using that accept timeouts. (NtQueryObject and GetFileType)
-        auto offload_function = std::thread([&] {
-            for (; i < handle_count; i++)
-            {
-                process_handle = NULL;
-                handle_copy = NULL;
+        // Index of the next handle to hand out. Drives termination.
+        std::atomic<ULONG_PTR> next_index{ 0 };
+        // Handles fully inspected. Only used as the watchdog's progress signal; it advances
+        // for skipped handles too, so only a genuinely stuck query looks like a stall.
+        std::atomic<ULONG_PTR> processed{ 0 };
 
-                auto handle_info = info_ptr->Handles + i;
-                auto pid = handle_info->UniqueProcessId;
+        std::mutex result_mutex;
+        std::vector<HandleInfo> result;
+    };
 
-                auto iter = pid_to_handle.find(pid);
-                if (iter != pid_to_handle.end())
-                {
-                    process_handle = iter->second;
-                }
-                else
-                {
-                    process_handle = OpenProcess(PROCESS_DUP_HANDLE, FALSE, static_cast<DWORD>(pid));
-                    if (!process_handle)
-                    {
-                        continue;
-                    }
-                    pid_to_handle[pid] = process_handle;
-                }
+    auto state = std::make_shared<SharedState>();
+    state->info = std::move(get_info_result);
+    state->info_ptr = reinterpret_cast<SYSTEM_HANDLE_INFORMATION_EX*>(state->info.memory.data());
+    state->handle_count = state->info_ptr->NumberOfHandles;
 
-                // According to this:
-                // https://stackoverflow.com/questions/46384048/enumerate-handles
-                // NtQueryObject could hang
+    // Each worker owns its scratch buffer and its process-handle cache outright, so an
+    // abandoned worker shares no mutable state. `result` is the one exception and is only
+    // touched while holding `result_mutex`, never across a blocking call.
+    auto worker = [this, state] {
+        std::vector<BYTE> object_info_buffer(DefaultResultBufferSize);
+        std::map<ULONG_PTR, HANDLE> pid_to_handle;
 
-                // TODO uncomment and investigate
-                // if (handle_info->GrantedAccess == 0x0012019f) {
-                //     continue;
-                // }
-
-                HANDLE local_handle_copy;
-                auto dh_result = DuplicateHandle(process_handle, reinterpret_cast<HANDLE>(handle_info->HandleValue), GetCurrentProcess(), &local_handle_copy, 0, 0, DUPLICATE_SAME_ACCESS);
-                if (dh_result == 0)
-                {
-                    // Ignore this handle.
-                    continue;
-                }
-                handle_copy = local_handle_copy;
-
-                ULONG return_length;
-                auto status = NtQueryObject(handle_copy, ObjectTypeInformation, object_info_buffer.data(), static_cast<ULONG>(object_info_buffer.size()), &return_length);
-                if (NT_ERROR(status))
-                {
-                    // Ignore this handle.
-                    CloseHandle(handle_copy);
-                    handle_copy = NULL;
-                    continue;
-                }
-
-                auto object_type_info = reinterpret_cast<OBJECT_TYPE_INFORMATION*>(object_info_buffer.data());
-                auto type_name = unicode_to_str(object_type_info->Name);
-
-                std::wstring file_name;
-
-                if (type_name == L"File")
-                {
-                    file_name = file_handle_to_kernel_name(handle_copy, object_info_buffer);
-                    result.push_back(HandleInfo{ pid, handle_info->HandleValue, type_name, file_name });
-                }
-
-                CloseHandle(handle_copy);
-                handle_copy = NULL;
-            }
-        });
-
-        offload_function.detach();
-        do
+        for (;;)
         {
-            Sleep(200); // Timeout in milliseconds for detecting that the system hang on getting information for a handle.
-            if (i >= handle_count)
+            const ULONG_PTR index = state->next_index++;
+            if (index >= state->handle_count)
             {
-                // We're done.
                 break;
             }
 
-            if (previous_i >= i)
+            auto handle_info = state->info_ptr->Handles + index;
+            auto pid = handle_info->UniqueProcessId;
+
+            // A `GrantedAccess == 0x0012019f` skip used to sit here behind a "TODO uncomment
+            // and investigate", suggested as the cure for the NtQueryObject hang. It does stop
+            // the hang, but it also stops the tool from finding anything: 0x0012019F is exactly
+            // FILE_GENERIC_READ | FILE_GENERIC_WRITE (0x120089 | 0x120116), the granted access
+            // of an ordinary read-write file handle, which is the case File Locksmith exists to
+            // report. With it enabled, a process holding a file opened with FILE_SHARE_NONE is
+            // no longer listed. The stall is handled below instead, by abandoning the stuck
+            // worker safely.
+
+            HANDLE process_handle = NULL;
+            auto iter = pid_to_handle.find(pid);
+            if (iter != pid_to_handle.end())
             {
-                // The thread looks like it's hanging on some handle. Let's kill it and resume.
-
-                // HACK: This is unsafe and may leak something, but looks like there's no way to properly clean up a thread when it's hanging on a system call.
-                TerminateThread(offload_function.native_handle(), 1);
-
-                // Close Handles that might be lingering.
-                if (handle_copy!=NULL)
+                process_handle = iter->second;
+            }
+            else
+            {
+                process_handle = OpenProcess(PROCESS_DUP_HANDLE, FALSE, static_cast<DWORD>(pid));
+                if (!process_handle)
                 {
-                    CloseHandle(handle_copy);
+                    state->processed++;
+                    continue;
                 }
-                i++;
+                pid_to_handle[pid] = process_handle;
+            }
+
+            HANDLE handle_copy = NULL;
+            auto dh_result = DuplicateHandle(process_handle, reinterpret_cast<HANDLE>(handle_info->HandleValue), GetCurrentProcess(), &handle_copy, 0, 0, DUPLICATE_SAME_ACCESS);
+            if (dh_result == 0)
+            {
+                // Ignore this handle.
+                state->processed++;
+                continue;
+            }
+
+            ULONG return_length;
+            auto status = NtQueryObject(handle_copy, ObjectTypeInformation, object_info_buffer.data(), static_cast<ULONG>(object_info_buffer.size()), &return_length);
+            if (NT_ERROR(status))
+            {
+                // Ignore this handle.
+                CloseHandle(handle_copy);
+                state->processed++;
+                continue;
+            }
+
+            auto object_type_info = reinterpret_cast<OBJECT_TYPE_INFORMATION*>(object_info_buffer.data());
+            auto type_name = unicode_to_str(object_type_info->Name);
+
+            if (type_name == L"File")
+            {
+                auto file_name = file_handle_to_kernel_name(handle_copy, object_info_buffer);
+
+                std::scoped_lock lock{ state->result_mutex };
+                state->result.push_back(HandleInfo{ pid, handle_info->HandleValue, type_name, file_name });
+            }
+
+            CloseHandle(handle_copy);
+            state->processed++;
+        }
+
+        for (auto [pid, handle] : pid_to_handle)
+        {
+            CloseHandle(handle);
+        }
+    };
+
+    constexpr DWORD poll_interval_ms = 200;
+    // A worker is only declared stuck after several consecutive polls with no progress at
+    // all. The previous code treated a single missed 200 ms tick as a hang, so a merely slow
+    // query on a busy machine was enough to trigger the recovery path.
+    constexpr int stalled_polls_before_abandon = 10;
+    // Bounds how much we leak, and how long a pathological machine can keep us here. When
+    // exceeded we return what has been collected so far instead of spawning more workers.
+    constexpr int max_abandoned_workers = 4;
+
+    int abandoned_workers = 0;
+
+    while (state->next_index < state->handle_count && abandoned_workers < max_abandoned_workers)
+    {
+        std::thread worker_thread(worker);
+
+        ULONG_PTR last_processed = state->processed;
+        int stalled_polls = 0;
+
+        for (;;)
+        {
+            // Valid here precisely because the thread has not been detached yet.
+            if (WaitForSingleObject(worker_thread.native_handle(), poll_interval_ms) == WAIT_OBJECT_0)
+            {
+                worker_thread.join();
                 break;
             }
-            previous_i = i;
-        } while (1);
 
+            const ULONG_PTR processed_now = state->processed;
+            if (processed_now != last_processed)
+            {
+                last_processed = processed_now;
+                stalled_polls = 0;
+                continue;
+            }
+
+            if (++stalled_polls < stalled_polls_before_abandon)
+            {
+                continue;
+            }
+
+            // Stuck in a call we cannot interrupt. Let it go and continue with a fresh
+            // worker; `next_index` has already moved past the offending handle.
+            worker_thread.detach();
+            abandoned_workers++;
+            break;
+        }
     }
 
-    for (auto [pid, handle] : pid_to_handle)
-    {
-        CloseHandle(handle);
-    }
-
-    return result;
+    std::scoped_lock lock{ state->result_mutex };
+    return state->result;
 }
 
 // Returns the list of all processes.


### PR DESCRIPTION
## Summary of the Pull Request

`NtdllExtensions::handles()` duplicates every handle in the system and calls `NtQueryObject` on it. Some handles make that call block indefinitely, so the loop runs on a worker thread and a watchdog tries to recover by terminating it. That recovery path turns out to be where the crash in #49789 comes from, and on the MSVC STL it also does not terminate anything.

This change drops `TerminateThread` and makes abandoning a stalled worker safe instead.

Measured on an affected machine, before and after:

| Build | Survived | Crashed |
|---|---|---|
| 0.100.2 as shipped | 5 / 12 | **7 / 12**, all `0xC0000005` in `PowerToys.FileLocksmithLib.Interop.dll` |
| With this change | **32 / 32** | 0 |

## PR Checklist

- [x] Closes: #49789
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

Notes on the unchecked items: no automated tests were added (see Validation below for why), no end-user-facing strings changed, no new binaries or projects, and no dev/user documentation is affected. This touches one existing `.cpp` only.

## Detailed Description of the Pull Request / Additional comments

### The current recovery path

```cpp
auto offload_function = std::thread([&] { /* enumerate handles */ });

offload_function.detach();
do
{
    Sleep(200);
    if (i >= handle_count) break;
    if (previous_i >= i)
    {
        // HACK: This is unsafe and may leak something ...
        TerminateThread(offload_function.native_handle(), 1);
        if (handle_copy != NULL) { CloseHandle(handle_copy); }
        i++;
        break;
    }
    previous_i = i;
} while (1);
```

**1. The terminate does not land.** `native_handle()` is called after `detach()`. That is undefined behaviour in general, and on the MSVC STL `detach()` clears the internal handle, so `native_handle()` returns null from that point on.

Verified with a standalone repro built with the same toolset (VS 2022 17.14 / MSVC 14.44) rather than assumed:

```cpp
std::thread t([] { Sleep(30000); });
printf("before: %p joinable=%d\n", t.native_handle(), (int)t.joinable());
t.detach();
printf("after:  %p joinable=%d\n", t.native_handle(), (int)t.joinable());
SetLastError(0);
BOOL ok = TerminateThread(t.native_handle(), 1);
printf("TerminateThread -> %d, GetLastError=%lu\n", (int)ok, GetLastError());
```

```
before: 00000000000000BC joinable=1
after:  0000000000000000 joinable=0
TerminateThread -> 0, GetLastError=6      (ERROR_INVALID_HANDLE)
```

**2. So workers accumulate.** Since nothing is terminated, the stalled worker keeps running, `i++` executes, the enclosing `while (i < handle_count)` iterates, and a second worker starts while the first is still alive. From then on both share, without synchronization:

| Shared object | Type | Used by both workers for |
|---|---|---|
| `pid_to_handle` | `std::map<ULONG_PTR, HANDLE>` | `insert` |
| `result` | `std::vector<HandleInfo>` | `push_back` |
| `object_info_buffer` | `std::vector<BYTE>` | `NtQueryObject` output buffer |

`i`, `process_handle` and `handle_copy` are `std::atomic`; these three are not. Concurrent `std::map::insert` and `std::vector::push_back` looks like the most direct route to the corruption, and it fits the nondeterministic fault site — #49789 has reports of both `0xC0000374` (heap corruption in `ntdll`) and `0xC0000005` (access violation inside the interop DLL) from the same operation. On my machine four crashes landed in three different WER buckets.

**3. Had it landed, that would also be unsafe.** Terminating a thread inside a syscall can leave the CRT heap lock held or a container half-updated. There is no safe way to stop a thread blocked in `NtQueryObject`, which is what the existing `HACK:` comment is getting at.

### What this change does

- **Drops `TerminateThread`.** A stalled worker is abandoned rather than killed.
- **Makes abandonment safe.** Each worker owns its scratch buffer and its process-handle cache, so an abandoned worker shares no mutable state. The result vector is the one shared object; it is only touched under a mutex, and that mutex is never held across a blocking call, so a stuck worker cannot be holding it.
- **Keeps abandoned workers harmless.** Everything reachable from a worker, including the `SystemExtendedHandleInformation` buffer that `info_ptr` points into, is owned by a `shared_ptr` captured by value, so it outlives the call whether or not the worker ever returns.
- **Relaxes the stall detector.** Several consecutive polls with no progress are required instead of a single missed 200 ms tick, so a merely slow query on a busy machine no longer trips it.
- **Bounds the cost.** At most 4 workers may be abandoned; past that the function returns what it collected rather than spawning more.

On a healthy machine behaviour is unchanged: one worker enumerates everything and is joined normally.

### A note on the `0x0012019f` TODO

The file carries this, just above the duplicated handle:

```cpp
// TODO uncomment and investigate
// if (handle_info->GrantedAccess == 0x0012019f) {
//     continue;
// }
```

I tried enabling it first, since the StackOverflow answer it cites offers it as the fix for the `NtQueryObject` hang. It does stop the hang, but it also stops the tool from finding anything, so this PR leaves it disabled.

`0x0012019F` is exactly `FILE_GENERIC_READ | FILE_GENERIC_WRITE` (`0x120089 | 0x120116`) — the granted access of an ordinary read-write file handle, which is the case File Locksmith exists to report.

Measured with the skip enabled: a helper process holding a temp file open with `FILE_SHARE_NONE` was no longer listed, and File Locksmith reported "No results found" for a file that was definitely locked. With the skip left disabled, the same process is listed again.

I replaced the `TODO` with a short note recording this, so the next person reading the file has the answer already. Happy to drop that comment if you would rather keep the file terse.

### Known gap

An abandoned worker still holds a raw `this` for the ntdll entry points, so it depends on the `NtdllExtensions` instance outliving it. Closing that would mean giving those function pointers shared ownership. I left it out to keep the diff focused, but I am glad to fold it in if you would prefer it handled here.

## Validation Steps Performed

Built with VS 2022 17.14 / MSVC 14.44.35207 / Windows SDK 26100, `Release|x64`. The project builds under its existing `/W4 /WX` and `/analyze` settings with **0 warnings and 0 errors**.

Validated by replacing `PowerToys.FileLocksmithLib.Interop.dll` in an installed 0.100.2 on Windows 11 26200 — the export surface (`DllCanUnloadNow`, `DllGetActivationFactory`) is unchanged, so the shipped managed UI loads it as-is.

**Crash resistance** — scripted launches of the File Locksmith UI, each given 18-20 s to finish enumerating:

| Build | Target | Launches | Crashed | `Application Error` events |
|---|---|---|---|---|
| As shipped | `C:\Windows\explorer.exe` | 12 | 7 (`0xC0000005` in the interop DLL) | 10 |
| Patched | `C:\Windows\explorer.exe` | 12 | 0 | 0 |
| Patched | `C:\Windows\System32\ntdll.dll` | 20 | 0 | 0 |

32 patched launches across two targets, no crash and no Windows error-log entry.

**Functional check** — a helper process holds a temp file open with `FILE_SHARE_NONE`, then File Locksmith is pointed at that file:

| Build | Result |
|---|---|
| As shipped | Lists the holding process |
| Patched | Lists the holding process (unchanged) |
| With the `0x0012019f` skip enabled | "No results found" — which is what ruled that approach out |

No automated tests were added. The failure is a timing-dependent race against live system-wide handle state, and I did not find a way to express that reliably as a unit test. Suggestions welcome if you would like one.