### PR TITLE
Shortcut Guide: add Ableton Live shortcut manifest

### DIFF
--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/+Ableton.Live.en-US.yml
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/+Ableton.Live.en-US.yml
@@ -1,0 +1,298 @@
+PackageName: +Ableton.Live
+Name: Ableton Live
+WindowFilter: "Ableton Live 12 Suite.exe;Ableton Live 12 Standard.exe;Ableton Live 12 Intro.exe;Ableton Live 12 Lite.exe;Ableton Live 11 Suite.exe;Ableton Live 11 Standard.exe;Ableton Live 11 Intro.exe;Ableton Live 11 Lite.exe;Ableton Live 10 Suite.exe;Ableton Live 10 Standard.exe;Ableton Live 10 Intro.exe;Ableton Live 10 Lite.exe;Ableton Live 9 Suite.exe;Ableton Live 9 Standard.exe;Ableton Live 9 Intro.exe;Ableton Live 9 Lite.exe;Live.exe"
+BackgroundProcess: false
+Shortcuts:
+  - SectionName: General
+    Properties:
+      - Name: New Live Set
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: false
+            Alt: false
+            Keys:
+              - N
+      - Name: Open Live Set
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: false
+            Alt: false
+            Keys:
+              - O
+      - Name: Save Live Set
+        Recommended: true
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: false
+            Alt: false
+            Keys:
+              - S
+      - Name: Save Live Set As
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: true
+            Alt: false
+            Keys:
+              - S
+      - Name: Preferences
+        Recommended: true
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: false
+            Alt: false
+            Keys:
+              - ','
+      - Name: Undo
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: false
+            Alt: false
+            Keys:
+              - Z
+      - Name: Redo
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: false
+            Alt: false
+            Keys:
+              - Y
+      - Name: Cut
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: false
+            Alt: false
+            Keys:
+              - X
+      - Name: Copy
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: false
+            Alt: false
+            Keys:
+              - C
+      - Name: Paste
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: false
+            Alt: false
+            Keys:
+              - V
+      - Name: Duplicate
+        Recommended: true
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: false
+            Alt: false
+            Keys:
+              - D
+      - Name: Select All
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: false
+            Alt: false
+            Keys:
+              - A
+
+  - SectionName: Views and Navigation
+    Properties:
+      - Name: Toggle Session / Arrangement View
+        Recommended: true
+        Shortcut:
+          - Win: false
+            Ctrl: false
+            Shift: false
+            Alt: false
+            Keys:
+              - "<Tab>"
+      - Name: Toggle Clip / Device View
+        Recommended: true
+        Shortcut:
+          - Win: false
+            Ctrl: false
+            Shift: true
+            Alt: false
+            Keys:
+              - "<Tab>"
+      - Name: Toggle Browser
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: false
+            Alt: true
+            Keys:
+              - B
+      - Name: Toggle Detail View
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: false
+            Alt: true
+            Keys:
+              - L
+      - Name: Toggle Info View
+        Shortcut:
+          - Win: false
+            Ctrl: false
+            Shift: true
+            Alt: false
+            Keys:
+              - '?'
+      - Name: Full Screen
+        Shortcut:
+          - Win: false
+            Ctrl: false
+            Shift: false
+            Alt: false
+            Keys:
+              - "<F11>"
+
+  - SectionName: Playback and Recording
+    Properties:
+      - Name: Play / Stop
+        Recommended: true
+        Shortcut:
+          - Win: false
+            Ctrl: false
+            Shift: false
+            Alt: false
+            Keys:
+              - "<Space>"
+      - Name: Continue Play from Stop Point
+        Shortcut:
+          - Win: false
+            Ctrl: false
+            Shift: true
+            Alt: false
+            Keys:
+              - "<Space>"
+      - Name: Play from Selection
+        Shortcut:
+          - Win: false
+            Ctrl: false
+            Shift: false
+            Alt: true
+            Keys:
+              - "<Space>"
+      - Name: Record
+        Recommended: true
+        Shortcut:
+          - Win: false
+            Ctrl: false
+            Shift: false
+            Alt: false
+            Keys:
+              - "<F9>"
+      - Name: Capture MIDI
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: true
+            Alt: false
+            Keys:
+              - C
+
+  - SectionName: Editing and Tracks
+    Properties:
+      - Name: Insert Audio Track
+        Recommended: true
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: false
+            Alt: false
+            Keys:
+              - T
+      - Name: Insert MIDI Track
+        Recommended: true
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: true
+            Alt: false
+            Keys:
+              - T
+      - Name: Insert Return Track
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: false
+            Alt: true
+            Keys:
+              - T
+      - Name: Group Tracks / Clips
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: false
+            Alt: false
+            Keys:
+              - G
+      - Name: Ungroup Tracks / Clips
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: true
+            Alt: false
+            Keys:
+              - G
+      - Name: Split Clip at Selection
+        Recommended: true
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: false
+            Alt: false
+            Keys:
+              - E
+      - Name: Consolidate
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: false
+            Alt: false
+            Keys:
+              - J
+      - Name: Rename
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: false
+            Alt: false
+            Keys:
+              - R
+      - Name: Quantize
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: false
+            Alt: false
+            Keys:
+              - U
+      - Name: Quantize Settings
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: true
+            Alt: false
+            Keys:
+              - U
+      - Name: Deactivate / Mute Clip or Note
+        Shortcut:
+          - Win: false
+            Ctrl: false
+            Shift: false
+            Alt: false
+            Keys:
+              - '0'

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Helpers/ManifestInterpreter.cs
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Helpers/ManifestInterpreter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -154,11 +154,6 @@ namespace ShortcutGuide.Helpers
             {
                 string filter = item.WindowFilter;
 
-                if (filter.EndsWith(".exe", StringComparison.InvariantCultureIgnoreCase))
-                {
-                    filter = filter[..^4];
-                }
-
                 if (filter == "*")
                 {
                     foreach (var app in item.Apps)
@@ -169,34 +164,45 @@ namespace ShortcutGuide.Helpers
                     continue;
                 }
 
-                Process[] foundProcesses = [];
-
-                try
+                string[] filterParts = filter.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                foreach (var filterPart in filterParts)
                 {
-                    foundProcesses = Process.GetProcessesByName(filter);
-                    if (foundProcesses.Length > 0)
+                    string targetFilter = filterPart;
+                    if (targetFilter.EndsWith(".exe", StringComparison.InvariantCultureIgnoreCase))
                     {
-                        foreach (var app in item.Apps)
+                        targetFilter = targetFilter[..^4];
+                    }
+
+                    Process[] foundProcesses = [];
+
+                    try
+                    {
+                        foundProcesses = Process.GetProcessesByName(targetFilter);
+                        if (foundProcesses.Length > 0)
                         {
-                            applicationIds[app] = foundProcesses[0].MainModule?.FileName;
+                            foreach (var app in item.Apps)
+                            {
+                                applicationIds[app] = foundProcesses[0].MainModule?.FileName;
+                            }
+
+                            break;
                         }
                     }
-                }
-                catch (Win32Exception ex)
-                {
-                    Trace.WriteLine($"Failed to inspect background process '{filter}': {ex.Message}");
-                }
-                catch (InvalidOperationException ex)
-                {
-                    Trace.WriteLine($"Failed to inspect background process '{filter}': {ex.Message}");
-                }
-                finally
-                {
-                    foreach (var process in foundProcesses)
+                    catch (Win32Exception ex)
                     {
-                        process.Dispose();
+                        Trace.WriteLine($"Failed to inspect background process '{targetFilter}': {ex.Message}");
                     }
-                }
+                    catch (InvalidOperationException ex)
+                    {
+                        Trace.WriteLine($"Failed to inspect background process '{targetFilter}': {ex.Message}");
+                    }
+                    finally
+                    {
+                        foreach (var process in foundProcesses)
+                        {
+                            process.Dispose();
+                        }
+                    }
             }
 
             return applicationIds;
@@ -213,12 +219,22 @@ namespace ShortcutGuide.Helpers
                     input = input[..^4];
                 }
 
-                if (filter.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+                string[] filterParts = filter.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                foreach (var part in filterParts)
                 {
-                    filter = filter[..^4];
+                    string target = part;
+                    if (target.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+                    {
+                        target = target[..^4];
+                    }
+
+                    if (string.Equals(input, target, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
                 }
 
-                return string.Equals(input, filter, StringComparison.OrdinalIgnoreCase);
+                return false;
             }
         }
     }

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Helpers/ManifestInterpreter.cs
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Helpers/ManifestInterpreter.cs
@@ -203,6 +203,7 @@ namespace ShortcutGuide.Helpers
                             process.Dispose();
                         }
                     }
+                }
             }
 
             return applicationIds;


### PR DESCRIPTION
## Summary of the Pull Request
Adds a built-in shortcut manifest for Ableton Live (covering Ableton Live 9–12 across Suite, Standard, Intro, and Lite editions) with standard general, navigation, playback/recording, and track editing shortcuts according to official Ableton documentation.

## PR Checklist
- [x] **Closes:** #50066
- [x] **Communication:** I've discussed this with core contributors already. If not please check the guideline.
- [x] **Tests:** Added manifest follows the existing `Assets/ShortcutGuide/Manifests/*.yml` schema.
- [x] **Localization:** All display strings in English.