### PR TITLE
[CmdPal] Rank global fallbacks by their title match

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -836,11 +836,9 @@ public sealed partial class MainListPage : DynamicListPage,
         return allApps.IsLoading || _tlcManager.IsLoading;
     }
 
-    // Almost verbatim ListHelpers.ScoreListItem. Fallbacks are tiered by the same lexical
-    // relationship as any other item (their dynamic title reflects the query), so a fallback
-    // whose title matches the query well ranks with the equivalent real matches. A fallback that
-    // did not match at all floors to FallbackFloor (see MainListRanker.ClassifyTier) rather than
-    // dropping, so always-available handlers keep showing without dominating the top.
+    // Almost verbatim ListHelpers.ScoreListItem. Fallbacks tier by the same title match as any
+    // other item, except a non-match floors to FallbackFloor (see MainListRanker.ClassifyTier) so
+    // the handler stays available instead of dropping.
     internal static int ScoreTopLevelItem(
         in FuzzyQuery query,
         IListItem topLevelOrAppItem,

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -836,9 +836,11 @@ public sealed partial class MainListPage : DynamicListPage,
         return allApps.IsLoading || _tlcManager.IsLoading;
     }
 
-    // Almost verbatim ListHelpers.ScoreListItem, but also accounting for the
-    // fact that we want fallback handlers down-weighted, so that they don't
-    // _always_ show up first.
+    // Almost verbatim ListHelpers.ScoreListItem. Fallbacks are tiered by the same lexical
+    // relationship as any other item (their dynamic title reflects the query), so a fallback
+    // whose title matches the query well ranks with the equivalent real matches. A fallback that
+    // did not match at all floors to FallbackFloor (see MainListRanker.ClassifyTier) rather than
+    // dropping, so always-available handlers keep showing without dominating the top.
     internal static int ScoreTopLevelItem(
         in FuzzyQuery query,
         IListItem topLevelOrAppItem,

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListRanker.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListRanker.cs
@@ -86,7 +86,10 @@ internal static class MainListRanker
     /// </summary>
     /// <param name="query">The raw query text.</param>
     /// <param name="title">The item's title.</param>
-    /// <param name="isFallback">Whether the item is a fallback (always ranked at the floor).</param>
+    /// <param name="isFallback">Whether the item is a fallback. A fallback is tiered by the same
+    /// lexical relationship as any other item (its dynamic title reflects the query), but is
+    /// floored to <see cref="RankTier.FallbackFloor"/> when nothing matched so an always-available
+    /// handler is never dropped.</param>
     /// <param name="isAliasExact">Whether the query exactly equals the item's alias.</param>
     /// <param name="isAliasSubstringMatch">Whether the item's alias starts with the query
     /// (a partial alias match). An alias is an explicit, user-assigned shortcut and may be
@@ -107,13 +110,30 @@ internal static class MainListRanker
             return RankTier.AliasExact;
         }
 
-        // Fallbacks always live at the floor so dynamic matches (e.g. RDP hosts) appear
-        // after direct command and app matches.
+        var lexicalTier = ClassifyLexicalTier(query, title, isAliasSubstringMatch, matchedLexically);
+
+        // A fallback earns whatever tier its title relationship deserves - a fallback whose
+        // dynamic title exactly matches the query is a genuine top result. But because a fallback
+        // is an always-available handler, a non-match floors to FallbackFloor rather than dropping
+        // it, so handlers like "Run command" and web search keep showing.
         if (isFallback)
         {
-            return RankTier.FallbackFloor;
+            return lexicalTier == RankTier.None ? RankTier.FallbackFloor : lexicalTier;
         }
 
+        return lexicalTier;
+    }
+
+    /// <summary>
+    /// Classifies the lexical relationship between the query and the title into a tier, with no
+    /// fallback flooring. Returns <see cref="RankTier.None"/> when nothing matched.
+    /// </summary>
+    private static RankTier ClassifyLexicalTier(
+        string query,
+        string title,
+        bool isAliasSubstringMatch,
+        bool matchedLexically)
+    {
         // A partial alias match is enough to keep the item visible even when nothing else
         // matched. It only floors to Fuzzy; a stronger title relationship below still wins.
         var matchedOrAlias = matchedLexically || isAliasSubstringMatch;
@@ -251,9 +271,10 @@ public enum RankTier
     /// <summary>No match. The item should be filtered out.</summary>
     None = 0,
 
-    /// <summary>The item only matched because it is an always-present fallback, or a
-    /// fallback whose dynamic title matched. Fallbacks live at the floor so they appear
-    /// after direct command/app matches.</summary>
+    /// <summary>A fallback whose title had no lexical relationship to the query. Fallbacks are
+    /// always-available handlers, so instead of dropping they floor here and appear after
+    /// direct command/app matches. A fallback whose dynamic title <i>does</i> match the query is
+    /// tiered by that relationship like any other item, not floored here.</summary>
     FallbackFloor = 1,
 
     /// <summary>The query matched as a fuzzy subsequence of the title, subtitle, or

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListRanker.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListRanker.cs
@@ -86,10 +86,8 @@ internal static class MainListRanker
     /// </summary>
     /// <param name="query">The raw query text.</param>
     /// <param name="title">The item's title.</param>
-    /// <param name="isFallback">Whether the item is a fallback. A fallback is tiered by the same
-    /// lexical relationship as any other item (its dynamic title reflects the query), but is
-    /// floored to <see cref="RankTier.FallbackFloor"/> when nothing matched so an always-available
-    /// handler is never dropped.</param>
+    /// <param name="isFallback">Whether the item is a fallback. A fallback tiers like any other
+    /// item, but floors to <see cref="RankTier.FallbackFloor"/> when nothing matches so it's never dropped.</param>
     /// <param name="isAliasExact">Whether the query exactly equals the item's alias.</param>
     /// <param name="isAliasSubstringMatch">Whether the item's alias starts with the query
     /// (a partial alias match). An alias is an explicit, user-assigned shortcut and may be
@@ -112,10 +110,8 @@ internal static class MainListRanker
 
         var lexicalTier = ClassifyLexicalTier(query, title, isAliasSubstringMatch, matchedLexically);
 
-        // A fallback earns whatever tier its title relationship deserves - a fallback whose
-        // dynamic title exactly matches the query is a genuine top result. But because a fallback
-        // is an always-available handler, a non-match floors to FallbackFloor rather than dropping
-        // it, so handlers like "Run command" and web search keep showing.
+        // A fallback's title reflects the query, so tier it like anything else. Floor a non-match
+        // instead of dropping it, so handlers like Run command and web search keep showing.
         if (isFallback)
         {
             return lexicalTier == RankTier.None ? RankTier.FallbackFloor : lexicalTier;
@@ -125,8 +121,8 @@ internal static class MainListRanker
     }
 
     /// <summary>
-    /// Classifies the lexical relationship between the query and the title into a tier, with no
-    /// fallback flooring. Returns <see cref="RankTier.None"/> when nothing matched.
+    /// Tiers the query-to-title match with no fallback flooring. Returns
+    /// <see cref="RankTier.None"/> when nothing matched.
     /// </summary>
     private static RankTier ClassifyLexicalTier(
         string query,
@@ -271,10 +267,8 @@ public enum RankTier
     /// <summary>No match. The item should be filtered out.</summary>
     None = 0,
 
-    /// <summary>A fallback whose title had no lexical relationship to the query. Fallbacks are
-    /// always-available handlers, so instead of dropping they floor here and appear after
-    /// direct command/app matches. A fallback whose dynamic title <i>does</i> match the query is
-    /// tiered by that relationship like any other item, not floored here.</summary>
+    /// <summary>A fallback that didn't match the query. It floors here instead of dropping so the
+    /// handler stays available, while a fallback whose title does match is tiered like any other item.</summary>
     FallbackFloor = 1,
 
     /// <summary>The query matched as a fuzzy subsequence of the title, subtitle, or

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/MainListRankerTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/MainListRankerTests.cs
@@ -21,7 +21,11 @@ public class MainListRankerTests
 {
     [DataTestMethod]
     [DataRow("gh", "GitHub", true, true, false, false, RankTier.AliasExact, DisplayName = "Alias-exact is the strongest, most explicit signal and beats even a fallback flag")]
-    [DataRow("anything", "Some Fallback", true, false, false, true, RankTier.FallbackFloor, DisplayName = "A fallback that is not alias-exact lands on the floor regardless of a lexical match")]
+    [DataRow("zzz", "Some Fallback", true, false, false, false, RankTier.FallbackFloor, DisplayName = "A fallback that did not match at all floors to FallbackFloor rather than dropping")]
+    [DataRow("reload", "Reload", true, false, false, true, RankTier.ExactTitle, DisplayName = "A fallback whose dynamic title exactly matches the query earns ExactTitle")]
+    [DataRow("rel", "Reload", true, false, false, true, RankTier.Prefix, DisplayName = "A fallback whose title starts with the query earns Prefix")]
+    [DataRow("vs", "Visual Studio Code", true, false, false, true, RankTier.AcronymWordBoundary, DisplayName = "A fallback acronym match earns AcronymWordBoundary")]
+    [DataRow("cmd", "Command Prompt", true, false, false, true, RankTier.Fuzzy, DisplayName = "A fallback fuzzy match earns Fuzzy")]
     [DataRow("calculator", "Calculator", false, false, false, true, RankTier.ExactTitle, DisplayName = "Exact title match")]
     [DataRow("cal", "Calculator", false, false, false, true, RankTier.Prefix, DisplayName = "Title prefix match")]
     [DataRow("code", "Visual Studio Code", false, false, false, true, RankTier.AcronymWordBoundary, DisplayName = "Word-boundary match")]
@@ -41,6 +45,29 @@ public class MainListRankerTests
         Assert.AreEqual(
             expected,
             MainListRanker.ClassifyTier(query, title, isFallback, isAliasExact, isAliasSubstringMatch, matchedLexically));
+    }
+
+    [TestMethod]
+    public void ClassifyThenPack_ExactFallbackOutranksFuzzyNonFallback()
+    {
+        // The reported bug: searching "reload" surfaced fuzzy junk (e.g. "Fast Virtual Desktops")
+        // above the exact "Reload" fallback because fallbacks were pinned to FallbackFloor. Now a
+        // fallback whose dynamic title exactly matches is tiered like any exact match, so it wins
+        // even against a fuzzy non-fallback carrying the maximum possible within-tier score.
+        var fallbackTier = MainListRanker.ClassifyTier(
+            "reload", "Reload", isFallback: true, isAliasExact: false, isAliasSubstringMatch: false, matchedLexically: true);
+        var fuzzyTier = MainListRanker.ClassifyTier(
+            "reload", "Fast Virtual Desktops", isFallback: false, isAliasExact: false, isAliasSubstringMatch: false, matchedLexically: true);
+
+        Assert.AreEqual(RankTier.ExactTitle, fallbackTier, "An exact-title fallback should be tiered ExactTitle");
+        Assert.AreEqual(RankTier.Fuzzy, fuzzyTier, "A loose subsequence match should be tiered Fuzzy");
+
+        var fallbackScore = MainListRanker.Pack(fallbackTier, withinTierScore: 0);
+        var fuzzyScore = MainListRanker.Pack(fuzzyTier, MainListRanker.TierStride - 1);
+
+        Assert.IsTrue(
+            fallbackScore > fuzzyScore,
+            "An exact-title fallback must outrank a fuzzy non-fallback even at the fuzzy item's best within-tier score");
     }
 
     [TestMethod]


### PR DESCRIPTION
Fallbacks were always getting buried under fuzzy junk, even though their title matched exactly what you typed. The recent MainListPage ranking overhaul pinned every fallback to the bottom tier, so a perfect match was treated the same as no match at all.

Global fallbacks now earn the tier their title/subtitle actually deserves. A fallback resolves a live title from your query, so when that title matches exactly (like "Reload" for "reload"), it ranks right alongside a real command's exact match instead of getting floored. Fallbacks that don't match anything still drop to the floor, so always-available handlers like Run command and web search keep showing without crowding the top. 

Non-global fallbacks stay in their own bottom section like before.


https://github.com/user-attachments/assets/685b8cc2-3a69-4ea8-91a9-cfba08a1d23c
