### PR TITLE
CmdPal: Icons (1/n) - Add opt-in icon loading diagnostics

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml
@@ -40,6 +40,8 @@
                         Height="16"
                         Margin="4,0,0,0"
                         HorizontalAlignment="Left"
+                        DiagnosticScope="Default"
+                        RequestSite="ContextMenu"
                         SourceKey="{x:Bind Icon, Mode=OneWay}"
                         SourceRequested="{x:Bind help:IconProvider.SourceRequested20}" />
                     <TextBlock
@@ -88,7 +90,9 @@
                         Height="16"
                         Margin="4,0,0,0"
                         HorizontalAlignment="Left"
+                        DiagnosticScope="Critical"
                         Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                        RequestSite="ContextMenu"
                         SourceKey="{x:Bind Icon, Mode=OneWay}"
                         SourceRequested="{x:Bind help:IconProvider.SourceRequested20}" />
                     <TextBlock

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/FallbackRanker.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/FallbackRanker.xaml
@@ -47,6 +47,8 @@
                                             Width="16"
                                             Height="16"
                                             AutomationProperties.AccessibilityView="Raw"
+                                            DiagnosticScope="RankerItem"
+                                            RequestSite="Fallback"
                                             SourceKey="{x:Bind Icon, Mode=OneWay}"
                                             SourceRequested="{x:Bind helpers:IconProvider.SourceRequested20}" />
                                     </cpcontrols:ContentIcon.Content>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/FiltersDropDown.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/FiltersDropDown.xaml
@@ -34,6 +34,8 @@
                         Margin="4,0"
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
+                        DiagnosticScope="MenuItem"
+                        RequestSite="Filter"
                         SourceKey="{x:Bind Icon}"
                         SourceRequested="{x:Bind help:IconProvider.SourceRequested20}" />
                     <TextBlock
@@ -72,6 +74,8 @@
                     Margin="0,0,8,0"
                     VerticalAlignment="Center"
                     AutomationProperties.AccessibilityView="Raw"
+                    DiagnosticScope="Selected"
+                    RequestSite="Filter"
                     SourceRequested="{x:Bind help:IconProvider.SourceRequested20}"
                     Visibility="Collapsed" />
                 <TextBlock x:Name="SelectedFilterText" VerticalAlignment="Center" />

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/IconBox.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/IconBox.cs
@@ -4,9 +4,11 @@
 
 using CommunityToolkit.WinUI.Deferred;
 using ManagedCommon;
+using Microsoft.CmdPal.UI.Helpers;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
 using Windows.Foundation;
 
 namespace Microsoft.CmdPal.UI.Controls;
@@ -17,10 +19,27 @@ namespace Microsoft.CmdPal.UI.Controls;
 public partial class IconBox : ContentControl
 {
     private const double DefaultIconFontSize = 16.0;
+    private static long _nextDiagnosticId;
 
     private double _lastScale;
     private ElementTheme _lastTheme;
     private double _lastFontSize;
+    private long _requestVersion;
+    private IconRequestMeasurement _activeRequestDiagnostics;
+    private long _diagnosticId;
+    private IconRequestSite _derivedRequestSite;
+    private bool _hasDerivedRequestSite;
+
+    /// <summary>
+    /// Gets or sets the semantic UI surface used to group this control's diagnostic measurements.
+    /// </summary>
+    public IconRequestSite RequestSite { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional static developer-authored label that distinguishes placements within a <see cref="RequestSite"/>.
+    /// Do not bind this property to item or user data.
+    /// </summary>
+    public string? DiagnosticScope { get; set; }
 
     /// <summary>
     /// Gets or sets the <see cref="IconSource"/> to display within the <see cref="IconBox"/>. Overwritten, if <see cref="SourceKey"/> is used instead.
@@ -60,7 +79,7 @@ public partial class IconBox : ContentControl
             _sourceRequested += value;
             if (_sourceRequested?.GetInvocationList().Length == 1)
             {
-                Refresh();
+                Refresh(IconRequestReason.HandlerAttached);
             }
 #if DEBUG
             if (_sourceRequested?.GetInvocationList().Length > 1)
@@ -69,7 +88,16 @@ public partial class IconBox : ContentControl
             }
 #endif
         }
-        remove => _sourceRequested -= value;
+
+        remove
+        {
+            _sourceRequested -= value;
+
+            if (_sourceRequested is null)
+            {
+                AdvanceRequestVersion();
+            }
+        }
     }
 
     public IconBox()
@@ -130,11 +158,15 @@ public partial class IconBox : ContentControl
         }
 
         _lastTheme = ActualTheme;
-        Refresh();
+        Refresh(IconRequestReason.ThemeChanged);
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)
     {
+        // Handler attachment can request an icon before this control enters the visual tree.
+        // Recompute any derived diagnostic placement now that its parent chain is available.
+        _hasDerivedRequestSite = false;
+        _derivedRequestSite = IconRequestSite.Unknown;
         _lastTheme = ActualTheme;
         UpdateLastFontSize();
 
@@ -144,7 +176,7 @@ public partial class IconBox : ContentControl
             XamlRoot.Changed += OnXamlRootChanged;
         }
 
-        Refresh();
+        Refresh(IconRequestReason.Loaded);
     }
 
     private void OnUnloaded(object sender, RoutedEventArgs e)
@@ -153,6 +185,9 @@ public partial class IconBox : ContentControl
         {
             XamlRoot.Changed -= OnXamlRootChanged;
         }
+
+        _hasDerivedRequestSite = false;
+        _derivedRequestSite = IconRequestSite.Unknown;
     }
 
     private void OnXamlRootChanged(XamlRoot sender, XamlRootChangedEventArgs args)
@@ -166,13 +201,101 @@ public partial class IconBox : ContentControl
 
         if ((changedLastTheme || changedScale) && SourceKey is not null)
         {
-            UpdateSourceKey(this, SourceKey);
+            var reason = IconRequestReason.None;
+            if (changedLastTheme)
+            {
+                reason |= IconRequestReason.ThemeChanged;
+            }
+
+            if (changedScale)
+            {
+                reason |= IconRequestReason.ScaleChanged;
+            }
+
+            UpdateSourceKey(this, SourceKey, reason);
         }
     }
 
-    private void Refresh()
+    private void Refresh(IconRequestReason reason = IconRequestReason.None)
     {
-        UpdateSourceKey(this, SourceKey);
+        UpdateSourceKey(this, SourceKey, reason);
+    }
+
+    private long AdvanceRequestVersion()
+    {
+        _activeRequestDiagnostics.Invalidate();
+        _activeRequestDiagnostics = default;
+        return ++_requestVersion;
+    }
+
+    private void TrackActiveRequest(long requestVersion, IconRequestMeasurement diagnostics)
+    {
+        if (requestVersion == _requestVersion)
+        {
+            _activeRequestDiagnostics = diagnostics;
+        }
+        else
+        {
+            diagnostics.Invalidate();
+        }
+    }
+
+    private void ClearActiveRequest(long requestVersion)
+    {
+        if (requestVersion == _requestVersion)
+        {
+            _activeRequestDiagnostics = default;
+        }
+    }
+
+    private IconRequestOrigin GetDiagnosticOrigin()
+    {
+        var requestSite = RequestSite == IconRequestSite.Unknown ? GetDerivedRequestSite() : RequestSite;
+        var diagnosticId = Volatile.Read(ref _diagnosticId);
+        if (diagnosticId == 0)
+        {
+            var candidate = Interlocked.Increment(ref _nextDiagnosticId);
+            var existing = Interlocked.CompareExchange(ref _diagnosticId, candidate, 0);
+            diagnosticId = existing == 0 ? candidate : existing;
+        }
+
+        return new IconRequestOrigin(diagnosticId, requestSite, DiagnosticScope);
+    }
+
+    private IconRequestSite GetDerivedRequestSite()
+    {
+        if (_hasDerivedRequestSite)
+        {
+            return _derivedRequestSite;
+        }
+
+        for (DependencyObject? current = VisualTreeHelper.GetParent(this); current is not null; current = VisualTreeHelper.GetParent(current))
+        {
+            _derivedRequestSite = current switch
+            {
+                MenuFlyoutItemBase or MenuFlyoutPresenter => IconRequestSite.ContextMenu,
+                ListViewItem or GridViewItem => IconRequestSite.ListItem,
+                _ => IconRequestSite.Unknown,
+            };
+
+            if (_derivedRequestSite != IconRequestSite.Unknown)
+            {
+                break;
+            }
+        }
+
+        // Unknown is only stable once the control is loaded. Before that, a missing parent merely
+        // means the visual tree is not ready yet and should not poison later attribution.
+        _hasDerivedRequestSite = _derivedRequestSite != IconRequestSite.Unknown || IsLoaded;
+        return _derivedRequestSite;
+    }
+
+    private string GetDiagnosticDescription()
+    {
+        var origin = GetDiagnosticOrigin();
+        return string.IsNullOrEmpty(origin.DiagnosticScope)
+            ? $"IconBox #{origin.IconBoxId}, site {origin.RequestSite}"
+            : $"IconBox #{origin.IconBoxId}, site {origin.RequestSite}/{origin.DiagnosticScope}";
     }
 
     private static void OnSourcePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -189,28 +312,34 @@ public partial class IconBox : ContentControl
                 self.Padding = default;
                 break;
             case FontIconSource fontIcon:
+                var fontElementStartedAt = IconLoadDiagnostics.BeginElementUpdate();
                 self.UpdateLastFontSize();
                 fontIcon.FontSize = self._lastFontSize;
                 if (self.Content is IconSourceElement iconSourceElement)
                 {
                     iconSourceElement.IconSource = fontIcon;
+                    IconLoadDiagnostics.RecordElementUpdate(reused: true, fontIcon, fontElementStartedAt);
                 }
                 else
                 {
                     self.Content = fontIcon.CreateIconElement();
+                    IconLoadDiagnostics.RecordElementUpdate(reused: false, fontIcon, fontElementStartedAt);
                 }
 
                 self.UpdatePaddingForFontIcon();
 
                 break;
             case BitmapIconSource bitmapIcon:
+                var bitmapElementStartedAt = IconLoadDiagnostics.BeginElementUpdate();
                 if (self.Content is IconSourceElement iconSourceElement2)
                 {
                     iconSourceElement2.IconSource = bitmapIcon;
+                    IconLoadDiagnostics.RecordElementUpdate(reused: true, bitmapIcon, bitmapElementStartedAt);
                 }
                 else
                 {
                     self.Content = bitmapIcon.CreateIconElement();
+                    IconLoadDiagnostics.RecordElementUpdate(reused: false, bitmapIcon, bitmapElementStartedAt);
                 }
 
                 self.Padding = default;
@@ -218,7 +347,9 @@ public partial class IconBox : ContentControl
                 break;
 
             case IconSource source:
+                var sourceElementStartedAt = IconLoadDiagnostics.BeginElementUpdate();
                 self.Content = source.CreateIconElement();
+                IconLoadDiagnostics.RecordElementUpdate(reused: false, source, sourceElementStartedAt);
                 self.Padding = default;
                 break;
 
@@ -234,22 +365,33 @@ public partial class IconBox : ContentControl
             return;
         }
 
-        UpdateSourceKey(self, e.NewValue);
+        UpdateSourceKey(self, e.NewValue, IconRequestReason.SourceChanged);
     }
 
-    private static void UpdateSourceKey(IconBox iconBox, object? sourceKey)
+    private static void UpdateSourceKey(
+        IconBox iconBox,
+        object? sourceKey,
+        IconRequestReason reason = IconRequestReason.None)
     {
+        var requestVersion = iconBox.AdvanceRequestVersion();
+
         if (sourceKey is null)
         {
             iconBox.Source = null;
             return;
         }
 
-        RequestIconFromSource(iconBox, sourceKey);
+        RequestIconFromSource(iconBox, sourceKey, requestVersion, reason);
     }
 
-    private static async void RequestIconFromSource(IconBox iconBox, object? sourceKey)
+    private static async void RequestIconFromSource(
+        IconBox iconBox,
+        object sourceKey,
+        long requestVersion,
+        IconRequestReason reason)
     {
+        var diagnostics = default(IconRequestMeasurement);
+
         try
         {
             var iconBoxSourceRequestedHandler = iconBox._sourceRequested;
@@ -263,7 +405,14 @@ public partial class IconBox : ContentControl
                 ? iconBox._lastScale
                 : (iconBox.XamlRoot?.RasterizationScale > 0 ? iconBox.XamlRoot.RasterizationScale : 1.0);
 
-            var eventArgs = new SourceRequestedEventArgs(sourceKey, iconBox._lastTheme, scale);
+            diagnostics = IconLoadDiagnostics.IsRecording
+                ? IconLoadDiagnostics.BeginRequest(reason, scale, iconBox.GetDiagnosticOrigin())
+                : default;
+            iconBox.TrackActiveRequest(requestVersion, diagnostics);
+            var eventArgs = new SourceRequestedEventArgs(sourceKey, iconBox._lastTheme, scale)
+            {
+                Diagnostics = diagnostics,
+            };
             await iconBoxSourceRequestedHandler.InvokeAsync(iconBox, eventArgs);
 
             // After the await:
@@ -275,16 +424,26 @@ public partial class IconBox : ContentControl
             if (!ReferenceEquals(sourceKey, iconBox.SourceKey))
             {
                 // If the requested icon has changed, then just bail
+                diagnostics.Complete(IconRequestStatus.Stale, eventArgs.Value);
                 return;
             }
 
             iconBox.Source = eventArgs.Value;
+            diagnostics.Complete(
+                eventArgs.Value is null ? IconRequestStatus.Empty : IconRequestStatus.Applied,
+                eventArgs.Value);
         }
         catch (Exception ex)
         {
+            diagnostics.Complete(IconRequestStatus.Failed);
+
             // Exception from TryEnqueue bypasses the global error handler,
             // and crashes the app.
-            Logger.LogError("Failed to set icon", ex);
+            Logger.LogError($"Failed to set icon ({iconBox.GetDiagnosticDescription()})", ex);
+        }
+        finally
+        {
+            iconBox.ClearActiveRequest(requestVersion);
         }
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/IconRequestSite.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/IconRequestSite.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CmdPal.UI.Controls;
+
+/// <summary>
+/// Identifies the semantic UI surface that requested an icon.
+/// </summary>
+public enum IconRequestSite
+{
+    Unknown,
+    ListItem,
+    ContextMenu,
+    PageHeader,
+    Details,
+    Filter,
+    Dock,
+    Toast,
+    Settings,
+    Parameter,
+    Image,
+    Tag,
+    Fallback,
+    EmptyState,
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ImageViewer.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ImageViewer.xaml
@@ -16,8 +16,10 @@
             x:Name="ZoomImage"
             HorizontalAlignment="Center"
             VerticalAlignment="Center"
+            DiagnosticScope="Viewer"
             IsTabStop="False"
             RenderTransformOrigin="0.5,0.5"
+            RequestSite="Image"
             SourceRequested="{x:Bind help:IconProvider.SourceRequestedOriginal}">
             <controls:IconBox.RenderTransform>
                 <TransformGroup>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SourceRequestedEventArgs.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SourceRequestedEventArgs.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using CommunityToolkit.Common.Deferred;
+using Microsoft.CmdPal.UI.Helpers;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
@@ -20,4 +21,6 @@ public class SourceRequestedEventArgs(object? key, ElementTheme requestedTheme, 
     public ElementTheme Theme => requestedTheme;
 
     public double Scale => scale;
+
+    internal IconRequestMeasurement Diagnostics { get; set; }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/Tag.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/Tag.xaml
@@ -74,6 +74,8 @@
                                 Grid.Column="0"
                                 Width="12"
                                 Height="12"
+                                DiagnosticScope="Default"
+                                RequestSite="Tag"
                                 SourceKey="{TemplateBinding Icon}">
                                 <local:IconBox.Margin>
                                     <Binding

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml
@@ -49,7 +49,9 @@
                                         Width="16"
                                         VerticalAlignment="Center"
                                         AutomationProperties.AccessibilityView="Raw"
+                                        DiagnosticScope="BandItem"
                                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                        RequestSite="Dock"
                                         SourceKey="{x:Bind Icon, Mode=OneWay}"
                                         SourceRequested="{x:Bind help:IconProvider.SourceRequested16}" />
                                 </local:DockItemControl.Icon>
@@ -164,7 +166,9 @@
                                         Width="20"
                                         Height="20"
                                         VerticalAlignment="Center"
+                                        DiagnosticScope="AddBand"
                                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                        RequestSite="Dock"
                                         SourceKey="{x:Bind IconViewModel, Mode=OneWay}"
                                         SourceRequested="{x:Bind help:IconProvider.SourceRequested20}" />
                                     <TextBlock

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/PinToDockDialogContent.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/PinToDockDialogContent.xaml
@@ -112,6 +112,8 @@
                             Width="16"
                             Height="16"
                             VerticalAlignment="Center"
+                            DiagnosticScope="PinPreview"
+                            RequestSite="Dock"
                             SourceRequested="{x:Bind help:IconProvider.SourceRequested20}" />
 
                         <!--  Text  -->

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/Controls/ImageContentViewer.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/Controls/ImageContentViewer.xaml
@@ -32,6 +32,8 @@
                         <controls:IconBox
                             x:Name="Image"
                             AutomationProperties.AccessibilityView="Raw"
+                            DiagnosticScope="Content"
+                            RequestSite="Image"
                             SourceKey="{x:Bind ViewModel.Image, Mode=OneWay}"
                             SourceRequested="{x:Bind help:IconProvider.SourceRequestedOriginal}" />
                     </Viewbox>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListItemsView.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListItemsView.xaml
@@ -361,7 +361,9 @@
                     Width="20"
                     Height="20"
                     AutomationProperties.AccessibilityView="Raw"
+                    DiagnosticScope="SingleRow"
                     Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    RequestSite="ListItem"
                     SourceKey="{x:Bind Icon, Mode=OneWay}"
                     SourceRequested="{x:Bind help:IconProvider.SourceRequested20}" />
 
@@ -473,7 +475,9 @@
                     Margin="0"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
+                    DiagnosticScope="SmallGrid"
                     Foreground="{ThemeResource TextFillColorPrimary}"
+                    RequestSite="ListItem"
                     SourceKey="{x:Bind Icon, Mode=OneWay}"
                     SourceRequested="{x:Bind help:IconProvider.SourceRequested32}" />
             </StackPanel>
@@ -501,7 +505,9 @@
                     VerticalAlignment="Center"
                     CharacterSpacing="12"
                     FontSize="14"
+                    DiagnosticScope="MediumGrid"
                     Foreground="{ThemeResource TextFillColorPrimary}"
+                    RequestSite="ListItem"
                     SourceKey="{x:Bind Icon, Mode=OneWay}"
                     SourceRequested="{x:Bind help:IconProvider.SourceRequested64}" />
                 <TextBlock
@@ -547,7 +553,9 @@
                         StretchDirection="Both">
                         <cpcontrols:IconBox
                             CornerRadius="4"
+                            DiagnosticScope="Gallery"
                             Foreground="{ThemeResource TextFillColorPrimary}"
+                            RequestSite="ListItem"
                             SourceKey="{x:Bind Icon, Mode=OneWay}"
                             SourceRequested="{x:Bind help:IconProvider.SourceRequested256}" />
                     </Viewbox>
@@ -686,7 +694,9 @@
                         Width="48"
                         Height="48"
                         Margin="8"
+                        DiagnosticScope="ListItems"
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        RequestSite="EmptyState"
                         SourceKey="{x:Bind ViewModel.EmptyContent.Icon, Mode=OneWay}"
                         SourceRequested="{x:Bind help:IconProvider.SourceRequested64}" />
                     <TextBlock

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ParametersPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ParametersPage.xaml
@@ -42,7 +42,9 @@
                                 Width="48"
                                 Height="48"
                                 Margin="8"
+                                DiagnosticScope="Command"
                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                RequestSite="Parameter"
                                 SourceKey="{x:Bind ViewModel.Command.Icon, Mode=OneWay}"
                                 SourceRequested="{x:Bind help:IconProvider.SourceRequested64}" />
                             <TextBlock

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/CachedIconSourceProvider.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/CachedIconSourceProvider.cs
@@ -29,16 +29,24 @@ internal sealed class CachedIconSourceProvider : IIconSourceProvider
     {
     }
 
-    public Task<IconSource?> GetIconSource(IconDataViewModel icon, double scale)
+    public Task<IconSource?> GetIconSource(IconDataViewModel icon, double scale, IconRequestMeasurement diagnostics = default)
     {
         var key = new IconCacheKey(icon, scale);
 
-        return _cache.TryGet(key, out var existingTask)
-            ? existingTask
-            : GetOrCreateSlowPath(key, icon, scale);
+        if (_cache.TryGet(key, out var existingTask))
+        {
+            diagnostics.RecordProviderResolution(IconProviderResolution.CacheHit, existingTask);
+            return existingTask;
+        }
+
+        return GetOrCreateSlowPath(key, icon, scale, diagnostics);
     }
 
-    private Task<IconSource?> GetOrCreateSlowPath(IconCacheKey key, IconDataViewModel icon, double scale)
+    private Task<IconSource?> GetOrCreateSlowPath(
+        IconCacheKey key,
+        IconDataViewModel icon,
+        double scale,
+        IconRequestMeasurement diagnostics)
     {
         var tcs = new TaskCompletionSource<IconSource?>(TaskCreationOptions.RunContinuationsAsynchronously);
         var task = tcs.Task;
@@ -46,8 +54,11 @@ internal sealed class CachedIconSourceProvider : IIconSourceProvider
         var pending = _inFlight.GetOrAdd(key, task);
         if (!ReferenceEquals(pending, task))
         {
+            diagnostics.RecordProviderResolution(IconProviderResolution.InFlight, pending);
             return pending;
         }
+
+        IconLoadMeasurement? loadDiagnostics = null;
 
         _ = task.ContinueWith(
             completed =>
@@ -70,20 +81,33 @@ internal sealed class CachedIconSourceProvider : IIconSourceProvider
 
         try
         {
+            var streamReference = icon.Data?.Unsafe;
+            loadDiagnostics = IconLoadDiagnostics.CreateLoad(
+                diagnostics,
+                icon.Icon,
+                streamReference is not null,
+                _iconSize.Width,
+                _iconSize.Height,
+                scale);
+            loadDiagnostics?.RegisterTask(task);
+            diagnostics.RecordProviderResolution(IconProviderResolution.NewLoad, loadDiagnostics);
+
             if (!_loader.TryEnqueueLoad(
                     icon.Icon,
                     icon.FontFamily,
-                    icon.Data?.Unsafe,
+                    streamReference,
                     _iconSize,
                     scale,
                     tcs,
-                    IconLoadPriority.Low))
+                    IconLoadPriority.Low,
+                    loadDiagnostics))
             {
                 tcs.TrySetException(new ObjectDisposedException(nameof(IIconLoaderService)));
             }
         }
         catch (Exception ex)
         {
+            loadDiagnostics?.Rejected();
             tcs.TrySetException(ex);
         }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IIconLoaderService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IIconLoaderService.cs
@@ -17,5 +17,6 @@ internal interface IIconLoaderService : IAsyncDisposable
         Size iconSize,
         double scale,
         TaskCompletionSource<IconSource?> tcs,
-        IconLoadPriority priority);
+        IconLoadPriority priority,
+        IconLoadMeasurement? diagnostics = null);
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IIconSourceProvider.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IIconSourceProvider.cs
@@ -9,5 +9,5 @@ namespace Microsoft.CmdPal.UI.Helpers;
 
 internal interface IIconSourceProvider
 {
-    Task<IconSource?> GetIconSource(IconDataViewModel icon, double scale);
+    Task<IconSource?> GetIconSource(IconDataViewModel icon, double scale, IconRequestMeasurement diagnostics = default);
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadDemandStage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadDemandStage.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+internal enum IconLoadDemandStage
+{
+    Unlinked,
+    BeforeEnqueue,
+    Queued,
+    WorkerActive,
+    Completed,
+    Rejected,
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadDiagnostics.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadDiagnostics.cs
@@ -1,0 +1,165 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using ManagedCommon;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media.Imaging;
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+/// <summary>
+/// Opt-in, process-local measurements for the CmdPal icon pipeline.
+/// No icon strings, paths, glyphs, application identifiers, or item data are recorded.
+/// Diagnostic scopes are static developer-authored labels.
+/// </summary>
+internal static class IconLoadDiagnostics
+{
+    private static readonly object ReportsLock = new();
+    private static readonly List<IconLoadDiagnosticsReport> Reports = [];
+    private static long _nextSessionId;
+    private static IconLoadDiagnosticsSession? _activeSession;
+
+    public static bool IsRecording => Volatile.Read(ref _activeSession) is not null;
+
+    public static long? ActiveSessionId => Volatile.Read(ref _activeSession)?.Id;
+
+    public static IReadOnlyList<IconLoadDiagnosticsReport> GetReports()
+    {
+        lock (ReportsLock)
+        {
+            return Reports.ToArray();
+        }
+    }
+
+    public static long Start()
+    {
+        var session = new IconLoadDiagnosticsSession(Interlocked.Increment(ref _nextSessionId));
+        Interlocked.Exchange(ref _activeSession, session)?.Stop();
+        return session.Id;
+    }
+
+    public static IconLoadDiagnosticsReport? StopAndCreateReport()
+    {
+        var session = Interlocked.Exchange(ref _activeSession, null);
+        if (session is null)
+        {
+            return null;
+        }
+
+        session.Stop();
+        var report = session.CreateReport();
+        lock (ReportsLock)
+        {
+            Reports.Add(report);
+        }
+
+        Logger.LogInfo(report.Text);
+
+        return report;
+    }
+
+    public static void Reset()
+    {
+        Interlocked.Exchange(ref _activeSession, null)?.Stop();
+        lock (ReportsLock)
+        {
+            Reports.Clear();
+        }
+    }
+
+    public static IconRequestMeasurement BeginRequest(IconRequestReason reason, double scale)
+    {
+        return BeginRequest(reason, scale, default);
+    }
+
+    public static IconRequestMeasurement BeginRequest(IconRequestReason reason, double scale, IconRequestOrigin origin)
+    {
+        var session = Volatile.Read(ref _activeSession);
+        return session is null
+            ? default
+            : session.BeginRequest(reason, scale, origin);
+    }
+
+    public static IconLoadMeasurement? CreateLoad(
+        IconRequestMeasurement request,
+        string? iconString,
+        bool hasStream,
+        double width,
+        double height,
+        double scale)
+    {
+        var session = request.Session ?? Volatile.Read(ref _activeSession);
+        if (session is null || !ReferenceEquals(session, Volatile.Read(ref _activeSession)))
+        {
+            return null;
+        }
+
+        return session.CreateLoad(ClassifyInput(iconString, hasStream), width, height, scale);
+    }
+
+    public static long BeginElementUpdate()
+    {
+        return Volatile.Read(ref _activeSession) is null ? 0 : Stopwatch.GetTimestamp();
+    }
+
+    public static void RecordElementUpdate(bool reused, IconSource? source, long startedAt)
+    {
+        var session = Volatile.Read(ref _activeSession);
+        if (session is null)
+        {
+            return;
+        }
+
+        var elapsedTicks = startedAt == 0 ? -1 : Stopwatch.GetTimestamp() - startedAt;
+        session.RecordElementUpdate(reused, ClassifyResult(source), elapsedTicks);
+    }
+
+    private static IconLoadInputKind ClassifyInput(string? iconString, bool hasStream)
+    {
+        if (!string.IsNullOrEmpty(iconString))
+        {
+            var path = iconString.AsSpan();
+            var comma = path.IndexOf(',');
+            if (comma >= 0)
+            {
+                path = path[..comma];
+            }
+
+            if (path.EndsWith(".exe", StringComparison.Ordinal)
+                || path.EndsWith(".dll", StringComparison.Ordinal)
+                || path.EndsWith(".lnk", StringComparison.Ordinal))
+            {
+                return IconLoadInputKind.ShellBinary;
+            }
+
+            return IconLoadInputKind.String;
+        }
+
+        return hasStream ? IconLoadInputKind.Stream : IconLoadInputKind.Empty;
+    }
+
+    internal static IconLoadResultKind ClassifyResult(IconSource? result)
+    {
+        try
+        {
+            return result switch
+            {
+                null => IconLoadResultKind.Empty,
+                FontIconSource font when font.FontFamily?.Source.StartsWith("Segoe UI Emoji", StringComparison.OrdinalIgnoreCase) == true => IconLoadResultKind.EmojiGlyph,
+                FontIconSource font when font.FontFamily?.Source.StartsWith("Segoe Fluent Icons", StringComparison.OrdinalIgnoreCase) == true => IconLoadResultKind.FluentGlyph,
+                FontIconSource => IconLoadResultKind.OtherGlyph,
+                ImageIconSource { ImageSource: SvgImageSource } => IconLoadResultKind.Svg,
+                ImageIconSource { ImageSource: SoftwareBitmapSource } => IconLoadResultKind.SoftwareBitmap,
+                ImageIconSource { ImageSource: BitmapImage } => IconLoadResultKind.Bitmap,
+                BitmapIconSource => IconLoadResultKind.Fallback,
+                _ => IconLoadResultKind.Other,
+            };
+        }
+        catch
+        {
+            return IconLoadResultKind.Other;
+        }
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadDiagnostics.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadDiagnostics.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using ManagedCommon;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Imaging;
 
@@ -33,9 +34,11 @@ internal static class IconLoadDiagnostics
         }
     }
 
-    public static long Start()
+    public static long Start(DispatcherQueue? dispatcherQueue = null)
     {
-        var session = new IconLoadDiagnosticsSession(Interlocked.Increment(ref _nextSessionId));
+        var session = new IconLoadDiagnosticsSession(
+            Interlocked.Increment(ref _nextSessionId),
+            dispatcherQueue);
         Interlocked.Exchange(ref _activeSession, session)?.Stop();
         return session.Id;
     }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadDiagnosticsReport.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadDiagnosticsReport.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+internal sealed record IconLoadDiagnosticsReport(
+    long SessionId,
+    DateTimeOffset StartedUtc,
+    DateTimeOffset EndedUtc,
+    TimeSpan Duration,
+    string Text);

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadDiagnosticsSession.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadDiagnosticsSession.cs
@@ -4,14 +4,20 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.CmdPal.UI.Controls;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.CmdPal.UI.Helpers;
 
+[SuppressMessage(
+    "Design",
+    "CA1001:Types that own disposable fields should be disposable",
+    Justification = "The diagnostics facade owns the session and always calls Stop. Avoid implementing a WinRT interface on this internal NativeAOT type.")]
 internal sealed class IconLoadDiagnosticsSession
 {
     private readonly object _stopLock = new();
@@ -32,6 +38,7 @@ internal sealed class IconLoadDiagnosticsSession
     private readonly DiagnosticHistogram _backgroundPreparationLatency = new();
     private readonly DiagnosticHistogram _dispatcherWaitLatency = new();
     private readonly DiagnosticHistogram _dispatcherWorkLatency = new();
+    private readonly DiagnosticHistogram _uiProbeWaitLatency = new();
     private readonly DiagnosticHistogram _elementUpdateLatency = new();
     private readonly InputKindMeasurements[] _inputKindMeasurements = CreateInputKindMeasurements();
     private readonly ElementKindMeasurements[] _elementKindMeasurements = CreateElementKindMeasurements();
@@ -44,9 +51,24 @@ internal sealed class IconLoadDiagnosticsSession
     private readonly ConcurrentDictionary<RequestOriginKey, RequestOriginMeasurements> _requestOriginMeasurements = new();
     private readonly long[] _invalidatedRequestLoadStages = new long[Enum.GetValues<IconLoadDemandStage>().Length];
     private readonly long[] _capacityInterferingSpeculativeStartsByInputKind = new long[Enum.GetValues<IconLoadInputKind>().Length];
+    private readonly long _processCpuStartedTicks;
+    private readonly long _managedAllocatedBytesStarted;
+    private readonly long _gcPauseStartedTicks;
+    private readonly int _gen0CollectionsStarted;
+    private readonly int _gen1CollectionsStarted;
+    private readonly int _gen2CollectionsStarted;
+    private readonly long _workingSetStartedBytes;
+    private readonly IconUiResponsivenessProbe? _uiResponsivenessProbe;
 
     private DateTimeOffset _stoppedUtc;
     private long _stoppedAt;
+    private long _processCpuStoppedTicks;
+    private long _managedAllocatedBytesStopped;
+    private long _gcPauseStoppedTicks;
+    private int _gen0CollectionsStopped;
+    private int _gen1CollectionsStopped;
+    private int _gen2CollectionsStopped;
+    private long _workingSetStoppedBytes;
     private long _nextRequestId;
     private long _nextLoadId;
     private long _requestsStarted;
@@ -73,13 +95,44 @@ internal sealed class IconLoadDiagnosticsSession
     private long _maximumActiveWorkers;
     private long _elementsCreated;
     private long _elementsReused;
+    private long _uiProbeEnqueued;
+    private long _uiProbeCompleted;
+    private long _uiProbeSkipped;
+    private long _uiProbeRejected;
 
     public long Id { get; }
 
-    internal IconLoadDiagnosticsSession(long id)
+    internal IconLoadDiagnosticsSession(long id, DispatcherQueue? dispatcherQueue = null)
     {
         Id = id;
+        _processCpuStartedTicks = GetProcessCpuTicks();
+        _managedAllocatedBytesStarted = GC.GetTotalAllocatedBytes(precise: false);
+        _gcPauseStartedTicks = GC.GetTotalPauseDuration().Ticks;
+        _gen0CollectionsStarted = GC.CollectionCount(0);
+        _gen1CollectionsStarted = GC.CollectionCount(1);
+        _gen2CollectionsStarted = GC.CollectionCount(2);
+        _workingSetStartedBytes = GetWorkingSetBytes();
+        if (dispatcherQueue is not null)
+        {
+            // The probe retains this session and starts RunAsync during construction. Keep its
+            // creation after all state used by RecordUiProbe* is initialized because a timer tick
+            // may call back as soon as RunAsync starts.
+            _uiResponsivenessProbe = new IconUiResponsivenessProbe(dispatcherQueue, this);
+        }
     }
+
+    internal void RecordUiProbeEnqueued() => Interlocked.Increment(ref _uiProbeEnqueued);
+
+    internal void RecordUiProbeCompleted(long elapsedTicks)
+    {
+        Interlocked.Increment(ref _uiProbeCompleted);
+        _uiProbeWaitLatency.Record(elapsedTicks);
+        IconLoadEventSource.Log.UiResponsivenessProbeCompleted(Id, ToMicroseconds(elapsedTicks));
+    }
+
+    internal void RecordUiProbeSkipped() => Interlocked.Increment(ref _uiProbeSkipped);
+
+    internal void RecordUiProbeRejected() => Interlocked.Increment(ref _uiProbeRejected);
 
     public IconRequestMeasurement BeginRequest(IconRequestReason reason, double scale, IconRequestOrigin origin)
     {
@@ -558,7 +611,16 @@ internal sealed class IconLoadDiagnosticsSession
             if (_stoppedAt == 0)
             {
                 _stoppedUtc = DateTimeOffset.UtcNow;
-                Volatile.Write(ref _stoppedAt, Stopwatch.GetTimestamp());
+                var stoppedAt = Stopwatch.GetTimestamp();
+                _uiResponsivenessProbe?.Stop();
+                _processCpuStoppedTicks = GetProcessCpuTicks();
+                _managedAllocatedBytesStopped = GC.GetTotalAllocatedBytes(precise: false);
+                _gcPauseStoppedTicks = GC.GetTotalPauseDuration().Ticks;
+                _gen0CollectionsStopped = GC.CollectionCount(0);
+                _gen1CollectionsStopped = GC.CollectionCount(1);
+                _gen2CollectionsStopped = GC.CollectionCount(2);
+                _workingSetStoppedBytes = GetWorkingSetBytes();
+                Volatile.Write(ref _stoppedAt, stoppedAt);
             }
         }
     }
@@ -569,12 +631,20 @@ internal sealed class IconLoadDiagnosticsSession
         var stoppedAt = Volatile.Read(ref _stoppedAt);
         var duration = TimeSpan.FromSeconds((stoppedAt - _startedAt) / (double)Stopwatch.Frequency);
 
-        var builder = new StringBuilder(2048);
+        var builder = new StringBuilder(4096);
         builder.AppendLine("CmdPal icon diagnostics");
         builder.Append("Session: ").AppendLine(Id.ToString(CultureInfo.InvariantCulture));
         builder.Append("Started UTC: ").AppendLine(_startedUtc.ToString("O", CultureInfo.InvariantCulture));
         builder.Append("Ended UTC: ").AppendLine(_stoppedUtc.ToString("O", CultureInfo.InvariantCulture));
         builder.Append("Duration: ").Append(FormatMilliseconds(stoppedAt - _startedAt)).AppendLine(" ms");
+        builder.AppendLine();
+
+        builder.AppendLine("Process work during session");
+        AppendProcessWorkMeasurements(builder, stoppedAt - _startedAt);
+        builder.AppendLine();
+
+        builder.AppendLine("UI responsiveness probe");
+        AppendUiResponsivenessMeasurements(builder);
         builder.AppendLine();
 
         builder.AppendLine("Requests");
@@ -630,6 +700,75 @@ internal sealed class IconLoadDiagnosticsSession
         builder.AppendLine("No icon strings, paths, glyphs, application identifiers, or item data are included. Diagnostic scopes are static developer labels.");
 
         return new IconLoadDiagnosticsReport(Id, _startedUtc, _stoppedUtc, duration, builder.ToString());
+    }
+
+    private void AppendProcessWorkMeasurements(StringBuilder builder, long durationTicks)
+    {
+        builder.AppendLine("  Definition: process-wide measurements include all CmdPal work during the session, not only icon loading.");
+
+        if (_processCpuStartedTicks < 0 || _processCpuStoppedTicks < 0)
+        {
+            builder.AppendLine("  Process CPU time: unavailable");
+        }
+        else
+        {
+            var cpuTicks = Math.Max(0, _processCpuStoppedTicks - _processCpuStartedTicks);
+            var cpuMilliseconds = TimeSpan.FromTicks(cpuTicks).TotalMilliseconds;
+            var durationMilliseconds = durationTicks * 1000D / Stopwatch.Frequency;
+            var equivalentCoreUtilization = durationMilliseconds <= 0
+                ? 0
+                : cpuMilliseconds * 100D / durationMilliseconds;
+            builder.Append("  Process CPU time: ")
+                .Append(cpuMilliseconds.ToString("0.###", CultureInfo.InvariantCulture))
+                .AppendLine(" ms");
+            builder.Append("  Equivalent logical-core utilization (100% = one fully busy logical core): ")
+                .Append(equivalentCoreUtilization.ToString("0.###", CultureInfo.InvariantCulture))
+                .AppendLine(" %");
+        }
+
+        var allocatedBytes = Math.Max(0, _managedAllocatedBytesStopped - _managedAllocatedBytesStarted);
+        builder.Append("  Managed allocations: ")
+            .Append(allocatedBytes.ToString(CultureInfo.InvariantCulture))
+            .Append(" bytes (")
+            .Append(FormatMebibytes(allocatedBytes))
+            .AppendLine(" MiB)");
+        AppendValue(builder, "Gen 0 collections", Math.Max(0, _gen0CollectionsStopped - _gen0CollectionsStarted));
+        AppendValue(builder, "Gen 1 collections", Math.Max(0, _gen1CollectionsStopped - _gen1CollectionsStarted));
+        AppendValue(builder, "Gen 2 collections", Math.Max(0, _gen2CollectionsStopped - _gen2CollectionsStarted));
+        builder.Append("  GC pause time: ")
+            .Append(TimeSpan.FromTicks(Math.Max(0, _gcPauseStoppedTicks - _gcPauseStartedTicks))
+                .TotalMilliseconds.ToString("0.###", CultureInfo.InvariantCulture))
+            .AppendLine(" ms");
+
+        if (_workingSetStartedBytes < 0 || _workingSetStoppedBytes < 0)
+        {
+            builder.AppendLine("  Working set: unavailable");
+        }
+        else
+        {
+            builder.Append("  Working set at start: ").Append(FormatMebibytes(_workingSetStartedBytes)).AppendLine(" MiB");
+            builder.Append("  Working set at stop: ").Append(FormatMebibytes(_workingSetStoppedBytes)).AppendLine(" MiB");
+            builder.Append("  Working set change: ")
+                .Append(FormatSignedMebibytes(_workingSetStoppedBytes - _workingSetStartedBytes))
+                .AppendLine(" MiB");
+        }
+    }
+
+    private void AppendUiResponsivenessMeasurements(StringBuilder builder)
+    {
+        builder.AppendLine("  Definition: a background clock posts at most one minimal normal-priority callback every 50 ms.");
+        builder.AppendLine("  Its delay measures how long executing dispatcher work blocks normal-priority responsiveness; it intentionally runs before queued low-priority icon callbacks.");
+        builder.AppendLine("  Use Dispatcher wait measurements for low-priority icon queue depth. This is a coarse signal, not frame time.");
+        builder.Append("  Enabled: ").AppendLine(_uiResponsivenessProbe is null ? "no" : "yes");
+        var enqueued = Volatile.Read(ref _uiProbeEnqueued);
+        var completed = Volatile.Read(ref _uiProbeCompleted);
+        var rejected = Volatile.Read(ref _uiProbeRejected);
+        AppendValue(builder, "Callbacks enqueued", enqueued);
+        AppendValue(builder, "Callbacks completed", completed);
+        AppendValue(builder, "Callbacks outstanding at stop", Math.Max(0, enqueued - completed - rejected));
+        AppendValue(builder, "Timer ticks skipped while a callback was pending", Volatile.Read(ref _uiProbeSkipped));
+        AppendValue(builder, "Callbacks rejected by DispatcherQueue", rejected);
+        _uiProbeWaitLatency.Append(builder, "Normal-priority queue wait");
     }
 
     private void AppendLoadDemandMeasurements(StringBuilder builder)
@@ -980,6 +1119,38 @@ internal sealed class IconLoadDiagnosticsSession
             current = previous;
         }
     }
+
+    private static long GetProcessCpuTicks()
+    {
+        try
+        {
+            using var process = Process.GetCurrentProcess();
+            return process.TotalProcessorTime.Ticks;
+        }
+        catch
+        {
+            return -1;
+        }
+    }
+
+    private static long GetWorkingSetBytes()
+    {
+        try
+        {
+            using var process = Process.GetCurrentProcess();
+            return process.WorkingSet64;
+        }
+        catch
+        {
+            return -1;
+        }
+    }
+
+    private static string FormatMebibytes(long bytes) =>
+        (bytes / (1024D * 1024D)).ToString("0.###", CultureInfo.InvariantCulture);
+
+    private static string FormatSignedMebibytes(long bytes) =>
+        (bytes / (1024D * 1024D)).ToString("+0.###;-0.###;0", CultureInfo.InvariantCulture);
 
     private static long ToMicroseconds(long ticks) => (long)(ticks * 1_000_000D / Stopwatch.Frequency);
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadDiagnosticsSession.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadDiagnosticsSession.cs
@@ -1,0 +1,1524 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Microsoft.CmdPal.UI.Controls;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+internal sealed class IconLoadDiagnosticsSession
+{
+    private readonly object _stopLock = new();
+    private readonly object _queueDemandLock = new();
+    private readonly DateTimeOffset _startedUtc = DateTimeOffset.UtcNow;
+    private readonly long _startedAt = Stopwatch.GetTimestamp();
+    private readonly long[] _requestStatuses = new long[Enum.GetValues<IconRequestStatus>().Length];
+    private readonly long[] _providerResolutions = new long[Enum.GetValues<IconProviderResolution>().Length];
+    private readonly long[] _inputKinds = new long[Enum.GetValues<IconLoadInputKind>().Length];
+    private readonly long[] _resultKinds = new long[Enum.GetValues<IconLoadResultKind>().Length];
+    private readonly DiagnosticHistogram[][] _requestLatencyByResolutionAndResult = CreateRequestMeasurements();
+    private readonly DiagnosticHistogram _requestLatency = new();
+    private readonly DiagnosticHistogram _loadLatency = new();
+    private readonly DiagnosticHistogram _directGlyphLatency = new();
+    private readonly DiagnosticHistogram _queueLatency = new();
+    private readonly DiagnosticHistogram _demandedQueueLatency = new();
+    private readonly DiagnosticHistogram _speculativeQueueLatency = new();
+    private readonly DiagnosticHistogram _backgroundPreparationLatency = new();
+    private readonly DiagnosticHistogram _dispatcherWaitLatency = new();
+    private readonly DiagnosticHistogram _dispatcherWorkLatency = new();
+    private readonly DiagnosticHistogram _elementUpdateLatency = new();
+    private readonly InputKindMeasurements[] _inputKindMeasurements = CreateInputKindMeasurements();
+    private readonly ElementKindMeasurements[] _elementKindMeasurements = CreateElementKindMeasurements();
+    private readonly ConditionalWeakTable<Task<IconSource?>, IconLoadMeasurement> _loadsByTask = new();
+    private readonly ConcurrentDictionary<long, RequestDemandState> _requestDemandStates = new();
+
+    // These lightweight states intentionally survive load completion so later cache hits can be
+    // attributed and the final per-load demand aggregates can be built without retaining icon tasks.
+    private readonly ConcurrentDictionary<long, LoadDemandState> _loadDemandStates = new();
+    private readonly ConcurrentDictionary<RequestOriginKey, RequestOriginMeasurements> _requestOriginMeasurements = new();
+    private readonly long[] _invalidatedRequestLoadStages = new long[Enum.GetValues<IconLoadDemandStage>().Length];
+    private readonly long[] _capacityInterferingSpeculativeStartsByInputKind = new long[Enum.GetValues<IconLoadInputKind>().Length];
+
+    private DateTimeOffset _stoppedUtc;
+    private long _stoppedAt;
+    private long _nextRequestId;
+    private long _nextLoadId;
+    private long _requestsStarted;
+    private long _loadsCreated;
+    private long _loadsRejected;
+    private long _directGlyphLoads;
+    private long _currentHighQueueDepth;
+    private long _currentLowQueueDepth;
+    private long _maximumHighQueueDepth;
+    private long _maximumLowQueueDepth;
+    private long _currentDemandedQueueDepth;
+    private long _currentSpeculativeQueueDepth;
+    private long _maximumDemandedQueueDepth;
+    private long _maximumSpeculativeQueueDepth;
+    private long _queuedDemandDemotions;
+    private long _queuedDemandPromotions;
+    private long _demandedWorkerStarts;
+    private long _speculativeWorkerStarts;
+    private long _speculativeStartsWithDemandedLoadsQueued;
+    private long _capacityInterferingSpeculativeStarts;
+    private long _demandedLoadsBeyondCapacityAtSpeculativeStarts;
+    private long _maximumDemandedLoadsBeyondCapacityAtSpeculativeStart;
+    private long _activeWorkers;
+    private long _maximumActiveWorkers;
+    private long _elementsCreated;
+    private long _elementsReused;
+
+    public long Id { get; }
+
+    internal IconLoadDiagnosticsSession(long id)
+    {
+        Id = id;
+    }
+
+    public IconRequestMeasurement BeginRequest(IconRequestReason reason, double scale, IconRequestOrigin origin)
+    {
+        origin = origin.Normalize();
+        var requestId = Interlocked.Increment(ref _nextRequestId);
+        Interlocked.Increment(ref _requestsStarted);
+        var originKey = new RequestOriginKey(origin.RequestSite, origin.DiagnosticScope);
+        var originMeasurements = _requestOriginMeasurements.GetOrAdd(originKey, static _ => new RequestOriginMeasurements());
+        originMeasurements.RecordStarted(origin.IconBoxId);
+        _requestDemandStates.TryAdd(requestId, new RequestDemandState(originMeasurements));
+        IconLoadEventSource.Log.RequestStarted(Id, requestId, (int)reason, scale);
+        IconLoadEventSource.Log.RequestOrigin(
+            Id,
+            requestId,
+            origin.IconBoxId,
+            (int)origin.RequestSite,
+            origin.DiagnosticScope);
+        return new IconRequestMeasurement(this, requestId, Stopwatch.GetTimestamp());
+    }
+
+    public IconLoadMeasurement CreateLoad(IconLoadInputKind inputKind, double width, double height, double scale)
+    {
+        var loadId = Interlocked.Increment(ref _nextLoadId);
+        Interlocked.Increment(ref _loadsCreated);
+        Interlocked.Increment(ref _inputKinds[(int)inputKind]);
+        _loadDemandStates.TryAdd(loadId, new LoadDemandState(this, loadId, inputKind));
+        IconLoadEventSource.Log.LoadCreated(Id, loadId, (int)inputKind, width, height, scale);
+        return new IconLoadMeasurement(this, loadId, inputKind);
+    }
+
+    public void RecordProviderResolution(long requestId, long loadId, IconProviderResolution resolution)
+    {
+        Interlocked.Increment(ref _providerResolutions[(int)resolution]);
+        if (_requestDemandStates.TryGetValue(requestId, out var requestState))
+        {
+            lock (requestState.SyncRoot)
+            {
+                requestState.Resolution = resolution;
+                requestState.LoadId = loadId;
+                requestState.OriginMeasurements.RecordProviderResolution(resolution);
+
+                if (loadId != 0 && _loadDemandStates.TryGetValue(loadId, out var demandState))
+                {
+                    var result = demandState.RecordResolution(
+                        resolution,
+                        requestState.Invalidated,
+                        requestState.InvalidatedAt);
+                    requestState.TracksLiveRequester = result.TracksLiveRequester;
+                    if (result.RetainedResultCacheHit)
+                    {
+                        IconLoadEventSource.Log.RetainedLoadCacheHit(Id, loadId, result.CacheHitsAfterCompletion);
+                    }
+
+                    if (requestState.Invalidated && !requestState.InvalidationAttributed)
+                    {
+                        RecordInvalidationAttribution(requestId, loadId, result.Stage, result.RemainingLiveRequesters);
+                        requestState.InvalidationAttributed = true;
+                    }
+                }
+                else if (requestState.Invalidated && !requestState.InvalidationAttributed)
+                {
+                    RecordInvalidationAttribution(requestId, 0, IconLoadDemandStage.Unlinked, 0);
+                    requestState.InvalidationAttributed = true;
+                }
+            }
+        }
+
+        IconLoadEventSource.Log.ProviderResolved(Id, requestId, loadId, (int)resolution);
+    }
+
+    public void InvalidateRequest(long requestId)
+    {
+        if (!_requestDemandStates.TryGetValue(requestId, out var requestState))
+        {
+            return;
+        }
+
+        lock (requestState.SyncRoot)
+        {
+            InvalidateRequest(requestId, requestState, Stopwatch.GetTimestamp());
+        }
+    }
+
+    public void RegisterLoad(Task<IconSource?> task, IconLoadMeasurement load)
+    {
+        _loadsByTask.Add(task, load);
+    }
+
+    public IconLoadMeasurement? FindLoad(Task<IconSource?> task)
+    {
+        return _loadsByTask.TryGetValue(task, out var load) ? load : null;
+    }
+
+    public void CompleteRequest(long requestId, IconRequestStatus status, IconLoadResultKind resultKind, long elapsedTicks)
+    {
+        Interlocked.Increment(ref _requestStatuses[(int)status]);
+        _requestLatency.Record(elapsedTicks);
+        IconLoadEventSource.Log.RequestCompleted(Id, requestId, (int)status, ToMicroseconds(elapsedTicks));
+
+        if (_requestDemandStates.TryRemove(requestId, out var requestState))
+        {
+            lock (requestState.SyncRoot)
+            {
+                requestState.OriginMeasurements.RecordCompleted(status, resultKind, elapsedTicks);
+
+                if (status == IconRequestStatus.Stale && !requestState.Invalidated)
+                {
+                    InvalidateRequest(requestId, requestState, Stopwatch.GetTimestamp());
+                }
+
+                if (requestState.TracksLiveRequester
+                    && requestState.LoadId != 0
+                    && _loadDemandStates.TryGetValue(requestState.LoadId, out var demandState))
+                {
+                    demandState.CompleteRequest();
+                    requestState.TracksLiveRequester = false;
+                }
+
+                if (requestState.Invalidated && !requestState.InvalidationAttributed)
+                {
+                    RecordInvalidationAttribution(requestId, 0, IconLoadDemandStage.Unlinked, 0);
+                    requestState.InvalidationAttributed = true;
+                }
+
+                if (requestState.Resolution is { } resolution)
+                {
+                    _requestLatencyByResolutionAndResult[(int)resolution][(int)resultKind].Record(elapsedTicks);
+                    IconLoadEventSource.Log.RequestAttributed(
+                        Id,
+                        requestId,
+                        (int)resolution,
+                        (int)resultKind,
+                        ToMicroseconds(elapsedTicks));
+                }
+            }
+        }
+    }
+
+    private void InvalidateRequest(long requestId, RequestDemandState requestState, long invalidatedAt)
+    {
+        if (requestState.Invalidated)
+        {
+            return;
+        }
+
+        requestState.Invalidated = true;
+        requestState.InvalidatedAt = invalidatedAt;
+
+        if (requestState.Resolution is null)
+        {
+            return;
+        }
+
+        if (requestState.LoadId != 0
+            && _loadDemandStates.TryGetValue(requestState.LoadId, out var demandState))
+        {
+            var result = demandState.InvalidateRequest(requestState.TracksLiveRequester, invalidatedAt);
+            requestState.TracksLiveRequester = false;
+            RecordInvalidationAttribution(
+                requestId,
+                requestState.LoadId,
+                result.Stage,
+                result.RemainingLiveRequesters);
+        }
+        else
+        {
+            RecordInvalidationAttribution(requestId, 0, IconLoadDemandStage.Unlinked, 0);
+        }
+
+        requestState.InvalidationAttributed = true;
+    }
+
+    private void RecordInvalidationAttribution(
+        long requestId,
+        long loadId,
+        IconLoadDemandStage stage,
+        int remainingLiveRequesters)
+    {
+        Interlocked.Increment(ref _invalidatedRequestLoadStages[(int)stage]);
+        IconLoadEventSource.Log.RequestInvalidated(
+            Id,
+            requestId,
+            loadId,
+            (int)stage,
+            remainingLiveRequesters);
+    }
+
+    public void RecordLoadEnqueued(long loadId, IconLoadPriority priority)
+    {
+        ref var currentDepth = ref (priority == IconLoadPriority.High
+            ? ref _currentHighQueueDepth
+            : ref _currentLowQueueDepth);
+        ref var maximumDepth = ref (priority == IconLoadPriority.High
+            ? ref _maximumHighQueueDepth
+            : ref _maximumLowQueueDepth);
+
+        var depth = Interlocked.Increment(ref currentDepth);
+        UpdateMaximum(ref maximumDepth, depth);
+        if (_loadDemandStates.TryGetValue(loadId, out var demandState))
+        {
+            demandState.MarkEnqueued();
+        }
+
+        IconLoadEventSource.Log.LoadEnqueued(Id, loadId, (int)priority, depth);
+    }
+
+    private void RecordDemandQueueEnqueued(long loadId, bool demanded)
+    {
+        long demandedDepth;
+        long speculativeDepth;
+        lock (_queueDemandLock)
+        {
+            if (demanded)
+            {
+                _currentDemandedQueueDepth++;
+                _maximumDemandedQueueDepth = Math.Max(_maximumDemandedQueueDepth, _currentDemandedQueueDepth);
+            }
+            else
+            {
+                _currentSpeculativeQueueDepth++;
+                _maximumSpeculativeQueueDepth = Math.Max(_maximumSpeculativeQueueDepth, _currentSpeculativeQueueDepth);
+            }
+
+            demandedDepth = _currentDemandedQueueDepth;
+            speculativeDepth = _currentSpeculativeQueueDepth;
+        }
+
+        var transition = demanded
+            ? IconLoadQueueDemandTransition.EnqueuedDemanded
+            : IconLoadQueueDemandTransition.EnqueuedSpeculative;
+        IconLoadEventSource.Log.LoadQueueDemandChanged(
+            Id,
+            loadId,
+            (int)transition,
+            demandedDepth,
+            speculativeDepth);
+    }
+
+    private void RecordQueuedDemandTransition(long loadId, bool becameDemanded)
+    {
+        long demandedDepth;
+        long speculativeDepth;
+        lock (_queueDemandLock)
+        {
+            if (becameDemanded)
+            {
+                Debug.Assert(_currentSpeculativeQueueDepth > 0, "A queued promotion requires a speculative load.");
+                _currentSpeculativeQueueDepth--;
+                _currentDemandedQueueDepth++;
+                _queuedDemandPromotions++;
+                _maximumDemandedQueueDepth = Math.Max(_maximumDemandedQueueDepth, _currentDemandedQueueDepth);
+            }
+            else
+            {
+                Debug.Assert(_currentDemandedQueueDepth > 0, "A queued demotion requires a demanded load.");
+                _currentDemandedQueueDepth--;
+                _currentSpeculativeQueueDepth++;
+                _queuedDemandDemotions++;
+                _maximumSpeculativeQueueDepth = Math.Max(_maximumSpeculativeQueueDepth, _currentSpeculativeQueueDepth);
+            }
+
+            demandedDepth = _currentDemandedQueueDepth;
+            speculativeDepth = _currentSpeculativeQueueDepth;
+        }
+
+        IconLoadEventSource.Log.LoadQueueDemandChanged(
+            Id,
+            loadId,
+            (int)(becameDemanded ? IconLoadQueueDemandTransition.Promoted : IconLoadQueueDemandTransition.Demoted),
+            demandedDepth,
+            speculativeDepth);
+    }
+
+    private void RecordDemandWorkerStarted(
+        long loadId,
+        IconLoadInputKind inputKind,
+        bool demanded,
+        long queueTicks,
+        long activeWorkers,
+        int workerCount)
+    {
+        long demandedDepth;
+        long speculativeDepth;
+        long demandedBeyondCapacity;
+        lock (_queueDemandLock)
+        {
+            if (demanded)
+            {
+                Debug.Assert(_currentDemandedQueueDepth > 0, "A demanded worker start requires a demanded queued load.");
+                _currentDemandedQueueDepth--;
+                _demandedWorkerStarts++;
+            }
+            else
+            {
+                Debug.Assert(_currentSpeculativeQueueDepth > 0, "A speculative worker start requires a speculative queued load.");
+                _currentSpeculativeQueueDepth--;
+                _speculativeWorkerStarts++;
+            }
+
+            demandedDepth = _currentDemandedQueueDepth;
+            speculativeDepth = _currentSpeculativeQueueDepth;
+            var remainingWorkerCapacity = Math.Max(0, workerCount - activeWorkers);
+            demandedBeyondCapacity = Math.Max(0, demandedDepth - remainingWorkerCapacity);
+
+            if (!demanded && demandedDepth > 0)
+            {
+                _speculativeStartsWithDemandedLoadsQueued++;
+            }
+
+            if (!demanded && demandedBeyondCapacity > 0)
+            {
+                _capacityInterferingSpeculativeStarts++;
+                _demandedLoadsBeyondCapacityAtSpeculativeStarts += demandedBeyondCapacity;
+                _maximumDemandedLoadsBeyondCapacityAtSpeculativeStart = Math.Max(
+                    _maximumDemandedLoadsBeyondCapacityAtSpeculativeStart,
+                    demandedBeyondCapacity);
+                _capacityInterferingSpeculativeStartsByInputKind[(int)inputKind]++;
+            }
+        }
+
+        if (demanded)
+        {
+            _demandedQueueLatency.Record(queueTicks);
+        }
+        else
+        {
+            _speculativeQueueLatency.Record(queueTicks);
+        }
+
+        IconLoadEventSource.Log.LoadDemandAtWorkerStart(
+            Id,
+            loadId,
+            demanded ? 1 : 0,
+            demandedDepth,
+            speculativeDepth,
+            activeWorkers,
+            workerCount,
+            demandedBeyondCapacity);
+    }
+
+    public void RecordLoadRejected(long loadId)
+    {
+        Interlocked.Increment(ref _loadsRejected);
+        if (_loadDemandStates.TryGetValue(loadId, out var demandState))
+        {
+            demandState.MarkRejected();
+        }
+
+        IconLoadEventSource.Log.LoadRejected(Id, loadId);
+    }
+
+    public void RecordWorkerStarted(
+        long loadId,
+        IconLoadInputKind inputKind,
+        IconLoadPriority priority,
+        long queueTicks,
+        int workerCount)
+    {
+        if (priority == IconLoadPriority.High)
+        {
+            Interlocked.Decrement(ref _currentHighQueueDepth);
+        }
+        else
+        {
+            Interlocked.Decrement(ref _currentLowQueueDepth);
+        }
+
+        _queueLatency.Record(queueTicks);
+        _inputKindMeasurements[(int)inputKind].QueueLatency.Record(queueTicks);
+        var activeWorkers = Interlocked.Increment(ref _activeWorkers);
+        UpdateMaximum(ref _maximumActiveWorkers, activeWorkers);
+        if (_loadDemandStates.TryGetValue(loadId, out var demandState))
+        {
+            var demandResult = demandState.MarkWorkerStarted(
+                Stopwatch.GetTimestamp(),
+                queueTicks,
+                activeWorkers,
+                Math.Max(1, workerCount));
+            if (demandResult.StartedWithoutLiveRequester)
+            {
+                IconLoadEventSource.Log.LoadStartedWithoutRequester(
+                    Id,
+                    loadId,
+                    ToMicroseconds(demandResult.WithoutRequesterElapsedTicks));
+            }
+        }
+
+        IconLoadEventSource.Log.LoadStarted(Id, loadId, ToMicroseconds(queueTicks), activeWorkers);
+    }
+
+    public void RecordBackgroundPreparation(long loadId, IconLoadInputKind inputKind, long elapsedTicks)
+    {
+        _backgroundPreparationLatency.Record(elapsedTicks);
+        _inputKindMeasurements[(int)inputKind].BackgroundPreparationLatency.Record(elapsedTicks);
+        IconLoadEventSource.Log.BackgroundPreparationCompleted(Id, loadId, ToMicroseconds(elapsedTicks));
+    }
+
+    public void RecordDispatcherWait(long loadId, IconLoadInputKind inputKind, long elapsedTicks)
+    {
+        _dispatcherWaitLatency.Record(elapsedTicks);
+        _inputKindMeasurements[(int)inputKind].DispatcherWaitLatency.Record(elapsedTicks);
+        IconLoadEventSource.Log.DispatcherWaitCompleted(Id, loadId, ToMicroseconds(elapsedTicks));
+    }
+
+    public void RecordDispatcherWork(long loadId, IconLoadInputKind inputKind, long elapsedTicks)
+    {
+        _dispatcherWorkLatency.Record(elapsedTicks);
+        _inputKindMeasurements[(int)inputKind].DispatcherWorkLatency.Record(elapsedTicks);
+        IconLoadEventSource.Log.DispatcherWorkCompleted(Id, loadId, ToMicroseconds(elapsedTicks));
+    }
+
+    public void RecordLoadCompleted(long loadId, IconLoadInputKind inputKind, IconLoadResultKind resultKind, long elapsedTicks)
+    {
+        Interlocked.Decrement(ref _activeWorkers);
+        Interlocked.Increment(ref _resultKinds[(int)resultKind]);
+        _loadLatency.Record(elapsedTicks);
+        _inputKindMeasurements[(int)inputKind].LoadLatency.Record(elapsedTicks);
+        RecordDemandCompletion(loadId, resultKind);
+        IconLoadEventSource.Log.LoadCompleted(Id, loadId, (int)resultKind, ToMicroseconds(elapsedTicks));
+    }
+
+    public void RecordDirectGlyphCompleted(long loadId, IconLoadInputKind inputKind, IconLoadResultKind resultKind, long elapsedTicks)
+    {
+        Interlocked.Increment(ref _directGlyphLoads);
+        Interlocked.Increment(ref _resultKinds[(int)resultKind]);
+        _directGlyphLatency.Record(elapsedTicks);
+        _inputKindMeasurements[(int)inputKind].DirectGlyphLatency.Record(elapsedTicks);
+        RecordDemandCompletion(loadId, resultKind);
+        IconLoadEventSource.Log.DirectGlyphLoadCompleted(Id, loadId, (int)resultKind, ToMicroseconds(elapsedTicks));
+    }
+
+    private void RecordDemandCompletion(long loadId, IconLoadResultKind resultKind)
+    {
+        if (!_loadDemandStates.TryGetValue(loadId, out var demandState))
+        {
+            return;
+        }
+
+        var demandResult = demandState.MarkCompleted(Stopwatch.GetTimestamp(), resultKind);
+        if (demandResult.CompletedWithoutLiveRequester)
+        {
+            IconLoadEventSource.Log.LoadCompletedWithoutRequester(
+                Id,
+                loadId,
+                ToMicroseconds(demandResult.WithoutRequesterElapsedTicks));
+        }
+    }
+
+    public void RecordElementUpdate(bool reused, IconLoadResultKind resultKind, long elapsedTicks)
+    {
+        var measurements = _elementKindMeasurements[(int)resultKind];
+        if (reused)
+        {
+            Interlocked.Increment(ref _elementsReused);
+        }
+        else
+        {
+            Interlocked.Increment(ref _elementsCreated);
+        }
+
+        measurements.Record(reused);
+        _elementUpdateLatency.Record(elapsedTicks);
+        measurements.UpdateLatency.Record(elapsedTicks);
+        IconLoadEventSource.Log.ElementUpdated(Id, (int)resultKind, reused, ToMicroseconds(elapsedTicks));
+    }
+
+    public void Stop()
+    {
+        if (Volatile.Read(ref _stoppedAt) != 0)
+        {
+            return;
+        }
+
+        lock (_stopLock)
+        {
+            if (_stoppedAt == 0)
+            {
+                _stoppedUtc = DateTimeOffset.UtcNow;
+                Volatile.Write(ref _stoppedAt, Stopwatch.GetTimestamp());
+            }
+        }
+    }
+
+    public IconLoadDiagnosticsReport CreateReport()
+    {
+        Stop();
+        var stoppedAt = Volatile.Read(ref _stoppedAt);
+        var duration = TimeSpan.FromSeconds((stoppedAt - _startedAt) / (double)Stopwatch.Frequency);
+
+        var builder = new StringBuilder(2048);
+        builder.AppendLine("CmdPal icon diagnostics");
+        builder.Append("Session: ").AppendLine(Id.ToString(CultureInfo.InvariantCulture));
+        builder.Append("Started UTC: ").AppendLine(_startedUtc.ToString("O", CultureInfo.InvariantCulture));
+        builder.Append("Ended UTC: ").AppendLine(_stoppedUtc.ToString("O", CultureInfo.InvariantCulture));
+        builder.Append("Duration: ").Append(FormatMilliseconds(stoppedAt - _startedAt)).AppendLine(" ms");
+        builder.AppendLine();
+
+        builder.AppendLine("Requests");
+        AppendValue(builder, "Started", Volatile.Read(ref _requestsStarted));
+        AppendEnumCounts<IconRequestStatus>(builder, _requestStatuses);
+        AppendValue(builder, "Outstanding at stop", Math.Max(0, Volatile.Read(ref _requestsStarted) - Sum(_requestStatuses)));
+        _requestLatency.Append(builder, "Request to completion");
+        builder.AppendLine();
+
+        builder.AppendLine("Provider resolution");
+        AppendEnumCounts<IconProviderResolution>(builder, _providerResolutions);
+        AppendRequestMeasurements(builder);
+        builder.AppendLine();
+
+        builder.AppendLine("Request origins");
+        AppendRequestOriginMeasurements(builder);
+        builder.AppendLine();
+
+        builder.AppendLine("Loads");
+        AppendValue(builder, "Created", Volatile.Read(ref _loadsCreated));
+        AppendValue(builder, "Rejected", Volatile.Read(ref _loadsRejected));
+        AppendValue(builder, "Direct glyph loads", Volatile.Read(ref _directGlyphLoads));
+        AppendValue(builder, "Active at stop", Math.Max(0, Volatile.Read(ref _activeWorkers)));
+        AppendValue(builder, "Maximum active workers", Volatile.Read(ref _maximumActiveWorkers));
+        AppendValue(builder, "Maximum high queue depth", Volatile.Read(ref _maximumHighQueueDepth));
+        AppendValue(builder, "Maximum low queue depth", Volatile.Read(ref _maximumLowQueueDepth));
+        _loadLatency.Append(builder, "Enqueue to completion");
+        _directGlyphLatency.Append(builder, "Direct glyph construction");
+        _queueLatency.Append(builder, "Queue wait");
+        _backgroundPreparationLatency.Append(builder, "Background preparation");
+        _dispatcherWaitLatency.Append(builder, "Dispatcher wait");
+        _dispatcherWorkLatency.Append(builder, "Dispatcher callback wall time");
+        builder.AppendLine();
+
+        builder.AppendLine("Load demand");
+        AppendLoadDemandMeasurements(builder);
+        builder.AppendLine();
+
+        builder.AppendLine("Input kinds");
+        AppendInputKindMeasurements(builder);
+        builder.AppendLine();
+
+        builder.AppendLine("New-load result kinds");
+        AppendEnumCounts<IconLoadResultKind>(builder, _resultKinds);
+        builder.AppendLine();
+
+        builder.AppendLine("Icon elements");
+        AppendValue(builder, "Created", Volatile.Read(ref _elementsCreated));
+        AppendValue(builder, "Reused", Volatile.Read(ref _elementsReused));
+        _elementUpdateLatency.Append(builder, "Update wall time");
+        AppendElementKindMeasurements(builder);
+        builder.AppendLine();
+        builder.AppendLine("No icon strings, paths, glyphs, application identifiers, or item data are included. Diagnostic scopes are static developer labels.");
+
+        return new IconLoadDiagnosticsReport(Id, _startedUtc, _stoppedUtc, duration, builder.ToString());
+    }
+
+    private void AppendLoadDemandMeasurements(StringBuilder builder)
+    {
+        var linkedRequests = 0L;
+        var loadsWithMultipleRequesters = 0L;
+        var maximumLiveRequesters = 0L;
+        var loadsWithLiveRequesters = 0L;
+        var liveRequesters = 0L;
+        var lostBeforeEnqueue = 0L;
+        var lostWhileQueued = 0L;
+        var lostWhileWorkerActive = 0L;
+        var loadsWhereDemandReturned = 0L;
+        var workersStartedWithoutRequester = 0L;
+        var loadsCompletedWithoutRequester = 0L;
+        var retainedLoadsLaterCacheHit = 0L;
+        var retainedResultCacheHits = 0L;
+        var unrequestedCompletionsByInputKind = new long[Enum.GetValues<IconLoadInputKind>().Length];
+        var unrequestedCompletionsByResultKind = new long[Enum.GetValues<IconLoadResultKind>().Length];
+        DiagnosticHistogram withoutRequesterToWorkerStart = new();
+        DiagnosticHistogram withoutRequesterToCompletion = new();
+
+        foreach (var demandState in _loadDemandStates.Values)
+        {
+            var snapshot = demandState.CreateSnapshot();
+            linkedRequests += snapshot.LinkedRequests;
+            if (snapshot.MaximumLiveRequesters > 1)
+            {
+                loadsWithMultipleRequesters++;
+            }
+
+            maximumLiveRequesters = Math.Max(maximumLiveRequesters, snapshot.MaximumLiveRequesters);
+            if (snapshot.LiveRequesters > 0)
+            {
+                loadsWithLiveRequesters++;
+                liveRequesters += snapshot.LiveRequesters;
+            }
+
+            lostBeforeEnqueue += snapshot.LostLastRequesterBeforeEnqueue;
+            lostWhileQueued += snapshot.LostLastRequesterWhileQueued;
+            lostWhileWorkerActive += snapshot.LostLastRequesterWhileWorkerActive;
+            if (snapshot.DemandReturnedBeforeCompletion)
+            {
+                loadsWhereDemandReturned++;
+            }
+
+            if (snapshot.WorkerStartedWithoutLiveRequester)
+            {
+                workersStartedWithoutRequester++;
+                withoutRequesterToWorkerStart.Record(snapshot.WithoutRequesterToWorkerStartTicks);
+            }
+
+            if (snapshot.CompletedWithoutLiveRequester)
+            {
+                loadsCompletedWithoutRequester++;
+                unrequestedCompletionsByInputKind[(int)snapshot.InputKind]++;
+                if (snapshot.ResultKind is { } resultKind)
+                {
+                    unrequestedCompletionsByResultKind[(int)resultKind]++;
+                }
+
+                withoutRequesterToCompletion.Record(snapshot.WithoutRequesterToCompletionTicks);
+            }
+
+            if (snapshot.CacheHitsAfterUnrequestedCompletion > 0)
+            {
+                retainedLoadsLaterCacheHit++;
+                retainedResultCacheHits += snapshot.CacheHitsAfterUnrequestedCompletion;
+            }
+        }
+
+        AppendValue(builder, "Requests linked to session loads", linkedRequests);
+        AppendValue(builder, "Loads with multiple simultaneous requesters", loadsWithMultipleRequesters);
+        AppendValue(builder, "Maximum simultaneous requesters per load", maximumLiveRequesters);
+        AppendValue(builder, "Loads with live requesters at stop", loadsWithLiveRequesters);
+        AppendValue(builder, "Live requesters at stop", liveRequesters);
+        AppendDemandQueueMeasurements(builder);
+        builder.AppendLine("  Invalidated requests by load stage");
+        AppendEnumCounts<IconLoadDemandStage>(builder, _invalidatedRequestLoadStages, "    ");
+        builder.AppendLine("  Demand-loss events after the last requester was invalidated");
+        AppendValue(builder, "Before enqueue", lostBeforeEnqueue, "    ");
+        AppendValue(builder, "Queued", lostWhileQueued, "    ");
+        AppendValue(builder, "Worker active", lostWhileWorkerActive, "    ");
+        AppendValue(builder, "Loads where demand returned before completion", loadsWhereDemandReturned);
+        AppendValue(builder, "Workers started with no live requester", workersStartedWithoutRequester);
+        AppendValue(builder, "Loads completed with no live requester", loadsCompletedWithoutRequester);
+        builder.AppendLine("  Loads completed with no live requester by input kind");
+        AppendEnumCounts<IconLoadInputKind>(builder, unrequestedCompletionsByInputKind, "    ");
+        builder.AppendLine("  Loads completed with no live requester by result kind");
+        AppendEnumCounts<IconLoadResultKind>(builder, unrequestedCompletionsByResultKind, "    ");
+        AppendValue(builder, "Completed-without-requester loads later cache-hit", retainedLoadsLaterCacheHit);
+        AppendValue(builder, "Later cache-hit requests", retainedResultCacheHits);
+        withoutRequesterToWorkerStart.Append(builder, "No-requester time before worker start");
+        withoutRequesterToCompletion.Append(builder, "No-requester time before load completion");
+        builder.AppendLine("  Scope: UI IconBox requests and IconLoader work only. Extension-side icon-data preloading, including CommandItemViewModel.InitializeProperties reading AppListItem.Icon for Installed Apps, occurs before this pipeline and is not classified as unused work.");
+    }
+
+    private void AppendDemandQueueMeasurements(StringBuilder builder)
+    {
+        long currentDemandedQueueDepth;
+        long currentSpeculativeQueueDepth;
+        long maximumDemandedQueueDepth;
+        long maximumSpeculativeQueueDepth;
+        long queuedDemandDemotions;
+        long queuedDemandPromotions;
+        long demandedWorkerStarts;
+        long speculativeWorkerStarts;
+        long speculativeStartsWithDemandedLoadsQueued;
+        long capacityInterferingSpeculativeStarts;
+        long demandedLoadsBeyondCapacityAtSpeculativeStarts;
+        long maximumDemandedLoadsBeyondCapacityAtSpeculativeStart;
+        long[] capacityInterferingSpeculativeStartsByInputKind;
+
+        lock (_queueDemandLock)
+        {
+            currentDemandedQueueDepth = _currentDemandedQueueDepth;
+            currentSpeculativeQueueDepth = _currentSpeculativeQueueDepth;
+            maximumDemandedQueueDepth = _maximumDemandedQueueDepth;
+            maximumSpeculativeQueueDepth = _maximumSpeculativeQueueDepth;
+            queuedDemandDemotions = _queuedDemandDemotions;
+            queuedDemandPromotions = _queuedDemandPromotions;
+            demandedWorkerStarts = _demandedWorkerStarts;
+            speculativeWorkerStarts = _speculativeWorkerStarts;
+            speculativeStartsWithDemandedLoadsQueued = _speculativeStartsWithDemandedLoadsQueued;
+            capacityInterferingSpeculativeStarts = _capacityInterferingSpeculativeStarts;
+            demandedLoadsBeyondCapacityAtSpeculativeStarts = _demandedLoadsBeyondCapacityAtSpeculativeStarts;
+            maximumDemandedLoadsBeyondCapacityAtSpeculativeStart = _maximumDemandedLoadsBeyondCapacityAtSpeculativeStart;
+            capacityInterferingSpeculativeStartsByInputKind = [.. _capacityInterferingSpeculativeStartsByInputKind];
+        }
+
+        builder.AppendLine("  Demand-aware queue view");
+        builder.AppendLine("    Definition: demanded means at least one live IconBox request; speculative means none. Measurement only; scheduling is unchanged.");
+        AppendValue(builder, "Demanded loads queued at stop", currentDemandedQueueDepth, "    ");
+        AppendValue(builder, "Speculative loads queued at stop", currentSpeculativeQueueDepth, "    ");
+        AppendValue(builder, "Maximum demanded queue depth", maximumDemandedQueueDepth, "    ");
+        AppendValue(builder, "Maximum speculative queue depth", maximumSpeculativeQueueDepth, "    ");
+        AppendValue(builder, "Queued demotions after demand loss", queuedDemandDemotions, "    ");
+        AppendValue(builder, "Queued promotions after demand returned", queuedDemandPromotions, "    ");
+        AppendValue(builder, "Workers started demanded", demandedWorkerStarts, "    ");
+        AppendValue(builder, "Workers started speculative", speculativeWorkerStarts, "    ");
+        AppendValue(builder, "Speculative starts with demanded loads queued", speculativeStartsWithDemandedLoadsQueued, "    ");
+        AppendValue(builder, "Speculative starts leaving demanded loads beyond remaining worker capacity", capacityInterferingSpeculativeStarts, "    ");
+        AppendValue(builder, "Demanded loads beyond remaining capacity across those starts", demandedLoadsBeyondCapacityAtSpeculativeStarts, "    ");
+        AppendValue(builder, "Maximum demanded loads beyond remaining capacity at one start", maximumDemandedLoadsBeyondCapacityAtSpeculativeStart, "    ");
+        builder.AppendLine("    Capacity-interfering speculative starts by input kind");
+        AppendEnumCounts<IconLoadInputKind>(builder, capacityInterferingSpeculativeStartsByInputKind, "      ");
+        _demandedQueueLatency.Append(builder, "Demanded queue wait", "    ");
+        _speculativeQueueLatency.Append(builder, "Speculative queue wait", "    ");
+    }
+
+    private void AppendInputKindMeasurements(StringBuilder builder)
+    {
+        var values = Enum.GetValues<IconLoadInputKind>();
+        for (var i = 0; i < values.Length; i++)
+        {
+            var count = Volatile.Read(ref _inputKinds[i]);
+            builder.Append("  ").Append(values[i]).Append(": ").AppendLine(count.ToString(CultureInfo.InvariantCulture));
+            if (count == 0)
+            {
+                continue;
+            }
+
+            var measurements = _inputKindMeasurements[i];
+            measurements.LoadLatency.Append(builder, "Enqueue to completion", "    ");
+            measurements.DirectGlyphLatency.Append(builder, "Direct glyph construction", "    ");
+            measurements.QueueLatency.Append(builder, "Queue wait", "    ");
+            measurements.BackgroundPreparationLatency.Append(builder, "Background preparation", "    ");
+            measurements.DispatcherWaitLatency.Append(builder, "Dispatcher wait", "    ");
+            measurements.DispatcherWorkLatency.Append(builder, "Dispatcher callback wall time", "    ");
+        }
+    }
+
+    private void AppendRequestMeasurements(StringBuilder builder)
+    {
+        builder.AppendLine("  Request to completion by resolution and result");
+        var resolutions = Enum.GetValues<IconProviderResolution>();
+        var resultKinds = Enum.GetValues<IconLoadResultKind>();
+        var attributedRequests = 0L;
+
+        for (var resolutionIndex = 0; resolutionIndex < resolutions.Length; resolutionIndex++)
+        {
+            builder.Append("    ").AppendLine(resolutions[resolutionIndex].ToString());
+            var hasSamples = false;
+            for (var resultIndex = 0; resultIndex < resultKinds.Length; resultIndex++)
+            {
+                var histogram = _requestLatencyByResolutionAndResult[resolutionIndex][resultIndex];
+                var count = histogram.Count;
+                if (count == 0)
+                {
+                    continue;
+                }
+
+                hasSamples = true;
+                attributedRequests += count;
+                histogram.Append(builder, resultKinds[resultIndex].ToString(), "      ");
+            }
+
+            if (!hasSamples)
+            {
+                builder.AppendLine("      no completed requests");
+            }
+        }
+
+        var unattributedRequests = Math.Max(0, Sum(_requestStatuses) - attributedRequests);
+        if (unattributedRequests > 0)
+        {
+            builder.Append("    Unattributed completed requests: ")
+                .AppendLine(unattributedRequests.ToString(CultureInfo.InvariantCulture));
+        }
+    }
+
+    private void AppendRequestOriginMeasurements(StringBuilder builder)
+    {
+        var origins = _requestOriginMeasurements.ToArray();
+        Array.Sort(
+            origins,
+            static (left, right) =>
+            {
+                var siteComparison = left.Key.RequestSite.CompareTo(right.Key.RequestSite);
+                return siteComparison != 0
+                    ? siteComparison
+                    : StringComparer.Ordinal.Compare(left.Key.DiagnosticScope, right.Key.DiagnosticScope);
+            });
+
+        if (origins.Length == 0)
+        {
+            builder.AppendLine("  no requests");
+            return;
+        }
+
+        foreach (var origin in origins)
+        {
+            builder.Append("  ").Append(origin.Key.RequestSite);
+            if (!string.IsNullOrEmpty(origin.Key.DiagnosticScope))
+            {
+                builder.Append(" / ").Append(origin.Key.DiagnosticScope);
+            }
+
+            builder.AppendLine();
+            origin.Value.Append(builder);
+        }
+
+        builder.AppendLine("  Individual process-local IconBox IDs are available in RequestOrigin ETW events.");
+    }
+
+    private void AppendElementKindMeasurements(StringBuilder builder)
+    {
+        var resultKinds = Enum.GetValues<IconLoadResultKind>();
+        var wroteHeader = false;
+        for (var i = 0; i < resultKinds.Length; i++)
+        {
+            var measurements = _elementKindMeasurements[i];
+            var created = measurements.Created;
+            var reused = measurements.Reused;
+            if (created + reused == 0)
+            {
+                continue;
+            }
+
+            if (!wroteHeader)
+            {
+                builder.AppendLine("  By source kind");
+                wroteHeader = true;
+            }
+
+            builder.Append("    ").Append(resultKinds[i])
+                .Append(": created=").Append(created.ToString(CultureInfo.InvariantCulture))
+                .Append(", reused=").AppendLine(reused.ToString(CultureInfo.InvariantCulture));
+            measurements.UpdateLatency.Append(builder, "Update wall time", "      ");
+        }
+    }
+
+    private static InputKindMeasurements[] CreateInputKindMeasurements()
+    {
+        var measurements = new InputKindMeasurements[Enum.GetValues<IconLoadInputKind>().Length];
+        for (var i = 0; i < measurements.Length; i++)
+        {
+            measurements[i] = new InputKindMeasurements();
+        }
+
+        return measurements;
+    }
+
+    private static DiagnosticHistogram[][] CreateRequestMeasurements()
+    {
+        var measurements = new DiagnosticHistogram[Enum.GetValues<IconProviderResolution>().Length][];
+        var resultKindCount = Enum.GetValues<IconLoadResultKind>().Length;
+        for (var resolutionIndex = 0; resolutionIndex < measurements.Length; resolutionIndex++)
+        {
+            measurements[resolutionIndex] = new DiagnosticHistogram[resultKindCount];
+            for (var resultIndex = 0; resultIndex < resultKindCount; resultIndex++)
+            {
+                measurements[resolutionIndex][resultIndex] = new DiagnosticHistogram();
+            }
+        }
+
+        return measurements;
+    }
+
+    private static ElementKindMeasurements[] CreateElementKindMeasurements()
+    {
+        var measurements = new ElementKindMeasurements[Enum.GetValues<IconLoadResultKind>().Length];
+        for (var i = 0; i < measurements.Length; i++)
+        {
+            measurements[i] = new ElementKindMeasurements();
+        }
+
+        return measurements;
+    }
+
+    private static void AppendEnumCounts<TEnum>(StringBuilder builder, long[] counts, string indentation = "  ")
+        where TEnum : struct, Enum
+    {
+        var values = Enum.GetValues<TEnum>();
+        for (var i = 0; i < values.Length; i++)
+        {
+            AppendValue(builder, values[i].ToString(), Volatile.Read(ref counts[i]), indentation);
+        }
+    }
+
+    private static void AppendValue(StringBuilder builder, string name, long value, string indentation = "  ")
+    {
+        builder.Append(indentation).Append(name).Append(": ").AppendLine(value.ToString(CultureInfo.InvariantCulture));
+    }
+
+    private static long Sum(long[] values)
+    {
+        var total = 0L;
+        for (var i = 0; i < values.Length; i++)
+        {
+            total += Volatile.Read(ref values[i]);
+        }
+
+        return total;
+    }
+
+    private static void UpdateMaximum(ref long maximum, long value)
+    {
+        var current = Volatile.Read(ref maximum);
+        while (value > current)
+        {
+            var previous = Interlocked.CompareExchange(ref maximum, value, current);
+            if (previous == current)
+            {
+                return;
+            }
+
+            current = previous;
+        }
+    }
+
+    private static long ToMicroseconds(long ticks) => (long)(ticks * 1_000_000D / Stopwatch.Frequency);
+
+    private static string FormatMilliseconds(long ticks) => (ticks * 1000D / Stopwatch.Frequency).ToString("0.###", CultureInfo.InvariantCulture);
+
+    private readonly record struct LoadResolutionResult(
+        bool TracksLiveRequester,
+        bool RetainedResultCacheHit,
+        int CacheHitsAfterCompletion,
+        IconLoadDemandStage Stage,
+        int RemainingLiveRequesters);
+
+    private readonly record struct LoadRequestInvalidationResult(
+        IconLoadDemandStage Stage,
+        int RemainingLiveRequesters);
+
+    private readonly record struct LoadWorkerDemandResult(
+        bool StartedWithoutLiveRequester,
+        long WithoutRequesterElapsedTicks);
+
+    private readonly record struct LoadCompletionDemandResult(
+        bool CompletedWithoutLiveRequester,
+        long WithoutRequesterElapsedTicks);
+
+    private readonly record struct LoadDemandSnapshot(
+        IconLoadInputKind InputKind,
+        IconLoadResultKind? ResultKind,
+        int LinkedRequests,
+        int MaximumLiveRequesters,
+        int LiveRequesters,
+        int LostLastRequesterBeforeEnqueue,
+        int LostLastRequesterWhileQueued,
+        int LostLastRequesterWhileWorkerActive,
+        bool DemandReturnedBeforeCompletion,
+        bool WorkerStartedWithoutLiveRequester,
+        long WithoutRequesterToWorkerStartTicks,
+        bool CompletedWithoutLiveRequester,
+        long WithoutRequesterToCompletionTicks,
+        int CacheHitsAfterUnrequestedCompletion);
+
+    private readonly record struct RequestOriginKey(
+        IconRequestSite RequestSite,
+        string DiagnosticScope);
+
+    private sealed class RequestOriginMeasurements
+    {
+        private readonly long[] _requestStatuses = new long[Enum.GetValues<IconRequestStatus>().Length];
+        private readonly long[] _providerResolutions = new long[Enum.GetValues<IconProviderResolution>().Length];
+        private readonly long[] _resultKinds = new long[Enum.GetValues<IconLoadResultKind>().Length];
+        private readonly DiagnosticHistogram[] _requestLatencyByStatus = CreateStatusMeasurements();
+        private readonly DiagnosticHistogram _requestLatency = new();
+        private readonly ConcurrentDictionary<long, byte> _iconBoxIds = new();
+        private long _requestsStarted;
+
+        public void RecordStarted(long iconBoxId)
+        {
+            Interlocked.Increment(ref _requestsStarted);
+            if (iconBoxId > 0)
+            {
+                _iconBoxIds.TryAdd(iconBoxId, 0);
+            }
+        }
+
+        public void RecordProviderResolution(IconProviderResolution resolution)
+        {
+            Interlocked.Increment(ref _providerResolutions[(int)resolution]);
+        }
+
+        public void RecordCompleted(IconRequestStatus status, IconLoadResultKind resultKind, long elapsedTicks)
+        {
+            Interlocked.Increment(ref _requestStatuses[(int)status]);
+            Interlocked.Increment(ref _resultKinds[(int)resultKind]);
+            _requestLatency.Record(elapsedTicks);
+            _requestLatencyByStatus[(int)status].Record(elapsedTicks);
+        }
+
+        public void Append(StringBuilder builder)
+        {
+            var requestsStarted = Volatile.Read(ref _requestsStarted);
+            AppendValue(builder, "Icon boxes", _iconBoxIds.Count, "    ");
+            AppendValue(builder, "Started", requestsStarted, "    ");
+            AppendEnumCounts<IconRequestStatus>(builder, _requestStatuses, "    ");
+            AppendValue(builder, "Outstanding at stop", Math.Max(0, requestsStarted - Sum(_requestStatuses)), "    ");
+            builder.AppendLine("    Provider resolution");
+            AppendEnumCounts<IconProviderResolution>(builder, _providerResolutions, "      ");
+            builder.AppendLine("    Result kinds");
+            AppendNonzeroResultKinds(builder);
+            _requestLatency.Append(builder, "Request to completion", "    ");
+            builder.AppendLine("    Request to completion by status");
+
+            var statuses = Enum.GetValues<IconRequestStatus>();
+            var wroteStatus = false;
+            for (var i = 0; i < statuses.Length; i++)
+            {
+                var histogram = _requestLatencyByStatus[i];
+                if (histogram.Count == 0)
+                {
+                    continue;
+                }
+
+                wroteStatus = true;
+                histogram.Append(builder, statuses[i].ToString(), "      ");
+            }
+
+            if (!wroteStatus)
+            {
+                builder.AppendLine("      no completed requests");
+            }
+        }
+
+        private void AppendNonzeroResultKinds(StringBuilder builder)
+        {
+            var resultKinds = Enum.GetValues<IconLoadResultKind>();
+            var wroteResult = false;
+            for (var i = 0; i < resultKinds.Length; i++)
+            {
+                var count = Volatile.Read(ref _resultKinds[i]);
+                if (count == 0)
+                {
+                    continue;
+                }
+
+                wroteResult = true;
+                AppendValue(builder, resultKinds[i].ToString(), count, "      ");
+            }
+
+            if (!wroteResult)
+            {
+                builder.AppendLine("      no completed requests");
+            }
+        }
+
+        private static DiagnosticHistogram[] CreateStatusMeasurements()
+        {
+            var measurements = new DiagnosticHistogram[Enum.GetValues<IconRequestStatus>().Length];
+            for (var i = 0; i < measurements.Length; i++)
+            {
+                measurements[i] = new DiagnosticHistogram();
+            }
+
+            return measurements;
+        }
+    }
+
+    private sealed class RequestDemandState
+    {
+        public RequestDemandState(RequestOriginMeasurements originMeasurements)
+        {
+            OriginMeasurements = originMeasurements;
+        }
+
+        public object SyncRoot { get; } = new();
+
+        public RequestOriginMeasurements OriginMeasurements { get; }
+
+        public IconProviderResolution? Resolution { get; set; }
+
+        public long LoadId { get; set; }
+
+        public bool TracksLiveRequester { get; set; }
+
+        public bool Invalidated { get; set; }
+
+        public long InvalidatedAt { get; set; }
+
+        public bool InvalidationAttributed { get; set; }
+    }
+
+    private sealed class LoadDemandState
+    {
+        private readonly object _lock = new();
+        private readonly IconLoadDiagnosticsSession _session;
+        private readonly long _loadId;
+        private readonly IconLoadInputKind _inputKind;
+        private IconLoadDemandStage _stage = IconLoadDemandStage.BeforeEnqueue;
+        private IconLoadResultKind? _resultKind;
+        private int _linkedRequests;
+        private int _liveRequesters;
+        private int _maximumLiveRequesters;
+        private int _lostLastRequesterBeforeEnqueue;
+        private int _lostLastRequesterWhileQueued;
+        private int _lostLastRequesterWhileWorkerActive;
+        private bool _withoutRequester;
+        private long _withoutRequesterAt;
+        private bool _demandReturnedBeforeCompletion;
+        private bool _workerStartedWithoutLiveRequester;
+        private long _withoutRequesterToWorkerStartTicks = -1;
+        private bool _completedWithoutLiveRequester;
+        private long _withoutRequesterToCompletionTicks = -1;
+        private int _cacheHitsAfterUnrequestedCompletion;
+
+        public LoadDemandState(IconLoadDiagnosticsSession session, long loadId, IconLoadInputKind inputKind)
+        {
+            _session = session;
+            _loadId = loadId;
+            _inputKind = inputKind;
+        }
+
+        public LoadResolutionResult RecordResolution(
+            IconProviderResolution resolution,
+            bool requesterInvalidated,
+            long invalidatedAt)
+        {
+            lock (_lock)
+            {
+                _linkedRequests++;
+                var wasDemanded = _liveRequesters > 0;
+
+                var retainedResultCacheHit = false;
+                if (resolution == IconProviderResolution.CacheHit && _completedWithoutLiveRequester)
+                {
+                    _cacheHitsAfterUnrequestedCompletion++;
+                    retainedResultCacheHit = true;
+                }
+
+                var tracksLiveRequester = false;
+                if (resolution is IconProviderResolution.NewLoad or IconProviderResolution.InFlight
+                    && _stage is not IconLoadDemandStage.Completed and not IconLoadDemandStage.Rejected)
+                {
+                    if (requesterInvalidated)
+                    {
+                        BeginWithoutRequester(invalidatedAt);
+                    }
+                    else
+                    {
+                        if (_liveRequesters == 0 && _withoutRequester)
+                        {
+                            _withoutRequester = false;
+                            _withoutRequesterAt = 0;
+                            _demandReturnedBeforeCompletion = true;
+                        }
+
+                        _liveRequesters++;
+                        _maximumLiveRequesters = Math.Max(_maximumLiveRequesters, _liveRequesters);
+                        tracksLiveRequester = true;
+                    }
+                }
+
+                if (!wasDemanded && _liveRequesters > 0 && _stage == IconLoadDemandStage.Queued)
+                {
+                    _session.RecordQueuedDemandTransition(_loadId, becameDemanded: true);
+                }
+
+                return new LoadResolutionResult(
+                    tracksLiveRequester,
+                    retainedResultCacheHit,
+                    _cacheHitsAfterUnrequestedCompletion,
+                    _stage,
+                    _liveRequesters);
+            }
+        }
+
+        public LoadRequestInvalidationResult InvalidateRequest(bool tracksLiveRequester, long invalidatedAt)
+        {
+            lock (_lock)
+            {
+                var wasDemanded = _liveRequesters > 0;
+                if (tracksLiveRequester && _liveRequesters > 0)
+                {
+                    _liveRequesters--;
+                }
+
+                if (tracksLiveRequester)
+                {
+                    BeginWithoutRequester(invalidatedAt);
+                }
+
+                if (wasDemanded && _liveRequesters == 0 && _stage == IconLoadDemandStage.Queued)
+                {
+                    _session.RecordQueuedDemandTransition(_loadId, becameDemanded: false);
+                }
+
+                return new LoadRequestInvalidationResult(_stage, _liveRequesters);
+            }
+        }
+
+        public void CompleteRequest()
+        {
+            lock (_lock)
+            {
+                if (_liveRequesters > 0)
+                {
+                    _liveRequesters--;
+                }
+            }
+        }
+
+        private void BeginWithoutRequester(long invalidatedAt)
+        {
+            if (_liveRequesters != 0
+                || _withoutRequester
+                || _stage is IconLoadDemandStage.Completed or IconLoadDemandStage.Rejected)
+            {
+                return;
+            }
+
+            _withoutRequester = true;
+            _withoutRequesterAt = invalidatedAt;
+            switch (_stage)
+            {
+                case IconLoadDemandStage.BeforeEnqueue:
+                    _lostLastRequesterBeforeEnqueue++;
+                    break;
+                case IconLoadDemandStage.Queued:
+                    _lostLastRequesterWhileQueued++;
+                    break;
+                case IconLoadDemandStage.WorkerActive:
+                    _lostLastRequesterWhileWorkerActive++;
+                    break;
+            }
+        }
+
+        public void MarkEnqueued()
+        {
+            lock (_lock)
+            {
+                if (_stage == IconLoadDemandStage.BeforeEnqueue)
+                {
+                    _stage = IconLoadDemandStage.Queued;
+                    _session.RecordDemandQueueEnqueued(_loadId, _liveRequesters > 0);
+                }
+            }
+        }
+
+        public void MarkRejected()
+        {
+            lock (_lock)
+            {
+                Debug.Assert(_stage == IconLoadDemandStage.BeforeEnqueue, "Only a load that was never queued can be rejected.");
+                if (_stage == IconLoadDemandStage.BeforeEnqueue)
+                {
+                    _stage = IconLoadDemandStage.Rejected;
+                }
+            }
+        }
+
+        public LoadWorkerDemandResult MarkWorkerStarted(
+            long startedAt,
+            long queueTicks,
+            long activeWorkers,
+            int workerCount)
+        {
+            lock (_lock)
+            {
+                if (_stage == IconLoadDemandStage.Queued)
+                {
+                    _session.RecordDemandWorkerStarted(
+                        _loadId,
+                        _inputKind,
+                        _liveRequesters > 0,
+                        queueTicks,
+                        activeWorkers,
+                        workerCount);
+                }
+
+                if (_stage is not IconLoadDemandStage.Completed and not IconLoadDemandStage.Rejected)
+                {
+                    _stage = IconLoadDemandStage.WorkerActive;
+                }
+
+                if (_withoutRequester && _liveRequesters == 0)
+                {
+                    _workerStartedWithoutLiveRequester = true;
+                    _withoutRequesterToWorkerStartTicks = Math.Max(0, startedAt - _withoutRequesterAt);
+                }
+
+                return new LoadWorkerDemandResult(
+                    _workerStartedWithoutLiveRequester,
+                    _withoutRequesterToWorkerStartTicks);
+            }
+        }
+
+        public LoadCompletionDemandResult MarkCompleted(long completedAt, IconLoadResultKind resultKind)
+        {
+            lock (_lock)
+            {
+                _stage = IconLoadDemandStage.Completed;
+                _resultKind = resultKind;
+                if (_withoutRequester && _liveRequesters == 0)
+                {
+                    _completedWithoutLiveRequester = true;
+                    _withoutRequesterToCompletionTicks = Math.Max(0, completedAt - _withoutRequesterAt);
+                }
+
+                return new LoadCompletionDemandResult(
+                    _completedWithoutLiveRequester,
+                    _withoutRequesterToCompletionTicks);
+            }
+        }
+
+        public LoadDemandSnapshot CreateSnapshot()
+        {
+            lock (_lock)
+            {
+                return new LoadDemandSnapshot(
+                    _inputKind,
+                    _resultKind,
+                    _linkedRequests,
+                    _maximumLiveRequesters,
+                    _liveRequesters,
+                    _lostLastRequesterBeforeEnqueue,
+                    _lostLastRequesterWhileQueued,
+                    _lostLastRequesterWhileWorkerActive,
+                    _demandReturnedBeforeCompletion,
+                    _workerStartedWithoutLiveRequester,
+                    _withoutRequesterToWorkerStartTicks,
+                    _completedWithoutLiveRequester,
+                    _withoutRequesterToCompletionTicks,
+                    _cacheHitsAfterUnrequestedCompletion);
+            }
+        }
+    }
+
+    private sealed class InputKindMeasurements
+    {
+        public DiagnosticHistogram LoadLatency { get; } = new();
+
+        public DiagnosticHistogram DirectGlyphLatency { get; } = new();
+
+        public DiagnosticHistogram QueueLatency { get; } = new();
+
+        public DiagnosticHistogram BackgroundPreparationLatency { get; } = new();
+
+        public DiagnosticHistogram DispatcherWaitLatency { get; } = new();
+
+        public DiagnosticHistogram DispatcherWorkLatency { get; } = new();
+    }
+
+    private sealed class ElementKindMeasurements
+    {
+        private long _created;
+        private long _reused;
+
+        public long Created => Volatile.Read(ref _created);
+
+        public long Reused => Volatile.Read(ref _reused);
+
+        public DiagnosticHistogram UpdateLatency { get; } = new();
+
+        public void Record(bool reused)
+        {
+            if (reused)
+            {
+                Interlocked.Increment(ref _reused);
+            }
+            else
+            {
+                Interlocked.Increment(ref _created);
+            }
+        }
+    }
+
+    private sealed class DiagnosticHistogram
+    {
+        private static readonly double[] BucketUpperBoundsMilliseconds =
+        [
+            0.1,
+            0.25,
+            0.5,
+            1,
+            2,
+            4,
+            8,
+            16,
+            33,
+            50,
+            100,
+            250,
+            500,
+            1000,
+            2500,
+            5000,
+        ];
+
+        private readonly long[] _buckets = new long[BucketUpperBoundsMilliseconds.Length + 1];
+        private long _count;
+        private long _sumTicks;
+        private long _maximumTicks;
+
+        public long Count => Volatile.Read(ref _count);
+
+        public void Record(long elapsedTicks)
+        {
+            if (elapsedTicks < 0)
+            {
+                return;
+            }
+
+            var elapsedMilliseconds = elapsedTicks * 1000D / Stopwatch.Frequency;
+            var bucket = 0;
+            while (bucket < BucketUpperBoundsMilliseconds.Length && elapsedMilliseconds > BucketUpperBoundsMilliseconds[bucket])
+            {
+                bucket++;
+            }
+
+            Interlocked.Increment(ref _buckets[bucket]);
+            Interlocked.Increment(ref _count);
+            Interlocked.Add(ref _sumTicks, elapsedTicks);
+            UpdateMaximum(ref _maximumTicks, elapsedTicks);
+        }
+
+        public void Append(StringBuilder builder, string name, string indentation = "  ")
+        {
+            var count = Volatile.Read(ref _count);
+            builder.Append(indentation).Append(name).Append(": ");
+            if (count == 0)
+            {
+                builder.AppendLine("no samples");
+                return;
+            }
+
+            var average = Volatile.Read(ref _sumTicks) * 1000D / Stopwatch.Frequency / count;
+            builder
+                .Append("count=").Append(count.ToString(CultureInfo.InvariantCulture))
+                .Append(", avg=").Append(average.ToString("0.###", CultureInfo.InvariantCulture)).Append(" ms")
+                .Append(", p50=").Append(FormatPercentile(count, 0.50))
+                .Append(", p95=").Append(FormatPercentile(count, 0.95))
+                .Append(", p99=").Append(FormatPercentile(count, 0.99))
+                .Append(", max=").Append(FormatMilliseconds(Volatile.Read(ref _maximumTicks))).AppendLine(" ms");
+        }
+
+        private string FormatPercentile(long count, double percentile)
+        {
+            var target = (long)Math.Ceiling(count * percentile);
+            var cumulative = 0L;
+            for (var i = 0; i < _buckets.Length; i++)
+            {
+                cumulative += Volatile.Read(ref _buckets[i]);
+                if (cumulative < target)
+                {
+                    continue;
+                }
+
+                return i < BucketUpperBoundsMilliseconds.Length
+                    ? $"<={BucketUpperBoundsMilliseconds[i].ToString("0.###", CultureInfo.InvariantCulture)} ms"
+                    : $">{BucketUpperBoundsMilliseconds[^1].ToString("0.###", CultureInfo.InvariantCulture)} ms";
+            }
+
+            return "n/a";
+        }
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadEventSource.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadEventSource.cs
@@ -1,0 +1,270 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.Tracing;
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+[EventSource(Name = "Microsoft.PowerToys.CmdPal.IconLoading")]
+internal sealed partial class IconLoadEventSource : EventSource
+{
+    public static IconLoadEventSource Log { get; } = new();
+
+    private IconLoadEventSource()
+    {
+    }
+
+    [Event(1, Level = EventLevel.Informational)]
+    public void RequestStarted(long sessionId, long requestId, int reason, double scale)
+    {
+        if (!IsEnabled())
+        {
+            return;
+        }
+
+        WriteEvent(1, sessionId, requestId, reason, scale);
+    }
+
+    [Event(2, Level = EventLevel.Informational)]
+    public void ProviderResolved(long sessionId, long requestId, long loadId, int resolution)
+    {
+        if (!IsEnabled())
+        {
+            return;
+        }
+
+        WriteEvent(2, sessionId, requestId, loadId, resolution);
+    }
+
+    [Event(3, Level = EventLevel.Informational)]
+    public void RequestCompleted(long sessionId, long requestId, int status, long elapsedMicroseconds)
+    {
+        if (!IsEnabled())
+        {
+            return;
+        }
+
+        WriteEvent(3, sessionId, requestId, status, elapsedMicroseconds);
+    }
+
+    [Event(4, Level = EventLevel.Informational)]
+    public void LoadCreated(long sessionId, long loadId, int inputKind, double width, double height, double scale)
+    {
+        if (!IsEnabled())
+        {
+            return;
+        }
+
+        WriteEvent(4, sessionId, loadId, inputKind, width, height, scale);
+    }
+
+    [Event(5, Level = EventLevel.Informational)]
+    public void LoadEnqueued(long sessionId, long loadId, int priority, long queueDepth)
+    {
+        if (!IsEnabled())
+        {
+            return;
+        }
+
+        WriteEvent(5, sessionId, loadId, priority, queueDepth);
+    }
+
+    [Event(6, Level = EventLevel.Warning)]
+    public void LoadRejected(long sessionId, long loadId)
+    {
+        if (!IsEnabled())
+        {
+            return;
+        }
+
+        WriteEvent(6, sessionId, loadId);
+    }
+
+    [Event(7, Level = EventLevel.Informational)]
+    public void LoadStarted(long sessionId, long loadId, long queueMicroseconds, long activeWorkers)
+    {
+        if (!IsEnabled())
+        {
+            return;
+        }
+
+        WriteEvent(7, sessionId, loadId, queueMicroseconds, activeWorkers);
+    }
+
+    [Event(8, Level = EventLevel.Informational)]
+    public void LoadCompleted(long sessionId, long loadId, int resultKind, long elapsedMicroseconds)
+    {
+        if (!IsEnabled())
+        {
+            return;
+        }
+
+        WriteEvent(8, sessionId, loadId, resultKind, elapsedMicroseconds);
+    }
+
+    [Event(9, Level = EventLevel.Informational)]
+    public void BackgroundPreparationCompleted(long sessionId, long loadId, long elapsedMicroseconds)
+    {
+        if (!IsEnabled())
+        {
+            return;
+        }
+
+        WriteEvent(9, sessionId, loadId, elapsedMicroseconds);
+    }
+
+    [Event(10, Level = EventLevel.Informational)]
+    public void DispatcherWaitCompleted(long sessionId, long loadId, long elapsedMicroseconds)
+    {
+        if (!IsEnabled())
+        {
+            return;
+        }
+
+        WriteEvent(10, sessionId, loadId, elapsedMicroseconds);
+    }
+
+    [Event(11, Level = EventLevel.Informational)]
+    public void DispatcherWorkCompleted(long sessionId, long loadId, long elapsedMicroseconds)
+    {
+        if (!IsEnabled())
+        {
+            return;
+        }
+
+        WriteEvent(11, sessionId, loadId, elapsedMicroseconds);
+    }
+
+    [Event(12, Level = EventLevel.Informational)]
+    public void DirectGlyphLoadCompleted(long sessionId, long loadId, int resultKind, long elapsedMicroseconds)
+    {
+        if (!IsEnabled())
+        {
+            return;
+        }
+
+        WriteEvent(12, sessionId, loadId, resultKind, elapsedMicroseconds);
+    }
+
+    [Event(13, Level = EventLevel.Informational)]
+    public void ElementUpdated(long sessionId, int resultKind, bool reused, long elapsedMicroseconds)
+    {
+        if (!IsEnabled())
+        {
+            return;
+        }
+
+        WriteEvent(13, sessionId, resultKind, reused, elapsedMicroseconds);
+    }
+
+    [Event(14, Level = EventLevel.Informational)]
+    public void RequestAttributed(long sessionId, long requestId, int resolution, int resultKind, long elapsedMicroseconds)
+    {
+        if (!IsEnabled())
+        {
+            return;
+        }
+
+        WriteEvent(14, sessionId, requestId, resolution, resultKind, elapsedMicroseconds);
+    }
+
+    [Event(15, Level = EventLevel.Informational)]
+    public void RequestInvalidated(long sessionId, long requestId, long loadId, int loadStage, int remainingLiveRequesters)
+    {
+        if (!IsEnabled())
+        {
+            return;
+        }
+
+        WriteEvent(15, sessionId, requestId, loadId, loadStage, remainingLiveRequesters);
+    }
+
+    [Event(16, Level = EventLevel.Informational)]
+    public void LoadStartedWithoutRequester(long sessionId, long loadId, long elapsedMicroseconds)
+    {
+        if (!IsEnabled())
+        {
+            return;
+        }
+
+        WriteEvent(16, sessionId, loadId, elapsedMicroseconds);
+    }
+
+    [Event(17, Level = EventLevel.Informational)]
+    public void LoadCompletedWithoutRequester(long sessionId, long loadId, long elapsedMicroseconds)
+    {
+        if (!IsEnabled())
+        {
+            return;
+        }
+
+        WriteEvent(17, sessionId, loadId, elapsedMicroseconds);
+    }
+
+    [Event(18, Level = EventLevel.Informational)]
+    public void RetainedLoadCacheHit(long sessionId, long loadId, int cacheHitRequests)
+    {
+        if (!IsEnabled())
+        {
+            return;
+        }
+
+        WriteEvent(18, sessionId, loadId, cacheHitRequests);
+    }
+
+    [Event(19, Level = EventLevel.Informational)]
+    public void RequestOrigin(long sessionId, long requestId, long iconBoxId, int requestSite, string diagnosticScope)
+    {
+        if (!IsEnabled())
+        {
+            return;
+        }
+
+        WriteEvent(19, sessionId, requestId, iconBoxId, requestSite, diagnosticScope);
+    }
+
+    [Event(20, Level = EventLevel.Informational)]
+    public void LoadQueueDemandChanged(
+        long sessionId,
+        long loadId,
+        int transition,
+        long demandedQueueDepth,
+        long speculativeQueueDepth)
+    {
+        if (!IsEnabled())
+        {
+            return;
+        }
+
+        WriteEvent(20, sessionId, loadId, transition, demandedQueueDepth, speculativeQueueDepth);
+    }
+
+    [Event(21, Level = EventLevel.Informational)]
+    public void LoadDemandAtWorkerStart(
+        long sessionId,
+        long loadId,
+        int demanded,
+        long demandedQueueDepth,
+        long speculativeQueueDepth,
+        long activeWorkers,
+        int workerCount,
+        long demandedBeyondCapacity)
+    {
+        if (!IsEnabled())
+        {
+            return;
+        }
+
+        WriteEvent(
+            21,
+            sessionId,
+            loadId,
+            demanded,
+            demandedQueueDepth,
+            speculativeQueueDepth,
+            activeWorkers,
+            workerCount,
+            demandedBeyondCapacity);
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadEventSource.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadEventSource.cs
@@ -267,4 +267,17 @@ internal sealed partial class IconLoadEventSource : EventSource
             workerCount,
             demandedBeyondCapacity);
     }
+
+    // Event IDs follow the final grouped diagnostics schema and intentionally remain sparse so
+    // independently reviewable layers can land without changing an event's published identity.
+    [Event(37, Level = EventLevel.Informational)]
+    public void UiResponsivenessProbeCompleted(long sessionId, long elapsedMicroseconds)
+    {
+        if (!IsEnabled())
+        {
+            return;
+        }
+
+        WriteEvent(37, sessionId, elapsedMicroseconds);
+    }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadInputKind.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadInputKind.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+internal enum IconLoadInputKind
+{
+    Empty,
+    String,
+    ShellBinary,
+    Stream,
+    SpecializedAppIcon,
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadMeasurement.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadMeasurement.cs
@@ -1,0 +1,191 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+internal sealed class IconLoadMeasurement
+{
+    private enum EnqueueState
+    {
+        Pending,
+        Enqueued,
+        Rejected,
+        Faulted,
+    }
+
+    private readonly long _createdAt = Stopwatch.GetTimestamp();
+    private long _enqueuedAt;
+    private int _queuePriority;
+    private int _enqueueState;
+    private int _started;
+    private int _completed;
+    private int _resultKind;
+    private TaskCompletionSource<bool>? _enqueueWaiter;
+
+    internal IconLoadDiagnosticsSession Session { get; }
+
+    internal long Id { get; }
+
+    internal IconLoadInputKind InputKind { get; }
+
+    internal IconLoadMeasurement(IconLoadDiagnosticsSession session, long id, IconLoadInputKind inputKind)
+    {
+        Session = session;
+        Id = id;
+        InputKind = inputKind;
+    }
+
+    public void Enqueued(IconLoadPriority priority)
+    {
+        _queuePriority = (int)priority;
+        _enqueuedAt = Stopwatch.GetTimestamp();
+        try
+        {
+            Session.RecordLoadEnqueued(Id, priority);
+            var published = PublishEnqueueState(EnqueueState.Enqueued);
+            Debug.Assert(published, "A load can only be enqueued once.");
+        }
+        catch
+        {
+            PublishEnqueueState(EnqueueState.Faulted);
+            throw;
+        }
+    }
+
+    public void RegisterTask(Task<IconSource?> task)
+    {
+        Session.RegisterLoad(task, this);
+    }
+
+    public void Rejected()
+    {
+        if (!PublishEnqueueState(EnqueueState.Rejected))
+        {
+            return;
+        }
+
+        if (Interlocked.Exchange(ref _completed, 1) == 0)
+        {
+            Session.RecordLoadRejected(Id);
+        }
+    }
+
+    public async ValueTask<bool> WorkerStartingAsync(int workerCount = 1)
+    {
+        if (!await WaitForEnqueueAsync().ConfigureAwait(false))
+        {
+            return false;
+        }
+
+        if (Interlocked.Exchange(ref _started, 1) != 0)
+        {
+            return false;
+        }
+
+        var now = Stopwatch.GetTimestamp();
+        Session.RecordWorkerStarted(Id, InputKind, (IconLoadPriority)_queuePriority, now - _enqueuedAt, workerCount);
+        return true;
+    }
+
+    public long BeginBackgroundPreparation() => Stopwatch.GetTimestamp();
+
+    public void CompleteBackgroundPreparation(long startedAt)
+    {
+        Session.RecordBackgroundPreparation(Id, InputKind, Stopwatch.GetTimestamp() - startedAt);
+    }
+
+    public long BeginDispatcherWait() => Stopwatch.GetTimestamp();
+
+    public long DispatcherStarted(long enqueuedAt)
+    {
+        var now = Stopwatch.GetTimestamp();
+        Session.RecordDispatcherWait(Id, InputKind, now - enqueuedAt);
+        return now;
+    }
+
+    public void DispatcherCompleted(long startedAt)
+    {
+        Session.RecordDispatcherWork(Id, InputKind, Stopwatch.GetTimestamp() - startedAt);
+    }
+
+    public void SetResult(IconSource? result)
+    {
+        _resultKind = (int)IconLoadDiagnostics.ClassifyResult(result);
+    }
+
+    public void CompleteDirectGlyph(IconSource? result)
+    {
+        SetResult(result);
+        if (Interlocked.Exchange(ref _completed, 1) == 0)
+        {
+            Session.RecordDirectGlyphCompleted(
+                Id,
+                InputKind,
+                (IconLoadResultKind)_resultKind,
+                Stopwatch.GetTimestamp() - _createdAt);
+        }
+    }
+
+    public void Complete()
+    {
+        if (Interlocked.Exchange(ref _completed, 1) == 0)
+        {
+            var enqueuedAt = Volatile.Read(ref _enqueuedAt);
+            if (enqueuedAt != 0 && Volatile.Read(ref _started) != 0)
+            {
+                Session.RecordLoadCompleted(Id, InputKind, (IconLoadResultKind)_resultKind, Stopwatch.GetTimestamp() - enqueuedAt);
+            }
+        }
+    }
+
+    public void Fail()
+    {
+        if (Interlocked.Exchange(ref _completed, 1) == 0)
+        {
+            var enqueuedAt = Volatile.Read(ref _enqueuedAt);
+            if (enqueuedAt != 0 && Volatile.Read(ref _started) != 0)
+            {
+                Session.RecordLoadCompleted(Id, InputKind, IconLoadResultKind.Failed, Stopwatch.GetTimestamp() - enqueuedAt);
+            }
+        }
+    }
+
+    private ValueTask<bool> WaitForEnqueueAsync()
+    {
+        var state = (EnqueueState)Volatile.Read(ref _enqueueState);
+        if (state != EnqueueState.Pending)
+        {
+            return new ValueTask<bool>(state == EnqueueState.Enqueued);
+        }
+
+        var waiter = Volatile.Read(ref _enqueueWaiter);
+        if (waiter is null)
+        {
+            var newWaiter = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            waiter = Interlocked.CompareExchange(ref _enqueueWaiter, newWaiter, null) ?? newWaiter;
+        }
+
+        state = (EnqueueState)Volatile.Read(ref _enqueueState);
+        if (state != EnqueueState.Pending)
+        {
+            waiter.TrySetResult(state == EnqueueState.Enqueued);
+        }
+
+        return new ValueTask<bool>(waiter.Task);
+    }
+
+    private bool PublishEnqueueState(EnqueueState state)
+    {
+        var previousState = (EnqueueState)Interlocked.CompareExchange(
+            ref _enqueueState,
+            (int)state,
+            (int)EnqueueState.Pending);
+        var publishedState = previousState == EnqueueState.Pending ? state : previousState;
+        Volatile.Read(ref _enqueueWaiter)?.TrySetResult(publishedState == EnqueueState.Enqueued);
+        return previousState == EnqueueState.Pending;
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadQueueDemandTransition.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadQueueDemandTransition.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+internal enum IconLoadQueueDemandTransition
+{
+    EnqueuedDemanded,
+    EnqueuedSpeculative,
+    Demoted,
+    Promoted,
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadResultKind.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadResultKind.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+internal enum IconLoadResultKind
+{
+    Empty,
+    Bitmap,
+    Svg,
+    SoftwareBitmap,
+    FluentGlyph,
+    EmojiGlyph,
+    OtherGlyph,
+    Fallback,
+    Other,
+    Failed,
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoaderService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoaderService.cs
@@ -47,14 +47,15 @@ internal sealed partial class IconLoaderService : IIconLoaderService
         Size iconSize,
         double scale,
         TaskCompletionSource<IconSource?> tcs,
-        IconLoadPriority priority = IconLoadPriority.Low)
+        IconLoadPriority priority = IconLoadPriority.Low,
+        IconLoadMeasurement? diagnostics = null)
     {
-        var workItem = () => LoadAndCompleteAsync(iconString, fontFamily, streamRef, iconSize, scale, tcs);
-
         if (priority == IconLoadPriority.High)
         {
-            if (_highPriorityQueue.Writer.TryWrite(workItem))
+            var highPriorityWorkItem = () => LoadAndCompleteAsync(iconString, fontFamily, streamRef, iconSize, scale, tcs, diagnostics);
+            if (_highPriorityQueue.Writer.TryWrite(highPriorityWorkItem))
             {
+                RecordEnqueued(diagnostics, IconLoadPriority.High);
                 return true;
             }
 
@@ -63,7 +64,28 @@ internal sealed partial class IconLoaderService : IIconLoaderService
 #endif
         }
 
-        return _lowPriorityQueue.Writer.TryWrite(workItem);
+        var lowPriorityWorkItem = () => LoadAndCompleteAsync(iconString, fontFamily, streamRef, iconSize, scale, tcs, diagnostics);
+        if (_lowPriorityQueue.Writer.TryWrite(lowPriorityWorkItem))
+        {
+            RecordEnqueued(diagnostics, IconLoadPriority.Low);
+            return true;
+        }
+
+        diagnostics?.Rejected();
+        return false;
+
+        static void RecordEnqueued(IconLoadMeasurement? diagnostics, IconLoadPriority actualPriority)
+        {
+            try
+            {
+                diagnostics?.Enqueued(actualPriority);
+            }
+            catch (Exception ex)
+            {
+                // Diagnostics must not fail work that was already published to the loader queue.
+                Logger.LogError("Failed to record icon load enqueue diagnostics", ex);
+            }
+        }
     }
 
     public async ValueTask DisposeAsync()
@@ -135,15 +157,23 @@ internal sealed partial class IconLoaderService : IIconLoaderService
         IRandomAccessStreamReference? streamRef,
         Size iconSize,
         double scale,
-        TaskCompletionSource<IconSource?> tcs)
+        TaskCompletionSource<IconSource?> tcs,
+        IconLoadMeasurement? diagnostics)
     {
         try
         {
-            var result = await LoadIconCoreAsync(iconString, fontFamily, streamRef, iconSize, scale).ConfigureAwait(false);
+            if (diagnostics is not null && !await diagnostics.WorkerStartingAsync(WorkerCount).ConfigureAwait(false))
+            {
+                diagnostics = null;
+            }
+
+            var result = await LoadIconCoreAsync(iconString, fontFamily, streamRef, iconSize, scale, diagnostics).ConfigureAwait(false);
+            diagnostics?.Complete();
             tcs.TrySetResult(result);
         }
         catch (Exception ex)
         {
+            diagnostics?.Fail();
             tcs.TrySetException(ex);
         }
     }
@@ -153,7 +183,8 @@ internal sealed partial class IconLoaderService : IIconLoaderService
         string? fontFamily,
         IRandomAccessStreamReference? streamRef,
         Size iconSize,
-        double scale)
+        double scale,
+        IconLoadMeasurement? diagnostics)
     {
         var scaledSize = iconSize.IsEmpty
             ? iconSize
@@ -161,8 +192,24 @@ internal sealed partial class IconLoaderService : IIconLoaderService
 
         if (!string.IsNullOrEmpty(iconString))
         {
+            var dispatcherEnqueuedAt = diagnostics?.BeginDispatcherWait() ?? 0;
             return await _dispatcherQueue
-                .EnqueueAsync(() => GetStringIconSource(iconString, fontFamily, scaledSize), LoadingPriorityOnDispatcher)
+                .EnqueueAsync(
+                    () =>
+                    {
+                        var dispatcherStartedAt = diagnostics?.DispatcherStarted(dispatcherEnqueuedAt) ?? 0;
+                        try
+                        {
+                            var result = GetStringIconSource(iconString, fontFamily, scaledSize);
+                            diagnostics?.SetResult(result);
+                            return result;
+                        }
+                        finally
+                        {
+                            diagnostics?.DispatcherCompleted(dispatcherStartedAt);
+                        }
+                    },
+                    LoadingPriorityOnDispatcher)
                 .ConfigureAwait(false);
         }
 
@@ -170,18 +217,31 @@ internal sealed partial class IconLoaderService : IIconLoaderService
         {
             try
             {
+                var preparationStartedAt = diagnostics?.BeginBackgroundPreparation() ?? 0;
                 using var bitmapStream = await streamRef.OpenReadAsync().AsTask().ConfigureAwait(false);
+                diagnostics?.CompleteBackgroundPreparation(preparationStartedAt);
 
+                var dispatcherEnqueuedAt = diagnostics?.BeginDispatcherWait() ?? 0;
                 return await _dispatcherQueue
                     .EnqueueAsync(BuildImageSource, LoadingPriorityOnDispatcher)
                     .ConfigureAwait(false);
 
                 async Task<IconSource?> BuildImageSource()
                 {
-                    var bitmap = new BitmapImage();
-                    ApplyDecodeSize(bitmap, scaledSize);
-                    await bitmap.SetSourceAsync(bitmapStream);
-                    return new ImageIconSource { ImageSource = bitmap };
+                    var dispatcherStartedAt = diagnostics?.DispatcherStarted(dispatcherEnqueuedAt) ?? 0;
+                    try
+                    {
+                        var bitmap = new BitmapImage();
+                        ApplyDecodeSize(bitmap, scaledSize);
+                        await bitmap.SetSourceAsync(bitmapStream);
+                        var result = new ImageIconSource { ImageSource = bitmap };
+                        diagnostics?.SetResult(result);
+                        return result;
+                    }
+                    finally
+                    {
+                        diagnostics?.DispatcherCompleted(dispatcherStartedAt);
+                    }
                 }
             }
 #pragma warning disable CS0168 // Variable is declared but never used

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconProvider.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconProvider.cs
@@ -55,10 +55,11 @@ public static partial class IconProvider
         {
             args.Value = args.Key switch
             {
-                IconDataViewModel iconData => await service.GetIconSource(iconData, args.Scale),
+                IconDataViewModel iconData => await service.GetIconSource(iconData, args.Scale, args.Diagnostics),
                 IconInfoViewModel iconInfo => await service.GetIconSource(
                     args.Theme == Microsoft.UI.Xaml.ElementTheme.Light ? iconInfo.Light : iconInfo.Dark,
-                    args.Scale),
+                    args.Scale,
+                    args.Diagnostics),
                 _ => null,
             };
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconProviderResolution.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconProviderResolution.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+internal enum IconProviderResolution
+{
+    NewLoad,
+    CacheHit,
+    InFlight,
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconRequestMeasurement.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconRequestMeasurement.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+internal readonly struct IconRequestMeasurement
+{
+    private readonly long _startedAt;
+
+    internal IconLoadDiagnosticsSession? Session { get; }
+
+    internal long Id { get; }
+
+    internal IconRequestMeasurement(IconLoadDiagnosticsSession session, long id, long startedAt)
+    {
+        Session = session;
+        Id = id;
+        _startedAt = startedAt;
+    }
+
+    public void RecordProviderResolution(IconProviderResolution resolution, IconLoadMeasurement? load)
+    {
+        if (Session is not { } session)
+        {
+            return;
+        }
+
+        var loadId = load is not null && ReferenceEquals(load.Session, session) ? load.Id : 0;
+        session.RecordProviderResolution(Id, loadId, resolution);
+    }
+
+    public void RecordProviderResolution(IconProviderResolution resolution, Task<IconSource?> task)
+    {
+        RecordProviderResolution(resolution, Session?.FindLoad(task));
+    }
+
+    public void Invalidate()
+    {
+        Session?.InvalidateRequest(Id);
+    }
+
+    public void Complete(IconRequestStatus status, IconSource? result = null)
+    {
+        if (Session is not { } session)
+        {
+            return;
+        }
+
+        var resultKind = status == IconRequestStatus.Failed
+            ? IconLoadResultKind.Failed
+            : IconLoadDiagnostics.ClassifyResult(result);
+        session.CompleteRequest(Id, status, resultKind, Stopwatch.GetTimestamp() - _startedAt);
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconRequestOrigin.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconRequestOrigin.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.UI.Controls;
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+internal readonly record struct IconRequestOrigin
+{
+    private const int MaximumDiagnosticScopeLength = 64;
+
+    public long IconBoxId { get; }
+
+    public IconRequestSite RequestSite { get; }
+
+    public string DiagnosticScope { get; }
+
+    public IconRequestOrigin(long iconBoxId, IconRequestSite requestSite, string? diagnosticScope)
+    {
+        IconBoxId = Math.Max(0, iconBoxId);
+        RequestSite = Enum.IsDefined(typeof(IconRequestSite), requestSite) ? requestSite : IconRequestSite.Unknown;
+        DiagnosticScope = NormalizeDiagnosticScope(diagnosticScope);
+    }
+
+    public IconRequestOrigin Normalize() => new(IconBoxId, RequestSite, DiagnosticScope);
+
+    private static string NormalizeDiagnosticScope(string? diagnosticScope)
+    {
+        if (string.IsNullOrWhiteSpace(diagnosticScope))
+        {
+            return string.Empty;
+        }
+
+        var scope = diagnosticScope.AsSpan().Trim();
+        if (scope.Length > MaximumDiagnosticScopeLength)
+        {
+            return string.Empty;
+        }
+
+        foreach (var character in scope)
+        {
+            var isAsciiLetter = character is >= 'A' and <= 'Z' or >= 'a' and <= 'z';
+            var isAsciiDigit = character is >= '0' and <= '9';
+            if (!isAsciiLetter && !isAsciiDigit && character is not '.' and not '-' and not '_')
+            {
+                return string.Empty;
+            }
+        }
+
+        return scope.Length == diagnosticScope.Length ? diagnosticScope : scope.ToString();
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconRequestReason.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconRequestReason.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+[Flags]
+internal enum IconRequestReason
+{
+    None = 0,
+    SourceChanged = 1 << 0,
+    HandlerAttached = 1 << 1,
+    Loaded = 1 << 2,
+    ThemeChanged = 1 << 3,
+    ScaleChanged = 1 << 4,
+    Retry = 1 << 5,
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconRequestStatus.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconRequestStatus.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+internal enum IconRequestStatus
+{
+    Applied,
+    Empty,
+    Stale,
+    Failed,
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconSourceProvider.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconSourceProvider.cs
@@ -26,26 +26,39 @@ internal sealed class IconSourceProvider : IIconSourceProvider
     {
     }
 
-    public Task<IconSource?> GetIconSource(IconDataViewModel icon, double scale)
+    public Task<IconSource?> GetIconSource(IconDataViewModel icon, double scale, IconRequestMeasurement diagnostics = default)
     {
         var tcs = new TaskCompletionSource<IconSource?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        IconLoadMeasurement? loadDiagnostics = null;
 
         try
         {
+            var streamReference = icon.Data?.Unsafe;
+            loadDiagnostics = IconLoadDiagnostics.CreateLoad(
+                diagnostics,
+                icon.Icon,
+                streamReference is not null,
+                _iconSize.Width,
+                _iconSize.Height,
+                scale);
+            diagnostics.RecordProviderResolution(IconProviderResolution.NewLoad, loadDiagnostics);
+
             if (!_loader.TryEnqueueLoad(
                     icon.Icon,
                     icon.FontFamily,
-                    icon.Data?.Unsafe,
+                    streamReference,
                     _iconSize,
                     scale,
                     tcs,
-                    _isPriority ? IconLoadPriority.High : IconLoadPriority.Low))
+                    _isPriority ? IconLoadPriority.High : IconLoadPriority.Low,
+                    loadDiagnostics))
             {
                 tcs.TrySetException(new ObjectDisposedException(nameof(IIconLoaderService)));
             }
         }
         catch (Exception ex)
         {
+            loadDiagnostics?.Rejected();
             tcs.TrySetException(ex);
         }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconUiResponsivenessProbe.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconUiResponsivenessProbe.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using ManagedCommon;
+using Microsoft.UI.Dispatching;
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+/// <summary>
+/// Samples normal-priority dispatcher responsiveness without allowing probes to queue up.
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1001:Types that own disposable fields should be disposable",
+    Justification = "The owning diagnostic session calls Stop, which cancels the loop and disposes the source after it exits. Avoid implementing a WinRT interface on this internal NativeAOT type.")]
+internal sealed class IconUiResponsivenessProbe
+{
+    private const long NoPendingProbe = long.MinValue;
+
+    private static readonly TimeSpan ProbeInterval = TimeSpan.FromMilliseconds(50);
+
+    private readonly Func<DispatcherQueuePriority, DispatcherQueueHandler, bool> _tryEnqueue;
+    private readonly DispatcherQueueHandler _probeCallback;
+    private readonly IconLoadDiagnosticsSession _session;
+    private readonly CancellationTokenSource _cancellation = new();
+    private readonly Task _runTask;
+    private int _active = 1;
+    private long _pendingSince = NoPendingProbe;
+
+    public IconUiResponsivenessProbe(
+        DispatcherQueue dispatcherQueue,
+        IconLoadDiagnosticsSession session)
+        : this(dispatcherQueue.TryEnqueue, session, startTimer: true)
+    {
+    }
+
+    internal IconUiResponsivenessProbe(
+        Func<DispatcherQueuePriority, DispatcherQueueHandler, bool> tryEnqueue,
+        IconLoadDiagnosticsSession session)
+        : this(tryEnqueue, session, startTimer: false)
+    {
+    }
+
+    private IconUiResponsivenessProbe(
+        Func<DispatcherQueuePriority, DispatcherQueueHandler, bool> tryEnqueue,
+        IconLoadDiagnosticsSession session,
+        bool startTimer)
+    {
+        _tryEnqueue = tryEnqueue;
+        _probeCallback = ProbeCallback;
+        _session = session;
+        _runTask = startTimer ? RunAsync() : Task.CompletedTask;
+    }
+
+    public void Stop()
+    {
+        if (Interlocked.Exchange(ref _active, 0) == 0)
+        {
+            return;
+        }
+
+        try
+        {
+            _cancellation.Cancel();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError("Failed to stop icon UI responsiveness probe", ex);
+        }
+
+        _ = _runTask.ContinueWith(
+            static (_, state) => ((CancellationTokenSource)state!).Dispose(),
+            _cancellation,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
+    private async Task RunAsync()
+    {
+        try
+        {
+            using var timer = new PeriodicTimer(ProbeInterval);
+            while (await timer.WaitForNextTickAsync(_cancellation.Token).ConfigureAwait(false))
+            {
+                OnTimerTick();
+            }
+        }
+        catch (OperationCanceledException) when (_cancellation.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError("Icon UI responsiveness probe failed", ex);
+        }
+    }
+
+    internal void OnTimerTick()
+    {
+        if (Volatile.Read(ref _active) == 0)
+        {
+            return;
+        }
+
+        var enqueuedAt = Stopwatch.GetTimestamp();
+        if (Interlocked.CompareExchange(ref _pendingSince, enqueuedAt, NoPendingProbe) != NoPendingProbe)
+        {
+            _session.RecordUiProbeSkipped();
+            return;
+        }
+
+        _session.RecordUiProbeEnqueued();
+        if (!_tryEnqueue(
+                DispatcherQueuePriority.Normal,
+                _probeCallback))
+        {
+            var rejectedAt = Interlocked.Exchange(ref _pendingSince, NoPendingProbe);
+            Debug.Assert(rejectedAt == enqueuedAt, "A rejected probe cannot have run its callback.");
+            _session.RecordUiProbeRejected();
+        }
+    }
+
+    private void ProbeCallback()
+    {
+        var completedAt = Stopwatch.GetTimestamp();
+        var enqueuedAt = Interlocked.Exchange(ref _pendingSince, NoPendingProbe);
+        if (Volatile.Read(ref _active) != 0 && enqueuedAt != NoPendingProbe)
+        {
+            _session.RecordUiProbeCompleted(completedAt - enqueuedAt);
+        }
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml
@@ -95,6 +95,8 @@
                                 Width="16"
                                 Height="16"
                                 Margin="0,3,8,0"
+                                DiagnosticScope="DetailsCommand"
+                                RequestSite="Details"
                                 SourceKey="{x:Bind Icon, Mode=OneWay}"
                                 SourceRequested="{x:Bind help:IconProvider.SourceRequested20}" />
                             <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{x:Bind Name}" />
@@ -347,7 +349,9 @@
                         Margin="4,0,4,0"
                         VerticalAlignment="Center"
                         ui:VisualExtensions.NormalizedCenterPoint="0.5,0.5"
+                        DiagnosticScope="CurrentPage"
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        RequestSite="PageHeader"
                         SourceKey="{x:Bind ViewModel.CurrentPage.Icon, Mode=OneWay}"
                         SourceRequested="{x:Bind help:IconProvider.SourceRequested20}"
                         Visibility="{x:Bind ViewModel.CurrentPage.IsRootPage, Mode=OneWay, Converter={StaticResource BoolToInvertedVisibilityConverter}}">
@@ -502,6 +506,8 @@
                             Margin="0,0,16,16"
                             HorizontalAlignment="Left"
                             AutomationProperties.AccessibilityView="Raw"
+                            DiagnosticScope="HeroImage"
+                            RequestSite="Details"
                             SourceKey="{x:Bind ViewModel.Details.HeroImage, Mode=OneWay}"
                             SourceRequested="{x:Bind help:IconProvider.SourceRequested64}"
                             Visibility="{x:Bind HasHeroImage, Mode=OneWay}" />

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/DockSettingsPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/DockSettingsPage.xaml
@@ -320,6 +320,8 @@
                                                     Width="20"
                                                     Height="20"
                                                     AutomationProperties.AccessibilityView="Raw"
+                                                    DiagnosticScope="DockBand"
+                                                    RequestSite="Settings"
                                                     SourceKey="{x:Bind Icon, Mode=OneWay}"
                                                     SourceRequested="{x:Bind helpers:IconProvider.SourceRequested20}" />
                                             </cpControls:ContentIcon.Content>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionPage.xaml
@@ -60,6 +60,8 @@
                                         Width="20"
                                         Height="20"
                                         AutomationProperties.AccessibilityView="Raw"
+                                        DiagnosticScope="ExtensionSummary"
+                                        RequestSite="Settings"
                                         SourceKey="{x:Bind ViewModel.Icon, Mode=OneWay}"
                                         SourceRequested="{x:Bind helpers:IconProvider.SourceRequested20}" />
                                 </cpcontrols:ContentIcon.Content>
@@ -105,6 +107,8 @@
                                                                 Width="20"
                                                                 Height="20"
                                                                 AutomationProperties.AccessibilityView="Raw"
+                                                                DiagnosticScope="TopLevelCommand"
+                                                                RequestSite="Settings"
                                                                 SourceKey="{x:Bind Icon, Mode=OneWay}"
                                                                 SourceRequested="{x:Bind helpers:IconProvider.SourceRequested20}" />
                                                         </cpcontrols:ContentIcon.Content>
@@ -183,6 +187,8 @@
                                                                 Width="20"
                                                                 Height="20"
                                                                 AutomationProperties.AccessibilityView="Raw"
+                                                                DiagnosticScope="Fallback"
+                                                                RequestSite="Settings"
                                                                 SourceKey="{x:Bind Icon, Mode=OneWay}"
                                                                 SourceRequested="{x:Bind helpers:IconProvider.SourceRequested20}" />
                                                         </cpcontrols:ContentIcon.Content>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionsPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionsPage.xaml
@@ -153,6 +153,8 @@
                                                             Width="20"
                                                             Height="20"
                                                             AutomationProperties.AccessibilityView="Raw"
+                                                            DiagnosticScope="ExtensionList"
+                                                            RequestSite="Settings"
                                                             SourceKey="{x:Bind Icon, Mode=OneWay}"
                                                             SourceRequested="{x:Bind helpers:IconProvider.SourceRequested20}" />
                                                     </controls:Case>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/IconDiagnosticsReportItem.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/IconDiagnosticsReportItem.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using Microsoft.CmdPal.UI.Helpers;
+
+namespace Microsoft.CmdPal.UI.Settings;
+
+internal sealed class IconDiagnosticsReportItem
+{
+    public IconLoadDiagnosticsReport Report { get; }
+
+    public string Header => $"Session {Report.SessionId}";
+
+    public string Description { get; }
+
+    public string CopyAutomationId => $"CmdPal_InternalPage_CopyIconDiagnostics_{Report.SessionId}";
+
+    public IconDiagnosticsReportItem(IconLoadDiagnosticsReport report)
+    {
+        Report = report;
+
+        var startedLocal = report.StartedUtc.ToLocalTime();
+        var endedLocal = report.EndedUtc.ToLocalTime();
+        Description = string.Format(
+            CultureInfo.CurrentCulture,
+            "Started: {0:G}  •  Ended: {1:G}  •  Duration: {2}",
+            startedLocal,
+            endedLocal,
+            FormatDuration(report.Duration));
+    }
+
+    private static string FormatDuration(TimeSpan duration)
+    {
+        return duration.TotalDays >= 1
+            ? duration.ToString("d'.'hh':'mm':'ss'.'fff", CultureInfo.InvariantCulture)
+            : duration.ToString("hh':'mm':'ss'.'fff", CultureInfo.InvariantCulture);
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/InternalPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/InternalPage.xaml
@@ -5,6 +5,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:Microsoft.CmdPal.UI.Settings"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="using:CommunityToolkit.WinUI"
     mc:Ignorable="d">
@@ -72,6 +73,72 @@
                             Click="OpenCurrentLogCardClicked"
                             Content="Open log" />
                     </controls:SettingsCard>
+                    <controls:SettingsExpander
+                        x:Name="IconDiagnosticsExpander"
+                        Description="Records anonymous request, cache, queue, dispatcher, and element timing. Stopped reports are written to the current log and remain available for this app session."
+                        Header="Icon loading diagnostics"
+                        HeaderIcon="{ui:FontIcon Glyph=&#xE9D9;}"
+                        IsExpanded="True"
+                        ItemsSource="{x:Bind IconDiagnosticReports, Mode=OneWay}">
+                        <StackPanel HorizontalAlignment="Right" Spacing="4">
+                            <CommandBar
+                                Background="Transparent"
+                                DefaultLabelPosition="Right"
+                                IsDynamicOverflowEnabled="True">
+                                <AppBarButton
+                                    x:Name="StartIconDiagnosticsButton"
+                                    AutomationProperties.AutomationId="CmdPal_InternalPage_StartIconDiagnostics"
+                                    Click="StartIconDiagnosticsClicked"
+                                    Label="Start">
+                                    <AppBarButton.Icon>
+                                        <SymbolIcon Symbol="Play" />
+                                    </AppBarButton.Icon>
+                                </AppBarButton>
+                                <AppBarButton
+                                    x:Name="StopIconDiagnosticsButton"
+                                    AutomationProperties.AutomationId="CmdPal_InternalPage_StopIconDiagnostics"
+                                    Click="StopIconDiagnosticsClicked"
+                                    Label="Stop">
+                                    <AppBarButton.Icon>
+                                        <SymbolIcon Symbol="Stop" />
+                                    </AppBarButton.Icon>
+                                </AppBarButton>
+                                <AppBarButton
+                                    AutomationProperties.AutomationId="CmdPal_InternalPage_ResetIconDiagnostics"
+                                    Click="ResetIconDiagnosticsClicked"
+                                    Label="Reset">
+                                    <AppBarButton.Icon>
+                                        <SymbolIcon Symbol="Refresh" />
+                                    </AppBarButton.Icon>
+                                </AppBarButton>
+                            </CommandBar>
+                            <TextBlock
+                                x:Name="IconDiagnosticsStatusTextBlock"
+                                MaxWidth="440"
+                                HorizontalAlignment="Right"
+                                Text="Not recording."
+                                TextAlignment="Right"
+                                TextWrapping="Wrap" />
+                        </StackPanel>
+                        <controls:SettingsExpander.ItemTemplate>
+                            <DataTemplate x:DataType="local:IconDiagnosticsReportItem">
+                                <controls:SettingsCard
+                                    Description="{x:Bind Description, Mode=OneTime}"
+                                    Header="{x:Bind Header, Mode=OneTime}"
+                                    HorizontalContentAlignment="Right">
+                                    <Button
+                                        AutomationProperties.AutomationId="{x:Bind CopyAutomationId, Mode=OneTime}"
+                                        Click="CopyIconDiagnosticsReportClicked"
+                                        Tag="{x:Bind Report, Mode=OneTime}">
+                                        <StackPanel Orientation="Horizontal" Spacing="8">
+                                            <SymbolIcon Symbol="Copy" />
+                                            <TextBlock Text="Copy report" />
+                                        </StackPanel>
+                                    </Button>
+                                </controls:SettingsCard>
+                            </DataTemplate>
+                        </controls:SettingsExpander.ItemTemplate>
+                    </controls:SettingsExpander>
                     <controls:SettingsCard
                         x:Name="ToggleDevRibbonVisibilitySettingsCard"
                         Description="This is only temporary and state is not saved"

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/InternalPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/InternalPage.xaml.cs
@@ -110,7 +110,7 @@ public sealed partial class InternalPage : Page
 
     private void StartIconDiagnosticsClicked(object sender, RoutedEventArgs e)
     {
-        var sessionId = IconLoadDiagnostics.Start();
+        var sessionId = IconLoadDiagnostics.Start(DispatcherQueue);
         IconDiagnosticsStatusTextBlock.Text = $"Recording session {sessionId}. Reproduce the icon workload, then select Stop.";
         UpdateIconDiagnosticsControls();
     }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/InternalPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/InternalPage.xaml.cs
@@ -2,9 +2,11 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.Messaging;
 using ManagedCommon;
 using Microsoft.CmdPal.Common.Services;
+using Microsoft.CmdPal.UI.Helpers;
 using Microsoft.CmdPal.UI.Messages;
 using Microsoft.CmdPal.UI.ViewModels.Services;
 using Microsoft.CommandPalette.Extensions.Toolkit;
@@ -24,6 +26,8 @@ public sealed partial class InternalPage : Page
     private readonly IApplicationInfoService _appInfoService;
     private readonly ISettingsService _settingsService;
 
+    internal ObservableCollection<IconDiagnosticsReportItem> IconDiagnosticReports { get; } = [];
+
     public string GalleryFeedUrl => _settingsService.Settings.GalleryFeedUrl ?? string.Empty;
 
     public bool ShowHwndFrame => _settingsService.Settings.ShowHwndFrame;
@@ -34,6 +38,8 @@ public sealed partial class InternalPage : Page
 
         _appInfoService = App.Current.Services.GetRequiredService<IApplicationInfoService>();
         _settingsService = App.Current.Services.GetRequiredService<ISettingsService>();
+        LoadIconDiagnosticsReports();
+        UpdateIconDiagnosticsControls();
     }
 
     private void GalleryFeedUrlTextBox_LostFocus(object sender, RoutedEventArgs e)
@@ -99,6 +105,91 @@ public sealed partial class InternalPage : Page
         catch (Exception ex)
         {
             Logger.LogError("Failed to open log file", ex);
+        }
+    }
+
+    private void StartIconDiagnosticsClicked(object sender, RoutedEventArgs e)
+    {
+        var sessionId = IconLoadDiagnostics.Start();
+        IconDiagnosticsStatusTextBlock.Text = $"Recording session {sessionId}. Reproduce the icon workload, then select Stop.";
+        UpdateIconDiagnosticsControls();
+    }
+
+    private void StopIconDiagnosticsClicked(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            var report = IconLoadDiagnostics.StopAndCreateReport();
+            if (report is null)
+            {
+                IconDiagnosticsStatusTextBlock.Text = "No icon diagnostics session is recording.";
+            }
+            else
+            {
+                IconDiagnosticReports.Insert(0, new IconDiagnosticsReportItem(report));
+                IconDiagnosticsExpander.IsExpanded = true;
+                IconDiagnosticsStatusTextBlock.Text = $"Session {report.SessionId} stopped. Its report was written to the current log and added below.";
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError("Failed to stop icon diagnostics", ex);
+            IconDiagnosticsStatusTextBlock.Text = "The icon diagnostics session could not be stopped.";
+        }
+
+        UpdateIconDiagnosticsControls();
+    }
+
+    private void ResetIconDiagnosticsClicked(object sender, RoutedEventArgs e)
+    {
+        IconLoadDiagnostics.Reset();
+        IconDiagnosticReports.Clear();
+        IconDiagnosticsStatusTextBlock.Text = "Icon diagnostics were reset.";
+        UpdateIconDiagnosticsControls();
+    }
+
+    private void CopyIconDiagnosticsReportClicked(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button { Tag: IconLoadDiagnosticsReport report })
+        {
+            return;
+        }
+
+        try
+        {
+            ClipboardHelper.SetText(report.Text);
+            IconDiagnosticsStatusTextBlock.Text = $"Session {report.SessionId} report copied to the clipboard.";
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError("Failed to copy icon diagnostics", ex);
+            IconDiagnosticsStatusTextBlock.Text = $"Session {report.SessionId} report could not be copied to the clipboard.";
+        }
+    }
+
+    private void LoadIconDiagnosticsReports()
+    {
+        var reports = IconLoadDiagnostics.GetReports();
+        for (var i = reports.Count - 1; i >= 0; i--)
+        {
+            IconDiagnosticReports.Add(new IconDiagnosticsReportItem(reports[i]));
+        }
+
+        if (IconDiagnosticReports.Count > 0)
+        {
+            IconDiagnosticsStatusTextBlock.Text = $"{IconDiagnosticReports.Count} report{(IconDiagnosticReports.Count == 1 ? string.Empty : "s")} available below.";
+        }
+    }
+
+    private void UpdateIconDiagnosticsControls()
+    {
+        var isRecording = IconLoadDiagnostics.IsRecording;
+        StartIconDiagnosticsButton.IsEnabled = !isRecording;
+        StopIconDiagnosticsButton.IsEnabled = isRecording;
+
+        if (isRecording && IconLoadDiagnostics.ActiveSessionId is { } sessionId)
+        {
+            IconDiagnosticsStatusTextBlock.Text = $"Recording session {sessionId}. Reproduce the icon workload, then select Stop.";
         }
     }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ToastWindow.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ToastWindow.xaml
@@ -32,6 +32,8 @@
                 Margin="0,0,8,0"
                 VerticalAlignment="Center"
                 AutomationProperties.AccessibilityView="Raw"
+                DiagnosticScope="Notification"
+                RequestSite="Toast"
                 SourceKey="{x:Bind ViewModel.Icon, Mode=OneWay}"
                 SourceRequested="{x:Bind help:IconProvider.SourceRequested16}"
                 Visibility="{x:Bind ViewModel.HasIcon, Mode=OneWay}" />
@@ -55,6 +57,8 @@
                         Height="16"
                         VerticalAlignment="Center"
                         AutomationProperties.AccessibilityView="Raw"
+                        DiagnosticScope="Command"
+                        RequestSite="Toast"
                         SourceKey="{x:Bind ViewModel.CommandIcon, Mode=OneWay}"
                         SourceRequested="{x:Bind help:IconProvider.SourceRequested16}"
                         Visibility="{x:Bind ViewModel.CommandHasIcon, Mode=OneWay}" />

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/CachedIconSourceProviderTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/CachedIconSourceProviderTests.cs
@@ -147,7 +147,8 @@ public class CachedIconSourceProviderTests
             Size iconSize,
             double scale,
             TaskCompletionSource<IconSource?> tcs,
-            IconLoadPriority priority)
+            IconLoadPriority priority,
+            IconLoadMeasurement? diagnostics = null)
         {
             Interlocked.Increment(ref _enqueueCount);
             if (!AcceptLoads)

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconLoadDiagnosticsTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconLoadDiagnosticsTests.cs
@@ -1,0 +1,566 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.UI.Controls;
+using Microsoft.CmdPal.UI.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.UI.UnitTests;
+
+[TestClass]
+[DoNotParallelize]
+public class IconLoadDiagnosticsTests
+{
+    [TestCleanup]
+    public void Cleanup()
+    {
+        IconLoadDiagnostics.Reset();
+    }
+
+    [TestMethod]
+    public void RecordingProducesAnonymousAggregateReport()
+    {
+        var sessionId = IconLoadDiagnostics.Start();
+        var request = IconLoadDiagnostics.BeginRequest(IconRequestReason.SourceChanged, 1.5);
+        var load = IconLoadDiagnostics.CreateLoad(
+            request,
+            @"C:\private\secret.exe,0",
+            hasStream: false,
+            width: 20,
+            height: 20,
+            scale: 1.5);
+
+        Assert.IsNotNull(load);
+        request.RecordProviderResolution(IconProviderResolution.NewLoad, load);
+        load.Enqueued(IconLoadPriority.Low);
+        StartWorker(load);
+        var preparationStartedAt = load.BeginBackgroundPreparation();
+        load.CompleteBackgroundPreparation(preparationStartedAt);
+        var dispatcherEnqueuedAt = load.BeginDispatcherWait();
+        var dispatcherStartedAt = load.DispatcherStarted(dispatcherEnqueuedAt);
+        load.DispatcherCompleted(dispatcherStartedAt);
+        load.SetResult(null);
+        load.Complete();
+        request.Complete(IconRequestStatus.Stale);
+        var elementStartedAt = IconLoadDiagnostics.BeginElementUpdate();
+        IconLoadDiagnostics.RecordElementUpdate(reused: false, source: null, elementStartedAt);
+        elementStartedAt = IconLoadDiagnostics.BeginElementUpdate();
+        IconLoadDiagnostics.RecordElementUpdate(reused: true, source: null, elementStartedAt);
+
+        var report = IconLoadDiagnostics.StopAndCreateReport();
+
+        Assert.IsNotNull(report);
+        Assert.AreEqual(sessionId, report.SessionId);
+        Assert.IsTrue(report.EndedUtc >= report.StartedUtc);
+        Assert.IsTrue(report.Duration >= TimeSpan.Zero);
+        StringAssert.Contains(report.Text, $"Session: {sessionId}");
+        StringAssert.Contains(report.Text, "Ended UTC:");
+        StringAssert.Contains(report.Text, "Started: 1");
+        StringAssert.Contains(report.Text, "Stale: 1");
+        StringAssert.Contains(report.Text, "NewLoad: 1");
+        StringAssert.Contains(report.Text, "Request to completion by resolution and result");
+        StringAssert.Contains(report.Text, "      Empty: count=1");
+        StringAssert.Contains(report.Text, "ShellBinary: 1");
+        StringAssert.Contains(report.Text, "    Enqueue to completion: count=1");
+        StringAssert.Contains(report.Text, "    Dispatcher wait: count=1");
+        StringAssert.Contains(report.Text, "Empty: 1");
+        StringAssert.Contains(report.Text, "Maximum low queue depth: 1");
+        StringAssert.Contains(report.Text, "Dispatcher wait: count=1");
+        StringAssert.Contains(report.Text, "Load demand");
+        StringAssert.Contains(report.Text, "Requests linked to session loads: 1");
+        StringAssert.Contains(report.Text, "    Completed: 1");
+        StringAssert.Contains(report.Text, "Loads completed with no live requester: 0");
+        StringAssert.Contains(report.Text, "CommandItemViewModel.InitializeProperties reading AppListItem.Icon");
+        StringAssert.Contains(report.Text, "Created: 1");
+        StringAssert.Contains(report.Text, "Reused: 1");
+        StringAssert.Contains(report.Text, "Update wall time: count=2");
+        StringAssert.Contains(report.Text, "Empty: created=1, reused=1");
+        Assert.IsFalse(report.Text.Contains("secret", StringComparison.OrdinalIgnoreCase));
+        Assert.IsFalse(report.Text.Contains(@"C:\private", StringComparison.OrdinalIgnoreCase));
+
+        var reports = IconLoadDiagnostics.GetReports();
+        Assert.HasCount(1, reports);
+        Assert.AreSame(report, reports[0]);
+    }
+
+    [TestMethod]
+    public void UppercaseShellExtensionRemainsStringInput()
+    {
+        IconLoadDiagnostics.Start();
+        var request = IconLoadDiagnostics.BeginRequest(IconRequestReason.SourceChanged, 1.0);
+        var load = IconLoadDiagnostics.CreateLoad(
+            request,
+            @"C:\Windows\APP.EXE,0",
+            hasStream: false,
+            width: 20,
+            height: 20,
+            scale: 1.0);
+
+        Assert.IsNotNull(load);
+        load.Rejected();
+        request.Complete(IconRequestStatus.Failed);
+
+        var report = IconLoadDiagnostics.StopAndCreateReport();
+
+        Assert.IsNotNull(report);
+        var inputKindsStart = report.Text.IndexOf("Input kinds", StringComparison.Ordinal);
+        var inputKindsEnd = report.Text.IndexOf("New-load result kinds", StringComparison.Ordinal);
+        Assert.IsTrue(inputKindsStart >= 0);
+        Assert.IsTrue(inputKindsEnd > inputKindsStart);
+        var inputKinds = report.Text[inputKindsStart..inputKindsEnd];
+        StringAssert.Contains(inputKinds, "  String: 1");
+        StringAssert.Contains(inputKinds, "  ShellBinary: 0");
+    }
+
+    [TestMethod]
+    public void DirectGlyphLoadDoesNotCountAsActiveWorker()
+    {
+        IconLoadDiagnostics.Start();
+        var request = IconLoadDiagnostics.BeginRequest(IconRequestReason.SourceChanged, 1.0);
+        var load = IconLoadDiagnostics.CreateLoad(
+            request,
+            "\uE700",
+            hasStream: false,
+            width: 20,
+            height: 20,
+            scale: 1.0);
+
+        Assert.IsNotNull(load);
+        request.RecordProviderResolution(IconProviderResolution.NewLoad, load);
+        load.CompleteDirectGlyph(result: null);
+        request.Complete(IconRequestStatus.Empty);
+
+        var report = IconLoadDiagnostics.StopAndCreateReport();
+
+        Assert.IsNotNull(report);
+        StringAssert.Contains(report.Text, "Direct glyph loads: 1");
+        StringAssert.Contains(report.Text, "Direct glyph construction: count=1");
+        StringAssert.Contains(report.Text, "Active at stop: 0");
+        StringAssert.Contains(report.Text, "Maximum active workers: 0");
+        StringAssert.Contains(report.Text, "Enqueue to completion: no samples");
+        StringAssert.Contains(report.Text, "New-load result kinds");
+        StringAssert.Contains(report.Text, "Empty: 1");
+    }
+
+    [TestMethod]
+    public void StaleQueuedRequestTracksRetainedCacheUse()
+    {
+        IconLoadDiagnostics.Start();
+        var request = IconLoadDiagnostics.BeginRequest(IconRequestReason.SourceChanged, 1.0);
+        var load = IconLoadDiagnostics.CreateLoad(
+            request,
+            "bitmap.png",
+            hasStream: false,
+            width: 20,
+            height: 20,
+            scale: 1.0);
+
+        Assert.IsNotNull(load);
+        var task = Task.FromResult<Microsoft.UI.Xaml.Controls.IconSource?>(null);
+        load.RegisterTask(task);
+        request.RecordProviderResolution(IconProviderResolution.NewLoad, load);
+        load.Enqueued(IconLoadPriority.Low);
+        request.Invalidate();
+        request.Complete(IconRequestStatus.Stale);
+        StartWorker(load);
+        load.SetResult(null);
+        load.Complete();
+
+        var cacheRequest = IconLoadDiagnostics.BeginRequest(IconRequestReason.Loaded, 1.0);
+        cacheRequest.RecordProviderResolution(IconProviderResolution.CacheHit, task);
+        cacheRequest.Complete(IconRequestStatus.Empty);
+
+        var report = IconLoadDiagnostics.StopAndCreateReport();
+
+        Assert.IsNotNull(report);
+        StringAssert.Contains(report.Text, "Requests linked to session loads: 2");
+        StringAssert.Contains(report.Text, "    Queued: 1");
+        StringAssert.Contains(report.Text, "  Invalidated requests by load stage");
+        StringAssert.Contains(report.Text, "  Demand-loss events after the last requester was invalidated");
+        StringAssert.Contains(report.Text, "    Queued: 1");
+        StringAssert.Contains(report.Text, "Workers started with no live requester: 1");
+        StringAssert.Contains(report.Text, "Loads completed with no live requester: 1");
+        StringAssert.Contains(report.Text, "Loads completed with no live requester by input kind");
+        StringAssert.Contains(report.Text, "Loads completed with no live requester by result kind");
+        StringAssert.Contains(report.Text, "Completed-without-requester loads later cache-hit: 1");
+        StringAssert.Contains(report.Text, "Later cache-hit requests: 1");
+        StringAssert.Contains(report.Text, "No-requester time before worker start: count=1");
+        StringAssert.Contains(report.Text, "No-requester time before load completion: count=1");
+    }
+
+    [TestMethod]
+    public void ReturnedInFlightDemandPreventsFalseAbandonment()
+    {
+        IconLoadDiagnostics.Start();
+        var firstRequest = IconLoadDiagnostics.BeginRequest(IconRequestReason.SourceChanged, 1.0);
+        var load = IconLoadDiagnostics.CreateLoad(
+            firstRequest,
+            "bitmap.png",
+            hasStream: false,
+            width: 20,
+            height: 20,
+            scale: 1.0);
+
+        Assert.IsNotNull(load);
+        firstRequest.RecordProviderResolution(IconProviderResolution.NewLoad, load);
+        var secondRequest = IconLoadDiagnostics.BeginRequest(IconRequestReason.SourceChanged, 1.0);
+        secondRequest.RecordProviderResolution(IconProviderResolution.InFlight, load);
+        load.Enqueued(IconLoadPriority.Low);
+
+        firstRequest.Invalidate();
+        firstRequest.Complete(IconRequestStatus.Stale);
+        secondRequest.Invalidate();
+        secondRequest.Complete(IconRequestStatus.Stale);
+
+        var returnedRequest = IconLoadDiagnostics.BeginRequest(IconRequestReason.Loaded, 1.0);
+        returnedRequest.RecordProviderResolution(IconProviderResolution.InFlight, load);
+        StartWorker(load);
+        load.SetResult(null);
+        load.Complete();
+        returnedRequest.Complete(IconRequestStatus.Empty);
+
+        var report = IconLoadDiagnostics.StopAndCreateReport();
+
+        Assert.IsNotNull(report);
+        StringAssert.Contains(report.Text, "Requests linked to session loads: 3");
+        StringAssert.Contains(report.Text, "Loads with multiple simultaneous requesters: 1");
+        StringAssert.Contains(report.Text, "Maximum simultaneous requesters per load: 2");
+        StringAssert.Contains(report.Text, "    Queued: 2");
+        StringAssert.Contains(report.Text, "    Queued: 1");
+        StringAssert.Contains(report.Text, "Loads where demand returned before completion: 1");
+        StringAssert.Contains(report.Text, "Queued demotions after demand loss: 1");
+        StringAssert.Contains(report.Text, "Queued promotions after demand returned: 1");
+        StringAssert.Contains(report.Text, "Workers started demanded: 1");
+        StringAssert.Contains(report.Text, "Workers started speculative: 0");
+        StringAssert.Contains(report.Text, "Workers started with no live requester: 0");
+        StringAssert.Contains(report.Text, "Loads completed with no live requester: 0");
+    }
+
+    [TestMethod]
+    public void DemandQueueReportSeparatesQueuedDemandFromCapacityInterference()
+    {
+        IconLoadDiagnostics.Start();
+
+        var firstSpeculativeRequest = IconLoadDiagnostics.BeginRequest(IconRequestReason.SourceChanged, 1.0);
+        var firstSpeculativeLoad = IconLoadDiagnostics.CreateLoad(
+            firstSpeculativeRequest,
+            "bitmap.png",
+            hasStream: false,
+            width: 20,
+            height: 20,
+            scale: 1.0);
+        Assert.IsNotNull(firstSpeculativeLoad);
+        firstSpeculativeRequest.RecordProviderResolution(IconProviderResolution.NewLoad, firstSpeculativeLoad);
+        firstSpeculativeLoad.Enqueued(IconLoadPriority.Low);
+        firstSpeculativeRequest.Invalidate();
+        firstSpeculativeRequest.Complete(IconRequestStatus.Stale);
+
+        var firstDemandedRequest = IconLoadDiagnostics.BeginRequest(IconRequestReason.SourceChanged, 1.0);
+        var firstDemandedLoad = IconLoadDiagnostics.CreateLoad(
+            firstDemandedRequest,
+            "bitmap.png",
+            hasStream: false,
+            width: 20,
+            height: 20,
+            scale: 1.0);
+        Assert.IsNotNull(firstDemandedLoad);
+        firstDemandedRequest.RecordProviderResolution(IconProviderResolution.NewLoad, firstDemandedLoad);
+        firstDemandedLoad.Enqueued(IconLoadPriority.Low);
+
+        StartWorker(firstSpeculativeLoad, workerCount: 1);
+        firstSpeculativeLoad.SetResult(null);
+        firstSpeculativeLoad.Complete();
+        StartWorker(firstDemandedLoad, workerCount: 1);
+        firstDemandedLoad.SetResult(null);
+        firstDemandedLoad.Complete();
+        firstDemandedRequest.Complete(IconRequestStatus.Empty);
+
+        var secondSpeculativeRequest = IconLoadDiagnostics.BeginRequest(IconRequestReason.SourceChanged, 1.0);
+        var secondSpeculativeLoad = IconLoadDiagnostics.CreateLoad(
+            secondSpeculativeRequest,
+            "bitmap.png",
+            hasStream: false,
+            width: 20,
+            height: 20,
+            scale: 1.0);
+        Assert.IsNotNull(secondSpeculativeLoad);
+        secondSpeculativeRequest.RecordProviderResolution(IconProviderResolution.NewLoad, secondSpeculativeLoad);
+        secondSpeculativeLoad.Enqueued(IconLoadPriority.Low);
+        secondSpeculativeRequest.Invalidate();
+        secondSpeculativeRequest.Complete(IconRequestStatus.Stale);
+
+        var secondDemandedRequest = IconLoadDiagnostics.BeginRequest(IconRequestReason.SourceChanged, 1.0);
+        var secondDemandedLoad = IconLoadDiagnostics.CreateLoad(
+            secondDemandedRequest,
+            "bitmap.png",
+            hasStream: false,
+            width: 20,
+            height: 20,
+            scale: 1.0);
+        Assert.IsNotNull(secondDemandedLoad);
+        secondDemandedRequest.RecordProviderResolution(IconProviderResolution.NewLoad, secondDemandedLoad);
+        secondDemandedLoad.Enqueued(IconLoadPriority.Low);
+
+        StartWorker(secondSpeculativeLoad, workerCount: 4);
+        secondSpeculativeLoad.SetResult(null);
+        secondSpeculativeLoad.Complete();
+        StartWorker(secondDemandedLoad, workerCount: 4);
+        secondDemandedLoad.SetResult(null);
+        secondDemandedLoad.Complete();
+        secondDemandedRequest.Complete(IconRequestStatus.Empty);
+
+        var report = IconLoadDiagnostics.StopAndCreateReport();
+
+        Assert.IsNotNull(report);
+        StringAssert.Contains(report.Text, "Maximum demanded queue depth: 1");
+        StringAssert.Contains(report.Text, "Maximum speculative queue depth: 1");
+        StringAssert.Contains(report.Text, "Queued demotions after demand loss: 2");
+        StringAssert.Contains(report.Text, "Queued promotions after demand returned: 0");
+        StringAssert.Contains(report.Text, "Workers started demanded: 2");
+        StringAssert.Contains(report.Text, "Workers started speculative: 2");
+        StringAssert.Contains(report.Text, "Speculative starts with demanded loads queued: 2");
+        StringAssert.Contains(report.Text, "Speculative starts leaving demanded loads beyond remaining worker capacity: 1");
+        StringAssert.Contains(report.Text, "Demanded loads beyond remaining capacity across those starts: 1");
+        StringAssert.Contains(report.Text, "Maximum demanded loads beyond remaining capacity at one start: 1");
+        StringAssert.Contains(report.Text, "Capacity-interfering speculative starts by input kind");
+        StringAssert.Contains(report.Text, "      String: 1");
+        StringAssert.Contains(report.Text, "Demanded queue wait: count=2");
+        StringAssert.Contains(report.Text, "Speculative queue wait: count=2");
+    }
+
+    [TestMethod]
+    public void InvalidationBeforeResolutionStillTracksLoadWithoutDemand()
+    {
+        IconLoadDiagnostics.Start();
+        var request = IconLoadDiagnostics.BeginRequest(IconRequestReason.SourceChanged, 1.0);
+        request.Invalidate();
+
+        var load = IconLoadDiagnostics.CreateLoad(
+            request,
+            "bitmap.png",
+            hasStream: false,
+            width: 20,
+            height: 20,
+            scale: 1.0);
+
+        Assert.IsNotNull(load);
+        request.RecordProviderResolution(IconProviderResolution.NewLoad, load);
+        load.Enqueued(IconLoadPriority.Low);
+        StartWorker(load);
+        load.SetResult(null);
+        load.Complete();
+        request.Complete(IconRequestStatus.Stale);
+
+        var report = IconLoadDiagnostics.StopAndCreateReport();
+
+        Assert.IsNotNull(report);
+        StringAssert.Contains(report.Text, "    BeforeEnqueue: 1");
+        StringAssert.Contains(report.Text, "Workers started with no live requester: 1");
+        StringAssert.Contains(report.Text, "Loads completed with no live requester: 1");
+    }
+
+    [TestMethod]
+    public void RequestLatencyIsAttributedToEveryProviderResolution()
+    {
+        IconLoadDiagnostics.Start();
+
+        foreach (var resolution in Enum.GetValues<IconProviderResolution>())
+        {
+            var request = IconLoadDiagnostics.BeginRequest(IconRequestReason.SourceChanged, 1.0);
+            request.RecordProviderResolution(resolution, load: null);
+            request.Complete(IconRequestStatus.Empty);
+        }
+
+        var report = IconLoadDiagnostics.StopAndCreateReport();
+
+        Assert.IsNotNull(report);
+        foreach (var resolution in Enum.GetValues<IconProviderResolution>())
+        {
+            StringAssert.Contains(report.Text, $"    {resolution}");
+        }
+
+        Assert.AreEqual(
+            Enum.GetValues<IconProviderResolution>().Length,
+            CountOccurrences(report.Text, "      Empty: count=1"));
+        Assert.IsFalse(report.Text.Contains("Unattributed completed requests", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public void RequestOriginsAggregateBySiteAndStaticScope()
+    {
+        IconLoadDiagnostics.Start();
+        var firstOrigin = new IconRequestOrigin(101, IconRequestSite.ListItem, "SingleRow");
+        var secondOrigin = new IconRequestOrigin(102, IconRequestSite.ListItem, "SingleRow");
+
+        var firstRequest = IconLoadDiagnostics.BeginRequest(IconRequestReason.SourceChanged, 1.0, firstOrigin);
+        firstRequest.RecordProviderResolution(IconProviderResolution.CacheHit, load: null);
+        firstRequest.Complete(IconRequestStatus.Applied);
+
+        var staleRequest = IconLoadDiagnostics.BeginRequest(IconRequestReason.SourceChanged, 1.0, firstOrigin);
+        staleRequest.RecordProviderResolution(IconProviderResolution.NewLoad, load: null);
+        staleRequest.Complete(IconRequestStatus.Stale);
+
+        var secondRequest = IconLoadDiagnostics.BeginRequest(IconRequestReason.Loaded, 1.0, secondOrigin);
+        secondRequest.RecordProviderResolution(IconProviderResolution.CacheHit, load: null);
+        secondRequest.Complete(IconRequestStatus.Applied);
+
+        var report = IconLoadDiagnostics.StopAndCreateReport();
+
+        Assert.IsNotNull(report);
+        StringAssert.Contains(report.Text, "Request origins");
+        StringAssert.Contains(report.Text, "  ListItem / SingleRow");
+        StringAssert.Contains(report.Text, "    Icon boxes: 2");
+        StringAssert.Contains(report.Text, "    Started: 3");
+        StringAssert.Contains(report.Text, "    Applied: 2");
+        StringAssert.Contains(report.Text, "    Stale: 1");
+        StringAssert.Contains(report.Text, "      NewLoad: 1");
+        StringAssert.Contains(report.Text, "      CacheHit: 2");
+        StringAssert.Contains(report.Text, "    Result kinds");
+        StringAssert.Contains(report.Text, "      Empty: 3");
+        StringAssert.Contains(report.Text, "      Applied: count=2");
+        StringAssert.Contains(report.Text, "      Stale: count=1");
+        StringAssert.Contains(report.Text, "Individual process-local IconBox IDs are available in RequestOrigin ETW events.");
+    }
+
+    [TestMethod]
+    public void DiagnosticScopeRejectsPathsAndReportInjection()
+    {
+        IconLoadDiagnostics.Start();
+        var origin = new IconRequestOrigin(101, IconRequestSite.Settings, "C:\\private\\secret.exe\r\nInjected: 1");
+        var request = IconLoadDiagnostics.BeginRequest(IconRequestReason.SourceChanged, 1.0, origin);
+        request.Complete(IconRequestStatus.Empty);
+
+        var report = IconLoadDiagnostics.StopAndCreateReport();
+
+        Assert.IsNotNull(report);
+        StringAssert.Contains(report.Text, "  Settings");
+        Assert.IsFalse(report.Text.Contains("secret", StringComparison.OrdinalIgnoreCase));
+        Assert.IsFalse(report.Text.Contains("Injected", StringComparison.OrdinalIgnoreCase));
+        Assert.IsFalse(report.Text.Contains("C:\\private", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [TestMethod]
+    public async Task WorkerArrivalBeforeEnqueueDoesNotBlockAndResumesAfterCommit()
+    {
+        IconLoadDiagnostics.Start();
+        var load = IconLoadDiagnostics.CreateLoad(
+            default,
+            "bitmap.png",
+            hasStream: false,
+            width: 20,
+            height: 20,
+            scale: 1.0);
+
+        Assert.IsNotNull(load);
+        var workerStart = load.WorkerStartingAsync().AsTask();
+
+        Assert.IsFalse(workerStart.IsCompleted);
+        load.Enqueued(IconLoadPriority.Low);
+        Assert.IsTrue(await workerStart.WaitAsync(TimeSpan.FromSeconds(5)));
+        load.SetResult(null);
+        load.Complete();
+
+        var report = IconLoadDiagnostics.StopAndCreateReport();
+
+        Assert.IsNotNull(report);
+        StringAssert.Contains(report.Text, "Maximum low queue depth: 1");
+        StringAssert.Contains(report.Text, "Active at stop: 0");
+        StringAssert.Contains(report.Text, "Enqueue to completion: count=1");
+    }
+
+    [TestMethod]
+    public async Task RejectionReleasesWorkerWaitingForEnqueueCommit()
+    {
+        IconLoadDiagnostics.Start();
+        var load = IconLoadDiagnostics.CreateLoad(
+            default,
+            "bitmap.png",
+            hasStream: false,
+            width: 20,
+            height: 20,
+            scale: 1.0);
+
+        Assert.IsNotNull(load);
+        var workerStart = load.WorkerStartingAsync().AsTask();
+
+        Assert.IsFalse(workerStart.IsCompleted);
+        load.Rejected();
+        Assert.IsFalse(await workerStart.WaitAsync(TimeSpan.FromSeconds(5)));
+
+        var report = IconLoadDiagnostics.StopAndCreateReport();
+
+        Assert.IsNotNull(report);
+        StringAssert.Contains(report.Text, "Rejected: 1");
+        StringAssert.Contains(report.Text, "Active at stop: 0");
+        StringAssert.Contains(report.Text, "Enqueue to completion: no samples");
+    }
+
+    [TestMethod]
+    public void CompletionWithoutEnqueueDoesNotRecordAbsoluteTimestamp()
+    {
+        IconLoadDiagnostics.Start();
+        var load = IconLoadDiagnostics.CreateLoad(
+            default,
+            "bitmap.png",
+            hasStream: false,
+            width: 20,
+            height: 20,
+            scale: 1.0);
+
+        Assert.IsNotNull(load);
+        load.SetResult(null);
+        load.Complete();
+
+        var report = IconLoadDiagnostics.StopAndCreateReport();
+
+        Assert.IsNotNull(report);
+        StringAssert.Contains(report.Text, "Active at stop: 0");
+        StringAssert.Contains(report.Text, "Enqueue to completion: no samples");
+    }
+
+    [TestMethod]
+    public void ReportsRemainAvailableUntilReset()
+    {
+        var firstSessionId = IconLoadDiagnostics.Start();
+        var firstReport = IconLoadDiagnostics.StopAndCreateReport();
+        var secondSessionId = IconLoadDiagnostics.Start();
+        var secondReport = IconLoadDiagnostics.StopAndCreateReport();
+
+        var reports = IconLoadDiagnostics.GetReports();
+
+        Assert.HasCount(2, reports);
+        Assert.AreEqual(firstSessionId, firstReport?.SessionId);
+        Assert.AreEqual(secondSessionId, secondReport?.SessionId);
+        Assert.AreSame(firstReport, reports[0]);
+        Assert.AreSame(secondReport, reports[1]);
+
+        IconLoadDiagnostics.Start();
+
+        IconLoadDiagnostics.Reset();
+
+        Assert.IsFalse(IconLoadDiagnostics.IsRecording);
+        Assert.IsNull(IconLoadDiagnostics.StopAndCreateReport());
+        Assert.IsEmpty(IconLoadDiagnostics.GetReports());
+    }
+
+    private static int CountOccurrences(string value, string text)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = value.IndexOf(text, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += text.Length;
+        }
+
+        return count;
+    }
+
+    private static void StartWorker(IconLoadMeasurement load, int workerCount = 1)
+    {
+        var workerStart = load.WorkerStartingAsync(workerCount).AsTask();
+        Assert.IsTrue(workerStart.IsCompletedSuccessfully);
+        Assert.IsTrue(workerStart.GetAwaiter().GetResult());
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconLoadDiagnosticsTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconLoadDiagnosticsTests.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.CmdPal.UI.Controls;
 using Microsoft.CmdPal.UI.Helpers;
+using Microsoft.UI.Dispatching;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.CmdPal.UI.UnitTests;
@@ -56,6 +57,10 @@ public class IconLoadDiagnosticsTests
         Assert.IsTrue(report.Duration >= TimeSpan.Zero);
         StringAssert.Contains(report.Text, $"Session: {sessionId}");
         StringAssert.Contains(report.Text, "Ended UTC:");
+        StringAssert.Contains(report.Text, "Process work during session");
+        StringAssert.Contains(report.Text, "Managed allocations:");
+        StringAssert.Contains(report.Text, "UI responsiveness probe");
+        StringAssert.Contains(report.Text, "  Enabled: no");
         StringAssert.Contains(report.Text, "Started: 1");
         StringAssert.Contains(report.Text, "Stale: 1");
         StringAssert.Contains(report.Text, "NewLoad: 1");
@@ -111,6 +116,62 @@ public class IconLoadDiagnosticsTests
         var inputKinds = report.Text[inputKindsStart..inputKindsEnd];
         StringAssert.Contains(inputKinds, "  String: 1");
         StringAssert.Contains(inputKinds, "  ShellBinary: 0");
+    }
+
+    [TestMethod]
+    public void UiResponsivenessProbeTracksCompletedSkippedRejectedAndOutstandingCallbacks()
+    {
+        var session = new IconLoadDiagnosticsSession(1);
+        var acceptCallback = true;
+        DispatcherQueueHandler? pendingCallback = null;
+        var observedPriorities = new List<DispatcherQueuePriority>();
+        var probe = new IconUiResponsivenessProbe(TryEnqueue, session);
+
+        probe.OnTimerTick();
+        Assert.IsNotNull(pendingCallback);
+        probe.OnTimerTick();
+
+        var completedCallback = pendingCallback;
+        pendingCallback = null;
+        completedCallback!();
+
+        acceptCallback = false;
+        probe.OnTimerTick();
+
+        acceptCallback = true;
+        probe.OnTimerTick();
+        Assert.IsNotNull(pendingCallback);
+
+        probe.Stop();
+        var report = session.CreateReport();
+
+        CollectionAssert.AreEqual(
+            new[]
+            {
+                DispatcherQueuePriority.Normal,
+                DispatcherQueuePriority.Normal,
+                DispatcherQueuePriority.Normal,
+            },
+            observedPriorities);
+        StringAssert.Contains(report.Text, "Callbacks enqueued: 3");
+        StringAssert.Contains(report.Text, "Callbacks completed: 1");
+        StringAssert.Contains(report.Text, "Callbacks outstanding at stop: 1");
+        StringAssert.Contains(report.Text, "Timer ticks skipped while a callback was pending: 1");
+        StringAssert.Contains(report.Text, "Callbacks rejected by DispatcherQueue: 1");
+        StringAssert.Contains(report.Text, "Normal-priority queue wait: count=1");
+
+        bool TryEnqueue(DispatcherQueuePriority priority, DispatcherQueueHandler callback)
+        {
+            observedPriorities.Add(priority);
+            if (!acceptCallback)
+            {
+                return false;
+            }
+
+            Assert.IsNull(pendingCallback);
+            pendingCallback = callback;
+            return true;
+        }
     }
 
     [TestMethod]

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/Microsoft.CmdPal.UI.UnitTests.csproj
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/Microsoft.CmdPal.UI.UnitTests.csproj
@@ -42,6 +42,7 @@
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconRequestReason.cs" Link="Helpers\Icons\IconRequestReason.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconRequestStatus.cs" Link="Helpers\Icons\IconRequestStatus.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconSourceProvider.cs" Link="Helpers\Icons\IconSourceProvider.cs" />
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconUiResponsivenessProbe.cs" Link="Helpers\Icons\IconUiResponsivenessProbe.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IIconLoaderService.cs" Link="Helpers\Icons\IIconLoaderService.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IIconSourceProvider.cs" Link="Helpers\Icons\IIconSourceProvider.cs" />
   </ItemGroup>

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/Microsoft.CmdPal.UI.UnitTests.csproj
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/Microsoft.CmdPal.UI.UnitTests.csproj
@@ -23,9 +23,24 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Controls\IconRequestSite.cs" Link="Controls\IconRequestSite.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\AdaptiveCache`2.cs" Link="Helpers\AdaptiveCache`2.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\CachedIconSourceProvider.cs" Link="Helpers\Icons\CachedIconSourceProvider.cs" />
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconLoadDemandStage.cs" Link="Helpers\Icons\IconLoadDemandStage.cs" />
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconLoadDiagnostics.cs" Link="Helpers\Icons\IconLoadDiagnostics.cs" />
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconLoadDiagnosticsReport.cs" Link="Helpers\Icons\IconLoadDiagnosticsReport.cs" />
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconLoadDiagnosticsSession.cs" Link="Helpers\Icons\IconLoadDiagnosticsSession.cs" />
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconLoadEventSource.cs" Link="Helpers\Icons\IconLoadEventSource.cs" />
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconLoadInputKind.cs" Link="Helpers\Icons\IconLoadInputKind.cs" />
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconLoadMeasurement.cs" Link="Helpers\Icons\IconLoadMeasurement.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconLoadPriority.cs" Link="Helpers\Icons\IconLoadPriority.cs" />
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconLoadQueueDemandTransition.cs" Link="Helpers\Icons\IconLoadQueueDemandTransition.cs" />
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconLoadResultKind.cs" Link="Helpers\Icons\IconLoadResultKind.cs" />
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconProviderResolution.cs" Link="Helpers\Icons\IconProviderResolution.cs" />
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconRequestMeasurement.cs" Link="Helpers\Icons\IconRequestMeasurement.cs" />
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconRequestOrigin.cs" Link="Helpers\Icons\IconRequestOrigin.cs" />
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconRequestReason.cs" Link="Helpers\Icons\IconRequestReason.cs" />
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconRequestStatus.cs" Link="Helpers\Icons\IconRequestStatus.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconSourceProvider.cs" Link="Helpers\Icons\IconSourceProvider.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IIconLoaderService.cs" Link="Helpers\Icons\IIconLoaderService.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IIconSourceProvider.cs" Link="Helpers\Icons\IIconSourceProvider.cs" />


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Part 1 of 12 in the CmdPal icon-loading series. Targets `main`. Next: #50182.

This PR makes icon loading and overall UI responsiveness measurable, with collection disabled during normal use.

- Records request outcomes, cache/in-flight resolution, loading phases, and static request-origin labels.
- Measures process CPU time, managed allocations, GC, working set, and dispatcher responsiveness.
- Keeps session reports with copy controls and normal-log output, without recording icon strings, paths, or item data.

Motivation: distinguish costly icon work from queueing and unrelated UI pressure before optimizing the pipeline.

### Evidence

This is instrumentation, not a claimed speedup.

- Tests cover aggregate reporting, session/report lifetime, and enqueue/completion races.
- Disabled-collection overhead has not been isolated against uninstrumented main; it must not be described as zero.

### Shared measurement method for this PR series

Later PRs refer here instead of repeating these definitions.

- Historical A/B/C results are from 2026-08-18: Release Native AOT, three alternating iterations per side, two passes per process, text diagnostics active, ETW disabled. Values are medians of per-run metrics. They describe earlier implementations, not fresh measurements of the rewritten commits or their new main base.
- A is complete keyboard traversal of All apps and Segoe icons. B is sparse/skipping viewport traversal, testing requests that jump ahead of linear loading. C is character-by-character Home search for Word, Excel, PowerPoint, and Visual Studio.
- Cold-ish means a fresh CmdPal process; OS caches and extension state were not forcibly cleared. Warm means the second pass in the same process, not a guarantee that every icon remains cached.
- Before → after compares adjacent historical stages unless stated otherwise. This diagnostics foundation is the instrumented main-equivalent reference, not unmodified main. The following materialization-diagnostics PR (#50182) adds the detailed observer carried through later stages.
- Applied latency starts at the `IconBox` request and ends when the result is applied. It excludes earlier view-model initialization and is not scroll-to-first-paint time. An average alone cannot establish perceived responsiveness.
- p95/p99 values are histogram upper bounds, written `≤`. Crossing a bucket boundary is not an exact percentage change in the percentile. Read averages alongside sample counts; “no samples” is not zero.
- Dispatcher wait measures queueing, not execution. Callback wall time can include an asynchronous transfer. Measured STA slices and icon-UI totals cover instrumented wall time, not all UI CPU, rendering, or layout work.
- “Update average” is the instrumented icon-element update duration, not the complete item update or request latency. CPU is whole-process CPU time; allocations are bytes allocated, not retained memory.
- Three runs show descriptive repeatability, not statistical significance. Report absolute deltas and tails alongside percentages; a small average can still hide a noticeable slow request. Population changes, thermal variation, and workload differences must remain visible.
- Reduced cumulative work is useful, but is not the same as a proportional improvement in responsiveness. Small, inconsistent changes are not established wins or regressions.

### Technical notes

- Probes stay compiled in and are guarded at runtime. This avoids conditional-compilation plumbing, but an inactive probe still has a small checking cost; enabled collection necessarily adds work.
- Text summaries and ETW serve different purposes: repeatable aggregate comparisons versus timestamped event correlation. ETW-enabled runs must be identified separately, not mixed into the text-only baseline.
- Request origins use static developer labels and process-local control IDs, not paths, user content, or persistent identifiers.

Implementation: `src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadDiagnostics.cs`.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #49934
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

