### PR TITLE
Add setting to disable cursor wrap in Game Mode (full screen D3D application).

### DIFF
--- a/src/modules/MouseUtils/CursorWrap/dllmain.cpp
+++ b/src/modules/MouseUtils/CursorWrap/dllmain.cpp
@@ -11,6 +11,7 @@
 #include "../../../common/logger/logger.h"
 #include "../../../common/utils/logger_helper.h"
 #include "../../../common/interop/shared_constants.h"
+#include "../../../common/utils/game_mode.h"
 #include <atomic>
 #include <thread>
 #include <vector>
@@ -56,6 +57,7 @@ namespace
     const wchar_t JSON_KEY_WRAP_MODE[] = L"wrap_mode";
     const wchar_t JSON_KEY_ACTIVATION_MODE[] = L"activation_mode";
     const wchar_t JSON_KEY_DISABLE_ON_SINGLE_MONITOR[] = L"disable_cursor_wrap_on_single_monitor";
+    const wchar_t JSON_KEY_DISABLE_IN_GAME_MODE[] = L"disable_cursor_wrap_in_game_mode";
 }
 
 // The PowerToy name that will be shown in the settings.
@@ -83,12 +85,17 @@ private:
     bool m_autoActivate = false;
     bool m_disableWrapDuringDrag = true; // Default to true to prevent wrap during drag
     bool m_disableOnSingleMonitor = false; // Default to false
+    bool m_disableInGameMode = false; // Default to false: only disable wrapping in game mode when the user opts in
     int m_wrapMode = 0; // 0=Both (default), 1=VerticalOnly, 2=HorizontalOnly
     int m_activationMode = 0; // 0=Always (default), 1=HoldingCtrl (wraps only while held), 2=HoldingShift (wraps only while held)
     
     // Mouse hook
     HHOOK m_mouseHook = nullptr;
     std::atomic<bool> m_hookActive{ false };
+
+    // Cached game mode state, refreshed at most once per GAME_MODE_POLL_MS from the mouse hook to keep the hot path quiet.
+    std::atomic<bool> m_gameModeActive{ false };
+    std::atomic<ULONGLONG> m_lastGameModeCheckTick{ 0 };
     
     // Core wrapping engine (edge-based polygon model)
     CursorWrapCore m_core;
@@ -107,6 +114,7 @@ private:
     HDEVNOTIFY m_deviceNotify = nullptr;
     static constexpr UINT_PTR TIMER_UPDATE_MONITORS = 1;
     static constexpr UINT DEBOUNCE_DELAY_MS = 500;
+    static constexpr ULONGLONG GAME_MODE_POLL_MS = 1000; // Re-check game mode at most this often from the mouse hook
 
 public:
     // Constructor
@@ -461,6 +469,21 @@ private:
             {
                 Logger::warn("Failed to initialize CursorWrap disable on single monitor from settings. Will use default value (false)");
             }
+
+            try
+            {
+                // Parse disable in game mode
+                auto propertiesObject = settingsObject.GetNamedObject(JSON_KEY_PROPERTIES);
+                if (propertiesObject.HasKey(JSON_KEY_DISABLE_IN_GAME_MODE))
+                {
+                    auto disableInGameModeObject = propertiesObject.GetNamedObject(JSON_KEY_DISABLE_IN_GAME_MODE);
+                    m_disableInGameMode = disableInGameModeObject.GetNamedBoolean(JSON_KEY_VALUE);
+                }
+            }
+            catch (...)
+            {
+                Logger::warn("Failed to initialize CursorWrap disable in game mode from settings. Will use default value (false)");
+            }
         }
         else
         {
@@ -494,6 +517,10 @@ private:
         {
             m_hookActive = true;
             Logger::info("CursorWrap mouse hook started successfully");
+
+            // Force a fresh game mode check on the first mouse move after activation.
+            m_lastGameModeCheckTick = 0;
+            m_gameModeActive = false;
 #ifdef _DEBUG
             Logger::info(L"CursorWrap DEBUG: Hook installed");
 #endif
@@ -512,6 +539,8 @@ private:
             UnhookWindowsHookEx(m_mouseHook);
             m_mouseHook = nullptr;
             m_hookActive = false;
+            m_gameModeActive = false;
+            m_lastGameModeCheckTick = 0;
             Logger::info("CursorWrap mouse hook stopped");
 #ifdef _DEBUG
             Logger::info("CursorWrap DEBUG: Mouse hook stopped");
@@ -689,6 +718,23 @@ private:
             
             if (g_cursorWrapInstance && g_cursorWrapInstance->m_hookActive)
             {
+                // Don't wrap while a fullscreen game is running. The shell query is throttled to at most
+                // once per GAME_MODE_POLL_MS so the hot path stays quiet, and it's skipped entirely when disabled.
+                if (g_cursorWrapInstance->m_disableInGameMode)
+                {
+                    ULONGLONG now = GetTickCount64();
+                    if (now - g_cursorWrapInstance->m_lastGameModeCheckTick >= GAME_MODE_POLL_MS)
+                    {
+                        g_cursorWrapInstance->m_gameModeActive = detect_game_mode();
+                        g_cursorWrapInstance->m_lastGameModeCheckTick = now;
+                    }
+
+                    if (g_cursorWrapInstance->m_gameModeActive)
+                    {
+                        return CallNextHookEx(nullptr, nCode, wParam, lParam);
+                    }
+                }
+
                 // Check activation mode to determine if wrapping should happen.
                 // 0=Always, 1=HoldingCtrl (wraps only when Ctrl held), 2=HoldingShift (wraps only when Shift held)
                 int activationMode = g_cursorWrapInstance->m_activationMode;

--- a/src/settings-ui/Settings.UI.Library/CursorWrapProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/CursorWrapProperties.cs
@@ -31,6 +31,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [JsonPropertyName("disable_cursor_wrap_on_single_monitor")]
         public BoolProperty DisableCursorWrapOnSingleMonitor { get; set; }
 
+        [JsonPropertyName("disable_cursor_wrap_in_game_mode")]
+        public BoolProperty DisableCursorWrapInGameMode { get; set; }
+
         public CursorWrapProperties()
         {
             ActivationShortcut = DefaultActivationShortcut;
@@ -39,6 +42,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             WrapMode = new IntProperty(0); // 0=Both (default), 1=VerticalOnly, 2=HorizontalOnly
             ActivationMode = new IntProperty(0); // 0=Always (default), 1=HoldingCtrl, 2=HoldingShift
             DisableCursorWrapOnSingleMonitor = new BoolProperty(false);
+            DisableCursorWrapInGameMode = new BoolProperty(false); // Default to false: only disable wrapping in game mode if the user opts in
         }
     }
 }

--- a/src/settings-ui/Settings.UI.Library/CursorWrapSettings.cs
+++ b/src/settings-ui/Settings.UI.Library/CursorWrapSettings.cs
@@ -70,6 +70,13 @@ namespace Microsoft.PowerToys.Settings.UI.Library
                 settingsUpgraded = true;
             }
 
+            // Add DisableCursorWrapInGameMode property if it doesn't exist (for users upgrading from older versions)
+            if (Properties.DisableCursorWrapInGameMode == null)
+            {
+                Properties.DisableCursorWrapInGameMode = new BoolProperty(false); // Default to false
+                settingsUpgraded = true;
+            }
+
             return settingsUpgraded;
         }
     }

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/MouseUtilsPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/MouseUtilsPage.xaml
@@ -65,6 +65,9 @@
                             <tkcontrols:SettingsCard ContentAlignment="Left" IsEnabled="{x:Bind ViewModel.IsCursorWrapEnabled, Mode=OneWay}">
                                 <CheckBox x:Uid="MouseUtils_CursorWrap_DisableOnSingleMonitor" IsChecked="{x:Bind ViewModel.CursorWrapDisableOnSingleMonitor, Mode=TwoWay}" />
                             </tkcontrols:SettingsCard>
+                            <tkcontrols:SettingsCard ContentAlignment="Left" IsEnabled="{x:Bind ViewModel.IsCursorWrapEnabled, Mode=OneWay}">
+                                <CheckBox x:Uid="MouseUtils_CursorWrap_DisableInGameMode" IsChecked="{x:Bind ViewModel.CursorWrapDisableInGameMode, Mode=TwoWay}" />
+                            </tkcontrols:SettingsCard>
                         </tkcontrols:SettingsExpander.Items>
                     </tkcontrols:SettingsExpander>
                 </controls:SettingsGroup>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -2789,6 +2789,10 @@ From there, simply click on one of the supported files in the File Explorer and 
   <data name="MouseUtils_CursorWrap_DisableOnSingleMonitor.Content" xml:space="preserve">
     <value>Disable wrapping when using a single monitor</value>
   </data>
+  <data name="MouseUtils_CursorWrap_DisableInGameMode.Content" xml:space="preserve">
+    <value>Do not activate when Game Mode is on</value>
+    <comment>"Game mode" is the Windows feature to prevent notification when playing a game.</comment>
+  </data>
   <data name="MouseUtils_CursorWrap_WrapMode.Header" xml:space="preserve">
     <value>Wrap mode</value>
   </data>

--- a/src/settings-ui/Settings.UI/ViewModels/MouseUtilsViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/MouseUtilsViewModel.cs
@@ -128,6 +128,9 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             // Null-safe access in case property wasn't upgraded yet - default to false
             _cursorWrapDisableOnSingleMonitor = CursorWrapSettingsConfig.Properties.DisableCursorWrapOnSingleMonitor?.Value ?? false;
 
+            // Null-safe access in case property wasn't upgraded yet - default to false
+            _cursorWrapDisableInGameMode = CursorWrapSettingsConfig.Properties.DisableCursorWrapInGameMode?.Value ?? false;
+
             int isEnabled = 0;
 
             Utilities.NativeMethods.SystemParametersInfo(Utilities.NativeMethods.SPI_GETCLIENTAREAANIMATION, 0, ref isEnabled, 0);
@@ -1303,6 +1306,34 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
+        public bool CursorWrapDisableInGameMode
+        {
+            get
+            {
+                return _cursorWrapDisableInGameMode;
+            }
+
+            set
+            {
+                if (value != _cursorWrapDisableInGameMode)
+                {
+                    _cursorWrapDisableInGameMode = value;
+
+                    // Ensure the property exists before setting value
+                    if (CursorWrapSettingsConfig.Properties.DisableCursorWrapInGameMode == null)
+                    {
+                        CursorWrapSettingsConfig.Properties.DisableCursorWrapInGameMode = new BoolProperty(value);
+                    }
+                    else
+                    {
+                        CursorWrapSettingsConfig.Properties.DisableCursorWrapInGameMode.Value = value;
+                    }
+
+                    NotifyCursorWrapPropertyChanged();
+                }
+            }
+        }
+
         public void NotifyCursorWrapPropertyChanged([CallerMemberName] string propertyName = null)
         {
             OnPropertyChanged(propertyName);
@@ -1383,5 +1414,6 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         private int _cursorWrapWrapMode; // 0=Both, 1=VerticalOnly, 2=HorizontalOnly
         private int _cursorWrapActivationMode; // 0=Always, 1=HoldingCtrl (wraps only while held), 2=HoldingShift (wraps only while held)
         private bool _cursorWrapDisableOnSingleMonitor; // Disable cursor wrap when only one monitor is connected
+        private bool _cursorWrapDisableInGameMode; // Disable cursor wrap while a fullscreen game is running
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request
This PR adds a new setting to CursorWrap to disable wrap when the system is in Game Mode - this is a relatively simple settings change, the implementation uses the existing src/common/utils/game_mode.h implementation.

## PR Checklist

- [ ] Closes: #49782 
<!--  - [x] Closes: #yyy (add separate lines for additional resolved issues) -->
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [x] **Dev docs:** Added/updated
- [x] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments
minor update to cursorwrap, add a new setting to disable wrap when GameMode is active (using src/common/utils/game_mode.h to determine GameMode/full screen D3D application).

## Validation Steps Performed
Built and tested on Windows 11, Surface Laptop 7 with a test D3D full screen application. existing functionality also tested.

