### PR TITLE
fix(release): reconcile preview deltas against full history

### DIFF
--- a/.github/skills/release-note-generation/references/preview-delta-resolution.md
+++ b/.github/skills/release-note-generation/references/preview-delta-resolution.md
@@ -20,6 +20,13 @@ Added         = Target identities - Previous identities
 Removed       = Previous identities - Target identities
 ```
 
+Compare each side against the other commit's full reachable history, not only
+the commits after the merge base. Stable cherry-picks can appear after the
+merge base even when the same PR was merged into `main` earlier. Equal PR
+identities or equivalent patches anywhere in the opposite history cancel.
+Aggregate merge commits that only promote an ancestor of the opposite branch
+also cancel; they are not independent release-note changes.
+
 Resolve commit identity in this order:
 
 1. Squash subject ending in `(#<number>)`.

--- a/.github/skills/release-note-generation/scripts/get-preview-release-delta.ps1
+++ b/.github/skills/release-note-generation/scripts/get-preview-release-delta.ps1
@@ -195,6 +195,57 @@ function New-IdentitySet {
     return ,$set
 }
 
+function Get-HistoryPrIdentitySet {
+    param([Parameter(Mandatory)][string]$Commit)
+
+    $set = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+    foreach ($subject in @(Invoke-Git log --format=%s $Commit)) {
+        $prNumber = Get-SubjectPrNumber -Subject ([string]$subject)
+        if ($prNumber) {
+            [void]$set.Add("pr:$prNumber")
+        }
+    }
+    return ,$set
+}
+
+function Get-EquivalentCommitSet {
+    param(
+        [Parameter(Mandatory)][string]$Upstream,
+        [Parameter(Mandatory)][string]$Head
+    )
+
+    $set = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+    foreach ($line in @(Invoke-Git cherry $Upstream $Head)) {
+        if ([string]$line -match "^-\s+([0-9a-fA-F]{40})$") {
+            [void]$set.Add($matches[1])
+        }
+    }
+    return ,$set
+}
+
+function Test-PromotionMerge {
+    param(
+        [Parameter(Mandatory)]$Record,
+        [Parameter(Mandatory)][string]$OtherTip
+    )
+
+    if ($Record.patchId) {
+        return $false
+    }
+
+    $parents = @(([string](Invoke-Git show -s --format=%P $Record.sha)).Trim() -split "\s+" | Where-Object { $_ })
+    if ($parents.Count -lt 2) {
+        return $false
+    }
+
+    foreach ($parent in $parents) {
+        if (Test-Ancestor -Ancestor $parent -Descendant $OtherTip) {
+            return $true
+        }
+    }
+    return $false
+}
+
 function Resolve-CrossSidePatchIdentities {
     param(
         [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Left,
@@ -274,6 +325,32 @@ Resolve-CrossSidePatchIdentities -Left $targetRecords -Right $previousRecords
 
 $previousIdentities = New-IdentitySet -Records $previousRecords
 $targetIdentities = New-IdentitySet -Records $targetRecords
+
+if ($deltaMode -eq "branch-transition") {
+    $previousHistoryPrIdentities = Get-HistoryPrIdentitySet -Commit $previousSha
+    $targetHistoryPrIdentities = Get-HistoryPrIdentitySet -Commit $targetSha
+    foreach ($identity in $previousHistoryPrIdentities) {
+        [void]$previousIdentities.Add($identity)
+    }
+    foreach ($identity in $targetHistoryPrIdentities) {
+        [void]$targetIdentities.Add($identity)
+    }
+
+    $previousEquivalentCommits = Get-EquivalentCommitSet -Upstream $targetSha -Head $previousSha
+    $targetEquivalentCommits = Get-EquivalentCommitSet -Upstream $previousSha -Head $targetSha
+    foreach ($record in $previousRecords) {
+        if ($previousEquivalentCommits.Contains([string]$record.sha) -or
+            (Test-PromotionMerge -Record $record -OtherTip $targetSha)) {
+            [void]$targetIdentities.Add([string]$record.identity)
+        }
+    }
+    foreach ($record in $targetRecords) {
+        if ($targetEquivalentCommits.Contains([string]$record.sha) -or
+            (Test-PromotionMerge -Record $record -OtherTip $previousSha)) {
+            [void]$previousIdentities.Add([string]$record.identity)
+        }
+    }
+}
 
 $addedPrs = Get-PrOutput -Records $targetRecords -OtherSide $previousIdentities
 $removedPrs = if ($deltaMode -eq "branch-transition") {

--- a/.github/skills/release-note-generation/tests/preview-release.Tests.ps1
+++ b/.github/skills/release-note-generation/tests/preview-release.Tests.ps1
@@ -37,6 +37,7 @@ function Add-TestCommit {
         [Parameter(Mandatory)][string]$Message
     )
 
+    Invoke-TestGit -Repository $Repository config core.safecrlf false | Out-Null
     Set-Content -LiteralPath (Join-Path $Repository $FileName) -Value $Content
     Invoke-TestGit -Repository $Repository add $FileName | Out-Null
     Invoke-TestGit -Repository $Repository commit -q -m $Message | Out-Null
@@ -438,6 +439,63 @@ Describe "preview release delta" {
         $result.deltaMode | Should Be "branch-transition"
         ($result.addedPrNumbers -join ",") | Should Be "102,104"
         ($result.removedPrNumbers -join ",") | Should Be "103"
+    }
+
+    It "does not remove a PR already present before the merge base on the target branch" {
+        $repo = Join-Path $TestDrive "full-history-identity"
+        New-Item -ItemType Directory -Path $repo | Out-Null
+        Invoke-TestGit -Repository $repo init -q | Out-Null
+        Invoke-TestGit -Repository $repo config user.email "test@example.com" | Out-Null
+        Invoke-TestGit -Repository $repo config user.name "Test User" | Out-Null
+        $root = Add-TestCommit -Repository $repo -FileName "root.txt" -Content "root" -Message "Root"
+        Invoke-TestGit -Repository $repo checkout -q -b main | Out-Null
+        Add-TestCommit -Repository $repo -FileName "feature.txt" -Content "main" -Message "Shared feature (#201)" | Out-Null
+        $mainTip = Add-TestCommit -Repository $repo -FileName "anchor.txt" -Content "anchor" -Message "Main anchor (#202)"
+
+        Invoke-TestGit -Repository $repo checkout -q -b stable $mainTip | Out-Null
+        $previous = Add-TestCommit -Repository $repo -FileName "stable.txt" -Content "stable adaptation" -Message "Shared feature (#201)"
+        Invoke-TestGit -Repository $repo checkout -q main | Out-Null
+        $target = Add-TestCommit -Repository $repo -FileName "added.txt" -Content "added" -Message "Main addition (#203)"
+        $output = Join-Path $TestDrive "full-history-output"
+
+        $result = & (Join-Path $scripts "get-preview-release-delta.ps1") `
+            -PreviousCommit $previous `
+            -TargetCommit $target `
+            -RepoPath $repo `
+            -OutputDirectory $output `
+            -NoGitHubLookup
+
+        ($result.addedPrNumbers -join ",") | Should Be "203"
+        $result.removedPrNumbers.Count | Should Be 0
+    }
+
+    It "does not report a merge that only promotes the other branch" {
+        $repo = Join-Path $TestDrive "promotion-merge"
+        New-Item -ItemType Directory -Path $repo | Out-Null
+        Invoke-TestGit -Repository $repo init -q | Out-Null
+        Invoke-TestGit -Repository $repo config user.email "test@example.com" | Out-Null
+        Invoke-TestGit -Repository $repo config user.name "Test User" | Out-Null
+        Add-TestCommit -Repository $repo -FileName "root.txt" -Content "root" -Message "Root" | Out-Null
+        Invoke-TestGit -Repository $repo checkout -q -b main | Out-Null
+        Add-TestCommit -Repository $repo -FileName "feature.txt" -Content "feature" -Message "Main feature (#301)" | Out-Null
+
+        Invoke-TestGit -Repository $repo checkout -q -b stable HEAD~1 | Out-Null
+        Add-TestCommit -Repository $repo -FileName "stable.txt" -Content "stable" -Message "Stable fix (#302)" | Out-Null
+        Invoke-TestGit -Repository $repo merge -q --no-ff main -m "Merge main into stable (#303)" | Out-Null
+        $previous = ([string](Invoke-TestGit -Repository $repo rev-parse HEAD)).Trim()
+        Invoke-TestGit -Repository $repo checkout -q main | Out-Null
+        $target = Add-TestCommit -Repository $repo -FileName "later.txt" -Content "later" -Message "Later main feature (#304)"
+        $output = Join-Path $TestDrive "promotion-output"
+
+        $result = & (Join-Path $scripts "get-preview-release-delta.ps1") `
+            -PreviousCommit $previous `
+            -TargetCommit $target `
+            -RepoPath $repo `
+            -OutputDirectory $output `
+            -NoGitHubLookup
+
+        ($result.addedPrNumbers -join ",") | Should Be "304"
+        ($result.removedPrNumbers -join ",") | Should Be "302"
     }
 }
 


### PR DESCRIPTION
## Summary of the Pull Request

Fixes preview release branch-transition deltas that incorrectly report stable cherry-picks as removed when the matching PR exists before the merge base in `main`.

The resolver now compares PR identities and equivalent patches against each branch's full reachable history. It also excludes content-free aggregate promotion merges, such as `main`-to-`stable` release merges, from semantic release notes.

## PR Checklist

- [x] **Tests:** Added/updated and all pass
- [x] **Dev docs:** Added/updated
- [x] **New binaries:** N/A

## Detailed Description of the Pull Request / Additional comments

`get-preview-release-delta.ps1` previously built identity sets only from commits after the merge base. A stable cherry-pick after that merge base was therefore reported as removed even when the same PR had already merged into `main` earlier with a different SHA.

The updated resolver:

- Collects PR identities from the full reachable history of both release commits.
- Uses `git cherry` to recognize equivalent patches across the full histories.
- Ignores merge commits with no independent patch when they only promote a parent already contained by the opposite branch.
- Documents the full-history comparison in `.github/skills/release-note-generation/references/preview-delta-resolution.md`.
- Adds regression coverage in `.github/skills/release-note-generation/tests/preview-release.Tests.ps1`.

This was exercised against preview build `155850552`, where the corrected delta changed from 11 added / 71 removed PRs to 11 added / 0 removed PRs. Of the false removals, 68 had the same PR identity in `main`, and three were aggregate promotion merges.

## Validation Steps Performed

- `Invoke-Pester .\.github\skills\release-note-generation\tests\preview-release.Tests.ps1 -EnableExit` - 26/26 passed.
- Recomputed build `155850552` against published stable `v0.101.2362.0`: 11 added, 0 removed, 0 unattributed commits.
- Ran the canonical preview dry-run verifier: PASS with 7/7 assets verified.