### PR TITLE
[AdvancedPaste] Add "Paste as .jpg file" action with configurable JPEG quality

### DIFF
--- a/src/modules/AdvancedPaste/AdvancedPaste.UnitTests/HelpersTests/TransformHelpersTests.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste.UnitTests/HelpersTests/TransformHelpersTests.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using AdvancedPaste.Helpers;
+using AdvancedPaste.Models;
+using AdvancedPaste.UnitTests.Mocks;
+using AdvancedPaste.UnitTests.Utils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Graphics.Imaging;
+using Windows.Storage;
+
+namespace AdvancedPaste.UnitTests.HelpersTests;
+
+[TestClass]
+public sealed class TransformHelpersTests
+{
+    [TestMethod]
+    public async Task TransformToJpgFileProducesJpegFileAndRespectsQuality()
+    {
+        var lowQualitySize = await GetJpgOutputFileSizeAsync(10);
+        var highQualitySize = await GetJpgOutputFileSizeAsync(100);
+
+        Assert.IsTrue(
+            lowQualitySize < highQualitySize,
+            $"Expected low quality output ({lowQualitySize} bytes) to be smaller than high quality output ({highQualitySize} bytes)");
+    }
+
+    private static async Task<ulong> GetJpgOutputFileSizeAsync(int jpgQuality)
+    {
+        var inputPackage = await ResourceUtils.GetImageAssetAsDataPackageAsync("image_with_text_example.png");
+
+        var outputPackage = await TransformHelpers.TransformAsync(PasteFormats.PasteAsJpgFile, inputPackage.GetView(), CancellationToken.None, new NoOpProgress(), jpgQuality);
+
+        var outputItems = await outputPackage.GetView().GetStorageItemsAsync();
+        Assert.AreEqual(1, outputItems.Count);
+        var outputFile = outputItems.Single() as StorageFile;
+        Assert.IsNotNull(outputFile);
+        Assert.AreEqual(".jpg", outputFile.FileType, ignoreCase: true, CultureInfo.InvariantCulture);
+
+        using (var readStream = await outputFile.OpenReadAsync())
+        {
+            var decoder = await BitmapDecoder.CreateAsync(readStream);
+            Assert.AreEqual(BitmapDecoder.JpegDecoderId, decoder.DecoderInformation.CodecId);
+        }
+
+        var outputFileSize = (await outputFile.GetBasicPropertiesAsync()).Size;
+        await outputPackage.GetView().TryCleanupAfterDelayAsync(TimeSpan.Zero);
+        return outputFileSize;
+    }
+}

--- a/src/modules/AdvancedPaste/AdvancedPaste.UnitTests/Mocks/IntegrationTestUserSettings.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste.UnitTests/Mocks/IntegrationTestUserSettings.cs
@@ -57,6 +57,8 @@ internal sealed class IntegrationTestUserSettings : IUserSettings
 
     public IReadOnlyList<PasteFormats> AdditionalActions => _additionalActions;
 
+    public int PasteAsJpgQuality => AdvancedPasteProperties.DefaultPasteAsJpgQuality;
+
     public string FixSpellingAndGrammarPrompt => string.Empty;
 
     public string FixSpellingAndGrammarSystemPrompt => string.Empty;

--- a/src/modules/AdvancedPaste/AdvancedPaste/Helpers/IUserSettings.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Helpers/IUserSettings.cs
@@ -27,6 +27,8 @@ namespace AdvancedPaste.Settings
 
         public IReadOnlyList<PasteFormats> AdditionalActions { get; }
 
+        public int PasteAsJpgQuality { get; }
+
         public string FixSpellingAndGrammarPrompt { get; }
 
         public string FixSpellingAndGrammarSystemPrompt { get; }

--- a/src/modules/AdvancedPaste/AdvancedPaste/Helpers/TransformHelpers.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Helpers/TransformHelpers.cs
@@ -10,7 +10,9 @@ using System.Threading.Tasks;
 
 using AdvancedPaste.Models;
 using ManagedCommon;
+using Microsoft.PowerToys.Settings.UI.Library;
 using Windows.ApplicationModel.DataTransfer;
+using Windows.Foundation;
 using Windows.Graphics.Imaging;
 using Windows.Storage.Streams;
 
@@ -18,7 +20,7 @@ namespace AdvancedPaste.Helpers;
 
 public static class TransformHelpers
 {
-    public static async Task<DataPackage> TransformAsync(PasteFormats format, DataPackageView clipboardData, CancellationToken cancellationToken, IProgress<double> progress)
+    public static async Task<DataPackage> TransformAsync(PasteFormats format, DataPackageView clipboardData, CancellationToken cancellationToken, IProgress<double> progress, int jpgQuality = AdvancedPasteProperties.DefaultPasteAsJpgQuality)
     {
         return format switch
         {
@@ -28,6 +30,7 @@ public static class TransformHelpers
             PasteFormats.ImageToText => await ImageToTextAsync(clipboardData, cancellationToken),
             PasteFormats.PasteAsTxtFile => await ToTxtFileAsync(clipboardData, cancellationToken),
             PasteFormats.PasteAsPngFile => await ToPngFileAsync(clipboardData, cancellationToken),
+            PasteFormats.PasteAsJpgFile => await ToJpgFileAsync(clipboardData, jpgQuality, cancellationToken),
             PasteFormats.PasteAsHtmlFile => await ToHtmlFileAsync(clipboardData, cancellationToken),
             PasteFormats.TranscodeToMp3 => await TranscodeHelpers.TranscodeToMp3Async(clipboardData, cancellationToken, progress),
             PasteFormats.TranscodeToMp4 => await TranscodeHelpers.TranscodeToMp4Async(clipboardData, cancellationToken, progress),
@@ -76,6 +79,25 @@ public static class TransformHelpers
         await encoder.FlushAsync();
 
         return await CreateDataPackageFromFileContentAsync(pngStream.AsStreamForRead(), "png", cancellationToken);
+    }
+
+    private static async Task<DataPackage> ToJpgFileAsync(DataPackageView clipboardData, int jpgQuality, CancellationToken cancellationToken)
+    {
+        Logger.LogTrace();
+
+        var clipboardBitmap = await clipboardData.GetImageContentAsync();
+
+        var encoderOptions = new BitmapPropertySet
+        {
+            ["ImageQuality"] = new BitmapTypedValue(Math.Clamp(jpgQuality, 1, 100) / 100f, PropertyType.Single),
+        };
+
+        using var jpgStream = new InMemoryRandomAccessStream();
+        var encoder = await BitmapEncoder.CreateAsync(BitmapEncoder.JpegEncoderId, jpgStream, encoderOptions);
+        encoder.SetSoftwareBitmap(clipboardBitmap);
+        await encoder.FlushAsync();
+
+        return await CreateDataPackageFromFileContentAsync(jpgStream.AsStreamForRead(), "jpg", cancellationToken);
     }
 
     private static async Task<DataPackage> ToTxtFileAsync(DataPackageView clipboardData, CancellationToken cancellationToken)

--- a/src/modules/AdvancedPaste/AdvancedPaste/Helpers/UserSettings.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Helpers/UserSettings.cs
@@ -46,6 +46,8 @@ namespace AdvancedPaste.Settings
 
         public IReadOnlyList<PasteFormats> AdditionalActions => _additionalActions;
 
+        public int PasteAsJpgQuality { get; private set; }
+
         public IReadOnlyList<AdvancedPasteCustomAction> CustomActions => _customActions;
 
         public string FixSpellingAndGrammarPrompt { get; private set; } = string.Empty;
@@ -75,6 +77,7 @@ namespace AdvancedPaste.Settings
             ShowAIPaste = true;
             CloseAfterLosingFocus = false;
             EnableClipboardPreview = true;
+            PasteAsJpgQuality = AdvancedPasteProperties.DefaultPasteAsJpgQuality;
             PasteAIConfiguration = new PasteAIConfiguration();
             _additionalActions = [];
             _customActions = [];
@@ -131,6 +134,7 @@ namespace AdvancedPaste.Settings
                                 ShowAIPaste = properties.ShowAIPaste;
                                 CloseAfterLosingFocus = properties.CloseAfterLosingFocus;
                                 EnableClipboardPreview = properties.EnableClipboardPreview;
+                                PasteAsJpgQuality = properties.PasteAsJpgQuality?.Value ?? AdvancedPasteProperties.DefaultPasteAsJpgQuality;
                                 PasteAIConfiguration = properties.PasteAIConfiguration ?? new PasteAIConfiguration();
 
                                 var fixSpellingAction = properties.AdditionalActions.FixSpellingAndGrammar;
@@ -150,6 +154,7 @@ namespace AdvancedPaste.Settings
                                     (PasteFormats.FixSpellingAndGrammar, [sourceAdditionalActions.FixSpellingAndGrammar]),
                                     (PasteFormats.PasteAsTxtFile, [sourceAdditionalActions.PasteAsFile, sourceAdditionalActions.PasteAsFile.PasteAsTxtFile]),
                                     (PasteFormats.PasteAsPngFile, [sourceAdditionalActions.PasteAsFile, sourceAdditionalActions.PasteAsFile.PasteAsPngFile]),
+                                    (PasteFormats.PasteAsJpgFile, [sourceAdditionalActions.PasteAsFile, sourceAdditionalActions.PasteAsFile.PasteAsJpgFile]),
                                     (PasteFormats.PasteAsHtmlFile, [sourceAdditionalActions.PasteAsFile, sourceAdditionalActions.PasteAsFile.PasteAsHtmlFile]),
                                     (PasteFormats.TranscodeToMp3, [sourceAdditionalActions.Transcode, sourceAdditionalActions.Transcode.TranscodeToMp3]),
                                     (PasteFormats.TranscodeToMp4, [sourceAdditionalActions.Transcode, sourceAdditionalActions.Transcode.TranscodeToMp4]),

--- a/src/modules/AdvancedPaste/AdvancedPaste/Models/PasteFormats.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Models/PasteFormats.cs
@@ -84,6 +84,17 @@ public enum PasteFormats
 
     [PasteFormatMetadata(
         IsCoreAction = false,
+        ResourceId = "PasteAsJpgFile",
+        IconGlyph = "\uE8B9",
+        RequiresAIService = false,
+        CanPreview = false,
+        SupportedClipboardFormats = ClipboardFormat.Image,
+        IPCKey = AdvancedPastePasteAsFileAction.PropertyNames.PasteAsJpgFile,
+        KernelFunctionDescription = "Takes an image in the clipboard and transforms it to a JPG (JPEG) file.")]
+    PasteAsJpgFile,
+
+    [PasteFormatMetadata(
+        IsCoreAction = false,
         ResourceId = "PasteAsHtmlFile",
         IconGlyph = "\uF6FA",
         RequiresAIService = false,

--- a/src/modules/AdvancedPaste/AdvancedPaste/Services/KernelServiceBase.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Services/KernelServiceBase.cs
@@ -377,7 +377,7 @@ public abstract class KernelServiceBase(
         ExecuteTransformAsync(
            kernel,
            new ActionChainItem(format, Arguments: []),
-           async dataPackageView => await TransformHelpers.TransformAsync(format, dataPackageView, kernel.GetCancellationToken(), kernel.GetProgress()));
+           async dataPackageView => await TransformHelpers.TransformAsync(format, dataPackageView, kernel.GetCancellationToken(), kernel.GetProgress(), _userSettings.PasteAsJpgQuality));
 
     private static async Task<string> ExecuteTransformAsync(Kernel kernel, ActionChainItem actionChainItem, Func<DataPackageView, Task<DataPackage>> transformFunc)
     {

--- a/src/modules/AdvancedPaste/AdvancedPaste/Services/PasteFormatExecutor.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Services/PasteFormatExecutor.cs
@@ -42,7 +42,7 @@ public sealed class PasteFormatExecutor(IKernelService kernelService, ICustomAct
                 PasteFormats.KernelQuery => await _kernelService.TransformClipboardAsync(pasteFormat.Prompt, clipboardData, pasteFormat.IsSavedQuery, cancellationToken, progress, pasteFormat.ProviderId),
                 PasteFormats.CustomTextTransformation => DataPackageHelpers.CreateFromText((await _customActionTransformService.TransformAsync(pasteFormat.Prompt, await clipboardData.GetTextOrHtmlTextAsync(), await clipboardData.GetImageAsPngBytesAsync(), cancellationToken, progress, providerIdOverride: pasteFormat.ProviderId))?.Content ?? string.Empty),
                 PasteFormats.FixSpellingAndGrammar => DataPackageHelpers.CreateFromText((await _customActionTransformService.TransformAsync(GetFixSpellingPrompt(), await clipboardData.GetTextOrHtmlTextAsync(), null, cancellationToken, progress, GetFixSpellingSystemPrompt(), pasteFormat.ProviderId))?.Content ?? string.Empty),
-                _ => await TransformHelpers.TransformAsync(format, clipboardData, cancellationToken, progress),
+                _ => await TransformHelpers.TransformAsync(format, clipboardData, cancellationToken, progress, _userSettings.PasteAsJpgQuality),
             });
     }
 

--- a/src/modules/AdvancedPaste/AdvancedPaste/Strings/en-us/Resources.resw
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Strings/en-us/Resources.resw
@@ -247,6 +247,9 @@
   <data name="PasteAsPngFile" xml:space="preserve">
     <value>Paste as .png file</value>
   </data>
+  <data name="PasteAsJpgFile" xml:space="preserve">
+    <value>Paste as .jpg file</value>
+  </data>
   <data name="PasteAsHtmlFile" xml:space="preserve">
     <value>Paste as .html file</value>
   </data>

--- a/src/modules/AdvancedPaste/AdvancedPasteModuleInterface/trace.cpp
+++ b/src/modules/AdvancedPaste/AdvancedPasteModuleInterface/trace.cpp
@@ -88,6 +88,7 @@ void Trace::AdvancedPaste_SettingsTelemetry(const PowertoyModuleIface::Hotkey& p
         TraceLoggingWideString(getAdditionalActionHotkeyCStr(L"ImageToText"), "ImageToTextHotkey"),
         TraceLoggingWideString(getAdditionalActionHotkeyCStr(L"PasteAsTxtFile"), "PasteAsTxtFileHotkey"),
         TraceLoggingWideString(getAdditionalActionHotkeyCStr(L"PasteAsPngFile"), "PasteAsPngFileHotkey"),
+        TraceLoggingWideString(getAdditionalActionHotkeyCStr(L"PasteAsJpgFile"), "PasteAsJpgFileHotkey"),
         TraceLoggingWideString(getAdditionalActionHotkeyCStr(L"PasteAsHtmlFile"), "PasteAsHtmlFileHotkey"),
         TraceLoggingWideString(getAdditionalActionHotkeyCStr(L"TranscodeToMp3"), "TranscodeToMp3Hotkey"),
         TraceLoggingWideString(getAdditionalActionHotkeyCStr(L"TranscodeToMp4"), "TranscodeToMp4Hotkey")

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Helpers/PowerToysShortcutsPopulator.cs
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Helpers/PowerToysShortcutsPopulator.cs
@@ -59,6 +59,7 @@ namespace ShortcutGuide.Helpers
                 {
                     content.Append(HotkeySettingsToYaml(advancedPasteProperties.AdditionalActions.PasteAsFile.PasteAsTxtFile.Shortcut, SettingsResourceLoader.GetString("AdvancedPaste/ModuleTitle"), SettingsResourceLoader.GetString("PasteAsTxtFile/Header")));
                     content.Append(HotkeySettingsToYaml(advancedPasteProperties.AdditionalActions.PasteAsFile.PasteAsPngFile.Shortcut, SettingsResourceLoader.GetString("AdvancedPaste/ModuleTitle"), SettingsResourceLoader.GetString("PasteAsPngFile/Header")));
+                    content.Append(HotkeySettingsToYaml(advancedPasteProperties.AdditionalActions.PasteAsFile.PasteAsJpgFile.Shortcut, SettingsResourceLoader.GetString("AdvancedPaste/ModuleTitle"), SettingsResourceLoader.GetString("PasteAsJpgFile/Header")));
                     content.Append(HotkeySettingsToYaml(advancedPasteProperties.AdditionalActions.PasteAsFile.PasteAsHtmlFile.Shortcut, SettingsResourceLoader.GetString("AdvancedPaste/ModuleTitle"), SettingsResourceLoader.GetString("PasteAsHtmlFile/Header")));
                 }
 

--- a/src/settings-ui/Settings.UI.Library/AdvancedPastePasteAsFileAction.cs
+++ b/src/settings-ui/Settings.UI.Library/AdvancedPastePasteAsFileAction.cs
@@ -15,11 +15,13 @@ public sealed class AdvancedPastePasteAsFileAction : Observable, IAdvancedPasteA
     {
         public const string PasteAsTxtFile = "paste-as-txt-file";
         public const string PasteAsPngFile = "paste-as-png-file";
+        public const string PasteAsJpgFile = "paste-as-jpg-file";
         public const string PasteAsHtmlFile = "paste-as-html-file";
     }
 
     private AdvancedPasteAdditionalAction _pasteAsTxtFile = new();
     private AdvancedPasteAdditionalAction _pasteAsPngFile = new();
+    private AdvancedPasteAdditionalAction _pasteAsJpgFile = new();
     private AdvancedPasteAdditionalAction _pasteAsHtmlFile = new();
     private bool _isShown = true;
 
@@ -44,6 +46,13 @@ public sealed class AdvancedPastePasteAsFileAction : Observable, IAdvancedPasteA
         init => Set(ref _pasteAsPngFile, value ?? new());
     }
 
+    [JsonPropertyName(PropertyNames.PasteAsJpgFile)]
+    public AdvancedPasteAdditionalAction PasteAsJpgFile
+    {
+        get => _pasteAsJpgFile;
+        init => Set(ref _pasteAsJpgFile, value ?? new());
+    }
+
     [JsonPropertyName(PropertyNames.PasteAsHtmlFile)]
     public AdvancedPasteAdditionalAction PasteAsHtmlFile
     {
@@ -52,5 +61,5 @@ public sealed class AdvancedPastePasteAsFileAction : Observable, IAdvancedPasteA
     }
 
     [JsonIgnore]
-    public IEnumerable<IAdvancedPasteAction> SubActions => [PasteAsTxtFile, PasteAsPngFile, PasteAsHtmlFile];
+    public IEnumerable<IAdvancedPasteAction> SubActions => [PasteAsTxtFile, PasteAsPngFile, PasteAsJpgFile, PasteAsHtmlFile];
 }

--- a/src/settings-ui/Settings.UI.Library/AdvancedPasteProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/AdvancedPasteProperties.cs
@@ -16,6 +16,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         public static readonly HotkeySettings DefaultPasteAsPlainTextShortcut = new HotkeySettings(true, true, true, false, 0x56); // Ctrl+Win+Alt+V
 
+        public const int DefaultPasteAsJpgQuality = 90;
+
         public AdvancedPasteProperties()
         {
             AdvancedPasteUIShortcut = DefaultAdvancedPasteUIShortcut;
@@ -30,6 +32,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             CloseAfterLosingFocus = false;
             EnableClipboardPreview = true;
             AutoCopySelectionForCustomActionHotkey = false;
+            PasteAsJpgQuality = new IntProperty(DefaultPasteAsJpgQuality);
             PasteAIConfiguration = new();
         }
 
@@ -106,6 +109,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [JsonPropertyName("additional-actions")]
         [CmdConfigureIgnoreAttribute]
         public AdvancedPasteAdditionalActions AdditionalActions { get; set; }
+
+        [JsonPropertyName("paste-as-jpg-quality")]
+        public IntProperty PasteAsJpgQuality { get; set; }
 
         [JsonPropertyName("paste-ai-configuration")]
         [CmdConfigureIgnoreAttribute]

--- a/src/settings-ui/Settings.UI.Library/AdvancedPasteSettings.cs
+++ b/src/settings-ui/Settings.UI.Library/AdvancedPasteSettings.cs
@@ -71,6 +71,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
                 "FixSpellingAndGrammar",
                 "PasteAsTxtFile",
                 "PasteAsPngFile",
+                "PasteAsJpgFile",
                 "PasteAsHtmlFile",
                 "TranscodeToMp3",
                 "TranscodeToMp4",

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPastePage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPastePage.xaml
@@ -376,6 +376,23 @@
                                     <ContentControl ContentTemplate="{StaticResource AdditionalActionTemplate}" />
                                 </tkcontrols:SettingsCard>
                                 <tkcontrols:SettingsCard
+                                    Name="PasteAsJpgFile"
+                                    x:Uid="PasteAsJpgFile"
+                                    DataContext="{Binding PasteAsJpgFile, Mode=TwoWay}"
+                                    IsEnabled="{x:Bind ViewModel.AdditionalActions.PasteAsFile.IsShown, Mode=OneWay}">
+                                    <ContentControl ContentTemplate="{StaticResource AdditionalActionTemplate}" />
+                                </tkcontrols:SettingsCard>
+                                <tkcontrols:SettingsCard
+                                    Name="PasteAsJpgQuality"
+                                    x:Uid="PasteAsJpgQuality"
+                                    IsEnabled="{x:Bind ViewModel.AdditionalActions.PasteAsFile.IsShown, Mode=OneWay}">
+                                    <Slider
+                                        MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                        Maximum="100"
+                                        Minimum="1"
+                                        Value="{x:Bind ViewModel.PasteAsJpgQuality, Mode=TwoWay}" />
+                                </tkcontrols:SettingsCard>
+                                <tkcontrols:SettingsCard
                                     Name="PasteAsHtmlFile"
                                     x:Uid="PasteAsHtmlFile"
                                     DataContext="{Binding PasteAsHtmlFile, Mode=TwoWay}"

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -2247,6 +2247,17 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
   <data name="PasteAsPngFile.Header" xml:space="preserve">
     <value>Paste as .png file</value>
   </data>
+  <data name="PasteAsJpgFile.Header" xml:space="preserve">
+    <value>Paste as .jpg file</value>
+  </data>
+  <data name="PasteAsJpgQuality.Header" xml:space="preserve">
+    <value>JPEG quality level</value>
+    <comment>JPEG is the image compression format, used when pasting the clipboard image as a .jpg file</comment>
+  </data>
+  <data name="PasteAsJpgQuality.Description" xml:space="preserve">
+    <value>Higher values produce better image quality but larger files</value>
+    <comment>Describes the JPEG quality level slider</comment>
+  </data>
   <data name="PasteAsHtmlFile.Header" xml:space="preserve">
     <value>Paste as .html file</value>
   </data>

--- a/src/settings-ui/Settings.UI/ViewModels/AdvancedPasteViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/AdvancedPasteViewModel.cs
@@ -592,6 +592,19 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
+        public int PasteAsJpgQuality
+        {
+            get => _advancedPasteSettings.Properties.PasteAsJpgQuality.Value;
+            set
+            {
+                if (value != _advancedPasteSettings.Properties.PasteAsJpgQuality.Value)
+                {
+                    _advancedPasteSettings.Properties.PasteAsJpgQuality.Value = value;
+                    NotifySettingsChanged();
+                }
+            }
+        }
+
         public bool AutoCopySelectionForCustomActionHotkey
         {
             get => _advancedPasteSettings.Properties.AutoCopySelectionForCustomActionHotkey;
@@ -1308,6 +1321,13 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             {
                 target.EnableClipboardPreview = source.EnableClipboardPreview;
                 OnPropertyChanged(nameof(EnableClipboardPreview));
+            }
+
+            var sourcePasteAsJpgQuality = source.PasteAsJpgQuality?.Value ?? AdvancedPasteProperties.DefaultPasteAsJpgQuality;
+            if (target.PasteAsJpgQuality.Value != sourcePasteAsJpgQuality)
+            {
+                target.PasteAsJpgQuality.Value = sourcePasteAsJpgQuality;
+                OnPropertyChanged(nameof(PasteAsJpgQuality));
             }
 
             if (target.AutoCopySelectionForCustomActionHotkey != source.AutoCopySelectionForCustomActionHotkey)


### PR DESCRIPTION
## Summary of the Pull Request

Adds a "Paste as .jpg" option to Advanced Paste, in cases of copying a large image (like a 4000x3000 photo or larger) and pasting it into various apps with size limits; in such cases it is more sensible (or required by size requirements) to paste it as an efficient jpg instead of a png.

Includes a jpg quality setting.

<img width="576" height="439" alt="obraz" src="https://github.com/user-attachments/assets/7f12349b-f962-4699-9ff1-eaa7061d7c3f" />

<img width="795" height="352" alt="obraz" src="https://github.com/user-attachments/assets/c4f3c982-b718-4ecf-92c9-350225e28283" />

## PR Checklist

- [x] Closes: #44002
- [x] **Communication:** I asked about implementing it in the [thread](https://github.com/microsoft/PowerToys/issues/28769#issuecomment-5339389039) and got an upvote from a maintainer
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Not necessary
- [ ] **New binaries:** No new binaries
- [x] **Documentation updated:** Opened PR [here](https://github.com/MicrosoftDocs/windows-dev-docs/pull/6098)

## Validation Steps Performed
Manually launched PowerToys, copied a large 4000x3000 photo from the internet, then pasted it as png (resulting in 13 MB), then pasted it as jpg (resulting in 986 kB) ✅