### PR TITLE
[Color Picker] Size format labels to their content

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorFormatControl.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorFormatControl.xaml
@@ -133,7 +133,7 @@
         CornerRadius="{DynamicResource ControlCornerRadius}">
         <Grid Margin="12,0,0,0">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="48" />
+                <ColumnDefinition Width="Auto" MinWidth="48" SharedSizeGroup="ColorFormatName" />
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="40" />
             </Grid.ColumnDefinitions>

--- a/src/modules/colorPicker/ColorPickerUI/Views/ColorEditorView.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/Views/ColorEditorView.xaml
@@ -238,6 +238,7 @@
                 <ScrollViewer IsTabStop="False">
                     <ItemsControl
                         FocusManager.IsFocusScope="True"
+                        Grid.IsSharedSizeScope="True"
                         IsTabStop="False"
                         ItemsSource="{Binding ColorRepresentations}"
                         KeyboardNavigation.DirectionalNavigation="Contained"


### PR DESCRIPTION
## Summary of the Pull Request

Closes: #25063

Color Picker currently gives the format-name column a fixed width of 48 px,
which can truncate longer format names such as `DECIMAL`.

This change allows the format-name column to size to its content while
preserving the existing 48 px minimum width. A shared-size group keeps the
value columns aligned across all visible format rows.

## PR Checklist

- [x] Closes: #25063
- [x] **Communication:** This issue is labeled `Help Wanted`.
- [ ] **Tests:** No automated tests were added because this is a XAML-only layout change. Repository CI will provide build validation.
- [x] **Localization:** No end-user-facing strings were added or changed.
- [x] **Dev docs:** Not applicable.
- [x] **New binaries:** Not applicable; no binaries were added.
- [x] **Documentation updated:** Not applicable.

## Detailed Description of the Pull Request / Additional comments

The format label column in `ColorFormatControl.xaml` previously used a fixed
width of 48 px.

Longer format names could therefore be truncated even when sufficient space was
available.

The column now uses automatic sizing with a minimum width of 48 px and
participates in a shared-size group.

The containing `ItemsControl` is also configured as a shared-size scope, so all
visible format rows use the width required by the widest format label while
keeping their corresponding values aligned.

This avoids choosing a larger arbitrary fixed width and preserves the existing
minimum size for shorter labels.

## Validation Steps Performed

- Confirmed that the branch changes only the two intended Color Picker XAML files.
- Confirmed that no runtime logic or user-facing strings are changed.
- Reviewed the resulting XAML layout changes for shared-size behavior.
- A full Windows PowerToys build was not run locally, so repository CI provides the authoritative build validation.