### PR TITLE
fix(installer): terminate remaining PowerToys processes during setup

### DIFF
--- a/installer/PowerToysSetupCustomActionsVNext/CustomAction.cpp
+++ b/installer/PowerToysSetupCustomActionsVNext/CustomAction.cpp
@@ -1579,7 +1579,7 @@ UINT __stdcall TerminateProcessesCA(MSIHANDLE hInstall)
     }
     processes.resize(bytes / sizeof(processes[0]));
 
-    std::array<std::wstring_view, 46> processesToTerminate = {
+    std::array<std::wstring_view, 54> processesToTerminate = {
         L"PowerToys.PowerLauncher.exe",
         L"PowerToys.Settings.exe",
         L"PowerToys.AdvancedPaste.exe",
@@ -1588,6 +1588,7 @@ UINT __stdcall TerminateProcessesCA(MSIHANDLE hInstall)
         L"PowerToys.FancyZonesEditor.exe",
         L"PowerToys.FileLocksmithUI.exe",
         L"PowerToys.MouseJumpUI.exe",
+        L"PowerToys.MouseJump.WinUI3.exe",
         L"PowerToys.ColorPickerUI.exe",
         L"PowerToys.AlwaysOnTop.exe",
         L"PowerToys.RegistryPreview.exe",
@@ -1623,6 +1624,13 @@ UINT __stdcall TerminateProcessesCA(MSIHANDLE hInstall)
         L"PowerToys.WorkspacesWindowArranger.exe",
         L"Microsoft.CmdPal.UI.exe",
         L"Microsoft.CmdPal.Ext.PowerToys.exe",
+        L"PowerToys.KeyboardManagerEditorUI.exe",
+        L"PowerToys.KeyboardManagerEditor.exe",
+        L"PowerToys.KeyboardManagerEngine.exe",
+        L"PowerToys.GrabAndMove.exe",
+        L"PowerToys.PowerAccent.exe",
+        L"PowerToys.PowerOCR.exe",
+        L"PowerToys.MeasureToolUI.exe",
         L"PowerToys.ShortcutGuide.exe",
         L"PowerToys.ZoomIt.exe",
         L"PowerToys.exe",


### PR DESCRIPTION
## Summary of the Pull Request

Extends `TerminateProcessesCA` in `installer\PowerToysSetupCustomActionsVNext\CustomAction.cpp` so setup closes the remaining independently running PowerToys executables before replacing installed files.

The list now covers Shortcut Guide, both current and legacy Keyboard Manager editors, Keyboard Manager Engine, the current Mouse Jump WinUI 3 executable, Grab and Move, Quick Accent, Text Extractor, and Screen Ruler. The legacy `PowerToys.MouseJumpUI.exe` entry remains for upgrade cleanup.

## PR Checklist

- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass — no automated behavior was added; targeted project build is currently blocked by a missing local C++/WinRT NuGet props file
- [x] **Localization:** No end-user-facing strings were added or changed

## Detailed Description of the Pull Request / Additional comments

The installer already performs a best-effort graceful close followed by forced termination for executable names in `processesToTerminate`. Several shipped out-of-process modules were not represented in that list, so user-open, orphaned, or unresponsive instances could remain during upgrade or uninstall and retain handles to installed files.

This change only expands the executable-name array and updates its fixed size. It does not alter shutdown ordering or termination behavior.

## Validation Steps Performed

- Verified the array contains exactly 54 entries with no duplicates.
- Verified all newly added names against current project outputs, installer manifests, or module process-launch sites.
- Preserved the legacy Mouse Jump executable name for upgrade cleanup.
- Confirmed `PowerToys.Update.exe` remains excluded because it orchestrates the update.
- Independently reviewed the committed diff with no findings.
- Attempted an x64 Debug build of `PowerToysSetupCustomActionsVNext.vcxproj`; MSBuild stopped before compilation because `Microsoft.Windows.CppWinRT.props` is missing from the local NuGet package cache.
