### PR TITLE
CmdPal: Fix Command Palette RDP extension not filtering search results

### DIFF
--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.RemoteDesktop.UnitTests/RemoteDesktopListPageTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.RemoteDesktop.UnitTests/RemoteDesktopListPageTests.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using Microsoft.CmdPal.Ext.RemoteDesktop.Commands;
 using Microsoft.CmdPal.Ext.RemoteDesktop.Pages;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -185,5 +186,21 @@ public class RemoteDesktopListPageTests
         var firstItem = items[0] as ConnectionListItem;
         Assert.IsNotNull(firstItem);
         Assert.AreEqual("192.168.1.100:3390", firstItem.ConnectionName);
+    }
+
+    [TestMethod]
+    public void PartialQuery_FiltersOutNonMatchingConnection()
+    {
+        // Arrange — "qwxyz" shares no characters with "alpha-server", so it can never fuzzy-match
+        var page = CreatePage("alpha-server", "qwxyz");
+
+        // Act — set SearchText (not just UpdateSearchText) so GetItems() sees the query too
+        page.SearchText = "alpha-server";
+        var items = page.GetItems();
+
+        // Assert — the non-matching connection is filtered out of the results
+        var names = items.OfType<ConnectionListItem>().Select(i => i.ConnectionName).ToList();
+        CollectionAssert.Contains(names, "alpha-server");
+        CollectionAssert.DoesNotContain(names, "qwxyz");
     }
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.RemoteDesktop/Pages/RemoteDesktopListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.RemoteDesktop/Pages/RemoteDesktopListPage.cs
@@ -65,7 +65,12 @@ internal sealed partial class RemoteDesktopListPage : DynamicListPage
 
     public override IListItem[] GetItems()
     {
-        var connections = _rdpConnectionsManager.Connections.ToArray();
+        var query = SearchText?.Trim() ?? string.Empty;
+        var allConnections = _rdpConnectionsManager.Connections;
+
+        var connections = string.IsNullOrWhiteSpace(query)
+            ? allConnections.ToArray()
+            : ListHelpers.FilterList(allConnections, query, (s, i) => ListHelpers.ScoreListItem(s, i)).ToArray();
 
         if (_arbitraryHostItem is null)
         {


### PR DESCRIPTION
The RDP extension's search box never actually filtered anything. Type whatever you wanted and the full connection list stayed put, with focus stuck on whatever item happened to be first. That's issue #50012.

## The plan

`GetItems()` was ignoring the typed search text entirely and just returning every connection every time. Now it scores and filters connections against the search text using the same `ListHelpers` scoring the extension already uses elsewhere (`ConnectionHelpers.FindConnection` does this same thing), so the list narrows and focus lands on a real match instead of whatever was first.

Added tests to cover the ranking and filtering behavior, and ran the full CmdPal unit test suite to make sure nothing else broke.