### PR TITLE
Fix WinUI title-bar startup crash in CJK environments

### DIFF
--- a/src/modules/EnvironmentVariables/EnvironmentVariables/EnvironmentVariablesXAML/MainWindow.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariables/EnvironmentVariablesXAML/MainWindow.xaml.cs
@@ -25,6 +25,10 @@ namespace EnvironmentVariables
         {
             this.InitializeComponent();
 
+            const string fallbackTitle = "Environment Variables";
+            Title = fallbackTitle;
+            titleBar.Title = fallbackTitle;
+
             ExtendsContentIntoTitleBar = true;
             SetTitleBar(titleBar);
             AppWindow.SetIcon("Assets/EnvironmentVariables/EnvironmentVariables.ico");
@@ -40,7 +44,7 @@ namespace EnvironmentVariables
             // window title populated.
             if (string.IsNullOrEmpty(title))
             {
-                title = "Environment Variables";
+                title = fallbackTitle;
             }
 
             Title = title;

--- a/src/modules/FileLocksmith/FileLocksmithUI/FileLocksmithXAML/MainWindow.xaml.cs
+++ b/src/modules/FileLocksmith/FileLocksmithUI/FileLocksmithXAML/MainWindow.xaml.cs
@@ -17,6 +17,11 @@ namespace FileLocksmithUI
         public MainWindow(bool isElevated)
         {
             InitializeComponent();
+
+            const string fallbackTitle = "File Locksmith";
+            Title = fallbackTitle;
+            titleBar.Title = fallbackTitle;
+
             mainPage.ViewModel.IsElevated = isElevated;
             SetTitleBar(titleBar);
             ExtendsContentIntoTitleBar = true;
@@ -31,7 +36,7 @@ namespace FileLocksmithUI
             // control while it reads AppWindow.Title during a deferred layout pass.
             if (string.IsNullOrEmpty(title))
             {
-                title = "File Locksmith";
+                title = fallbackTitle;
             }
 
             Title = title;

--- a/src/modules/Hosts/Hosts/HostsXAML/MainWindow.xaml.cs
+++ b/src/modules/Hosts/Hosts/HostsXAML/MainWindow.xaml.cs
@@ -26,6 +26,10 @@ namespace Hosts
         {
             InitializeComponent();
 
+            const string fallbackTitle = "Hosts File Editor";
+            Title = fallbackTitle;
+            titleBar.Title = fallbackTitle;
+
             ExtendsContentIntoTitleBar = true;
             SetTitleBar(titleBar);
             AppWindow.SetIcon("Assets/Hosts/Hosts.ico");
@@ -39,7 +43,7 @@ namespace Hosts
             // control while it reads AppWindow.Title during a deferred layout pass.
             if (string.IsNullOrEmpty(title))
             {
-                title = "Hosts File Editor";
+                title = fallbackTitle;
             }
 
             Title = title;

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/OverlayWindow.xaml.cs
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/OverlayWindow.xaml.cs
@@ -76,6 +76,9 @@ namespace ShortcutGuide
         {
             this.InitializeComponent();
 
+            const string fallbackTitle = "Shortcut Guide";
+            this.Title = fallbackTitle;
+
             // The base TransparentWindow already applies the
             // TransparentTintBackdrop, extends content into the title bar and
             // collapses it, and strips the native chrome.
@@ -86,7 +89,7 @@ namespace ShortcutGuide
             // control while it reads AppWindow.Title during a deferred layout pass.
             if (string.IsNullOrEmpty(title))
             {
-                title = "Shortcut Guide";
+                title = fallbackTitle;
             }
 
             this.Title = title;

--- a/src/modules/registrypreview/RegistryPreview/RegistryPreviewXAML/MainWindow.xaml.cs
+++ b/src/modules/registrypreview/RegistryPreview/RegistryPreviewXAML/MainWindow.xaml.cs
@@ -34,6 +34,10 @@ namespace RegistryPreview
         {
             this.InitializeComponent();
 
+            // Seed a non-empty title before any title-bar setup or window initialization.
+            titleBar.Title = APPNAME;
+            AppWindow.Title = APPNAME;
+
             // Open settings file; this moved to after the window tweak because it gives the window time to start up
             settingsFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + @"\Microsoft\PowerToys\" + APPNAME;
             OpenWindowPlacementFile(settingsFolder, windowPlacementFile);
@@ -47,13 +51,6 @@ namespace RegistryPreview
             WindowHelpers.ForceTopBorder1PixelInsetOnWindows10(windowHandle);
             SetTitleBar(titleBar);
             AppWindow.SetIcon("Assets\\RegistryPreview\\RegistryPreview.ico");
-
-            // Ensure a non-empty window title before the title bar's first layout reads it.
-            // UpdateWindowTitle() only runs later (on file load), so without this the native
-            // window title would be empty during startup, which can fault the WinUI TitleBar
-            // control while it reads AppWindow.Title during a deferred layout pass.
-            titleBar.Title = APPNAME;
-            AppWindow.Title = APPNAME;
 
             // if have settings, update the location of the window
             if (jsonWindowPlacement != null)

--- a/src/settings-ui/Settings.UI/SettingsXAML/Controls/Dashboard/ShortcutConflictWindow.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Controls/Dashboard/ShortcutConflictWindow.xaml.cs
@@ -40,6 +40,10 @@ namespace Microsoft.PowerToys.Settings.UI.SettingsXAML.Controls.Dashboard
 
             this.Activated += Window_Activated_SetIcon;
 
+            const string fallbackTitle = "PowerToys shortcut conflicts";
+            this.Title = fallbackTitle;
+            titleBar.Title = fallbackTitle;
+
             // Set localized window title
             var resourceLoader = ResourceLoaderInstance.ResourceLoader;
             ExtendsContentIntoTitleBar = true;
@@ -52,10 +56,11 @@ namespace Microsoft.PowerToys.Settings.UI.SettingsXAML.Controls.Dashboard
             // control while it reads AppWindow.Title during a deferred layout pass.
             if (string.IsNullOrEmpty(windowTitle))
             {
-                windowTitle = "PowerToys shortcut conflicts";
+                windowTitle = fallbackTitle;
             }
 
             this.Title = windowTitle;
+            titleBar.Title = windowTitle;
             this.CenterOnScreen();
 
             ViewModel.OnPageLoaded();


### PR DESCRIPTION
## Summary

Fixes #49880

Ensure affected PowerToys WinUI windows have a non-empty native title before custom title-bar initialization begins. This closes the startup window in which WinUI `TitleBar` can read an empty `AppWindow.Title` and terminate the process.

## Changes

- Seed a safe fallback title immediately after `InitializeComponent()` in:
  - Environment Variables
  - File Locksmith
  - Hosts
  - Shortcut Guide
  - Settings' Shortcut Conflict window
- Move Registry Preview's existing fallback before title-bar setup.
- Reapply the localized or administrator title afterward, preserving existing resource behavior.
- Keep the fallback available if a localized resource lookup returns an empty string.

## Why this is needed

Community reports in CJK environments show the same `Microsoft.UI.Windowing.dll + 0x4bc71` / `0xe0464645` crash signature associated with the empty-title startup path. The earlier mitigation populated the fallback after title-bar setup; this change seeds both the native and custom title-bar titles before that setup.

## Validation

- Debug x64 builds succeeded for Environment Variables, File Locksmith, Hosts, Shortcut Guide, Registry Preview, and Settings UI.
- Builds used the repository `tools\\build\\build.ps1` workflow after targeted NuGet restore.
- The source diff is limited to the six title-bar windows above.
- Runtime reproduction on the development machine remains pending. The recommended affected-environment matrix is `zh-CN`, `zh-TW`, and `ja-JP`, PowerToys language set to Windows Default, both runner elevation states, both Environment Variables administrator-launch settings, and repeated startup/close loops.

## Author validation

- [x] I have tested these changes locally.
- [x] I have reviewed the changed code for syntax and behavior.
- [ ] I have attached a runtime recording or crash comparison from an affected CJK environment.