### PR TITLE
CmdPal: Fix clipboard history details image previews

### DIFF
--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests/DetailsMarkdownHelperTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests/DetailsMarkdownHelperTests.cs
@@ -27,13 +27,13 @@ public class DetailsMarkdownHelperTests
     }
 
     [TestMethod]
-    public void BuildImageBody_ReturnsMarkdownImage_WithFitAndFixedHeightHints()
+    public void BuildImageBody_ReturnsMarkdownImage_WithFitAndMaxHeightHints()
     {
         var path = @"C:\Temp\clipboard.png";
 
         var body = DetailsMarkdownHelper.BuildImageBody(path, "Image");
 
-        Assert.AreEqual("![Image](file:///C:/Temp/clipboard.png?--x-cmdpal-fit=fit&--x-cmdpal-height=200)", body);
+        Assert.AreEqual("![Image](file:///C:/Temp/clipboard.png?--x-cmdpal-fit=fit&--x-cmdpal-maxheight=200)", body);
     }
 
     [TestMethod]

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests/DetailsMarkdownHelperTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests/DetailsMarkdownHelperTests.cs
@@ -27,13 +27,13 @@ public class DetailsMarkdownHelperTests
     }
 
     [TestMethod]
-    public void BuildImageBody_ReturnsMarkdownImage_WithFitHint()
+    public void BuildImageBody_ReturnsMarkdownImage_WithFitAndFixedHeightHints()
     {
         var path = @"C:\Temp\clipboard.png";
 
         var body = DetailsMarkdownHelper.BuildImageBody(path, "Image");
 
-        Assert.AreEqual("![Image](file:///C:/Temp/clipboard.png?--x-cmdpal-fit=fit)", body);
+        Assert.AreEqual("![Image](file:///C:/Temp/clipboard.png?--x-cmdpal-fit=fit&--x-cmdpal-height=200)", body);
     }
 
     [TestMethod]

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests/DetailsMarkdownHelperTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests/DetailsMarkdownHelperTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests;
+
+[TestClass]
+public class DetailsMarkdownHelperTests
+{
+    [TestMethod]
+    public void BuildTextBody_PreservesLineBreaksAndIndentation()
+    {
+        var body = DetailsMarkdownHelper.BuildTextBody("first line\n    indented line\nlast line");
+
+        Assert.AreEqual("```text\nfirst line\n    indented line\nlast line\n```", body);
+    }
+
+    [TestMethod]
+    public void BuildTextBody_UsesLongerFence_WhenTextContainsFence()
+    {
+        var body = DetailsMarkdownHelper.BuildTextBody("before ``` after");
+
+        Assert.AreEqual("````text\nbefore ``` after\n````", body);
+    }
+
+    [TestMethod]
+    public void BuildImageBody_ReturnsMarkdownImage_WithFitHint()
+    {
+        var path = @"C:\Temp\clipboard.png";
+
+        var body = DetailsMarkdownHelper.BuildImageBody(path, "Image");
+
+        Assert.AreEqual("![Image](file:///C:/Temp/clipboard.png?--x-cmdpal-fit=fit)", body);
+    }
+
+    [TestMethod]
+    public void BuildImageBody_UsesProvidedAltText()
+    {
+        var path = @"C:\Temp\clipboard.png";
+
+        var body = DetailsMarkdownHelper.BuildImageBody(path, "Clipboard image");
+
+        StringAssert.StartsWith(body, "![Clipboard image](file:///");
+    }
+
+    [TestMethod]
+    public void BuildImageBody_ReturnsEmpty_WhenImageDataIsNull()
+    {
+        var body = DetailsMarkdownHelper.BuildImageBody(null, "Image");
+
+        Assert.AreEqual(string.Empty, body);
+    }
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/ClipboardHistoryCommandsProvider.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/ClipboardHistoryCommandsProvider.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
 using Microsoft.CmdPal.Ext.ClipboardHistory.Pages;
 using Microsoft.CommandPalette.Extensions;
@@ -12,12 +13,13 @@ namespace Microsoft.CmdPal.Ext.ClipboardHistory;
 public partial class ClipboardHistoryCommandsProvider : CommandProvider
 {
     private readonly ListItem _clipboardHistoryListItem;
+    private readonly ClipboardHistoryListPage _clipboardHistoryPage;
     private readonly SettingsManager _settingsManager = new();
 
     public ClipboardHistoryCommandsProvider()
     {
-        var page = new ClipboardHistoryListPage(_settingsManager);
-        _clipboardHistoryListItem = new ListItem(page)
+        _clipboardHistoryPage = new ClipboardHistoryListPage(_settingsManager);
+        _clipboardHistoryListItem = new ListItem(_clipboardHistoryPage)
         {
             Title = Properties.Resources.list_item_title,
             Icon = Icons.ClipboardListIcon,
@@ -35,5 +37,12 @@ public partial class ClipboardHistoryCommandsProvider : CommandProvider
     public override IListItem[] TopLevelCommands()
     {
         return [_clipboardHistoryListItem];
+    }
+
+    public override void Dispose()
+    {
+        _clipboardHistoryPage.Dispose();
+        base.Dispose();
+        GC.SuppressFinalize(this);
     }
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/DetailsMarkdownHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/DetailsMarkdownHelper.cs
@@ -8,6 +8,8 @@ namespace Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
 
 internal static class DetailsMarkdownHelper
 {
+    private const int ImagePreviewHeight = 200;
+
     public static string BuildTextBody(string? text)
     {
         if (string.IsNullOrEmpty(text))
@@ -27,5 +29,5 @@ internal static class DetailsMarkdownHelper
     public static string BuildImageBody(string? imagePath, string altText)
         => string.IsNullOrEmpty(imagePath)
             ? string.Empty
-            : $"![{altText}]({new Uri(imagePath).AbsoluteUri}?--x-cmdpal-fit=fit)";
+            : $"![{altText}]({new Uri(imagePath).AbsoluteUri}?--x-cmdpal-fit=fit&--x-cmdpal-height={ImagePreviewHeight})";
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/DetailsMarkdownHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/DetailsMarkdownHelper.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
 
 internal static class DetailsMarkdownHelper
 {
-    private const int ImagePreviewHeight = 200;
+    private const int ImagePreviewMaxHeight = 200;
 
     public static string BuildTextBody(string? text)
     {
@@ -29,5 +29,5 @@ internal static class DetailsMarkdownHelper
     public static string BuildImageBody(string? imagePath, string altText)
         => string.IsNullOrEmpty(imagePath)
             ? string.Empty
-            : $"![{altText}]({new Uri(imagePath).AbsoluteUri}?--x-cmdpal-fit=fit&--x-cmdpal-height={ImagePreviewHeight})";
+            : $"![{altText}]({new Uri(imagePath).AbsoluteUri}?--x-cmdpal-fit=fit&--x-cmdpal-maxheight={ImagePreviewMaxHeight})";
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/DetailsMarkdownHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/DetailsMarkdownHelper.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
+
+internal static class DetailsMarkdownHelper
+{
+    public static string BuildTextBody(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return string.Empty;
+        }
+
+        var fence = "```";
+        while (text.Contains(fence, StringComparison.Ordinal))
+        {
+            fence += "`";
+        }
+
+        return $"{fence}text\n{text}\n{fence}";
+    }
+
+    public static string BuildImageBody(string? imagePath, string altText)
+        => string.IsNullOrEmpty(imagePath)
+            ? string.Empty
+            : $"![{altText}]({new Uri(imagePath).AbsoluteUri}?--x-cmdpal-fit=fit)";
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Models/ClipboardItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Models/ClipboardItem.cs
@@ -22,6 +22,8 @@ public class ClipboardItem
 
     public RandomAccessStreamReference? ImageData { get; set; }
 
+    public string? ImagePath { get; set; }
+
     public string GetDataType()
     {
         // Check if there is valid image data

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Pages/ClipboardHistoryListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Pages/ClipboardHistoryListPage.cs
@@ -95,6 +95,11 @@ internal sealed partial class ClipboardHistoryListPage : ListPage, IDisposable
 
                     if (imageReceived is not null)
                     {
+                        if (disposed.Value)
+                        {
+                            return;
+                        }
+
                         item.ImageData = imageReceived;
                         item.ImagePath = GetImagePath(item.Item.Id);
                         await CacheImageAsync(imageReceived, item.ImagePath).ConfigureAwait(false);
@@ -114,8 +119,12 @@ internal sealed partial class ClipboardHistoryListPage : ListPage, IDisposable
         }
         finally
         {
-            CleanupCachedImages(clipboardHistory.Where(static item => item.ImagePath is not null).Select(static item => item.ImagePath!));
             loadInFlight.Value = false;
+
+            // Dispose can race this worker, so cleanup happens after the in-flight flag is cleared.
+            CleanupCachedImages(disposed.Value
+                ? []
+                : clipboardHistory.Where(static item => item.ImagePath is not null).Select(static item => item.ImagePath!));
             if (!loadSucceeded)
             {
                 hasLoadedOnce.Value = false;
@@ -240,14 +249,14 @@ internal sealed partial class ClipboardHistoryListPage : ListPage, IDisposable
 
     private void StartClipboardHistoryLoad()
     {
-        IsLoading = true;
-
-        // https://github.com/microsoft/windows-rs/issues/317
-        // The synchronous prefix must run in STA or the clipboard API hangs.
-        // Continuations use the thread pool because this raw thread has no
-        // synchronization context.
         try
         {
+            SetLoadingState(true);
+
+            // https://github.com/microsoft/windows-rs/issues/317
+            // The synchronous prefix must run in STA or the clipboard API hangs.
+            // Continuations use the thread pool because this raw thread has no
+            // synchronization context.
             var thread = new Thread(() =>
             {
                 try
@@ -266,8 +275,20 @@ internal sealed partial class ClipboardHistoryListPage : ListPage, IDisposable
         {
             loadInFlight.Value = false;
             hasLoadedOnce.Value = false;
-            IsLoading = false;
+            SetLoadingState(false);
             TryLogMessage($"Failed to start clipboard history load thread: {ex}");
+        }
+    }
+
+    private void SetLoadingState(bool value)
+    {
+        try
+        {
+            IsLoading = value;
+        }
+        catch (Exception ex)
+        {
+            TryLogMessage($"Failed to set clipboard history loading state: {ex}");
         }
     }
 
@@ -300,7 +321,11 @@ internal sealed partial class ClipboardHistoryListPage : ListPage, IDisposable
         }
 
         Clipboard.HistoryChanged -= TrackClipboardHistoryChanged_EventHandler;
-        CleanupCachedImages([]);
+        if (!loadInFlight.Value)
+        {
+            CleanupCachedImages([]);
+        }
+
         GC.SuppressFinalize(this);
     }
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Pages/ClipboardHistoryListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Pages/ClipboardHistoryListPage.cs
@@ -4,7 +4,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
@@ -13,21 +16,24 @@ using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using Microsoft.Win32;
 using Windows.ApplicationModel.DataTransfer;
+using Windows.Storage.Streams;
 
 namespace Microsoft.CmdPal.Ext.ClipboardHistory.Pages;
 
 internal sealed partial class ClipboardHistoryListPage : ListPage
 {
     private readonly SettingsManager _settingsManager;
-    private readonly ObservableCollection<ClipboardItem> clipboardHistory;
     private readonly string _defaultIconPath;
+    private volatile ClipboardItem[] clipboardHistory = [];
+    private int hasLoadedOnce;
+    private int loadInFlight;
+    private int reloadRequested;
 
     public ClipboardHistoryListPage(SettingsManager settingsManager)
     {
         ArgumentNullException.ThrowIfNull(settingsManager);
 
         _settingsManager = settingsManager;
-        clipboardHistory = [];
         _defaultIconPath = string.Empty;
         Icon = Icons.ClipboardListIcon;
         Name = Properties.Resources.clipboard_history_page_name;
@@ -37,29 +43,19 @@ internal sealed partial class ClipboardHistoryListPage : ListPage
         Clipboard.HistoryChanged += TrackClipboardHistoryChanged_EventHandler;
     }
 
-    private void TrackClipboardHistoryChanged_EventHandler(object? sender, ClipboardHistoryChangedEventArgs? e) => RaiseItemsChanged(0);
+    private void TrackClipboardHistoryChanged_EventHandler(object? sender, ClipboardHistoryChangedEventArgs? e)
+    {
+        Interlocked.Exchange(ref reloadRequested, 1);
+        LoadClipboardHistoryInSTA();
+    }
 
     private bool IsClipboardHistoryEnabled()
     {
         var registryKey = @"HKEY_CURRENT_USER\Software\Microsoft\Clipboard\";
         try
         {
-            var enableClipboardHistory = (int)(Registry.GetValue(registryKey, "EnableClipboardHistory", false) ?? 0);
+            var enableClipboardHistory = (int)(Registry.GetValue(registryKey, "EnableClipboardHistory", 0) ?? 0);
             return enableClipboardHistory != 0;
-        }
-        catch (Exception)
-        {
-            return false;
-        }
-    }
-
-    private bool IsClipboardHistoryDisabledByGPO()
-    {
-        var registryKey = @"HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\System\";
-        try
-        {
-            var allowClipboardHistory = Registry.GetValue(registryKey, "AllowClipboardHistory", null);
-            return allowClipboardHistory is not null ? (int)allowClipboardHistory == 0 : false;
         }
         catch (Exception)
         {
@@ -69,6 +65,7 @@ internal sealed partial class ClipboardHistoryListPage : ListPage
 
     private async Task LoadClipboardHistoryAsync()
     {
+        var loadSucceeded = false;
         try
         {
             List<ClipboardItem> items = [];
@@ -78,7 +75,7 @@ internal sealed partial class ClipboardHistoryListPage : ListPage
                 return;
             }
 
-            var historyItems = await Clipboard.GetHistoryItemsAsync();
+            var historyItems = await Clipboard.GetHistoryItemsAsync().AsTask().ConfigureAwait(false);
             if (historyItems.Status != ClipboardHistoryItemsResultStatus.Success)
             {
                 return;
@@ -88,7 +85,7 @@ internal sealed partial class ClipboardHistoryListPage : ListPage
             {
                 if (item.Content.Contains(StandardDataFormats.Text))
                 {
-                    var text = await item.Content.GetTextAsync();
+                    var text = await item.Content.GetTextAsync().AsTask().ConfigureAwait(false);
                     items.Add(new ClipboardItem { Settings = _settingsManager, Content = text, Item = item });
                 }
                 else if (item.Content.Contains(StandardDataFormats.Bitmap))
@@ -97,22 +94,23 @@ internal sealed partial class ClipboardHistoryListPage : ListPage
                 }
             }
 
-            clipboardHistory.Clear();
-
             foreach (var item in items)
             {
                 if (item.Item.Content.Contains(StandardDataFormats.Bitmap))
                 {
-                    var imageReceived = await item.Item.Content.GetBitmapAsync();
+                    var imageReceived = await item.Item.Content.GetBitmapAsync().AsTask().ConfigureAwait(false);
 
                     if (imageReceived is not null)
                     {
                         item.ImageData = imageReceived;
+                        item.ImagePath = GetImagePath(item.Item.Id);
+                        await CacheImageAsync(imageReceived, item.ImagePath).ConfigureAwait(false);
                     }
                 }
-
-                clipboardHistory.Add(item);
             }
+
+            clipboardHistory = [.. items];
+            loadSucceeded = true;
         }
         catch (Exception ex)
         {
@@ -121,39 +119,176 @@ internal sealed partial class ClipboardHistoryListPage : ListPage
             ExtensionHost.ShowStatus(new StatusMessage() { Message = Properties.Resources.clipboard_failed_to_load, State = MessageState.Error }, StatusContext.Page);
             ExtensionHost.LogMessage(ex.ToString());
         }
+        finally
+        {
+            CleanupCachedImages(clipboardHistory.Where(static item => item.ImagePath is not null).Select(static item => item.ImagePath!));
+            Interlocked.Exchange(ref loadInFlight, 0);
+            if (!loadSucceeded)
+            {
+                Interlocked.Exchange(ref hasLoadedOnce, 0);
+            }
+
+            try
+            {
+                IsLoading = false;
+            }
+            catch (Exception ex)
+            {
+                TryLogMessage($"Failed to clear clipboard history loading state: {ex}");
+            }
+
+            if (loadSucceeded)
+            {
+                try
+                {
+                    RaiseItemsChanged(0);
+                }
+                catch (Exception ex)
+                {
+                    TryLogMessage($"Failed to notify clipboard history update: {ex}");
+                }
+
+                if (Interlocked.Exchange(ref reloadRequested, 0) != 0)
+                {
+                    LoadClipboardHistoryInSTA();
+                }
+            }
+        }
+    }
+
+    private static string GetImagePath(string id)
+    {
+        var directory = GetCacheDirectory();
+        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(id)));
+        return Path.Combine(directory, $"{hash}.png");
+    }
+
+    private static void CleanupCachedImages(IEnumerable<string> activePaths)
+    {
+        try
+        {
+            var activeFileNames = activePaths.Select(Path.GetFileName).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var directory = GetCacheDirectory();
+            if (!Directory.Exists(directory))
+            {
+                return;
+            }
+
+            foreach (var path in Directory.EnumerateFiles(directory, "*.png"))
+            {
+                if (!activeFileNames.Contains(Path.GetFileName(path)))
+                {
+                    try
+                    {
+                        File.Delete(path);
+                    }
+                    catch (IOException ex)
+                    {
+                        TryLogMessage($"Failed to remove cached clipboard image: {ex.Message}");
+                    }
+                    catch (UnauthorizedAccessException ex)
+                    {
+                        TryLogMessage($"Failed to remove cached clipboard image: {ex.Message}");
+                    }
+                }
+            }
+        }
+        catch (IOException ex)
+        {
+            TryLogMessage($"Failed to enumerate cached clipboard images: {ex.Message}");
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            TryLogMessage($"Failed to enumerate cached clipboard images: {ex.Message}");
+        }
+    }
+
+    private static async Task CacheImageAsync(RandomAccessStreamReference imageData, string path)
+    {
+        try
+        {
+            using var stream = await imageData.OpenReadAsync().AsTask().ConfigureAwait(false);
+            using var input = stream.AsStreamForRead();
+            var directory = Path.GetDirectoryName(path)!;
+            Directory.CreateDirectory(directory);
+            using var output = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Read, 64 * 1024, useAsync: true);
+            await input.CopyToAsync(output).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            TryLogMessage($"Failed to cache clipboard image data: {ex}");
+        }
+    }
+
+    private static string GetCacheDirectory() => Path.Combine(Path.GetTempPath(), "PowerToys", "CmdPal", "ClipboardHistory");
+
+    private static void TryLogMessage(string message)
+    {
+        try
+        {
+            ExtensionHost.LogMessage(message);
+        }
+        catch (Exception)
+        {
+            // Logging must not take down the unobserved STA worker.
+        }
     }
 
     private void LoadClipboardHistoryInSTA()
     {
+        if (Interlocked.Exchange(ref loadInFlight, 1) != 0)
+        {
+            return;
+        }
+
+        Interlocked.Exchange(ref reloadRequested, 0);
+        StartClipboardHistoryLoad();
+    }
+
+    private void StartClipboardHistoryLoad()
+    {
+        IsLoading = true;
+
         // https://github.com/microsoft/windows-rs/issues/317
-        // Clipboard API needs to be called in STA or it
-        // hangs.
+        // The synchronous prefix must run in STA or the clipboard API hangs.
+        // Continuations use the thread pool because this raw thread has no
+        // synchronization context.
         var thread = new Thread(() =>
         {
-            var t = LoadClipboardHistoryAsync();
-            t.ConfigureAwait(false);
-            t.Wait();
+            try
+            {
+                LoadClipboardHistoryAsync().GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                TryLogMessage($"Clipboard history load thread failed: {ex}");
+            }
         });
         thread.SetApartmentState(ApartmentState.STA);
         thread.Start();
-        thread.Join();
     }
 
     private ListItem[] GetClipboardHistoryListItems()
     {
-        LoadClipboardHistoryInSTA();
         List<ListItem> listItems = [];
-        for (var i = 0; i < clipboardHistory.Count; i++)
+        foreach (var item in clipboardHistory)
         {
-            var item = clipboardHistory[i];
-            if (item is not null)
-            {
-                listItems.Add(new ClipboardListItem(item, _settingsManager));
-            }
+            listItems.Add(new ClipboardListItem(item, _settingsManager));
         }
 
         return listItems.ToArray();
     }
 
-    public override IListItem[] GetItems() => GetClipboardHistoryListItems();
+    public override IListItem[] GetItems()
+    {
+        // This registry read is only a cheap pre-filter. Clipboard.IsHistoryEnabled()
+        // remains the authoritative check inside the load.
+        if (Volatile.Read(ref hasLoadedOnce) == 0 && IsClipboardHistoryEnabled() &&
+            Interlocked.CompareExchange(ref hasLoadedOnce, 1, 0) == 0)
+        {
+            LoadClipboardHistoryInSTA();
+        }
+
+        return GetClipboardHistoryListItems();
+    }
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Pages/ClipboardHistoryListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Pages/ClipboardHistoryListPage.cs
@@ -10,24 +10,25 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CmdPal.Common.Helpers;
 using Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
 using Microsoft.CmdPal.Ext.ClipboardHistory.Models;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
-using Microsoft.Win32;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Storage.Streams;
 
 namespace Microsoft.CmdPal.Ext.ClipboardHistory.Pages;
 
-internal sealed partial class ClipboardHistoryListPage : ListPage
+internal sealed partial class ClipboardHistoryListPage : ListPage, IDisposable
 {
     private readonly SettingsManager _settingsManager;
     private readonly string _defaultIconPath;
     private volatile ClipboardItem[] clipboardHistory = [];
-    private int hasLoadedOnce;
-    private int loadInFlight;
-    private int reloadRequested;
+    private InterlockedBoolean hasLoadedOnce;
+    private InterlockedBoolean loadInFlight;
+    private InterlockedBoolean reloadRequested;
+    private InterlockedBoolean disposed;
 
     public ClipboardHistoryListPage(SettingsManager settingsManager)
     {
@@ -45,22 +46,13 @@ internal sealed partial class ClipboardHistoryListPage : ListPage
 
     private void TrackClipboardHistoryChanged_EventHandler(object? sender, ClipboardHistoryChangedEventArgs? e)
     {
-        Interlocked.Exchange(ref reloadRequested, 1);
-        LoadClipboardHistoryInSTA();
-    }
+        if (disposed.Value)
+        {
+            return;
+        }
 
-    private bool IsClipboardHistoryEnabled()
-    {
-        var registryKey = @"HKEY_CURRENT_USER\Software\Microsoft\Clipboard\";
-        try
-        {
-            var enableClipboardHistory = (int)(Registry.GetValue(registryKey, "EnableClipboardHistory", 0) ?? 0);
-            return enableClipboardHistory != 0;
-        }
-        catch (Exception)
-        {
-            return false;
-        }
+        reloadRequested.Value = true;
+        LoadClipboardHistoryInSTA();
     }
 
     private async Task LoadClipboardHistoryAsync()
@@ -68,6 +60,7 @@ internal sealed partial class ClipboardHistoryListPage : ListPage
         var loadSucceeded = false;
         try
         {
+            CleanupCachedImages(clipboardHistory.Where(static item => item.ImagePath is not null).Select(static item => item.ImagePath!));
             List<ClipboardItem> items = [];
 
             if (!Clipboard.IsHistoryEnabled())
@@ -122,10 +115,10 @@ internal sealed partial class ClipboardHistoryListPage : ListPage
         finally
         {
             CleanupCachedImages(clipboardHistory.Where(static item => item.ImagePath is not null).Select(static item => item.ImagePath!));
-            Interlocked.Exchange(ref loadInFlight, 0);
+            loadInFlight.Value = false;
             if (!loadSucceeded)
             {
-                Interlocked.Exchange(ref hasLoadedOnce, 0);
+                hasLoadedOnce.Value = false;
             }
 
             try
@@ -137,7 +130,7 @@ internal sealed partial class ClipboardHistoryListPage : ListPage
                 TryLogMessage($"Failed to clear clipboard history loading state: {ex}");
             }
 
-            if (loadSucceeded)
+            if (loadSucceeded && !disposed.Value)
             {
                 try
                 {
@@ -147,11 +140,11 @@ internal sealed partial class ClipboardHistoryListPage : ListPage
                 {
                     TryLogMessage($"Failed to notify clipboard history update: {ex}");
                 }
+            }
 
-                if (Interlocked.Exchange(ref reloadRequested, 0) != 0)
-                {
-                    LoadClipboardHistoryInSTA();
-                }
+            if (!disposed.Value && reloadRequested.Clear())
+            {
+                LoadClipboardHistoryInSTA();
             }
         }
     }
@@ -236,12 +229,12 @@ internal sealed partial class ClipboardHistoryListPage : ListPage
 
     private void LoadClipboardHistoryInSTA()
     {
-        if (Interlocked.Exchange(ref loadInFlight, 1) != 0)
+        if (!loadInFlight.Set())
         {
             return;
         }
 
-        Interlocked.Exchange(ref reloadRequested, 0);
+        reloadRequested.Clear();
         StartClipboardHistoryLoad();
     }
 
@@ -253,19 +246,29 @@ internal sealed partial class ClipboardHistoryListPage : ListPage
         // The synchronous prefix must run in STA or the clipboard API hangs.
         // Continuations use the thread pool because this raw thread has no
         // synchronization context.
-        var thread = new Thread(() =>
+        try
         {
-            try
+            var thread = new Thread(() =>
             {
-                LoadClipboardHistoryAsync().GetAwaiter().GetResult();
-            }
-            catch (Exception ex)
-            {
-                TryLogMessage($"Clipboard history load thread failed: {ex}");
-            }
-        });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
+                try
+                {
+                    LoadClipboardHistoryAsync().GetAwaiter().GetResult();
+                }
+                catch (Exception ex)
+                {
+                    TryLogMessage($"Clipboard history load thread failed: {ex}");
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+        }
+        catch (Exception ex)
+        {
+            loadInFlight.Value = false;
+            hasLoadedOnce.Value = false;
+            IsLoading = false;
+            TryLogMessage($"Failed to start clipboard history load thread: {ex}");
+        }
     }
 
     private ListItem[] GetClipboardHistoryListItems()
@@ -281,14 +284,23 @@ internal sealed partial class ClipboardHistoryListPage : ListPage
 
     public override IListItem[] GetItems()
     {
-        // This registry read is only a cheap pre-filter. Clipboard.IsHistoryEnabled()
-        // remains the authoritative check inside the load.
-        if (Volatile.Read(ref hasLoadedOnce) == 0 && IsClipboardHistoryEnabled() &&
-            Interlocked.CompareExchange(ref hasLoadedOnce, 1, 0) == 0)
+        if (!disposed.Value && hasLoadedOnce.Set())
         {
             LoadClipboardHistoryInSTA();
         }
 
         return GetClipboardHistoryListItems();
+    }
+
+    public void Dispose()
+    {
+        if (!disposed.Set())
+        {
+            return;
+        }
+
+        Clipboard.HistoryChanged -= TrackClipboardHistoryChanged_EventHandler;
+        CleanupCachedImages([]);
+        GC.SuppressFinalize(this);
     }
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Pages/ClipboardListItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Pages/ClipboardListItem.cs
@@ -231,12 +231,10 @@ internal sealed partial class ClipboardListItem : ListItem
 
         if (_item.IsImage)
         {
-            var iconData = new IconData(_item.ImageData);
-            var heroImage = new IconInfo(iconData);
             return new Details
             {
                 Title = _item.GetDataType(),
-                HeroImage = heroImage,
+                Body = DetailsMarkdownHelper.BuildImageBody(_item.ImagePath, Properties.Resources.clipboard_item_image_title),
                 Metadata = [.. metadata],
             };
         }
@@ -246,7 +244,7 @@ internal sealed partial class ClipboardListItem : ListItem
             return new Details
             {
                 Title = _item.GetDataType(),
-                Body = $"```text\n{_item.Content}\n```",
+                Body = DetailsMarkdownHelper.BuildTextBody(_item.Content),
                 Metadata = [.. metadata],
             };
         }


### PR DESCRIPTION
Clipboard History image previews were stuck in the small HeroImage slot making them hard to see. This PR aims to fix that, plus an improvement to copied text displaying

Now:

- Clipboard images are rendered through the existing local image provider using stable, item keyed cache files.
- Those cached images are cleaned up after each history load
- Clipboard text is also cleaned a bit to always stretch the full width and styled a little nicer.

The image remains downscale only. Small clipboard images won’t be stretched just to fill the panel.

Closes #41698

## Show it to me?

https://github.com/user-attachments/assets/ab670860-ed34-4f3c-807c-84da3564e468