### PR TITLE
Add plain text fallback support to peek

### DIFF
--- a/PowerToys.slnx
+++ b/PowerToys.slnx
@@ -937,6 +937,10 @@
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />
     </Project>
+    <Project Path="src/modules/peek/Peek.FilePreviewer.UnitTests/Peek.FilePreviewer.UnitTests.csproj">
+      <Platform Solution="*|ARM64" Project="ARM64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
     <Project Path="src/modules/peek/Peek.UI/Peek.UI.csproj">
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />

--- a/src/modules/peek/Peek.FilePreviewer.UnitTests/Peek.FilePreviewer.UnitTests.csproj
+++ b/src/modules/peek/Peek.FilePreviewer.UnitTests/Peek.FilePreviewer.UnitTests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- Look at Directory.Build.props in root for common stuff as well -->
+  <Import Project="$(RepoRoot)src\Common.Dotnet.CsWinRT.props" />
+
+  <PropertyGroup>
+    <SelfContained>true</SelfContained>
+    <RuntimeIdentifier Condition="'$(Platform)' == 'x64'">win-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(Platform)' == 'ARM64'">win-arm64</RuntimeIdentifier>
+    <IsPackable>false</IsPackable>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\tests\Peek.FilePreviewer.Tests\</OutputPath>
+    <RootNamespace>Peek.FilePreviewer.UnitTests</RootNamespace>
+    <AssemblyName>PowerToys.Peek.FilePreviewer.UnitTests</AssemblyName>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Peek.FilePreviewer\Peek.FilePreviewer.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/modules/peek/Peek.FilePreviewer.UnitTests/ReadHelperTests.cs
+++ b/src/modules/peek/Peek.FilePreviewer.UnitTests/ReadHelperTests.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Peek.FilePreviewer.Previewers;
+
+namespace Peek.FilePreviewer.UnitTests
+{
+    [TestClass]
+    public class ReadHelperTests
+    {
+        private string _tempFilePath = string.Empty;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            _tempFilePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".tmp");
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            if (File.Exists(_tempFilePath))
+            {
+                File.Delete(_tempFilePath);
+            }
+        }
+
+        [TestMethod]
+        public async Task Read_PlainTextFile_ShouldReturnContent()
+        {
+            File.WriteAllText(_tempFilePath, "Hello, world!", Encoding.UTF8);
+
+            string content = await ReadHelper.Read(_tempFilePath);
+
+            Assert.AreEqual("Hello, world!", content);
+        }
+
+        [TestMethod]
+        public async Task Read_FileExceedsMaxSize_ShouldThrow()
+        {
+            byte[] buffer = new byte[ReadHelper.MaxReadableFileSizeBytes + 1];
+            File.WriteAllBytes(_tempFilePath, buffer);
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => ReadHelper.Read(_tempFilePath));
+        }
+    }
+}

--- a/src/modules/peek/Peek.FilePreviewer.UnitTests/ReadHelperTests.cs
+++ b/src/modules/peek/Peek.FilePreviewer.UnitTests/ReadHelperTests.cs
@@ -4,7 +4,9 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Peek.FilePreviewer.Previewers;
@@ -48,6 +50,95 @@ namespace Peek.FilePreviewer.UnitTests
             File.WriteAllBytes(_tempFilePath, buffer);
 
             await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => ReadHelper.Read(_tempFilePath));
+        }
+
+        [TestMethod]
+        public async Task Read_FileExceedsExplicitMaxSize_ShouldThrow()
+        {
+            File.WriteAllText(_tempFilePath, new string('a', 4096), Encoding.UTF8);
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => ReadHelper.Read(_tempFilePath, maxReadableFileSizeBytes: 1024));
+        }
+
+        [TestMethod]
+        public async Task Read_FileWithinExplicitMaxSize_ShouldReturnContent()
+        {
+            File.WriteAllText(_tempFilePath, "small enough", Encoding.UTF8);
+
+            string content = await ReadHelper.Read(_tempFilePath, maxReadableFileSizeBytes: 1024);
+
+            Assert.AreEqual("small enough", content);
+        }
+
+        [TestMethod]
+        public async Task Read_Utf16LeFileWithBom_ShouldDecodeAndStripBom()
+        {
+            File.WriteAllText(_tempFilePath, "Unicode café", Encoding.Unicode);
+
+            string content = await ReadHelper.Read(_tempFilePath);
+
+            Assert.AreEqual("Unicode café", content);
+        }
+
+        [TestMethod]
+        public async Task Read_Utf8FileWithBom_ShouldDecodeAndStripBom()
+        {
+            File.WriteAllText(_tempFilePath, "text with bom", new UTF8Encoding(encoderShouldEmitUTF8Identifier: true));
+
+            string content = await ReadHelper.Read(_tempFilePath);
+
+            Assert.AreEqual("text with bom", content);
+        }
+
+        [TestMethod]
+        public async Task Read_Cancelled_ShouldThrow()
+        {
+            File.WriteAllText(_tempFilePath, "Hello, world!", Encoding.UTF8);
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsExceptionAsync<OperationCanceledException>(
+                () => ReadHelper.Read(_tempFilePath, ReadHelper.MaxReadableFileSizeBytes, cts.Token));
+        }
+
+        // Larger than the 64 KB charset-detection sample: the body must still be decoded to EOF,
+        // not just the sampled prefix.
+        [TestMethod]
+        public async Task Read_FileLargerThanCharsetSample_ShouldReturnFullContent()
+        {
+            string expected = new string('a', 200_000);
+            File.WriteAllText(_tempFilePath, expected, Encoding.UTF8);
+
+            string content = await ReadHelper.Read(_tempFilePath);
+
+            Assert.AreEqual(expected, content);
+        }
+
+        // File larger than the sample, non-UTF-8 encoding identified from a BOM in the sampled prefix:
+        // the streamed decode must honour that encoding and strip the BOM for the whole body.
+        [TestMethod]
+        public async Task Read_LargeUtf16FileWithBom_ShouldDecodeFullContent()
+        {
+            string expected = "café résumé " + new string('x', 200_000);
+            File.WriteAllText(_tempFilePath, expected, Encoding.Unicode);
+
+            string content = await ReadHelper.Read(_tempFilePath);
+
+            Assert.AreEqual(expected, content);
+        }
+
+        // File larger than the sample, dense non-ASCII UTF-8 (no BOM) in the sampled prefix: detection
+        // should pick UTF-8 and every multi-byte character must survive the streamed decode.
+        [TestMethod]
+        public async Task Read_LargeUtf8FileNoBom_ShouldDecodeCorrectly()
+        {
+            string prefix = string.Concat(Enumerable.Repeat("café résumé naïve piñata ", 400));
+            string expected = prefix + new string('x', 200_000);
+            File.WriteAllText(_tempFilePath, expected, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+            string content = await ReadHelper.Read(_tempFilePath);
+
+            Assert.AreEqual(expected, content);
         }
     }
 }

--- a/src/modules/peek/Peek.FilePreviewer.UnitTests/TextFileHelperTests.cs
+++ b/src/modules/peek/Peek.FilePreviewer.UnitTests/TextFileHelperTests.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Peek.FilePreviewer.Previewers;
+
+namespace Peek.FilePreviewer.UnitTests
+{
+    [TestClass]
+    public class TextFileHelperTests
+    {
+        private string _tempFilePath = string.Empty;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            _tempFilePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".tmp");
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            if (File.Exists(_tempFilePath))
+            {
+                // File.Delete(_tempFilePath);
+            }
+        }
+
+        [TestMethod]
+        public void IsTextFile_PlainAsciiContent_ShouldReturnTrue()
+        {
+            File.WriteAllText(_tempFilePath, "Hello, world!\r\nThis is a plain text file.");
+
+            Assert.IsTrue(TextFileHelper.IsTextFile(_tempFilePath));
+        }
+
+        [TestMethod]
+        public void IsTextFile_EmptyFile_ShouldReturnTrue()
+        {
+            File.WriteAllBytes(_tempFilePath, Array.Empty<byte>());
+
+            Assert.IsTrue(TextFileHelper.IsTextFile(_tempFilePath));
+        }
+
+        [TestMethod]
+        public void IsTextFile_ContentWithNulByte_ShouldReturnFalse()
+        {
+            byte[] content = Encoding.UTF8.GetBytes("some text before");
+            byte[] withNul = new byte[content.Length + 1];
+            Array.Copy(content, withNul, content.Length);
+            withNul[content.Length] = 0;
+            File.WriteAllBytes(_tempFilePath, withNul);
+
+            Assert.IsFalse(TextFileHelper.IsTextFile(_tempFilePath));
+        }
+
+        [TestMethod]
+        public void IsTextFile_Utf8WithBom_ShouldReturnTrue()
+        {
+            File.WriteAllText(_tempFilePath, "Text with a BOM", new UTF8Encoding(true));
+
+            Assert.IsTrue(TextFileHelper.IsTextFile(_tempFilePath));
+        }
+
+        [TestMethod]
+        public void IsTextFile_NonExistentFile_ShouldReturnFalse()
+        {
+            string missingPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".missing");
+
+            Assert.IsFalse(TextFileHelper.IsTextFile(missingPath));
+        }
+
+        // Only the first 8000 bytes are sniffed, so a NUL byte past that point must not affect the result.
+        [TestMethod]
+        public void IsTextFile_NulByteBeyondSampleWindow_ShouldReturnTrue()
+        {
+            byte[] buffer = new byte[9000];
+            for (int i = 0; i < buffer.Length; i++)
+            {
+                buffer[i] = (byte)'a';
+            }
+
+            buffer[8500] = 0;
+            File.WriteAllBytes(_tempFilePath, buffer);
+
+            Assert.IsTrue(TextFileHelper.IsTextFile(_tempFilePath));
+        }
+
+        [TestMethod]
+        public void IsTextFile_NulByteWithinSampleWindow_ShouldReturnFalse()
+        {
+            byte[] buffer = new byte[9000];
+            for (int i = 0; i < buffer.Length; i++)
+            {
+                buffer[i] = (byte)'a';
+            }
+
+            buffer[7999] = 0;
+            File.WriteAllBytes(_tempFilePath, buffer);
+
+            Assert.IsFalse(TextFileHelper.IsTextFile(_tempFilePath));
+        }
+    }
+}

--- a/src/modules/peek/Peek.FilePreviewer.UnitTests/TextFileHelperTests.cs
+++ b/src/modules/peek/Peek.FilePreviewer.UnitTests/TextFileHelperTests.cs
@@ -26,7 +26,7 @@ namespace Peek.FilePreviewer.UnitTests
         {
             if (File.Exists(_tempFilePath))
             {
-                // File.Delete(_tempFilePath);
+                File.Delete(_tempFilePath);
             }
         }
 
@@ -62,6 +62,38 @@ namespace Peek.FilePreviewer.UnitTests
         public void IsTextFile_Utf8WithBom_ShouldReturnTrue()
         {
             File.WriteAllText(_tempFilePath, "Text with a BOM", new UTF8Encoding(true));
+
+            Assert.IsTrue(TextFileHelper.IsTextFile(_tempFilePath));
+        }
+
+        [TestMethod]
+        public void IsTextFile_Utf16LeWithBom_ShouldReturnTrue()
+        {
+            File.WriteAllText(_tempFilePath, "Text with a UTF-16LE BOM", Encoding.Unicode);
+
+            Assert.IsTrue(TextFileHelper.IsTextFile(_tempFilePath));
+        }
+
+        [TestMethod]
+        public void IsTextFile_Utf16BeWithBom_ShouldReturnTrue()
+        {
+            File.WriteAllText(_tempFilePath, "Text with a UTF-16BE BOM", Encoding.BigEndianUnicode);
+
+            Assert.IsTrue(TextFileHelper.IsTextFile(_tempFilePath));
+        }
+
+        [TestMethod]
+        public void IsTextFile_Utf32LeWithBom_ShouldReturnTrue()
+        {
+            File.WriteAllText(_tempFilePath, "Text with a UTF-32LE BOM", new UTF32Encoding(bigEndian: false, byteOrderMark: true));
+
+            Assert.IsTrue(TextFileHelper.IsTextFile(_tempFilePath));
+        }
+
+        [TestMethod]
+        public void IsTextFile_Utf32BeWithBom_ShouldReturnTrue()
+        {
+            File.WriteAllText(_tempFilePath, "Text with a UTF-32BE BOM", new UTF32Encoding(bigEndian: true, byteOrderMark: true));
 
             Assert.IsTrue(TextFileHelper.IsTextFile(_tempFilePath));
         }

--- a/src/modules/peek/Peek.FilePreviewer.UnitTests/TextFileHelperTests.cs
+++ b/src/modules/peek/Peek.FilePreviewer.UnitTests/TextFileHelperTests.cs
@@ -99,6 +99,20 @@ namespace Peek.FilePreviewer.UnitTests
         }
 
         [TestMethod]
+        public void IsTextFile_FileExceedsMaxSize_ShouldReturnFalse()
+        {
+            byte[] buffer = new byte[ReadHelper.MaxReadableFileSizeBytes + 1];
+            for (int i = 0; i < buffer.Length; i++)
+            {
+                buffer[i] = (byte)'a';
+            }
+
+            File.WriteAllBytes(_tempFilePath, buffer);
+
+            Assert.IsFalse(TextFileHelper.IsTextFile(_tempFilePath));
+        }
+
+        [TestMethod]
         public void IsTextFile_NonExistentFile_ShouldReturnFalse()
         {
             string missingPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".missing");

--- a/src/modules/peek/Peek.FilePreviewer.UnitTests/TextFileHelperTests.cs
+++ b/src/modules/peek/Peek.FilePreviewer.UnitTests/TextFileHelperTests.cs
@@ -5,6 +5,8 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Peek.FilePreviewer.Previewers;
 
@@ -31,23 +33,23 @@ namespace Peek.FilePreviewer.UnitTests
         }
 
         [TestMethod]
-        public void IsTextFile_PlainAsciiContent_ShouldReturnTrue()
+        public async Task IsTextFile_PlainAsciiContent_ShouldReturnTrue()
         {
             File.WriteAllText(_tempFilePath, "Hello, world!\r\nThis is a plain text file.");
 
-            Assert.IsTrue(TextFileHelper.IsTextFile(_tempFilePath));
+            Assert.IsTrue(await TextFileHelper.IsTextFileAsync(_tempFilePath, CancellationToken.None));
         }
 
         [TestMethod]
-        public void IsTextFile_EmptyFile_ShouldReturnTrue()
+        public async Task IsTextFile_EmptyFile_ShouldReturnTrue()
         {
             File.WriteAllBytes(_tempFilePath, Array.Empty<byte>());
 
-            Assert.IsTrue(TextFileHelper.IsTextFile(_tempFilePath));
+            Assert.IsTrue(await TextFileHelper.IsTextFileAsync(_tempFilePath, CancellationToken.None));
         }
 
         [TestMethod]
-        public void IsTextFile_ContentWithNulByte_ShouldReturnFalse()
+        public async Task IsTextFile_ContentWithNulByte_ShouldReturnFalse()
         {
             byte[] content = Encoding.UTF8.GetBytes("some text before");
             byte[] withNul = new byte[content.Length + 1];
@@ -55,51 +57,51 @@ namespace Peek.FilePreviewer.UnitTests
             withNul[content.Length] = 0;
             File.WriteAllBytes(_tempFilePath, withNul);
 
-            Assert.IsFalse(TextFileHelper.IsTextFile(_tempFilePath));
+            Assert.IsFalse(await TextFileHelper.IsTextFileAsync(_tempFilePath, CancellationToken.None));
         }
 
         [TestMethod]
-        public void IsTextFile_Utf8WithBom_ShouldReturnTrue()
+        public async Task IsTextFile_Utf8WithBom_ShouldReturnTrue()
         {
             File.WriteAllText(_tempFilePath, "Text with a BOM", new UTF8Encoding(true));
 
-            Assert.IsTrue(TextFileHelper.IsTextFile(_tempFilePath));
+            Assert.IsTrue(await TextFileHelper.IsTextFileAsync(_tempFilePath, CancellationToken.None));
         }
 
         [TestMethod]
-        public void IsTextFile_Utf16LeWithBom_ShouldReturnTrue()
+        public async Task IsTextFile_Utf16LeWithBom_ShouldReturnTrue()
         {
             File.WriteAllText(_tempFilePath, "Text with a UTF-16LE BOM", Encoding.Unicode);
 
-            Assert.IsTrue(TextFileHelper.IsTextFile(_tempFilePath));
+            Assert.IsTrue(await TextFileHelper.IsTextFileAsync(_tempFilePath, CancellationToken.None));
         }
 
         [TestMethod]
-        public void IsTextFile_Utf16BeWithBom_ShouldReturnTrue()
+        public async Task IsTextFile_Utf16BeWithBom_ShouldReturnTrue()
         {
             File.WriteAllText(_tempFilePath, "Text with a UTF-16BE BOM", Encoding.BigEndianUnicode);
 
-            Assert.IsTrue(TextFileHelper.IsTextFile(_tempFilePath));
+            Assert.IsTrue(await TextFileHelper.IsTextFileAsync(_tempFilePath, CancellationToken.None));
         }
 
         [TestMethod]
-        public void IsTextFile_Utf32LeWithBom_ShouldReturnTrue()
+        public async Task IsTextFile_Utf32LeWithBom_ShouldReturnTrue()
         {
             File.WriteAllText(_tempFilePath, "Text with a UTF-32LE BOM", new UTF32Encoding(bigEndian: false, byteOrderMark: true));
 
-            Assert.IsTrue(TextFileHelper.IsTextFile(_tempFilePath));
+            Assert.IsTrue(await TextFileHelper.IsTextFileAsync(_tempFilePath, CancellationToken.None));
         }
 
         [TestMethod]
-        public void IsTextFile_Utf32BeWithBom_ShouldReturnTrue()
+        public async Task IsTextFile_Utf32BeWithBom_ShouldReturnTrue()
         {
             File.WriteAllText(_tempFilePath, "Text with a UTF-32BE BOM", new UTF32Encoding(bigEndian: true, byteOrderMark: true));
 
-            Assert.IsTrue(TextFileHelper.IsTextFile(_tempFilePath));
+            Assert.IsTrue(await TextFileHelper.IsTextFileAsync(_tempFilePath, CancellationToken.None));
         }
 
         [TestMethod]
-        public void IsTextFile_FileExceedsMaxSize_ShouldReturnFalse()
+        public async Task IsTextFile_FileExceedsMaxSize_ShouldReturnFalse()
         {
             byte[] buffer = new byte[ReadHelper.MaxReadableFileSizeBytes + 1];
             for (int i = 0; i < buffer.Length; i++)
@@ -109,20 +111,20 @@ namespace Peek.FilePreviewer.UnitTests
 
             File.WriteAllBytes(_tempFilePath, buffer);
 
-            Assert.IsFalse(TextFileHelper.IsTextFile(_tempFilePath));
+            Assert.IsFalse(await TextFileHelper.IsTextFileAsync(_tempFilePath, CancellationToken.None));
         }
 
         [TestMethod]
-        public void IsTextFile_NonExistentFile_ShouldReturnFalse()
+        public async Task IsTextFile_NonExistentFile_ShouldReturnFalse()
         {
             string missingPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".missing");
 
-            Assert.IsFalse(TextFileHelper.IsTextFile(missingPath));
+            Assert.IsFalse(await TextFileHelper.IsTextFileAsync(missingPath, CancellationToken.None));
         }
 
         // Only the first 8000 bytes are sniffed, so a NUL byte past that point must not affect the result.
         [TestMethod]
-        public void IsTextFile_NulByteBeyondSampleWindow_ShouldReturnTrue()
+        public async Task IsTextFile_NulByteBeyondSampleWindow_ShouldReturnTrue()
         {
             byte[] buffer = new byte[9000];
             for (int i = 0; i < buffer.Length; i++)
@@ -133,11 +135,11 @@ namespace Peek.FilePreviewer.UnitTests
             buffer[8500] = 0;
             File.WriteAllBytes(_tempFilePath, buffer);
 
-            Assert.IsTrue(TextFileHelper.IsTextFile(_tempFilePath));
+            Assert.IsTrue(await TextFileHelper.IsTextFileAsync(_tempFilePath, CancellationToken.None));
         }
 
         [TestMethod]
-        public void IsTextFile_NulByteWithinSampleWindow_ShouldReturnFalse()
+        public async Task IsTextFile_NulByteWithinSampleWindow_ShouldReturnFalse()
         {
             byte[] buffer = new byte[9000];
             for (int i = 0; i < buffer.Length; i++)
@@ -148,7 +150,17 @@ namespace Peek.FilePreviewer.UnitTests
             buffer[7999] = 0;
             File.WriteAllBytes(_tempFilePath, buffer);
 
-            Assert.IsFalse(TextFileHelper.IsTextFile(_tempFilePath));
+            Assert.IsFalse(await TextFileHelper.IsTextFileAsync(_tempFilePath, CancellationToken.None));
+        }
+
+        [TestMethod]
+        public async Task IsTextFile_Cancelled_ShouldThrow()
+        {
+            File.WriteAllText(_tempFilePath, "Hello, world!");
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsExceptionAsync<OperationCanceledException>(() => TextFileHelper.IsTextFileAsync(_tempFilePath, cts.Token));
         }
     }
 }

--- a/src/modules/peek/Peek.FilePreviewer.UnitTests/TextFileHelperTests.cs
+++ b/src/modules/peek/Peek.FilePreviewer.UnitTests/TextFileHelperTests.cs
@@ -37,7 +37,7 @@ namespace Peek.FilePreviewer.UnitTests
         {
             File.WriteAllText(_tempFilePath, "Hello, world!\r\nThis is a plain text file.");
 
-            Assert.IsTrue(await TextFileHelper.IsTextFileAsync(_tempFilePath, CancellationToken.None));
+            Assert.IsTrue(await TextFileHelper.IsTextFileAsync(_tempFilePath));
         }
 
         [TestMethod]
@@ -45,7 +45,7 @@ namespace Peek.FilePreviewer.UnitTests
         {
             File.WriteAllBytes(_tempFilePath, Array.Empty<byte>());
 
-            Assert.IsTrue(await TextFileHelper.IsTextFileAsync(_tempFilePath, CancellationToken.None));
+            Assert.IsTrue(await TextFileHelper.IsTextFileAsync(_tempFilePath));
         }
 
         [TestMethod]
@@ -57,7 +57,7 @@ namespace Peek.FilePreviewer.UnitTests
             withNul[content.Length] = 0;
             File.WriteAllBytes(_tempFilePath, withNul);
 
-            Assert.IsFalse(await TextFileHelper.IsTextFileAsync(_tempFilePath, CancellationToken.None));
+            Assert.IsFalse(await TextFileHelper.IsTextFileAsync(_tempFilePath));
         }
 
         [TestMethod]
@@ -65,7 +65,7 @@ namespace Peek.FilePreviewer.UnitTests
         {
             File.WriteAllText(_tempFilePath, "Text with a BOM", new UTF8Encoding(true));
 
-            Assert.IsTrue(await TextFileHelper.IsTextFileAsync(_tempFilePath, CancellationToken.None));
+            Assert.IsTrue(await TextFileHelper.IsTextFileAsync(_tempFilePath));
         }
 
         [TestMethod]
@@ -73,7 +73,7 @@ namespace Peek.FilePreviewer.UnitTests
         {
             File.WriteAllText(_tempFilePath, "Text with a UTF-16LE BOM", Encoding.Unicode);
 
-            Assert.IsTrue(await TextFileHelper.IsTextFileAsync(_tempFilePath, CancellationToken.None));
+            Assert.IsTrue(await TextFileHelper.IsTextFileAsync(_tempFilePath));
         }
 
         [TestMethod]
@@ -81,7 +81,7 @@ namespace Peek.FilePreviewer.UnitTests
         {
             File.WriteAllText(_tempFilePath, "Text with a UTF-16BE BOM", Encoding.BigEndianUnicode);
 
-            Assert.IsTrue(await TextFileHelper.IsTextFileAsync(_tempFilePath, CancellationToken.None));
+            Assert.IsTrue(await TextFileHelper.IsTextFileAsync(_tempFilePath));
         }
 
         [TestMethod]
@@ -89,7 +89,7 @@ namespace Peek.FilePreviewer.UnitTests
         {
             File.WriteAllText(_tempFilePath, "Text with a UTF-32LE BOM", new UTF32Encoding(bigEndian: false, byteOrderMark: true));
 
-            Assert.IsTrue(await TextFileHelper.IsTextFileAsync(_tempFilePath, CancellationToken.None));
+            Assert.IsTrue(await TextFileHelper.IsTextFileAsync(_tempFilePath));
         }
 
         [TestMethod]
@@ -97,7 +97,7 @@ namespace Peek.FilePreviewer.UnitTests
         {
             File.WriteAllText(_tempFilePath, "Text with a UTF-32BE BOM", new UTF32Encoding(bigEndian: true, byteOrderMark: true));
 
-            Assert.IsTrue(await TextFileHelper.IsTextFileAsync(_tempFilePath, CancellationToken.None));
+            Assert.IsTrue(await TextFileHelper.IsTextFileAsync(_tempFilePath));
         }
 
         [TestMethod]
@@ -111,7 +111,23 @@ namespace Peek.FilePreviewer.UnitTests
 
             File.WriteAllBytes(_tempFilePath, buffer);
 
-            Assert.IsFalse(await TextFileHelper.IsTextFileAsync(_tempFilePath, CancellationToken.None));
+            Assert.IsFalse(await TextFileHelper.IsTextFileAsync(_tempFilePath));
+        }
+
+        [TestMethod]
+        public async Task IsTextFile_FileExceedsExplicitMaxSize_ShouldReturnFalse()
+        {
+            File.WriteAllText(_tempFilePath, new string('a', 4096));
+
+            Assert.IsFalse(await TextFileHelper.IsTextFileAsync(_tempFilePath, maxFileSizeBytes: 1024));
+        }
+
+        [TestMethod]
+        public async Task IsTextFile_FileWithinExplicitMaxSize_ShouldReturnTrue()
+        {
+            File.WriteAllText(_tempFilePath, "small text");
+
+            Assert.IsTrue(await TextFileHelper.IsTextFileAsync(_tempFilePath, maxFileSizeBytes: 1024));
         }
 
         [TestMethod]
@@ -119,7 +135,7 @@ namespace Peek.FilePreviewer.UnitTests
         {
             string missingPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".missing");
 
-            Assert.IsFalse(await TextFileHelper.IsTextFileAsync(missingPath, CancellationToken.None));
+            Assert.IsFalse(await TextFileHelper.IsTextFileAsync(missingPath));
         }
 
         // Only the first 8000 bytes are sniffed, so a NUL byte past that point must not affect the result.
@@ -135,7 +151,7 @@ namespace Peek.FilePreviewer.UnitTests
             buffer[8500] = 0;
             File.WriteAllBytes(_tempFilePath, buffer);
 
-            Assert.IsTrue(await TextFileHelper.IsTextFileAsync(_tempFilePath, CancellationToken.None));
+            Assert.IsTrue(await TextFileHelper.IsTextFileAsync(_tempFilePath));
         }
 
         [TestMethod]
@@ -150,7 +166,7 @@ namespace Peek.FilePreviewer.UnitTests
             buffer[7999] = 0;
             File.WriteAllBytes(_tempFilePath, buffer);
 
-            Assert.IsFalse(await TextFileHelper.IsTextFileAsync(_tempFilePath, CancellationToken.None));
+            Assert.IsFalse(await TextFileHelper.IsTextFileAsync(_tempFilePath));
         }
 
         [TestMethod]
@@ -160,7 +176,7 @@ namespace Peek.FilePreviewer.UnitTests
             using var cts = new CancellationTokenSource();
             cts.Cancel();
 
-            await Assert.ThrowsExceptionAsync<OperationCanceledException>(() => TextFileHelper.IsTextFileAsync(_tempFilePath, cts.Token));
+            await Assert.ThrowsExceptionAsync<OperationCanceledException>(() => TextFileHelper.IsTextFileAsync(_tempFilePath, cancellationToken: cts.Token));
         }
     }
 }

--- a/src/modules/peek/Peek.FilePreviewer.UnitTests/WebBrowserPreviewerTests.cs
+++ b/src/modules/peek/Peek.FilePreviewer.UnitTests/WebBrowserPreviewerTests.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Peek.Common.Models;
+using Peek.FilePreviewer.Previewers;
+
+namespace Peek.FilePreviewer.UnitTests
+{
+    [TestClass]
+    public class WebBrowserPreviewerTests
+    {
+        private string _tempFilePath = string.Empty;
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            if (!string.IsNullOrEmpty(_tempFilePath) && File.Exists(_tempFilePath))
+            {
+                File.Delete(_tempFilePath);
+            }
+        }
+
+        private string CreateTempFile(string extension, byte[] content)
+        {
+            _tempFilePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + extension);
+            File.WriteAllBytes(_tempFilePath, content);
+            return _tempFilePath;
+        }
+
+        [TestMethod]
+        public void IsItemSupported_MarkdownExtension_ShouldReturnTrue()
+        {
+            var item = new FileItem(@"C:\some\file.md", "file.md");
+
+            Assert.IsTrue(WebBrowserPreviewer.IsItemSupported(item));
+        }
+
+        [TestMethod]
+        public void IsItemSupported_UnrecognizedExtension_ShouldReturnFalse()
+        {
+            var item = new FileItem(@"C:\some\file.zzzzunknown", "file.zzzzunknown");
+
+            Assert.IsFalse(WebBrowserPreviewer.IsItemSupported(item));
+        }
+
+        [TestMethod]
+        public void IsTextFallbackSupported_UnrecognizedExtensionWithTextContent_ShouldReturnTrue()
+        {
+            string path = CreateTempFile(".zzzzunknown", Encoding.UTF8.GetBytes("plain text content"));
+            var item = new FileItem(path, Path.GetFileName(path));
+
+            Assert.IsTrue(WebBrowserPreviewer.IsTextFallbackSupported(item));
+        }
+
+        [TestMethod]
+        public void IsTextFallbackSupported_UnrecognizedExtensionWithBinaryContent_ShouldReturnFalse()
+        {
+            string path = CreateTempFile(".zzzzunknown", new byte[] { 0x00, 0x01, 0x02, 0x03 });
+            var item = new FileItem(path, Path.GetFileName(path));
+
+            Assert.IsFalse(WebBrowserPreviewer.IsTextFallbackSupported(item));
+        }
+
+        // IsItemSupported should short-circuit the fallback for extensions Peek already recognizes.
+        [TestMethod]
+        public void IsTextFallbackSupported_AlreadySupportedExtension_ShouldReturnFalse()
+        {
+            string path = CreateTempFile(".md", Encoding.UTF8.GetBytes("# heading"));
+            var item = new FileItem(path, Path.GetFileName(path));
+
+            Assert.IsFalse(WebBrowserPreviewer.IsTextFallbackSupported(item));
+        }
+
+        [TestMethod]
+        public void IsTextFallbackSupported_FolderItem_ShouldReturnFalse()
+        {
+            var item = new FolderItem(@"C:\some\folder", "folder", "folder");
+
+            Assert.IsFalse(WebBrowserPreviewer.IsTextFallbackSupported(item));
+        }
+
+        [TestMethod]
+        public void IsTextFallbackSupported_MissingFile_ShouldReturnFalse()
+        {
+            string missingPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".zzzzunknown");
+            var item = new FileItem(missingPath, Path.GetFileName(missingPath));
+
+            Assert.IsFalse(WebBrowserPreviewer.IsTextFallbackSupported(item));
+        }
+    }
+}

--- a/src/modules/peek/Peek.FilePreviewer.UnitTests/WebBrowserPreviewerTests.cs
+++ b/src/modules/peek/Peek.FilePreviewer.UnitTests/WebBrowserPreviewerTests.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.IO;
-using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Peek.Common.Models;
 using Peek.FilePreviewer.Previewers;
@@ -14,24 +13,6 @@ namespace Peek.FilePreviewer.UnitTests
     [TestClass]
     public class WebBrowserPreviewerTests
     {
-        private string _tempFilePath = string.Empty;
-
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            if (!string.IsNullOrEmpty(_tempFilePath) && File.Exists(_tempFilePath))
-            {
-                File.Delete(_tempFilePath);
-            }
-        }
-
-        private string CreateTempFile(string extension, byte[] content)
-        {
-            _tempFilePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + extension);
-            File.WriteAllBytes(_tempFilePath, content);
-            return _tempFilePath;
-        }
-
         [TestMethod]
         public void IsItemSupported_MarkdownExtension_ShouldReturnTrue()
         {
@@ -49,48 +30,37 @@ namespace Peek.FilePreviewer.UnitTests
         }
 
         [TestMethod]
-        public void IsTextFallbackSupported_UnrecognizedExtensionWithTextContent_ShouldReturnTrue()
+        public void IsFallbackCandidate_UnrecognizedExtension_ShouldReturnTrue()
         {
-            string path = CreateTempFile(".zzzzunknown", Encoding.UTF8.GetBytes("plain text content"));
-            var item = new FileItem(path, Path.GetFileName(path));
+            var item = new FileItem(@"C:\some\file.zzzzunknown", "file.zzzzunknown");
 
-            Assert.IsTrue(WebBrowserPreviewer.IsTextFallbackSupported(item));
-        }
-
-        [TestMethod]
-        public void IsTextFallbackSupported_UnrecognizedExtensionWithBinaryContent_ShouldReturnFalse()
-        {
-            string path = CreateTempFile(".zzzzunknown", new byte[] { 0x00, 0x01, 0x02, 0x03 });
-            var item = new FileItem(path, Path.GetFileName(path));
-
-            Assert.IsFalse(WebBrowserPreviewer.IsTextFallbackSupported(item));
+            Assert.IsTrue(WebBrowserPreviewer.IsFallbackCandidate(item));
         }
 
         // IsItemSupported should short-circuit the fallback for extensions Peek already recognizes.
         [TestMethod]
-        public void IsTextFallbackSupported_AlreadySupportedExtension_ShouldReturnFalse()
+        public void IsFallbackCandidate_AlreadySupportedExtension_ShouldReturnFalse()
         {
-            string path = CreateTempFile(".md", Encoding.UTF8.GetBytes("# heading"));
-            var item = new FileItem(path, Path.GetFileName(path));
+            var item = new FileItem(@"C:\some\file.md", "file.md");
 
-            Assert.IsFalse(WebBrowserPreviewer.IsTextFallbackSupported(item));
+            Assert.IsFalse(WebBrowserPreviewer.IsFallbackCandidate(item));
         }
 
         [TestMethod]
-        public void IsTextFallbackSupported_FolderItem_ShouldReturnFalse()
+        public void IsFallbackCandidate_FolderItem_ShouldReturnFalse()
         {
             var item = new FolderItem(@"C:\some\folder", "folder", "folder");
 
-            Assert.IsFalse(WebBrowserPreviewer.IsTextFallbackSupported(item));
+            Assert.IsFalse(WebBrowserPreviewer.IsFallbackCandidate(item));
         }
 
         [TestMethod]
-        public void IsTextFallbackSupported_MissingFile_ShouldReturnFalse()
+        public void IsFallbackCandidate_MissingFile_ShouldReturnTrue()
         {
             string missingPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".zzzzunknown");
             var item = new FileItem(missingPath, Path.GetFileName(missingPath));
 
-            Assert.IsFalse(WebBrowserPreviewer.IsTextFallbackSupported(item));
+            Assert.IsTrue(WebBrowserPreviewer.IsFallbackCandidate(item));
         }
     }
 }

--- a/src/modules/peek/Peek.FilePreviewer/Models/IPreviewSettings.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Models/IPreviewSettings.cs
@@ -15,5 +15,7 @@ namespace Peek.FilePreviewer.Models
         public bool SourceCodeStickyScroll { get; }
 
         public bool SourceCodeMinimap { get; }
+
+        public long SourceCodeMaxFileSizeBytes { get; }
     }
 }

--- a/src/modules/peek/Peek.FilePreviewer/Models/PreviewSettings.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Models/PreviewSettings.cs
@@ -32,6 +32,8 @@ namespace Peek.FilePreviewer.Models
 
         public bool SourceCodeMinimap { get; private set; }
 
+        public long SourceCodeMaxFileSizeBytes { get; private set; }
+
         public PreviewSettings()
         {
             _settingsUtils = SettingsUtils.Default;
@@ -40,6 +42,7 @@ namespace Peek.FilePreviewer.Models
             SourceCodeFontSize = 14;
             SourceCodeStickyScroll = true;
             SourceCodeMinimap = false;
+            SourceCodeMaxFileSizeBytes = (long)PeekPreviewSettings.DefaultSourceCodeMaxFileSize * 1024;
 
             LoadSettingsFromJson();
 
@@ -74,6 +77,7 @@ namespace Peek.FilePreviewer.Models
                             SourceCodeFontSize = settings.SourceCodeFontSize.Value;
                             SourceCodeStickyScroll = settings.SourceCodeStickyScroll.Value;
                             SourceCodeMinimap = settings.SourceCodeMinimap.Value;
+                            SourceCodeMaxFileSizeBytes = (long)settings.SourceCodeMaxFileSize.Value * 1024;
                         }
 
                         retry = false;

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/PreviewerFactory.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/PreviewerFactory.cs
@@ -62,9 +62,11 @@ namespace Peek.FilePreviewer.Previewers
             {
                 return new SpecialFolderPreviewer(item);
             }
-            else if (WebBrowserPreviewer.IsTextFallbackSupported(item))
+            else if (WebBrowserPreviewer.IsFallbackCandidate(item))
             {
-                // No recognized extension, but the content was sniffed as text - preview it as plain text.
+                // No recognized extension. The content check is done asynchronously in
+                // LoadDisplayInfoAsync; if it isn't text, the previewer fails over to
+                // the default/info preview.
                 return new WebBrowserPreviewer(item, _previewSettings);
             }
 

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/PreviewerFactory.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/PreviewerFactory.cs
@@ -62,6 +62,11 @@ namespace Peek.FilePreviewer.Previewers
             {
                 return new SpecialFolderPreviewer(item);
             }
+            else if (WebBrowserPreviewer.IsTextFallbackSupported(item))
+            {
+                // No recognized extension, but the content was sniffed as text - preview it as plain text.
+                return new WebBrowserPreviewer(item, _previewSettings);
+            }
 
             // Other previewer types check their supported file types here
             return CreateDefaultPreviewer(item);

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/Helpers/ReadHelper.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/Helpers/ReadHelper.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -12,19 +13,43 @@ namespace Peek.FilePreviewer.Previewers
 {
     public static class ReadHelper
     {
+        // Content read here is later base64-encoded, embedded in a temp HTML file, and decoded by
+        // WebView2, so an unbounded read can cause a large memory spike.
+        public const long MaxReadableFileSizeBytes = 10 * 1024 * 1024; // 10 MB
+
         public static async Task<string> Read(string path)
         {
+            using var fs = OpenReadOnly(path);
+            if (fs.Length > MaxReadableFileSizeBytes)
+            {
+                throw new InvalidOperationException($"File '{path}' exceeds the maximum previewable size of {MaxReadableFileSizeBytes} bytes.");
+            }
+
             DetectionResult result = CharsetDetector.DetectFromFile(path);
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 
             // Check if the detected encoding is not null; otherwise, default to UTF-8
             Encoding encodingToUse = result.Detected?.Encoding ?? Encoding.UTF8;
 
-            using var fs = OpenReadOnly(path);
             using var sr = new StreamReader(fs, encodingToUse);
 
-            string content = await sr.ReadToEndAsync();
-            return content;
+            // Read incrementally rather than all at once, so a file that grows past the limit while
+            // being read (e.g. an actively written log) is still caught instead of only relying on
+            // the length check above.
+            var buffer = new char[81920];
+            var content = new StringBuilder();
+            int charsRead;
+            while ((charsRead = await sr.ReadAsync(buffer, 0, buffer.Length)) > 0)
+            {
+                content.Append(buffer, 0, charsRead);
+
+                if (fs.Position > MaxReadableFileSizeBytes)
+                {
+                    throw new InvalidOperationException($"File '{path}' exceeds the maximum previewable size of {MaxReadableFileSizeBytes} bytes.");
+                }
+            }
+
+            return content.ToString();
         }
 
         public static FileStream OpenReadOnly(string path)

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/Helpers/ReadHelper.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/Helpers/ReadHelper.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 using UtfUnknown;
@@ -13,39 +14,53 @@ namespace Peek.FilePreviewer.Previewers
 {
     public static class ReadHelper
     {
-        // Content read here is later base64-encoded, embedded in a temp HTML file, and decoded by
-        // WebView2, so an unbounded read can cause a large memory spike.
+        // Fallback cap used when the caller doesn't pass an explicit limit. Content read here is later
+        // base64-encoded, embedded in a temp HTML file, and decoded by WebView2, so an unbounded read
+        // can cause a large memory spike. The user-configurable limit lives in Peek preview settings.
         public const long MaxReadableFileSizeBytes = 10 * 1024 * 1024; // 10 MB
 
-        public static async Task<string> Read(string path)
+        // Prefix size fed to the charset detector. Sampling keeps detection (and its scan) bounded
+        // regardless of file size; a file that is plain ASCII for its first CharsetSampleSizeBytes but
+        // carries non-ASCII content only later could be mis-detected, a trade-off that matches how
+        // editors and tools like git sniff encoding.
+        private const int CharsetSampleSizeBytes = 64 * 1024;
+
+        public static async Task<string> Read(string path, long maxReadableFileSizeBytes = MaxReadableFileSizeBytes, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             using var fs = OpenReadOnly(path);
-            if (fs.Length > MaxReadableFileSizeBytes)
+            if (fs.Length > maxReadableFileSizeBytes)
             {
-                throw new InvalidOperationException($"File '{path}' exceeds the maximum previewable size of {MaxReadableFileSizeBytes} bytes.");
+                throw new InvalidOperationException($"File '{path}' exceeds the maximum previewable size of {maxReadableFileSizeBytes} bytes.");
             }
 
-            DetectionResult result = CharsetDetector.DetectFromFile(path);
+            // Detect the charset from a bounded prefix of the same file stream handle.
+            int sampleSize = (int)Math.Min(fs.Length, CharsetSampleSizeBytes);
+            var sample = new byte[sampleSize];
+            int sampleRead = await fs.ReadAtLeastAsync(sample, sampleSize, throwOnEndOfStream: false, cancellationToken).ConfigureAwait(false);
+
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            DetectionResult result = CharsetDetector.DetectFromBytes(sampleRead == sample.Length ? sample : sample[..sampleRead]);
 
             // Check if the detected encoding is not null; otherwise, default to UTF-8
             Encoding encodingToUse = result.Detected?.Encoding ?? Encoding.UTF8;
 
-            using var sr = new StreamReader(fs, encodingToUse);
-
-            // Read incrementally rather than all at once, so a file that grows past the limit while
-            // being read (e.g. an actively written log) is still caught instead of only relying on
-            // the length check above.
+            // Rewind and stream the decode so the whole file is never held in memory at once.
+            // StreamReader strips a byte order mark rather than surface it as a leading U+FEFF character; the per-chunk
+            // length check catches a file being appended to that would otherwise grow the preview past the limit.
+            fs.Position = 0;
+            using var sr = new StreamReader(fs, encodingToUse, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true);
             var buffer = new char[81920];
             var content = new StringBuilder();
             int charsRead;
-            while ((charsRead = await sr.ReadAsync(buffer, 0, buffer.Length)) > 0)
+            while ((charsRead = await sr.ReadAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false)) > 0)
             {
                 content.Append(buffer, 0, charsRead);
 
-                if (fs.Position > MaxReadableFileSizeBytes)
+                if (fs.Position > maxReadableFileSizeBytes)
                 {
-                    throw new InvalidOperationException($"File '{path}' exceeds the maximum previewable size of {MaxReadableFileSizeBytes} bytes.");
+                    throw new InvalidOperationException($"File '{path}' exceeds the maximum previewable size of {maxReadableFileSizeBytes} bytes.");
                 }
             }
 

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/Helpers/TextFileHelper.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/Helpers/TextFileHelper.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using ManagedCommon;
+
+namespace Peek.FilePreviewer.Previewers
+{
+    /// <summary>
+    /// Heuristically detects whether a file's content is text, so files with no extension
+    /// or an extension Peek doesn't otherwise recognize can still fall back to a plain text
+    /// preview instead of just showing file details.
+    /// </summary>
+    public static class TextFileHelper
+    {
+        // Matches the sample size commonly used by tools like git to decide whether a file is text or binary.
+        private const int SampleSize = 8000;
+
+        public static bool IsTextFile(string path)
+        {
+            try
+            {
+                using var stream = ReadHelper.OpenReadOnly(path);
+                int bytesToRead = (int)Math.Min(SampleSize, stream.Length);
+                if (bytesToRead == 0)
+                {
+                    return true;
+                }
+
+                var buffer = new byte[bytesToRead];
+                int bytesRead = stream.Read(buffer, 0, bytesToRead);
+
+                // A NUL byte in the sample is a strong signal of binary content.
+                for (int i = 0; i < bytesRead; i++)
+                {
+                    if (buffer[i] == 0)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError("Failed to determine if file is text: " + ex.Message);
+                return false;
+            }
+        }
+    }
+}

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/Helpers/TextFileHelper.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/Helpers/TextFileHelper.cs
@@ -32,6 +32,12 @@ namespace Peek.FilePreviewer.Previewers
                 var buffer = new byte[bytesToRead];
                 int bytesRead = stream.Read(buffer, 0, bytesToRead);
 
+                // If the file starts with a Unicode BOM, we can assume it's a text file.
+                if (HasUnicodeBom(buffer, bytesRead))
+                {
+                    return true;
+                }
+
                 // A NUL byte in the sample is a strong signal of binary content.
                 for (int i = 0; i < bytesRead; i++)
                 {
@@ -48,6 +54,29 @@ namespace Peek.FilePreviewer.Previewers
                 Logger.LogError("Failed to determine if file is text: " + ex.Message);
                 return false;
             }
+        }
+
+        /// <summary>
+        /// Determines whether the given buffer contains a Unicode BOM (Byte Order Mark) for UTF-16 or UTF-32.
+        /// </summary>
+        /// <param name="buffer">The byte array to check for a BOM.</param>
+        /// <param name="bytesRead">The number of bytes read into the buffer.</param>
+        /// <returns>True if the buffer contains a Unicode BOM; otherwise, false.</returns>
+        private static bool HasUnicodeBom(byte[] buffer, int bytesRead)
+        {
+            // UTF-32 BOMs must be checked before UTF-16, since the UTF-32LE BOM (FF FE 00 00) starts with the UTF-16LE BOM (FF FE).
+            bool isUtf32 = bytesRead >= 4 &&
+                ((buffer[0] == 0xFF && buffer[1] == 0xFE && buffer[2] == 0x00 && buffer[3] == 0x00) ||
+                 (buffer[0] == 0x00 && buffer[1] == 0x00 && buffer[2] == 0xFE && buffer[3] == 0xFF));
+            if (isUtf32)
+            {
+                return true;
+            }
+
+            bool isUtf16 = bytesRead >= 2 &&
+                ((buffer[0] == 0xFF && buffer[1] == 0xFE) ||
+                 (buffer[0] == 0xFE && buffer[1] == 0xFF));
+            return isUtf16;
         }
     }
 }

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/Helpers/TextFileHelper.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/Helpers/TextFileHelper.cs
@@ -18,11 +18,21 @@ namespace Peek.FilePreviewer.Previewers
         // Matches the sample size commonly used by tools like git to decide whether a file is text or binary.
         private const int SampleSize = 8000;
 
+        // Files larger than this are rejected outright, so an oversized file never reaches ReadHelper.Read
+        // and the Monaco/WebView pipeline, which load the full content into memory. See ReadHelper.MaxReadableFileSizeBytes,
+        // which enforces the same limit while actually reading a file's content.
+        private const long MaxFileSizeBytes = ReadHelper.MaxReadableFileSizeBytes;
+
         public static bool IsTextFile(string path)
         {
             try
             {
                 using var stream = ReadHelper.OpenReadOnly(path);
+                if (stream.Length > MaxFileSizeBytes)
+                {
+                    return false;
+                }
+
                 int bytesToRead = (int)Math.Min(SampleSize, stream.Length);
                 if (bytesToRead == 0)
                 {

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/Helpers/TextFileHelper.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/Helpers/TextFileHelper.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 using ManagedCommon;
 
@@ -23,10 +25,18 @@ namespace Peek.FilePreviewer.Previewers
         // which enforces the same limit while actually reading a file's content.
         private const long MaxFileSizeBytes = ReadHelper.MaxReadableFileSizeBytes;
 
-        public static bool IsTextFile(string path)
+        /// <summary>
+        /// Determines whether the file at the given path is likely to be a text file, based on its size and content.
+        /// </summary>
+        /// <param name="path">The path to the file to check.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+        /// <returns>True if the file is likely to be a text file; otherwise, false.</returns>
+        public static async Task<bool> IsTextFileAsync(string path, CancellationToken cancellationToken)
         {
             try
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 using var stream = ReadHelper.OpenReadOnly(path);
                 if (stream.Length > MaxFileSizeBytes)
                 {
@@ -40,7 +50,7 @@ namespace Peek.FilePreviewer.Previewers
                 }
 
                 var buffer = new byte[bytesToRead];
-                int bytesRead = stream.Read(buffer, 0, bytesToRead);
+                int bytesRead = await stream.ReadAsync(buffer.AsMemory(0, bytesToRead), cancellationToken);
 
                 // If the file starts with a Unicode BOM, we can assume it's a text file.
                 if (HasUnicodeBom(buffer, bytesRead))
@@ -58,6 +68,11 @@ namespace Peek.FilePreviewer.Previewers
                 }
 
                 return true;
+            }
+            catch (OperationCanceledException)
+            {
+                // Let navigation cancellation propagate instead of being reported as "not text".
+                throw;
             }
             catch (Exception ex)
             {

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/Helpers/TextFileHelper.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/Helpers/TextFileHelper.cs
@@ -20,25 +20,24 @@ namespace Peek.FilePreviewer.Previewers
         // Matches the sample size commonly used by tools like git to decide whether a file is text or binary.
         private const int SampleSize = 8000;
 
-        // Files larger than this are rejected outright, so an oversized file never reaches ReadHelper.Read
-        // and the Monaco/WebView pipeline, which load the full content into memory. See ReadHelper.MaxReadableFileSizeBytes,
-        // which enforces the same limit while actually reading a file's content.
-        private const long MaxFileSizeBytes = ReadHelper.MaxReadableFileSizeBytes;
-
         /// <summary>
         /// Determines whether the file at the given path is likely to be a text file, based on its size and content.
         /// </summary>
         /// <param name="path">The path to the file to check.</param>
+        /// <param name="maxFileSizeBytes">
+        /// Files larger than this are rejected outright, so an oversized file never reaches ReadHelper.Read
+        /// and the Monaco/WebView pipeline, which load the full content into memory.
+        /// </param>
         /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
         /// <returns>True if the file is likely to be a text file; otherwise, false.</returns>
-        public static async Task<bool> IsTextFileAsync(string path, CancellationToken cancellationToken)
+        public static async Task<bool> IsTextFileAsync(string path, long maxFileSizeBytes = ReadHelper.MaxReadableFileSizeBytes, CancellationToken cancellationToken = default)
         {
             try
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
                 using var stream = ReadHelper.OpenReadOnly(path);
-                if (stream.Length > MaxFileSizeBytes)
+                if (stream.Length > maxFileSizeBytes)
                 {
                     return false;
                 }
@@ -50,7 +49,10 @@ namespace Peek.FilePreviewer.Previewers
                 }
 
                 var buffer = new byte[bytesToRead];
-                int bytesRead = await stream.ReadAsync(buffer.AsMemory(0, bytesToRead), cancellationToken);
+
+                // A single ReadAsync can return fewer bytes than requested (common on network or
+                // compressed streams), so keep reading until the sample buffer is full or we hit EOF.
+                int bytesRead = await stream.ReadAtLeastAsync(buffer.AsMemory(0, bytesToRead), bytesToRead, throwOnEndOfStream: false, cancellationToken).ConfigureAwait(false);
 
                 // If the file starts with a Unicode BOM, we can assume it's a text file.
                 if (HasUnicodeBom(buffer, bytesRead))

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/WebBrowserPreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/WebBrowserPreviewer.cs
@@ -137,18 +137,19 @@ namespace Peek.FilePreviewer.Previewers
                         // Simple html file to preview. Shouldn't do things like enabling scripts or using a virtual mapped directory.
                         Preview = new Uri(File.Path);
                     }
-                    else if (MonacoHelper.SupportedMonacoFileTypes.Contains(extension))
+                    else if (extension == ".pdf")
                     {
-                        // Source code files use Monaco editor
+                        Preview = new Uri(File.Path);
+                    }
+                    else
+                    {
+                        // Source code files use Monaco editor. Extensions Monaco doesn't recognize
+                        // (including files with no extension, sniffed as text by IsTextFallbackSupported)
+                        // fall back to plaintext highlighting.
                         IsDevFilePreview = true;
                         CustomContextMenu = true;
                         var raw = await ReadHelper.Read(File.Path.ToString());
                         Preview = new Uri(MonacoHelper.PreviewTempFile(raw, extension, TempFolderPath.Path, _previewSettings.SourceCodeTryFormat, _previewSettings.SourceCodeWrapText, _previewSettings.SourceCodeStickyScroll, _previewSettings.SourceCodeFontSize, _previewSettings.SourceCodeMinimap));
-                    }
-                    else
-                    {
-                        // Fallback for other supported file types (e.g., PDF)
-                        Preview = new Uri(File.Path);
                     }
                 });
             });
@@ -166,6 +167,16 @@ namespace Peek.FilePreviewer.Previewers
         public static bool IsItemSupported(IFileSystemItem item)
         {
             return _supportedFileTypes.Contains(item.Extension) || MonacoHelper.SupportedMonacoFileTypes.Contains(item.Extension);
+        }
+
+        /// <summary>
+        /// Last-resort check for files with no extension, or an extension Peek doesn't otherwise
+        /// recognize, whose content is sniffed to be text. Should only be consulted after every
+        /// other previewer (including the shell preview handler) has declined the item.
+        /// </summary>
+        public static bool IsTextFallbackSupported(IFileSystemItem item)
+        {
+            return item is FileItem && !IsItemSupported(item) && TextFileHelper.IsTextFile(item.Path);
         }
 
         private bool HasFailedLoadingPreview()

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/WebBrowserPreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/WebBrowserPreviewer.cs
@@ -97,7 +97,8 @@ namespace Peek.FilePreviewer.Previewers
         {
             cancellationToken.ThrowIfCancellationRequested();
             State = PreviewState.Loading;
-            await LoadDisplayInfoAsync(cancellationToken);
+            DisplayInfoTask = LoadDisplayInfoAsync(cancellationToken);
+            await DisplayInfoTask; // Wait for the display info to load before checking for errors
 
             if (HasFailedLoadingPreview())
             {
@@ -111,10 +112,19 @@ namespace Peek.FilePreviewer.Previewers
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
+                string extension = File.Extension;
+
+                // Items that reach the previewer as a fallback-candidate haven't had their content verified
+                // as text yet - that cheap check deliberately skips file I/O so it's safe to run
+                // synchronously on the UI thread.
+                bool needsContentSniff = !IsItemSupported(File);
+                if (needsContentSniff && !await TextFileHelper.IsTextFileAsync(File.Path, cancellationToken))
+                {
+                    throw new NotSupportedException($"'{File.Path}' has an unrecognized extension and its content was not sniffed as text.");
+                }
+
                 await Dispatcher.RunOnUiThread(async () =>
                 {
-                    string extension = File.Extension;
-
                     // Default: non-dev file preview with standard context menu
                     IsDevFilePreview = false;
                     CustomContextMenu = false;
@@ -144,8 +154,7 @@ namespace Peek.FilePreviewer.Previewers
                     else
                     {
                         // Source code files use Monaco editor. Extensions Monaco doesn't recognize
-                        // (including files with no extension, sniffed as text by IsTextFallbackSupported)
-                        // fall back to plaintext highlighting.
+                        // (including files with no extension) fall back to plaintext highlighting..
                         IsDevFilePreview = true;
                         CustomContextMenu = true;
                         var raw = await ReadHelper.Read(File.Path.ToString());
@@ -171,12 +180,13 @@ namespace Peek.FilePreviewer.Previewers
 
         /// <summary>
         /// Last-resort check for files with no extension, or an extension Peek doesn't otherwise
-        /// recognize, whose content is sniffed to be text. Should only be consulted after every
-        /// other previewer (including the shell preview handler) has declined the item.
+        /// recognize, whose content should be checked to confirm if it is text. Should only be
+        /// consulted after every other previewer (including the shell preview handler)
+        /// has declined the item.
         /// </summary>
-        public static bool IsTextFallbackSupported(IFileSystemItem item)
+        public static bool IsFallbackCandidate(IFileSystemItem item)
         {
-            return item is FileItem && !IsItemSupported(item) && TextFileHelper.IsTextFile(item.Path);
+            return item is FileItem && !IsItemSupported(item);
         }
 
         private bool HasFailedLoadingPreview()

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/WebBrowserPreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/WebBrowserPreviewer.cs
@@ -114,52 +114,53 @@ namespace Peek.FilePreviewer.Previewers
 
                 string extension = File.Extension;
 
-                // Items that reach the previewer as a fallback-candidate haven't had their content verified
-                // as text yet - that cheap check deliberately skips file I/O so it's safe to run
-                // synchronously on the UI thread.
-                bool needsContentSniff = !IsItemSupported(File);
-                if (needsContentSniff && !await TextFileHelper.IsTextFileAsync(File.Path, cancellationToken))
+                // Default: non-dev file preview with standard context menu
+                bool isDevFilePreview = false;
+                bool customContextMenu = false;
+                Uri previewUri;
+
+                // Determine preview strategy based on file type priority
+                if (extension == ".md")
                 {
-                    throw new NotSupportedException($"'{File.Path}' has an unrecognized extension and its content was not sniffed as text.");
+                    // Markdown files use custom renderer
+                    var raw = await ReadHelper.Read(File.Path.ToString(), _previewSettings.SourceCodeMaxFileSizeBytes, cancellationToken).ConfigureAwait(false);
+                    previewUri = new Uri(MarkdownHelper.PreviewTempFile(raw, File.Path, TempFolderPath.Path));
+                }
+                else if (extension == ".svg")
+                {
+                    // SVG files are rendered directly by WebView2 for better compatibility
+                    // with complex SVGs from Adobe Illustrator, Inkscape, etc.
+                    previewUri = new Uri(File.Path);
+                }
+                else if (extension == ".html" || extension == ".htm")
+                {
+                    // Simple html file to preview. Shouldn't do things like enabling scripts or using a virtual mapped directory.
+                    previewUri = new Uri(File.Path);
+                }
+                else if (extension == ".pdf")
+                {
+                    previewUri = new Uri(File.Path);
+                }
+                else
+                {
+                    // Source code files use Monaco editor
+                    // Only extensions Monaco doesn't recognize are sniffed to check if they can be displayed as plain text.
+                    if (!IsItemSupported(File) && !await TextFileHelper.IsTextFileAsync(File.Path, _previewSettings.SourceCodeMaxFileSizeBytes, cancellationToken).ConfigureAwait(false))
+                    {
+                        throw new NotSupportedException($"'{File.Path}' has an unrecognized extension and its content was not sniffed as text.");
+                    }
+
+                    isDevFilePreview = true;
+                    customContextMenu = true;
+                    var raw = await ReadHelper.Read(File.Path.ToString(), _previewSettings.SourceCodeMaxFileSizeBytes, cancellationToken).ConfigureAwait(false);
+                    previewUri = new Uri(MonacoHelper.PreviewTempFile(raw, extension, TempFolderPath.Path, _previewSettings.SourceCodeTryFormat, _previewSettings.SourceCodeWrapText, _previewSettings.SourceCodeStickyScroll, _previewSettings.SourceCodeFontSize, _previewSettings.SourceCodeMinimap));
                 }
 
-                await Dispatcher.RunOnUiThread(async () =>
+                await Dispatcher.RunOnUiThread(() =>
                 {
-                    // Default: non-dev file preview with standard context menu
-                    IsDevFilePreview = false;
-                    CustomContextMenu = false;
-
-                    // Determine preview strategy based on file type priority
-                    if (extension == ".md")
-                    {
-                        // Markdown files use custom renderer
-                        var raw = await ReadHelper.Read(File.Path.ToString());
-                        Preview = new Uri(MarkdownHelper.PreviewTempFile(raw, File.Path, TempFolderPath.Path));
-                    }
-                    else if (extension == ".svg")
-                    {
-                        // SVG files are rendered directly by WebView2 for better compatibility
-                        // with complex SVGs from Adobe Illustrator, Inkscape, etc.
-                        Preview = new Uri(File.Path);
-                    }
-                    else if (extension == ".html" || extension == ".htm")
-                    {
-                        // Simple html file to preview. Shouldn't do things like enabling scripts or using a virtual mapped directory.
-                        Preview = new Uri(File.Path);
-                    }
-                    else if (extension == ".pdf")
-                    {
-                        Preview = new Uri(File.Path);
-                    }
-                    else
-                    {
-                        // Source code files use Monaco editor. Extensions Monaco doesn't recognize
-                        // (including files with no extension) fall back to plaintext highlighting..
-                        IsDevFilePreview = true;
-                        CustomContextMenu = true;
-                        var raw = await ReadHelper.Read(File.Path.ToString());
-                        Preview = new Uri(MonacoHelper.PreviewTempFile(raw, extension, TempFolderPath.Path, _previewSettings.SourceCodeTryFormat, _previewSettings.SourceCodeWrapText, _previewSettings.SourceCodeStickyScroll, _previewSettings.SourceCodeFontSize, _previewSettings.SourceCodeMinimap));
-                    }
+                    IsDevFilePreview = isDevFilePreview;
+                    CustomContextMenu = customContextMenu;
+                    Preview = previewUri;
                 });
             });
         }

--- a/src/settings-ui/Settings.UI.Library/PeekPreviewSettings.cs
+++ b/src/settings-ui/Settings.UI.Library/PeekPreviewSettings.cs
@@ -13,6 +13,9 @@ namespace Settings.UI.Library
     {
         public const string FileName = "preview-settings.json";
 
+        // Default cap for the source-code preview in kilobytes, files above the limit fall back to the info preview.
+        public const int DefaultSourceCodeMaxFileSize = 10240;
+
         public BoolProperty SourceCodeWrapText { get; set; }
 
         public BoolProperty SourceCodeTryFormat { get; set; }
@@ -23,6 +26,8 @@ namespace Settings.UI.Library
 
         public BoolProperty SourceCodeMinimap { get; set; }
 
+        public IntProperty SourceCodeMaxFileSize { get; set; }
+
         public PeekPreviewSettings()
         {
             SourceCodeWrapText = new BoolProperty(false);
@@ -30,6 +35,7 @@ namespace Settings.UI.Library
             SourceCodeFontSize = new IntProperty(14);
             SourceCodeStickyScroll = new BoolProperty(true);
             SourceCodeMinimap = new BoolProperty(false);
+            SourceCodeMaxFileSize = new IntProperty(DefaultSourceCodeMaxFileSize);
         }
 
         public string ToJsonString()

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PeekPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PeekPage.xaml
@@ -111,6 +111,17 @@
                             <tkcontrols:SettingsCard ContentAlignment="Left" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
                                 <CheckBox x:Uid="Peek_SourceCode_Minimap" IsChecked="{x:Bind ViewModel.SourceCodeMinimap, Mode=TwoWay}" />
                             </tkcontrols:SettingsCard>
+                            <tkcontrols:SettingsCard
+                                Name="PeekSourceCodeMaxFileSize"
+                                x:Uid="Peek_SourceCode_MaxFileSize"
+                                IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
+                                <NumberBox
+                                    MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                    Maximum="102400"
+                                    Minimum="1"
+                                    SpinButtonPlacementMode="Compact"
+                                    Value="{x:Bind ViewModel.SourceCodeMaxFileSize, Mode=TwoWay}" />
+                            </tkcontrols:SettingsCard>
                         </tkcontrols:SettingsExpander.Items>
                     </tkcontrols:SettingsExpander>
                 </controls:SettingsGroup>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -4658,6 +4658,14 @@ Activate by holding the key for the character you want to add an accent to, then
   <data name="Peek_SourceCode_Minimap.Content" xml:space="preserve">
     <value>Show minimap</value>
   </data>
+  <data name="Peek_SourceCode_MaxFileSize.Header" xml:space="preserve">
+    <value>Maximum file size to preview</value>
+    <comment>Size refers to the disk space used by a file</comment>
+  </data>
+  <data name="Peek_SourceCode_MaxFileSize.Description" xml:space="preserve">
+    <value>The maximum size, in kilobytes, for files to be displayed. This is a safety mechanism to prevent loading large files into RAM. Larger files show the file details instead.</value>
+    <comment>"RAM" refers to random access memory; "size" refers to disk space</comment>
+  </data>
   <data name="ShowPluginsOverview_All.Content" xml:space="preserve">
     <value>All</value>
   </data>

--- a/src/settings-ui/Settings.UI/ViewModels/PeekViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/PeekViewModel.cs
@@ -364,6 +364,20 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
+        public int SourceCodeMaxFileSize
+        {
+            get => _peekPreviewSettings.SourceCodeMaxFileSize.Value;
+            set
+            {
+                if (_peekPreviewSettings.SourceCodeMaxFileSize.Value != value)
+                {
+                    _peekPreviewSettings.SourceCodeMaxFileSize.Value = value;
+                    OnPropertyChanged(nameof(SourceCodeMaxFileSize));
+                    SavePreviewSettings();
+                }
+            }
+        }
+
         private void NotifySettingsChanged()
         {
             // Do not send IPC message if the settings file has been updated by Peek itself.


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This pull request adds support to the peek utility to view files with unknown extensions as plain text files instead of falling back and just displaying info about the file.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #49878 
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The following are screen shots with some examples I have found looking through files within this repo. The `.slnx` file type should eventually be covered by a change to Monaco's supported files to read those files with syntax highlighting but this change shows that we can at least view the content of new file types instead of being shown only the file details.
|Before|After|
|-|-|
| <img width="670" height="495" alt="image" src="https://github.com/user-attachments/assets/2deb4a23-dbc3-43fa-8001-94691e9c59eb" /> | <img width="1044" height="651" alt="image" src="https://github.com/user-attachments/assets/6e033703-3ab0-46c6-b022-6f16ceebf928" /> |
|<img width="666" height="541" alt="image" src="https://github.com/user-attachments/assets/c472da10-ccb3-4c9b-a195-5fb53a11b631" />|<img width="851" height="783" alt="image" src="https://github.com/user-attachments/assets/b4f450d9-076f-4e8a-ba7f-5299b2c19e62" />|
|<img width="666" height="493" alt="image" src="https://github.com/user-attachments/assets/6cbc7264-3797-49c8-9d38-32dd3dce27db" />|<img width="991" height="965" alt="image" src="https://github.com/user-attachments/assets/e0065c0e-0670-476b-876f-fb4af19413fe" />|

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
I've ran the build using the provided build steps using this script: `.\tools\build\build.ps1`. After running this build I was able to run the built PowerToys version locally on my PC. While running the new build I was able to test the change on different files types. Using this build I took the screen shots shown in the previous heading.
