### PR TITLE
fix(shortcut-guide): restore transparent overlay on Windows 10

### DIFF
--- a/src/common/Common.UI.Controls/Window/TransparentWindow/TransparentWindow.cs
+++ b/src/common/Common.UI.Controls/Window/TransparentWindow/TransparentWindow.cs
@@ -55,27 +55,16 @@ namespace Microsoft.PowerToys.Common.UI.Controls.Window;
 public partial class TransparentWindow : WinUIEx.WindowEx
 {
     private const uint DwmwaColorNone = 0xFFFFFFFE;
-    private const int DwmwaNcRenderingPolicy = 2;
     private const int DwmwaCloak = 13;
     private const int DwmwaWindowCornerPreference = 33;
     private const int DwmwaBorderColor = 34;
     private const int DwmwcpDoNotRound = 1;
-    private const int DwmncrpDisabled = 2;
 
     private const int GwlpHwndParent = -8;
     private const int GwlExStyle = -20;
-    private const int WsExDlgModalFrame = 0x00000001;
     private const int WsExTransparent = 0x00000020;
     private const int WsExToolWindow = 0x00000080;
-    private const int WsExWindowEdge = 0x00000100;
-    private const int WsExClientEdge = 0x00000200;
     private const int WsExAppWindow = 0x00040000;
-
-    private const uint SwpNoSize = 0x0001;
-    private const uint SwpNoMove = 0x0002;
-    private const uint SwpNoZOrder = 0x0004;
-    private const uint SwpNoActivate = 0x0010;
-    private const uint SwpFrameChanged = 0x0020;
 
     private const int SwHide = 0;
     private const int SwShowNa = 8;
@@ -129,56 +118,6 @@ public partial class TransparentWindow : WinUIEx.WindowEx
         }
 
         ApplyExStyleBit(WsExToolWindow, true);
-    }
-
-    /// <summary>
-    /// Opt-in, aggressive frame elimination for <b>full-monitor / edge-to-edge</b>
-    /// overlays (e.g. Shortcut Guide), layered on top of
-    /// <see cref="ApplyTransparentChrome"/>. On such a window the HWND edge
-    /// coincides with the screen edge, so any residual 1-pixel DWM seam shows as
-    /// a faint full-screen outline; this removes it by dropping the 3-D edge
-    /// extended styles, disabling non-client rendering, and extending the frame
-    /// across the whole client area.
-    /// </summary>
-    /// <remarks>
-    /// This is intentionally <b>not</b> applied by default: content-sized
-    /// surfaces inset their visible card behind transparent padding, so any
-    /// phantom border falls in the transparent margin and is invisible — and the
-    /// aggressive bits here (disabled NC rendering + sheet-of-glass frame) carry
-    /// needless compositing risk for those surfaces. Like
-    /// <see cref="ApplyTransparentChrome"/> it is idempotent and may be re-called
-    /// after a cross-monitor move.
-    /// </remarks>
-    protected void ApplyFullBleedHardening()
-    {
-        if (_hwnd == 0)
-        {
-            return;
-        }
-
-        // Drop the 3-D-ish window edges Windows draws for ordinary top-level
-        // windows; the remaining 1-px line around a transparent overlay comes
-        // from these extended styles.
-        ApplyExStyleBit(WsExWindowEdge, false);
-        ApplyExStyleBit(WsExClientEdge, false);
-        ApplyExStyleBit(WsExDlgModalFrame, false);
-
-        unsafe
-        {
-            // Disable non-client rendering entirely so the DWM doesn't draw ANY
-            // frame/border chrome (not even a 1-px line).
-            int ncrpDisabled = DwmncrpDisabled;
-            _ = DwmSetWindowAttribute(_hwnd, DwmwaNcRenderingPolicy, &ncrpDisabled, sizeof(int));
-        }
-
-        // Extend the frame into the entire client area. With a transparent
-        // backdrop this eliminates the last possible seam between the
-        // non-client and client regions that the DWM might draw.
-        var margins = new Margins { CxLeftWidth = -1, CxRightWidth = -1, CyTopHeight = -1, CyBottomHeight = -1 };
-        _ = DwmExtendFrameIntoClientArea(_hwnd, ref margins);
-
-        // Force DWM to re-evaluate the frame after the style/frame changes.
-        _ = SetWindowPos(_hwnd, 0, 0, 0, 0, 0, SwpNoMove | SwpNoSize | SwpNoZOrder | SwpNoActivate | SwpFrameChanged);
     }
 
     /// <summary>
@@ -479,22 +418,6 @@ public partial class TransparentWindow : WinUIEx.WindowEx
     [return: MarshalAs(UnmanagedType.Bool)]
     private static partial bool ShowWindow(nint hWnd, int nCmdShow);
 
-    [LibraryImport("user32.dll")]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static partial bool SetWindowPos(nint hWnd, nint hWndInsertAfter, int x, int y, int cx, int cy, uint uFlags);
-
-    [LibraryImport("dwmapi.dll")]
-    private static partial int DwmExtendFrameIntoClientArea(nint hwnd, ref Margins pMarInset);
-
     [LibraryImport("dwmapi.dll")]
     private static unsafe partial int DwmSetWindowAttribute(nint hwnd, int dwAttribute, void* pvAttribute, int cbAttribute);
-
-    [StructLayout(LayoutKind.Sequential)]
-    private struct Margins
-    {
-        public int CxLeftWidth;
-        public int CxRightWidth;
-        public int CyTopHeight;
-        public int CyBottomHeight;
-    }
 }

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/OverlayWindow.xaml
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/OverlayWindow.xaml
@@ -22,12 +22,6 @@
         (the shared Common.UI.Controls backdrop).
     -->
     <!--
-        The base TransparentWindow applies the TransparentTintBackdrop and strips
-        the native chrome; this overlay additionally opts into the full-bleed DWM
-        hardening because it is edge-to-edge (see ApplyFullBleedHardening).
-    -->
-
-    <!--
         OverlayRoot must have a Background brush so it is hit-test opaque —
         otherwise clicks on the transparent margin fall through to whatever
         is underneath and the click-outside-to-close UX breaks. A fully

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/OverlayWindow.xaml.cs
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/OverlayWindow.xaml.cs
@@ -126,12 +126,6 @@ namespace ShortcutGuide
                 }
             };
 
-            // Edge-to-edge overlay: opt into the aggressive full-bleed DWM
-            // hardening so the OS never reveals a 1-px frame seam around the
-            // monitor-sized transparent window. The baseline chrome is already
-            // applied by the base constructor.
-            this.ApplyFullBleedHardening();
-
             // Pre-size and position BEFORE Activate so the first frame the
             // user sees is already at the correct work-area size on the
             // cursor's monitor. Doing this in OnActivated produces a single
@@ -494,11 +488,8 @@ namespace ShortcutGuide
 
             // Cross-monitor moves can trigger WM_DPICHANGED, and Windows may
             // reset some of our DWM attributes (border color, corner pref)
-            // during that transition. Re-apply them defensively so the
-            // overlay never reveals an OS-drawn 1-px stroke or rounded
-            // shadow.
+            // during that transition. Re-apply the baseline transparent chrome.
             this.ApplyTransparentChrome();
-            this.ApplyFullBleedHardening();
 
             // The taskbar pane is anchored against the bottom of the work area,
             // so any move/resize needs a fresh layout pass.


### PR DESCRIPTION
## Summary of the Pull Request

Restores the transparent Shortcut Guide overlay on Windows 10 by removing the full-bleed DWM hardening introduced for the monitor-sized host window.

The hardening set `DWMWA_NCRENDERING_POLICY` to `DWMNCRP_DISABLED`, which disables earlier `DwmEnableBlurBehindWindow` and `DwmExtendFrameIntoClientArea` behavior used by WinUIEx's transparent backdrop. Shortcut Guide now relies on the existing baseline transparent chrome instead.

## PR Checklist

- [x] Closes: #49975
- [x] Closes: #50076
- [x] **Communication:** Investigated from the active reports and validated with a core contributor
- [x] **Tests:** Existing build validation and manual end-to-end validation pass; no automated test covers DWM composition behavior
- [x] **Localization:** N/A; no end-user-facing strings changed

## Detailed Description of the Pull Request / Additional comments

- Removes `ApplyFullBleedHardening` and its DWM/style interop from `src/common/Common.UI.Controls/Window/TransparentWindow/TransparentWindow.cs`.
- Removes both Shortcut Guide call sites and updates the related comments in `src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/OverlayWindow.xaml` and `OverlayWindow.xaml.cs`.
- Keeps `ApplyTransparentChrome`, including native-frame removal, DWM border suppression, corner suppression, and tool-window behavior. It is still reapplied after cross-monitor moves.

This avoids disabling the DWM path required for transparency while preserving the normal borderless overlay setup.

## Validation Steps Performed

- Built the complete x64 Debug `PowerToys.slnx` successfully with an empty errors log.
- Launched `x64\Debug\PowerToys.exe` and confirmed the rebuilt Shortcut Guide process was active.
- Invoked Shortcut Guide through the Runner and manually confirmed the overlay rendered transparently and behaved correctly on the Windows 11 development machine.