### PR TITLE
[Settings] Move NEW tag from Shortcut Guide to Window Hopper

### DIFF
--- a/src/settings-ui/Settings.UI/OOBE/ViewModel/OobeShellViewModel.cs
+++ b/src/settings-ui/Settings.UI/OOBE/ViewModel/OobeShellViewModel.cs
@@ -44,7 +44,7 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.ViewModel
             (PowerToysModules.TextExtractor, false),
             (PowerToysModules.MeasureTool, false),
             (PowerToysModules.Hosts, false),
-            (PowerToysModules.AltWindowCycle, false),
+            (PowerToysModules.AltWindowCycle, true),
             (PowerToysModules.Workspaces, false),
             (PowerToysModules.GrabAndMove, false),
             (PowerToysModules.RegistryPreview, false),

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/ShellPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/ShellPage.xaml
@@ -236,11 +236,7 @@
                             x:Uid="Shell_ShortcutGuide"
                             helpers:NavHelper.NavigateTo="views:ShortcutGuidePage"
                             AutomationProperties.AutomationId="ShortcutGuideNavItem"
-                            Icon="{ui:BitmapIcon Source=/Assets/Settings/Icons/ShortcutGuide.png}">
-                            <NavigationViewItem.InfoBadge>
-                                <InfoBadge Style="{StaticResource NewInfoBadge}" />
-                            </NavigationViewItem.InfoBadge>
-                        </NavigationViewItem>
+                            Icon="{ui:BitmapIcon Source=/Assets/Settings/Icons/ShortcutGuide.png}" />
                         <NavigationViewItem
                             x:Name="TextExtractorNavigationItem"
                             x:Uid="Shell_TextExtractor"
@@ -254,9 +250,6 @@
                             AutomationProperties.AutomationId="ZoomItNavItem"
                             Icon="{ui:BitmapIcon Source=/Assets/Settings/Icons/ZoomIt.png}" />
                     </NavigationViewItem.MenuItems>
-                    <NavigationViewItem.InfoBadge>
-                        <InfoBadge Style="{StaticResource NewInfoBadge}" />
-                    </NavigationViewItem.InfoBadge>
                 </NavigationViewItem>
 
                 <!--  Windowing & Layouts  -->
@@ -266,6 +259,9 @@
                     AutomationProperties.AutomationId="WindowingAndLayoutsNavItem"
                     Icon="{ui:BitmapIcon Source=/Assets/Settings/Icons/WindowingAndLayouts.png}"
                     SelectsOnInvoked="False">
+                    <NavigationViewItem.InfoBadge>
+                        <InfoBadge Style="{StaticResource NewInfoBadge}" />
+                    </NavigationViewItem.InfoBadge>
                     <NavigationViewItem.MenuItems>
                         <NavigationViewItem
                             x:Name="AlwaysOnTopNavigationItem"
@@ -296,7 +292,11 @@
                             x:Uid="Shell_AltWindowCycle"
                             helpers:NavHelper.NavigateTo="views:AltWindowCyclePage"
                             AutomationProperties.AutomationId="AltWindowCycleNavItem"
-                            Icon="{ui:BitmapIcon Source=/Assets/Settings/Icons/WindowHopper.png}" />
+                            Icon="{ui:BitmapIcon Source=/Assets/Settings/Icons/WindowHopper.png}">
+                            <NavigationViewItem.InfoBadge>
+                                <InfoBadge Style="{StaticResource NewInfoBadge}" />
+                            </NavigationViewItem.InfoBadge>
+                        </NavigationViewItem>
                         <NavigationViewItem
                             x:Name="WorkspacesNavigationItem"
                             x:Uid="Shell_Workspaces"

--- a/src/settings-ui/Settings.UI/ViewModels/DashboardViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/DashboardViewModel.cs
@@ -223,7 +223,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                     IsEnabled = gpo == GpoRuleConfigured.Enabled || (gpo != GpoRuleConfigured.Disabled && ModuleHelper.GetIsModuleEnabled(generalSettingsConfig, moduleType)),
                     IsLocked = gpo == GpoRuleConfigured.Enabled || gpo == GpoRuleConfigured.Disabled,
                     Icon = ModuleHelper.GetModuleTypeFluentIconName(moduleType),
-                    IsNew = moduleType == ModuleType.ShortcutGuide,
+                    IsNew = moduleType == ModuleType.AltWindowCycle,
                     DashboardModuleItems = GetModuleItems(moduleType),
                     ClickCommand = new RelayCommand<object>(DashboardListItemClick),
                 };


### PR DESCRIPTION
## Summary of the Pull Request

Moves the `NEW` tag from Shortcut Guide to Window Hopper across Settings:

- Moves the navigation badge, including the collapsed parent-category badge, from System Tools to Windowing & Layouts.
- Marks Window Hopper instead of Shortcut Guide as new on the Dashboard.
- Marks Window Hopper as the new module in the OOBE module metadata.

## PR Checklist

- [ ] Closes: #xxx
- [x] **Communication:** Requested by a PowerToys contributor
- [ ] **Tests:** Not run
- [x] **Localization:** No end-user-facing strings were added or changed
- [ ] **Dev docs:** Not applicable
- [ ] **New binaries:** Not applicable
- [ ] **Documentation updated:** Not applicable

## Detailed Description of the Pull Request / Additional comments

Shortcut Guide no longer shows the `NEW` tag in the Settings navigation or Dashboard. Window Hopper now shows it in both locations. The parent navigation badges were moved as well so the correct category surfaces the tag when collapsed.

The OOBE metadata already had Shortcut Guide marked as not new; this change marks Window Hopper as new.

## Validation Steps Performed

- Ran `git diff --check`.
- Parsed `ShellPage.xaml` as XML.
- Ran source-level assertions verifying badge ownership for Shortcut Guide, System Tools, Window Hopper, and Windowing & Layouts.
- Build and tests were not run, following the repository instruction to avoid builds during routine verification.