### PR TITLE
[Screen Ruler] Fix edge detection at index 0 and SAD truncation in bounds mode

### DIFF
--- a/src/modules/MeasureTool/MeasureToolCore/BGRATextureView.h
+++ b/src/modules/MeasureTool/MeasureToolCore/BGRATextureView.h
@@ -118,7 +118,9 @@ struct BGRATextureView
         else
         {
             // Method 2: Test whether sum of all channel differences is smaller than tolerance
-            const int32_t score = _mm_cvtsi128_si32(_mm_sad_epu8(distances, _mm_setzero_si128())) & std::numeric_limits<uint8_t>::max();
+            // The 4 channel differences sum to at most 1020, so masking with 0xFF wrapped
+            // anything above 255 back down into the tolerance range.
+            const int32_t score = _mm_cvtsi128_si32(_mm_sad_epu8(distances, _mm_setzero_si128())) & std::numeric_limits<uint16_t>::max();
             return score <= tolerance;
         }
     }

--- a/src/modules/MeasureTool/MeasureToolCore/BGRATextureView.h
+++ b/src/modules/MeasureTool/MeasureToolCore/BGRATextureView.h
@@ -118,8 +118,7 @@ struct BGRATextureView
         else
         {
             // Method 2: Test whether sum of all channel differences is smaller than tolerance
-            // The 4 channel differences sum to at most 1020, so masking with 0xFF wrapped
-            // anything above 255 back down into the tolerance range.
+            // The 4 channel differences sum to at most 1020, so the low 16 bits hold the full score
             const int32_t score = _mm_cvtsi128_si32(_mm_sad_epu8(distances, _mm_setzero_si128())) & std::numeric_limits<uint16_t>::max();
             return score <= tolerance;
         }

--- a/src/modules/MeasureTool/MeasureToolCore/EdgeDetection.cpp
+++ b/src/modules/MeasureTool/MeasureToolCore/EdgeDetection.cpp
@@ -29,7 +29,7 @@ inline long FindEdge(const BGRATextureView& texture, const POINT centerPoint, co
             }
             else
             {
-                if (--x == 0)
+                if (--x < 0)
                     break;
             }
         }
@@ -42,7 +42,7 @@ inline long FindEdge(const BGRATextureView& texture, const POINT centerPoint, co
             }
             else
             {
-                if (--y == 0)
+                if (--y < 0)
                     break;
             }
         }


### PR DESCRIPTION
Two small fixes in Screen Ruler's edge detection, for #46947 and #46946.

`FindEdge` decrements the coordinate before comparing it to zero, so it never tests row/column 0 and bounds sitting on the edge come out a pixel too wide. It now stops when the coordinate goes negative.

In total mode `PixelsClose` masks the SAD result with `0xFF`, which is the default path, so any four-channel sum over 255 wrapped back into tolerance: white against `#A9A9A9` sums to 258 and scored as 2. `0xFFFF` covers the full range; I kept a mask rather than dropping it so the `<limits>` include stays used.

No test project for MeasureToolCore yet, so I checked both in a standalone harness; the wider mask only adds edges, never removes them.

Closes: #46947
Closes: #46946
