### PR TITLE
CmdPal: Fix dock items not activating with keyboard

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml
@@ -37,6 +37,7 @@
                         <DataTemplate x:DataType="dockVm:DockItemViewModel">
                             <local:DockItemControl
                                 Title="{x:Bind Title, Mode=OneWay}"
+                                KeyDown="BandItem_KeyDown"
                                 RightTapped="BandItem_RightTapped"
                                 Subtitle="{x:Bind Subtitle, Mode=OneWay}"
                                 Tag="{x:Bind}"

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml.cs
@@ -305,17 +305,8 @@ public sealed partial class DockControl : UserControl, IRecipient<CloseContextMe
     private void BandItem_Tapped(object sender, Microsoft.UI.Xaml.Input.TappedRoutedEventArgs e)
     {
         // Ignore clicks when in edit mode - allow drag behavior instead
-        if (IsEditMode)
+        if (TryInvokeBandItem(sender))
         {
-            return;
-        }
-
-        if (sender is DockItemControl dockItem && dockItem.DataContext is DockBandViewModel band && dockItem.Tag is DockItemViewModel item)
-        {
-            // Use the center of the border as the point to open at
-            var borderCenter = GetDockItemCenter(dockItem);
-
-            InvokeItem(item, borderCenter);
             e.Handled = true;
         }
     }
@@ -329,13 +320,28 @@ public sealed partial class DockControl : UserControl, IRecipient<CloseContextMe
             return;
         }
 
-        if (sender is DockItemControl dockItem && dockItem.DataContext is DockBandViewModel band && dockItem.Tag is DockItemViewModel item)
+        if (TryInvokeBandItem(sender))
         {
-            var borderCenter = GetDockItemCenter(dockItem);
-
-            InvokeItem(item, borderCenter);
             e.Handled = true;
         }
+    }
+
+    private bool TryInvokeBandItem(object sender)
+    {
+        if (IsEditMode)
+        {
+            return false;
+        }
+
+        if (sender is not DockItemControl dockItem || dockItem.Tag is not DockItemViewModel item)
+        {
+            return false;
+        }
+
+        // Use the center of the border as the point to open at.
+        var borderCenter = GetDockItemCenter(dockItem);
+        InvokeItem(item, borderCenter);
+        return true;
     }
 
     private ContextMenuFilterLocation GetDockContextMenuFilterLocation()

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml.cs
@@ -19,9 +19,11 @@ using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Foundation;
+using Windows.System;
 
 using RS_ = Microsoft.CmdPal.UI.Helpers.ResourceLoaderInstance;
 
@@ -311,6 +313,24 @@ public sealed partial class DockControl : UserControl, IRecipient<CloseContextMe
         if (sender is DockItemControl dockItem && dockItem.DataContext is DockBandViewModel band && dockItem.Tag is DockItemViewModel item)
         {
             // Use the center of the border as the point to open at
+            var borderCenter = GetDockItemCenter(dockItem);
+
+            InvokeItem(item, borderCenter);
+            e.Handled = true;
+        }
+    }
+
+    private void BandItem_KeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        // Tapped only fires for pointer input, so keyboard focus + Enter/Space
+        // never invoked a dock item. This is the keyboard side of BandItem_Tapped.
+        if (IsEditMode || (e.Key != VirtualKey.Enter && e.Key != VirtualKey.Space))
+        {
+            return;
+        }
+
+        if (sender is DockItemControl dockItem && dockItem.DataContext is DockBandViewModel band && dockItem.Tag is DockItemViewModel item)
+        {
             var borderCenter = GetDockItemCenter(dockItem);
 
             InvokeItem(item, borderCenter);


### PR DESCRIPTION
Tab into a Dock item, give it focus, hit Enter or Space, and nothing happens. Fixes #49409.

## The plan

Dock items only invoke through a `Tapped` handler, and `Tapped` doesn't fire for keyboard input on a plain `Control`. Added a `KeyDown` handler on the dock item that checks for Enter or Space and runs through the same invoke path `Tapped` already uses, so keyboard and mouse now behave the same way.