### PR TITLE
[CmdPal] Window Walker: match app name and window title together

### DIFF
--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WindowWalker.UnitTests/Microsoft.CmdPal.Ext.WindowWalker.UnitTests.csproj
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WindowWalker.UnitTests/Microsoft.CmdPal.Ext.WindowWalker.UnitTests.csproj
@@ -6,8 +6,6 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <RootNamespace>Microsoft.CmdPal.Ext.WindowWalker.UnitTests</RootNamespace>
-    <!-- This project currently contains shared test helpers only (no test methods). -->
-    <TestingPlatformDisableCustomTestTarget>true</TestingPlatformDisableCustomTestTarget>
     <OutputPath>$(RepoRoot)$(Platform)\$(Configuration)\WinUI3Apps\CmdPal\tests\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WindowWalker.UnitTests/WindowSearchScorerTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WindowWalker.UnitTests/WindowSearchScorerTests.cs
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CmdPal.Ext.WindowWalker.Helpers;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.Ext.WindowWalker.UnitTests;
+
+[TestClass]
+public class WindowSearchScorerTests
+{
+    // A Microsoft Word window holding "budget.docx", as in issue #40910.
+    private const string WordTitle = "budget.docx - Word";
+    private const string WordProcess = "WINWORD";
+
+    /// <summary>
+    /// The behavior before multi-word support: score the whole query against each field and
+    /// take the better of the two. Used to prove single-word queries are unaffected.
+    /// </summary>
+    private static int LegacyScore(string query, string title, string processName)
+        => Math.Max(
+            FuzzyStringMatcher.ScoreFuzzy(query, title),
+            FuzzyStringMatcher.ScoreFuzzy(query, processName ?? string.Empty));
+
+    [DataTestMethod]
+    [DataRow("word budget")]
+    [DataRow("budget word")]
+    [DataRow("winword budget")]
+    [DataRow("budget.docx word")]
+    public void Score_ProcessAndTitleWordsInAnyOrder_Matches(string query)
+    {
+        var score = WindowSearchScorer.Score(query, WordTitle, WordProcess);
+
+        Assert.IsTrue(score > 0, $"Expected '{query}' to match the Word window, but scored {score}.");
+    }
+
+    [TestMethod]
+    public void Score_CompoundQuery_DistinguishesBetweenWindowsOfTheSameProcess()
+    {
+        var budget = WindowSearchScorer.Score("word budget", WordTitle, WordProcess);
+        var resume = WindowSearchScorer.Score("word budget", "resume.docx - Word", WordProcess);
+
+        Assert.IsTrue(budget > 0, "The budget document should match.");
+        Assert.AreEqual(0, resume, "A different document of the same process should not match.");
+    }
+
+    [TestMethod]
+    public void Score_BrowserWindows_MatchProcessPlusTabTitle()
+    {
+        const string process = "chrome";
+        const string powerToysTab = "microsoft/PowerToys: Windows system utilities - Google Chrome";
+        const string gmailTab = "Inbox (12) - Gmail - Google Chrome";
+
+        Assert.IsTrue(WindowSearchScorer.Score("chrome powertoys", powerToysTab, process) > 0);
+        Assert.AreEqual(0, WindowSearchScorer.Score("chrome powertoys", gmailTab, process));
+        Assert.IsTrue(WindowSearchScorer.Score("chrome gmail", gmailTab, process) > 0);
+    }
+
+    [TestMethod]
+    public void Score_MoreThanTwoWords_Matches()
+    {
+        var score = WindowSearchScorer.Score("chrome inbox gmail", "Inbox (12) - Gmail - Google Chrome", "chrome");
+
+        Assert.IsTrue(score > 0, $"Expected a three-word query to match, but scored {score}.");
+    }
+
+    [TestMethod]
+    public void Score_BareTitle_IsFoundByProcessPlusTitle()
+    {
+        // Explorer windows are titled with just the folder name, so the process name is the
+        // only way to say "the Explorer window showing Downloads".
+        Assert.IsTrue(WindowSearchScorer.Score("explorer downloads", "Downloads", "explorer") > 0);
+        Assert.AreEqual(0, WindowSearchScorer.Score("explorer documents", "Downloads", "explorer"));
+    }
+
+    [DataTestMethod]
+    [DataRow("word spreadsheet")]
+    [DataRow("budget excel")]
+    [DataRow("word budget nonexistentword")]
+    public void Score_WordMatchingNeitherField_DoesNotMatch(string query)
+    {
+        var score = WindowSearchScorer.Score(query, WordTitle, WordProcess);
+
+        Assert.AreEqual(0, score, $"Expected '{query}' not to match, but scored {score}.");
+    }
+
+    [DataTestMethod]
+    [DataRow("word")]
+    [DataRow("budget")]
+    [DataRow("winword")]
+    [DataRow("docx")]
+    [DataRow("zzz")]
+    public void Score_SingleWordQuery_IsUnchangedFromLegacyBehavior(string query)
+    {
+        var score = WindowSearchScorer.Score(query, WordTitle, WordProcess);
+
+        Assert.AreEqual(LegacyScore(query, WordTitle, WordProcess), score);
+    }
+
+    [TestMethod]
+    public void Score_IsNeverLowerThanLegacyScore()
+    {
+        // A multi-word query that the whole-query path already matched, because the title
+        // contains it literally.
+        const string title = "Quarterly budget review - Word";
+        const string query = "budget review";
+
+        var score = WindowSearchScorer.Score(query, title, WordProcess);
+
+        Assert.IsTrue(
+            score >= LegacyScore(query, title, WordProcess),
+            "Multi-word support must never score lower than the previous whole-query behavior.");
+    }
+
+    [TestMethod]
+    public void Score_SurroundingAndRepeatedWhitespace_IsIgnored()
+    {
+        var expected = WindowSearchScorer.Score("word budget", WordTitle, WordProcess);
+
+        Assert.AreEqual(expected, WindowSearchScorer.Score("  word   budget  ", WordTitle, WordProcess));
+        Assert.AreEqual(expected, WindowSearchScorer.Score("word\tbudget", WordTitle, WordProcess));
+    }
+
+    [DataTestMethod]
+    [DataRow(null)]
+    [DataRow("")]
+    [DataRow("   ")]
+    public void Score_EmptyQuery_ReturnsZero(string query)
+    {
+        Assert.AreEqual(0, WindowSearchScorer.Score(query, WordTitle, WordProcess));
+    }
+
+    [TestMethod]
+    public void Score_NullOrEmptyFields_DoesNotThrow()
+    {
+        Assert.AreEqual(0, WindowSearchScorer.Score("word budget", null, null));
+        Assert.AreEqual(0, WindowSearchScorer.Score("word budget", string.Empty, string.Empty));
+
+        // A window with no title can still be found by its process name alone.
+        Assert.IsTrue(WindowSearchScorer.Score("winword", null, WordProcess) > 0);
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WindowWalker.UnitTests/WindowSearchScorerTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WindowWalker.UnitTests/WindowSearchScorerTests.cs
@@ -115,19 +115,42 @@ public class WindowSearchScorerTests
             "Multi-word support must never score lower than the previous whole-query behavior.");
     }
 
-    [TestMethod]
-    public void Score_SurroundingAndRepeatedWhitespace_IsIgnored()
+    [DataTestMethod]
+    [DataRow("  word   budget  ", DisplayName = "Surrounding and repeated spaces")]
+    [DataRow("word\tbudget", DisplayName = "Tab")]
+    [DataRow("word\u00A0budget", DisplayName = "Non-breaking space")]
+    [DataRow("word\u2009budget", DisplayName = "Thin space")]
+    [DataRow("word\u3000budget", DisplayName = "Ideographic space")]
+    [DataRow("\u00A0word \u00A0 budget\t", DisplayName = "Mixed and repeated whitespace")]
+    public void Score_AnyWhitespace_SeparatesWords(string query)
     {
+        // Whatever separates the words, the query has to behave like "word budget".
         var expected = WindowSearchScorer.Score("word budget", WordTitle, WordProcess);
 
-        Assert.AreEqual(expected, WindowSearchScorer.Score("  word   budget  ", WordTitle, WordProcess));
-        Assert.AreEqual(expected, WindowSearchScorer.Score("word\tbudget", WordTitle, WordProcess));
+        Assert.IsTrue(expected > 0, "Precondition: the plain-space query matches.");
+        Assert.AreEqual(expected, WindowSearchScorer.Score(query, WordTitle, WordProcess));
+    }
+
+    [DataTestMethod]
+    [DataRow("budget\u00A0review", DisplayName = "Non-breaking space")]
+    [DataRow("  budget   review ", DisplayName = "Surrounding and repeated spaces")]
+    public void Score_WholeQueryMatch_SurvivesWhitespaceNormalization(string query)
+    {
+        // The title contains "budget review" literally, so the whole-query path scores it far
+        // higher than the per-word average. That must not be lost to whitespace which the title
+        // does not contain verbatim.
+        const string title = "Quarterly budget review - Word";
+
+        Assert.AreEqual(
+            WindowSearchScorer.Score("budget review", title, WordProcess),
+            WindowSearchScorer.Score(query, title, WordProcess));
     }
 
     [DataTestMethod]
     [DataRow(null)]
     [DataRow("")]
     [DataRow("   ")]
+    [DataRow("\u00A0\t \u3000")]
     public void Score_EmptyQuery_ReturnsZero(string query)
     {
         Assert.AreEqual(0, WindowSearchScorer.Score(query, WordTitle, WordProcess));

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Helpers/WindowSearchScorer.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Helpers/WindowSearchScorer.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CmdPal.Ext.WindowWalker.Helpers;
+
+/// <summary>
+/// Scores an open window against a search query, matching the query against both the
+/// window title and the owning process name.
+/// </summary>
+internal static class WindowSearchScorer
+{
+    private static readonly char[] QuerySeparators = [' ', '\t'];
+
+    /// <summary>
+    /// Scores <paramref name="query"/> against a window's <paramref name="title"/> and
+    /// <paramref name="processName"/>.
+    /// </summary>
+    /// <remarks>
+    /// A single-word query is scored against each field as a whole, and the better of the two
+    /// wins. A multi-word query is additionally scored word by word, with each word free to
+    /// match either field, so that queries which name the app and part of its title together
+    /// ("word budget") match in any order. Every word must match something for the word-by-word
+    /// score to apply; otherwise the whole-query score stands. The result is never lower than
+    /// the whole-query score, so anything that matched before still matches.
+    /// </remarks>
+    /// <param name="query">The user's search text.</param>
+    /// <param name="title">The window title.</param>
+    /// <param name="processName">The name of the process owning the window.</param>
+    /// <returns>A score, where 0 means no match.</returns>
+    internal static int Score(string? query, string? title, string? processName)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return 0;
+        }
+
+        title ??= string.Empty;
+        processName ??= string.Empty;
+
+        var wholeQueryScore = ScoreBothFields(query, title, processName);
+
+        var words = query.Split(QuerySeparators, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (words.Length < 2)
+        {
+            return wholeQueryScore;
+        }
+
+        var total = 0;
+        foreach (var word in words)
+        {
+            var wordScore = ScoreBothFields(word, title, processName);
+            if (wordScore == 0)
+            {
+                // A word that matches neither field means this window isn't what was asked for.
+                return wholeQueryScore;
+            }
+
+            total += wordScore;
+        }
+
+        // Average rather than sum, to keep the per-word score on the same scale as the
+        // whole-query score the two are compared against.
+        return Math.Max(wholeQueryScore, total / words.Length);
+    }
+
+    private static int ScoreBothFields(string needle, string title, string processName)
+        => Math.Max(
+            FuzzyStringMatcher.ScoreFuzzy(needle, title),
+            FuzzyStringMatcher.ScoreFuzzy(needle, processName));
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Helpers/WindowSearchScorer.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Helpers/WindowSearchScorer.cs
@@ -10,8 +10,6 @@ namespace Microsoft.CmdPal.Ext.WindowWalker.Helpers;
 /// </summary>
 internal static class WindowSearchScorer
 {
-    private static readonly char[] QuerySeparators = [' ', '\t'];
-
     /// <summary>
     /// Scores <paramref name="query"/> against a window's <paramref name="title"/> and
     /// <paramref name="processName"/>.
@@ -22,7 +20,9 @@ internal static class WindowSearchScorer
     /// match either field, so that queries which name the app and part of its title together
     /// ("word budget") match in any order. Every word must match something for the word-by-word
     /// score to apply; otherwise the whole-query score stands. The result is never lower than
-    /// the whole-query score, so anything that matched before still matches.
+    /// the whole-query score, so anything that matched before still matches. Words are separated
+    /// by any Unicode whitespace, and the query is whitespace-normalized before being scored as
+    /// a whole.
     /// </remarks>
     /// <param name="query">The user's search text.</param>
     /// <param name="title">The window title.</param>
@@ -38,9 +38,16 @@ internal static class WindowSearchScorer
         title ??= string.Empty;
         processName ??= string.Empty;
 
-        var wholeQueryScore = ScoreBothFields(query, title, processName);
+        // Split on every kind of Unicode whitespace rather than just the space bar: a pasted
+        // query can carry a non-breaking space, and folding that into a word would silently
+        // drop the query back to single-word behavior.
+        var words = query.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
 
-        var words = query.Split(QuerySeparators, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        // Score the normalized query, so whitespace that does not appear in the title verbatim
+        // (a non-breaking space, a run of spaces, surrounding padding) cannot by itself defeat
+        // a whole-query match.
+        var wholeQueryScore = ScoreBothFields(string.Join(' ', words), title, processName);
+
         if (words.Length < 2)
         {
             return wholeQueryScore;

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Pages/WindowWalkerListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Pages/WindowWalkerListPage.cs
@@ -375,11 +375,7 @@ internal sealed partial class WindowWalkerListPage : DynamicListPage, IDisposabl
     }
 
     private static int ScoreFunction(string query, WindowEntry entry)
-    {
-        var titleScore = FuzzyStringMatcher.ScoreFuzzy(query, entry.Item.Title);
-        var processNameScore = FuzzyStringMatcher.ScoreFuzzy(query, entry.Window.Process.Name ?? string.Empty);
-        return Math.Max(titleScore, processNameScore);
-    }
+        => WindowSearchScorer.Score(query, entry.Item.Title, entry.Window.Process.Name);
 
     private void SetLoadingComplete(CancellationTokenSource cancellationTokenSource)
     {


### PR DESCRIPTION
## Summary of the Pull Request

Window Walker scores the whole query against the window title and the process name separately and takes the better of the two. A query that names both the app and part of its title — `word budget` — therefore matches neither field, and `ListHelpers.FilterListWithScores` drops anything scoring 0, so the window disappears from the results entirely.

This scores each word of a multi-word query against **both** fields, letting each word match either one, so the app name and title words can be given in any order.

Following @zadjii-msft's suggestion on the issue:

> Seems reasonable to me. Shouldn't be too terribly hard to split the query into words, and add the weighting of each separate word, instead of weighting the whole query string.

### Behavior

Every word must match something, which is what lets a compound query pick one document out of several belonging to the same app. The result is never lower than the previous whole-query score, so **anything that matched before still matches, with at least the same score**; single-word queries take the old path unchanged.

Scores from the new code vs. the old, for the same inputs:

| Query | Window | Before | After |
|---|---|---|---|
| `explorer downloads` | Downloads *(explorer)* | 0 | 184 |
| `explorer documents` | Downloads *(explorer)* | 0 | 0 |
| `word budget` | budget.docx - Word *(WINWORD)* | 0 | 68 |
| `word budget` | resume.docx - Word *(WINWORD)* | 0 | 0 |
| `chrome powertoys` | microsoft/PowerToys … - Google Chrome *(chrome)* | 0 | 148 |
| `chrome powertoys` | Inbox (12) - Gmail - Google Chrome *(chrome)* | 0 | 0 |
| `code powertoys` | WindowWalkerListPage.cs - PowerToys - VS Code *(Code)* | 0 | 122 |
| `word` | budget.docx - Word *(WINWORD)* | 41 | 41 |
| `budget` | budget.docx - Word *(WINWORD)* | 95 | 95 |
| `budget review` | Quarterly budget review - Word *(WINWORD)* | 424 | 424 |

The last three rows are the no-regression cases: single-word queries and multi-word queries that already matched a field as a whole are untouched.

## PR Checklist

- [x] Closes: #40910
- [x] **Communication:** approach was proposed by @zadjii-msft on the issue and is followed here.
- [x] **Tests:** 22 unit tests added, covering the issue scenario, word order, three-word queries, no-false-positives, whitespace handling, null/empty inputs, and explicit no-regression assertions against the previous scoring.
- [x] **Localization:** no new user-facing strings.
- [ ] **Documentation updated:** not needed.

## Detailed Description of the Pull Request / Additional comments

`ScoreFunction` is extracted into a new `WindowSearchScorer.Score(query, title, processName)`. `Window`'s constructor is `internal Window(IntPtr hwnd)` and needs a live window handle, so the previous inline scoring could not be unit tested; a pure string function can be.

Two implementation notes for reviewers:

- **Averaged, not summed.** Within a single query every candidate has the same word count, so sum vs. average is a monotonic transform and cannot change relative ranking among multi-word results. It matters only where the per-word score is compared against the whole-query score, and averaging keeps those two on the same scale.
- **`Math.Max` against the whole-query score, never replacing it.** This is what makes the change strictly additive.

`Microsoft.CmdPal.Ext.WindowWalker.UnitTests` previously contained only the shared `Settings` helper and so carried `<TestingPlatformDisableCustomTestTarget>true</TestingPlatformDisableCustomTestTarget>`. That is removed here, otherwise the new tests are not discovered or run.

Existing `FuzzyStringMatcher.ScoreFuzzy` does all the actual matching — no new matching math, so diacritics and Pinyin handling are unchanged.

## Validation Steps Performed

Built `Microsoft.CmdPal.UI` (x64/Debug) and registered the dev package, then ran the real Command Palette against three Explorer windows — Downloads, Documents and Pictures. One `explorer.exe` process, three distinct titles, which is the exact shape of the bug.

Both rows below are the same build, same three windows; only the scoring differs:

| | `explorer` | `explorer downloads` |
|---|---|---|
| **Before** | all three windows listed | **"No open windows found"** |
| **After** | all three windows listed | narrows to **Downloads - File Explorer** |

The left column is the control: it shows the Downloads window is open and findable, so the empty result in the right-hand "before" cell is the bug and not a missing window.

Also confirmed single-word searches and the empty-query list are unchanged.

Unit tests: 22/22 passing via `vstest.console.exe`.

### Screenshots
Before
Explorer
<img width="776" height="462" alt="before-1-explorer" src="https://github.com/user-attachments/assets/dc689807-607a-4a2c-a639-af04f99b5156" />
Compound keyword
<img width="776" height="462" alt="before-2-compound" src="https://github.com/user-attachments/assets/dfa06b14-2f2a-4ec4-8281-202d7654ef58" />
After
Explorer
<img width="776" height="462" alt="after-1-explorer" src="https://github.com/user-attachments/assets/a5d3c254-83d5-4acb-a46c-a91ee82d3b6c" />
Compound keyword
<img width="776" height="462" alt="after-2-compound" src="https://github.com/user-attachments/assets/7515bb8f-b610-43f0-ab97-286b4fdb591a" />
<img width="1600" height="1070" alt="before-after" src="https://github.com/user-attachments/assets/0d7d003e-3750-4e69-b9a4-c5c320621402" />


