### PR TITLE
Fix WebSearch plugin dropping multi-word search queries (unquoted %1 substitution)

### DIFF
--- a/src/modules/launcher/Wox.Infrastructure/Helper.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Helper.cs
@@ -157,7 +157,18 @@ namespace Wox.Infrastructure
             }
             else if (pattern.Contains("%1", StringComparison.Ordinal))
             {
-                arguments = pattern.Replace("%1", arguments);
+                if (pattern.Contains("\"%1\"", StringComparison.Ordinal))
+                {
+                    // Pattern already wraps %1 in quotes (e.g. "chrome.exe" -- "%1"); substitute as-is to avoid double-quoting.
+                    arguments = pattern.Replace("%1", arguments);
+                }
+                else
+                {
+                    // Pattern does not quote %1 (e.g. Edge's own "--single-argument %1" fallback). Quote the substituted
+                    // value so multi-word arguments survive as a single token instead of being split on whitespace by
+                    // the shell, and escape any embedded quotes so they don't prematurely close the quoted argument.
+                    arguments = pattern.Replace("%1", $"\"{arguments.Replace("\"", "\\\"", StringComparison.Ordinal)}\"");
+                }
             }
 
             return OpenInShell(path, arguments, workingDir, runAs, runWithHiddenWindow);


### PR DESCRIPTION
## Summary
- PowerToys Run's WebSearch plugin builds its search argument as an unquoted
  string in `Main.cs` (e.g. `"? best pizza"`).
- `Helper.OpenCommandInShell` substitutes this into the default browser's
  registered `%1` placeholder with no quoting:
  `arguments = pattern.Replace("%1", arguments);`
- On any argument pattern that doesn't already wrap `%1` in quotes itself
  (e.g. Edge's own hardcoded fallback, `MSEdgeArgumentsPattern = "--single-argument %1"`
  in `DefaultBrowserInfo.cs`), the resulting command line gets split on
  whitespace into multiple separate arguments instead of one. A search for
  "best pizza" launches the browser with three separate argv entries
  (`?`, `best`, `pizza`) instead of a single search string, and everything
  after the first word is silently dropped.
- Browsers whose registered command already quotes `%1` (a common pattern,
  e.g. `"chrome.exe" -- "%1"`) are unaffected, since the quotes are literal
  text in the pattern itself and survive the substitution regardless of
  whether the substituted value is quoted - this is why the bug doesn't
  reproduce on every system, only ones resolving to an unquoted pattern.

## Fix
Quote the substituted value in the case where the pattern doesn't already
quote `%1`, and escape embedded quote characters in the query so they can't
prematurely close the quoted argument. Patterns that already quote `%1` are
left untouched to avoid double-quoting.

## Test plan
- [x] Confirmed the root cause against `Helper.cs`/`Main.cs`/`DefaultBrowserInfo.cs`
      directly (both on the `v0.100.2` release tag and current `main` - identical
      at this location).
- [x] Manually verified the underlying quoting behavior: launching the same
      target process with an unquoted multi-word argument produces multiple
      separate argv entries (reproducing the drop), while launching it with
      the identical text as a single quoted argument preserves it intact.
- [ ] Not yet verified against a full local PowerToys build/CI run - only the
      isolated `Helper.cs` change and the quoting mechanism it relies on were
      tested directly, not the built plugin end-to-end. Flagging for a
      maintainer or CI to confirm before merge.

## Disclosure
This fix was found and prepared with the help of Claude (Anthropic) - root
cause analysis, the code change, and this PR description were AI-assisted.
I've reviewed and understand the change before submitting it.
