### PR TITLE
CmdPal: Icons (3/n) - Harden icon caches and coalesce redundant refreshes

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/IconBox.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/IconBox.cs
@@ -24,6 +24,7 @@ public partial class IconBox : ContentControl
     private double _lastScale;
     private ElementTheme _lastTheme;
     private double _lastFontSize;
+    private IconRefreshState _refreshState;
     private long _requestVersion;
     private IconRequestMeasurement _activeRequestDiagnostics;
     private long _diagnosticId;
@@ -76,13 +77,15 @@ public partial class IconBox : ContentControl
     {
         add
         {
+            var hadHandler = _sourceRequested is not null;
             _sourceRequested += value;
-            if (_sourceRequested?.GetInvocationList().Length == 1)
+
+            if (!hadHandler && _sourceRequested is not null)
             {
-                Refresh(IconRequestReason.HandlerAttached);
+                RequestRefresh(IconRequestReason.HandlerAttached);
             }
 #if DEBUG
-            if (_sourceRequested?.GetInvocationList().Length > 1)
+            else if (value is not null)
             {
                 Logger.LogWarning("There shouldn't be more than one handler for IconBox.SourceRequested");
             }
@@ -96,6 +99,7 @@ public partial class IconBox : ContentControl
             if (_sourceRequested is null)
             {
                 AdvanceRequestVersion();
+                MarkRefreshPending(IconRequestReason.None);
             }
         }
     }
@@ -158,7 +162,7 @@ public partial class IconBox : ContentControl
         }
 
         _lastTheme = ActualTheme;
-        Refresh(IconRequestReason.ThemeChanged);
+        RequestRefresh(IconRequestReason.ThemeChanged);
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)
@@ -167,16 +171,37 @@ public partial class IconBox : ContentControl
         // Recompute any derived diagnostic placement now that its parent chain is available.
         _hasDerivedRequestSite = false;
         _derivedRequestSite = IconRequestSite.Unknown;
-        _lastTheme = ActualTheme;
+        var newTheme = ActualTheme;
+        var newScale = XamlRoot?.RasterizationScale ?? 1.0;
+        var changedTheme = _lastTheme != newTheme;
+        var changedScale = Math.Abs(newScale - _lastScale) > 0.01;
+
+        _lastTheme = newTheme;
+        _lastScale = newScale;
         UpdateLastFontSize();
 
         if (XamlRoot is not null)
         {
-            _lastScale = XamlRoot.RasterizationScale;
             XamlRoot.Changed += OnXamlRootChanged;
         }
 
-        Refresh(IconRequestReason.Loaded);
+        if (SourceKey is not null && (changedTheme || changedScale))
+        {
+            var reason = IconRequestReason.Loaded;
+            if (changedTheme)
+            {
+                reason |= IconRequestReason.ThemeChanged;
+            }
+
+            if (changedScale)
+            {
+                reason |= IconRequestReason.ScaleChanged;
+            }
+
+            MarkRefreshPending(reason);
+        }
+
+        Refresh();
     }
 
     private void OnUnloaded(object sender, RoutedEventArgs e)
@@ -199,7 +224,7 @@ public partial class IconBox : ContentControl
         _lastScale = newScale;
         _lastTheme = ActualTheme;
 
-        if ((changedLastTheme || changedScale) && SourceKey is not null)
+        if (SourceKey is not null && (changedLastTheme || changedScale))
         {
             var reason = IconRequestReason.None;
             if (changedLastTheme)
@@ -212,13 +237,33 @@ public partial class IconBox : ContentControl
                 reason |= IconRequestReason.ScaleChanged;
             }
 
-            UpdateSourceKey(this, SourceKey, reason);
+            RequestRefresh(reason);
         }
     }
 
-    private void Refresh(IconRequestReason reason = IconRequestReason.None)
+    private void MarkRefreshPending(IconRequestReason reason) =>
+        _refreshState.Request(SourceKey is not null, reason);
+
+    private void RequestRefresh(IconRequestReason reason)
     {
-        UpdateSourceKey(this, SourceKey, reason);
+        MarkRefreshPending(reason);
+        Refresh();
+    }
+
+    private void Refresh()
+    {
+        var sourceKey = SourceKey;
+        var sourceRequested = _sourceRequested;
+        if (!_refreshState.TryConsume(
+                IsLoaded,
+                sourceKey is not null,
+                sourceRequested is not null,
+                out var reason))
+        {
+            return;
+        }
+
+        RequestIconFromSource(this, sourceKey!, sourceRequested!, AdvanceRequestVersion(), reason);
     }
 
     private long AdvanceRequestVersion()
@@ -365,28 +410,22 @@ public partial class IconBox : ContentControl
             return;
         }
 
-        UpdateSourceKey(self, e.NewValue, IconRequestReason.SourceChanged);
-    }
+        self.AdvanceRequestVersion();
 
-    private static void UpdateSourceKey(
-        IconBox iconBox,
-        object? sourceKey,
-        IconRequestReason reason = IconRequestReason.None)
-    {
-        var requestVersion = iconBox.AdvanceRequestVersion();
-
-        if (sourceKey is null)
+        if (e.NewValue is null)
         {
-            iconBox.Source = null;
+            self._refreshState.Clear();
+            self.Source = null;
             return;
         }
 
-        RequestIconFromSource(iconBox, sourceKey, requestVersion, reason);
+        self.RequestRefresh(IconRequestReason.SourceChanged);
     }
 
     private static async void RequestIconFromSource(
         IconBox iconBox,
         object sourceKey,
+        TypedEventHandler<IconBox, SourceRequestedEventArgs> sourceRequested,
         long requestVersion,
         IconRequestReason reason)
     {
@@ -394,13 +433,6 @@ public partial class IconBox : ContentControl
 
         try
         {
-            var iconBoxSourceRequestedHandler = iconBox._sourceRequested;
-
-            if (iconBoxSourceRequestedHandler is null)
-            {
-                return;
-            }
-
             var scale = iconBox._lastScale > 0
                 ? iconBox._lastScale
                 : (iconBox.XamlRoot?.RasterizationScale > 0 ? iconBox.XamlRoot.RasterizationScale : 1.0);
@@ -413,7 +445,7 @@ public partial class IconBox : ContentControl
             {
                 Diagnostics = diagnostics,
             };
-            await iconBoxSourceRequestedHandler.InvokeAsync(iconBox, eventArgs);
+            await sourceRequested.InvokeAsync(iconBox, eventArgs);
 
             // After the await:
             // Is the icon we're looking up now, the one we still
@@ -421,7 +453,7 @@ public partial class IconBox : ContentControl
             // list virtualization situation, it's very possible we
             // may have already been set to a new icon before we
             // even got back from the await.
-            if (!ReferenceEquals(sourceKey, iconBox.SourceKey))
+            if (requestVersion != iconBox._requestVersion || !ReferenceEquals(sourceKey, iconBox.SourceKey))
             {
                 // If the requested icon has changed, then just bail
                 diagnostics.Complete(IconRequestStatus.Stale, eventArgs.Value);
@@ -436,6 +468,13 @@ public partial class IconBox : ContentControl
         catch (Exception ex)
         {
             diagnostics.Complete(IconRequestStatus.Failed);
+
+            if (requestVersion == iconBox._requestVersion)
+            {
+                // Do not dispatch immediately: a deterministic failure would recurse forever.
+                // Keep the request pending for the next external lifecycle or source trigger.
+                iconBox.MarkRefreshPending(IconRequestReason.Retry);
+            }
 
             // Exception from TryEnqueue bypasses the global error handler,
             // and crashes the app.

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/IconRefreshState.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/IconRefreshState.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.UI.Helpers;
+
+namespace Microsoft.CmdPal.UI.Controls;
+
+/// <summary>
+/// Coalesces IconBox refresh requests until every dispatch requirement is available.
+/// </summary>
+internal struct IconRefreshState
+{
+    private bool _isPending;
+    private IconRequestReason _reason;
+
+    public void Request(bool hasSource, IconRequestReason reason)
+    {
+        if (!hasSource)
+        {
+            Clear();
+            return;
+        }
+
+        _isPending = true;
+        _reason |= reason;
+    }
+
+    public bool TryConsume(
+        bool isLoaded,
+        bool hasSource,
+        bool hasHandler,
+        out IconRequestReason reason)
+    {
+        if (!_isPending || !isLoaded || !hasSource || !hasHandler)
+        {
+            reason = IconRequestReason.None;
+            return false;
+        }
+
+        reason = _reason;
+        Clear();
+        return true;
+    }
+
+    public void Clear()
+    {
+        _isPending = false;
+        _reason = IconRequestReason.None;
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/AdaptiveCache`2.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/AdaptiveCache`2.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -22,7 +22,6 @@ internal sealed class AdaptiveCache<TKey, TValue>
     private readonly Action<TKey, TValue, AdaptiveCacheRemovalReason, int, int>? _removalCallback;
 
     private readonly ConcurrentDictionary<TKey, CacheEntry> _map;
-    private readonly ConcurrentStack<CacheEntry> _pool = [];
     private readonly WaitCallback _maintenanceCallback;
 
     // ConcurrentDictionary.Count acquires every stripe lock. Keep an approximate count so
@@ -68,30 +67,23 @@ internal sealed class AdaptiveCache<TKey, TValue>
             return entry.Value!;
         }
 
-        if (!_pool.TryPop(out var newEntry))
-        {
-            newEntry = new CacheEntry();
-        }
-
         var value = factory(key, arg);
         var tick = Interlocked.Increment(ref _currentTick);
-        newEntry.Initialize(key, value, 1.0, tick);
+        var newEntry = new CacheEntry(value, 1.0, tick);
 
-        if (_map.TryAdd(key, newEntry))
+        while (!_map.TryAdd(key, newEntry))
         {
-            Interlocked.Increment(ref _entryCount);
-        }
-        else
-        {
-            newEntry.Clear();
-            _pool.Push(newEntry);
-
             if (_map.TryGetValue(key, out var existing))
             {
                 existing.Update(tick);
                 return existing.Value!;
             }
+
+            // The entry that defeated TryAdd was removed before the follow-up lookup.
+            // Retry with the value we already created rather than returning it uncached.
         }
+
+        Interlocked.Increment(ref _entryCount);
 
         if (ShouldMaintenanceRun())
         {
@@ -117,35 +109,34 @@ internal sealed class AdaptiveCache<TKey, TValue>
     public void Add(TKey key, TValue value)
     {
         var tick = Interlocked.Increment(ref _currentTick);
+        var newEntry = new CacheEntry(value, 1.0, tick);
 
-        if (_map.TryGetValue(key, out var existing))
+        while (true)
         {
-            existing.Update(tick);
-            _removalCallback?.Invoke(
-                key,
-                existing.Value,
-                AdaptiveCacheRemovalReason.Replaced,
-                ApproximateCount,
-                _capacity);
-            existing.SetValue(value);
-            return;
-        }
+            if (_map.TryGetValue(key, out var existing))
+            {
+                // Add is also an access. Carry the adaptive history into the immutable
+                // replacement instead of making a hot key look newly inserted.
+                var replacement = new CacheEntry(value, existing.GetFrequency() + 1.0, tick);
+                if (_map.TryUpdate(key, replacement, existing))
+                {
+                    _removalCallback?.Invoke(
+                        key,
+                        existing.Value,
+                        AdaptiveCacheRemovalReason.Replaced,
+                        ApproximateCount,
+                        _capacity);
+                    break;
+                }
 
-        if (!_pool.TryPop(out var newEntry))
-        {
-            newEntry = new CacheEntry();
-        }
+                continue;
+            }
 
-        newEntry.Initialize(key, value, 1.0, tick);
-
-        if (_map.TryAdd(key, newEntry))
-        {
-            Interlocked.Increment(ref _entryCount);
-        }
-        else
-        {
-            newEntry.Clear();
-            _pool.Push(newEntry);
+            if (_map.TryAdd(key, newEntry))
+            {
+                Interlocked.Increment(ref _entryCount);
+                break;
+            }
         }
 
         if (ShouldMaintenanceRun())
@@ -154,20 +145,30 @@ internal sealed class AdaptiveCache<TKey, TValue>
         }
     }
 
-    public bool TryRemove(TKey key) => TryRemove(key, AdaptiveCacheRemovalReason.Explicit);
+    public bool TryRemove(TKey key) => TryRemove(key, AdaptiveCacheRemovalReason.Explicit, expected: null);
 
-    private bool TryRemove(TKey key, AdaptiveCacheRemovalReason reason)
+    private bool TryRemove(TKey key, AdaptiveCacheRemovalReason reason, CacheEntry? expected)
     {
-        if (_map.TryRemove(key, out var evicted))
+        CacheEntry evicted;
+        if (expected is null)
         {
-            Interlocked.Decrement(ref _entryCount);
-            _removalCallback?.Invoke(key, evicted.Value, reason, ApproximateCount, _capacity);
-            evicted.Clear();
-            _pool.Push(evicted);
-            return true;
+            if (!_map.TryRemove(key, out evicted!))
+            {
+                return false;
+            }
+        }
+        else if (!_map.TryRemove(new KeyValuePair<TKey, CacheEntry>(key, expected)))
+        {
+            return false;
+        }
+        else
+        {
+            evicted = expected;
         }
 
-        return false;
+        Interlocked.Decrement(ref _entryCount);
+        _removalCallback?.Invoke(key, evicted.Value, reason, ApproximateCount, _capacity);
+        return true;
     }
 
     public void Clear()
@@ -176,7 +177,7 @@ internal sealed class AdaptiveCache<TKey, TValue>
         // while Keys snapshots under every stripe lock.
         foreach (var (key, _) in _map)
         {
-            TryRemove(key, AdaptiveCacheRemovalReason.Clear);
+            TryRemove(key, AdaptiveCacheRemovalReason.Clear, expected: null);
         }
 
         Interlocked.Exchange(ref _currentTick, 0);
@@ -220,7 +221,8 @@ internal sealed class AdaptiveCache<TKey, TValue>
             {
                 TryRemove(
                     key,
-                    overCapacity ? AdaptiveCacheRemovalReason.Capacity : AdaptiveCacheRemovalReason.LowScore);
+                    overCapacity ? AdaptiveCacheRemovalReason.Capacity : AdaptiveCacheRemovalReason.LowScore,
+                    entry);
             }
         }
     }
@@ -244,20 +246,16 @@ internal sealed class AdaptiveCache<TKey, TValue>
     }
 
     /// <summary>
-    /// Represents a single pooled entry in the cache, containing the value and
-    /// atomic metadata for adaptive eviction logic.
+    /// Represents an immutable cached value with atomic adaptive-eviction metadata.
+    /// Entries are never reused: a lock-free reader may retain an entry after the
+    /// dictionary has concurrently removed it.
     /// </summary>
     private sealed class CacheEntry
     {
         /// <summary>
-        /// Gets the key associated with this entry. Used primarily for identification during cleanup.
+        /// Gets the cached value.
         /// </summary>
-        public TKey Key { get; private set; } = default!;
-
-        /// <summary>
-        /// Gets the cached value. This reference is cleared on eviction to allow GC collection.
-        /// </summary>
-        public TValue Value { get; private set; } = default!;
+        public TValue Value { get; }
 
         /// <summary>
         /// Stores the frequency count as double bits to allow for Interlocked atomic math.
@@ -274,23 +272,11 @@ internal sealed class AdaptiveCache<TKey, TValue>
         /// </summary>
         private long _lastAccessTick;
 
-        public void Initialize(TKey key, TValue value, double frequency, long lastAccessTick)
+        public CacheEntry(TValue value, double frequency, long lastAccessTick)
         {
-            Key = key;
             Value = value;
             _frequencyBits = BitConverter.DoubleToInt64Bits(frequency);
             _lastAccessTick = lastAccessTick;
-        }
-
-        public void SetValue(TValue value)
-        {
-            Value = value;
-        }
-
-        public void Clear()
-        {
-            Key = default!;
-            Value = default!;
         }
 
         public void Update(long tick)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/CachedIconSourceProvider.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/CachedIconSourceProvider.cs
@@ -7,11 +7,14 @@ using System.Runtime.CompilerServices;
 using Microsoft.CmdPal.UI.ViewModels;
 using Microsoft.UI.Xaml.Controls;
 using Windows.Foundation;
+using Windows.Storage.Streams;
 
 namespace Microsoft.CmdPal.UI.Helpers;
 
 internal sealed class CachedIconSourceProvider : IIconSourceProvider
 {
+    private static readonly ConditionalWeakTable<IRandomAccessStreamReference, StreamIdentity> StreamIdentities = new();
+
     private readonly AdaptiveCache<IconCacheKey, Task<IconSource?>> _cache;
     private readonly ConcurrentDictionary<IconCacheKey, Task<IconSource?>> _inFlight = new();
     private readonly Size _iconSize;
@@ -145,27 +148,34 @@ internal sealed class CachedIconSourceProvider : IIconSourceProvider
     {
         private readonly string? _icon;
         private readonly string? _fontFamily;
-        private readonly int _streamRefHashCode;
+        private readonly StreamIdentity? _streamIdentity;
         private readonly int _scale;
 
         public IconCacheKey(IconDataViewModel icon, double scale)
         {
             _icon = icon.Icon;
             _fontFamily = icon.FontFamily;
-            _streamRefHashCode = icon.Data?.Unsafe is { } stream
-                ? RuntimeHelpers.GetHashCode(stream)
-                : 0;
+            _streamIdentity = icon.Data?.Unsafe is { } stream
+                ? StreamIdentities.GetValue(stream, static _ => new StreamIdentity())
+                : null;
             _scale = (int)(100 * Math.Round(scale, 2));
         }
 
         public bool Equals(IconCacheKey other) =>
             _icon == other._icon &&
             _fontFamily == other._fontFamily &&
-            _streamRefHashCode == other._streamRefHashCode &&
+            ReferenceEquals(_streamIdentity, other._streamIdentity) &&
             _scale == other._scale;
 
         public override bool Equals(object? obj) => obj is IconCacheKey other && Equals(other);
 
-        public override int GetHashCode() => HashCode.Combine(_icon, _fontFamily, _streamRefHashCode, _scale);
+        public override int GetHashCode() => HashCode.Combine(_icon, _fontFamily, _streamIdentity, _scale);
+    }
+
+    // A RuntimeHelpers.GetHashCode value is not unique. Keep a weak mapping from each
+    // stream reference to a stable token so cached keys cannot alias distinct streams,
+    // without making the cache retain the stream and its encoded image data.
+    private sealed class StreamIdentity
+    {
     }
 }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/AdaptiveCacheTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/AdaptiveCacheTests.cs
@@ -16,6 +16,39 @@ namespace Microsoft.CmdPal.UI.UnitTests;
 public class AdaptiveCacheTests
 {
     [TestMethod]
+    [Timeout(5_000)]
+    public async Task LookupOverlappingEvictionDoesNotObserveAnotherKeysValue()
+    {
+        using var comparisonStarted = new ManualResetEventSlim();
+        using var continueComparison = new ManualResetEventSlim();
+        var cache = new AdaptiveCache<BlockingKey, int>(capacity: 4, decayInterval: TimeSpan.FromHours(1));
+        cache.Add(new BlockingKey(1), 101);
+
+        var lookup = Task.Run(() =>
+        {
+            var found = cache.TryGet(
+                new BlockingKey(1, comparisonStarted, continueComparison),
+                out var value);
+            return (Found: found, Value: value);
+        });
+
+        Assert.IsTrue(comparisonStarted.Wait(TimeSpan.FromSeconds(2)), "The lookup did not reach its key comparison.");
+        try
+        {
+            Assert.IsTrue(cache.TryRemove(new BlockingKey(1)));
+            cache.Add(new BlockingKey(2), 202);
+        }
+        finally
+        {
+            continueComparison.Set();
+        }
+
+        var result = await lookup;
+        Assert.IsTrue(result.Found);
+        Assert.AreEqual(101, result.Value);
+    }
+
+    [TestMethod]
     public void ApproximateCountChangesOnlyForSuccessfulMutations()
     {
         var cache = new AdaptiveCache<int, int>(capacity: 8);
@@ -35,6 +68,78 @@ public class AdaptiveCacheTests
 
         cache.Clear();
         Assert.AreEqual(0, cache.ApproximateCount);
+    }
+
+    [TestMethod]
+    public void ReplacingValuePreservesAdaptiveFrequency()
+    {
+        var cache = new AdaptiveCache<int, int>(capacity: 4, decayInterval: TimeSpan.FromHours(1));
+        cache.Add(1, 101);
+        for (var i = 0; i < 1_000; i++)
+        {
+            Assert.IsTrue(cache.TryGet(1, out _));
+        }
+
+        cache.Add(1, 102);
+        cache.Add(2, 202);
+        for (var i = 0; i < 2_000; i++)
+        {
+            Assert.IsTrue(cache.TryGet(2, out _));
+        }
+
+        var cleanup = typeof(AdaptiveCache<int, int>).GetMethod(
+            "PerformCleanup",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        Assert.IsNotNull(cleanup);
+        cleanup.Invoke(cache, null);
+
+        Assert.IsTrue(cache.TryGet(1, out var replacement));
+        Assert.AreEqual(102, replacement);
+    }
+
+    [TestMethod]
+    [Timeout(5_000)]
+    public async Task GetOrAddRetriesWhenCompetingEntryDisappears()
+    {
+        using var factoryStarted = new ManualResetEventSlim();
+        using var continueFactory = new ManualResetEventSlim();
+        using var lookupStarted = new ManualResetEventSlim();
+        using var continueLookup = new ManualResetEventSlim();
+        var cache = new AdaptiveCache<BlockingHashKey, int>(capacity: 4, decayInterval: TimeSpan.FromHours(1));
+
+        // The initial miss, losing TryAdd, and follow-up lookup are hash calls 1, 2,
+        // and 3. Pause the third so the competing entry can disappear before lookup.
+        var requestedKey = new BlockingHashKey(
+            1,
+            blockOnHashCall: 3,
+            hashCallStarted: lookupStarted,
+            continueHashCall: continueLookup);
+
+        var getOrAdd = Task.Run(() => cache.GetOrAdd(
+            requestedKey,
+            static (_, state) =>
+            {
+                state.FactoryStarted.Set();
+                if (!state.ContinueFactory.Wait(TimeSpan.FromSeconds(2)))
+                {
+                    throw new TimeoutException("The competing cache entry was not inserted.");
+                }
+
+                return 101;
+            },
+            (FactoryStarted: factoryStarted, ContinueFactory: continueFactory)));
+
+        Assert.IsTrue(factoryStarted.Wait(TimeSpan.FromSeconds(2)), "The value factory did not start.");
+        cache.Add(new BlockingHashKey(1), 202);
+        continueFactory.Set();
+
+        Assert.IsTrue(lookupStarted.Wait(TimeSpan.FromSeconds(2)), "The follow-up cache lookup did not start.");
+        Assert.IsTrue(cache.TryRemove(new BlockingHashKey(1)));
+        continueLookup.Set();
+
+        Assert.AreEqual(101, await getOrAdd);
+        Assert.IsTrue(cache.TryGet(new BlockingHashKey(1), out var cached));
+        Assert.AreEqual(101, cached);
     }
 
     [TestMethod]
@@ -138,6 +243,88 @@ public class AdaptiveCacheTests
         for (var key = 0; key < workerCount * itemsPerWorker; key++)
         {
             Assert.IsFalse(cache.TryGet(key, out _), $"Cache still contains key {key} after Clear.");
+        }
+    }
+
+    private sealed class BlockingKey : IEquatable<BlockingKey>
+    {
+        private readonly ManualResetEventSlim? _comparisonStarted;
+        private readonly ManualResetEventSlim? _continueComparison;
+
+        public int Value { get; }
+
+        public BlockingKey(
+            int value,
+            ManualResetEventSlim? comparisonStarted = null,
+            ManualResetEventSlim? continueComparison = null)
+        {
+            Value = value;
+            _comparisonStarted = comparisonStarted;
+            _continueComparison = continueComparison;
+        }
+
+        public bool Equals(BlockingKey? other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            var blockingKey = _comparisonStarted is not null ? this : other;
+            if (blockingKey._comparisonStarted is not null)
+            {
+                blockingKey._comparisonStarted.Set();
+                if (blockingKey._continueComparison?.Wait(TimeSpan.FromSeconds(2)) != true)
+                {
+                    throw new TimeoutException("The cache lookup key comparison was not released.");
+                }
+            }
+
+            return Value == other.Value;
+        }
+
+        public override bool Equals(object? obj) => Equals(obj as BlockingKey);
+
+        public override int GetHashCode() => Value;
+    }
+
+    private sealed class BlockingHashKey : IEquatable<BlockingHashKey>
+    {
+        private readonly int _blockOnHashCall;
+        private readonly ManualResetEventSlim? _hashCallStarted;
+        private readonly ManualResetEventSlim? _continueHashCall;
+        private int _hashCalls;
+
+        public int Value { get; }
+
+        public BlockingHashKey(
+            int value,
+            int blockOnHashCall = 0,
+            ManualResetEventSlim? hashCallStarted = null,
+            ManualResetEventSlim? continueHashCall = null)
+        {
+            Value = value;
+            _blockOnHashCall = blockOnHashCall;
+            _hashCallStarted = hashCallStarted;
+            _continueHashCall = continueHashCall;
+        }
+
+        public bool Equals(BlockingHashKey? other) => other is not null && Value == other.Value;
+
+        public override bool Equals(object? obj) => Equals(obj as BlockingHashKey);
+
+        public override int GetHashCode()
+        {
+            if (Interlocked.Increment(ref _hashCalls) == _blockOnHashCall)
+            {
+                _hashCallStarted?.Set();
+                if (_continueHashCall?.Wait(TimeSpan.FromSeconds(2)) != true)
+                {
+                    throw new TimeoutException("The cache lookup hash calculation was not released.");
+                }
+            }
+
+            return Value;
         }
     }
 }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/CachedIconSourceProviderTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/CachedIconSourceProviderTests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Concurrent;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Microsoft.CmdPal.UI.Helpers;
 using Microsoft.CmdPal.UI.ViewModels;
 using Microsoft.UI.Xaml.Controls;
@@ -14,7 +15,7 @@ using Windows.Storage.Streams;
 namespace Microsoft.CmdPal.UI.UnitTests;
 
 [TestClass]
-public class CachedIconSourceProviderTests
+public partial class CachedIconSourceProviderTests
 {
     [TestMethod]
     [Timeout(5_000)]
@@ -59,6 +60,43 @@ public class CachedIconSourceProviderTests
 
         Assert.AreSame(first, cached);
         Assert.AreEqual(1, loader.EnqueueCount);
+    }
+
+    [TestMethod]
+    [Timeout(5_000)]
+    public async Task DistinctStreamReferencesWithCollidingRuntimeHashesDoNotShareLoad()
+    {
+        var collision = FindRuntimeHashCollision();
+        if (collision is null)
+        {
+            Assert.Inconclusive("No runtime identity-hash collision was found among 500,000 live objects.");
+            return;
+        }
+
+        var (firstStream, secondStream) = collision.Value;
+        Assert.AreNotSame(firstStream, secondStream);
+        Assert.AreEqual(RuntimeHelpers.GetHashCode(firstStream), RuntimeHelpers.GetHashCode(secondStream));
+
+        var loader = new ControllableIconLoader();
+        var provider = new CachedIconSourceProvider(loader, new Size(20, 20), cacheSize: 16);
+        var firstIcon = new IconDataViewModel
+        {
+            Data = new IconDataStreamReference { Unsafe = firstStream },
+        };
+        var secondIcon = new IconDataViewModel
+        {
+            Data = new IconDataStreamReference { Unsafe = secondStream },
+        };
+
+        var first = provider.GetIconSource(firstIcon, 1.0);
+        var second = provider.GetIconSource(secondIcon, 1.0);
+
+        Assert.AreNotSame(first, second);
+        Assert.AreEqual(2, loader.EnqueueCount);
+
+        loader.CompleteNext(null);
+        loader.CompleteNext(null);
+        await Task.WhenAll(first, second);
     }
 
     [TestMethod]
@@ -129,6 +167,32 @@ public class CachedIconSourceProviderTests
         var inFlight = field!.GetValue(provider)!;
         var countProperty = inFlight.GetType().GetProperty("Count");
         return (int)countProperty!.GetValue(inFlight)!;
+    }
+
+    private static (TestStreamReference First, TestStreamReference Second)? FindRuntimeHashCollision()
+    {
+        const int MaximumCandidates = 500_000;
+        var referencesByHash = new Dictionary<int, TestStreamReference>();
+
+        for (var i = 0; i < MaximumCandidates; i++)
+        {
+            var candidate = new TestStreamReference();
+            var hash = RuntimeHelpers.GetHashCode(candidate);
+            if (referencesByHash.TryGetValue(hash, out var existing))
+            {
+                return (existing, candidate);
+            }
+
+            referencesByHash.Add(hash, candidate);
+        }
+
+        return null;
+    }
+
+    private sealed partial class TestStreamReference : IRandomAccessStreamReference
+    {
+        public IAsyncOperation<IRandomAccessStreamWithContentType> OpenReadAsync() =>
+            throw new NotSupportedException("The cache-key test does not open its stream references.");
     }
 
     private sealed class ControllableIconLoader : IIconLoaderService

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconRefreshStateTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconRefreshStateTests.cs
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.UI.Controls;
+using Microsoft.CmdPal.UI.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.UI.UnitTests;
+
+[TestClass]
+public class IconRefreshStateTests
+{
+    [TestMethod]
+    public void SourceThenHandlerCoalescesReasonsUntilDispatch()
+    {
+        var state = default(IconRefreshState);
+        state.Request(hasSource: true, reason: IconRequestReason.SourceChanged);
+
+        Assert.IsFalse(state.TryConsume(
+            isLoaded: true,
+            hasSource: true,
+            hasHandler: false,
+            out _));
+
+        state.Request(hasSource: true, reason: IconRequestReason.HandlerAttached);
+
+        Assert.IsTrue(state.TryConsume(
+            isLoaded: true,
+            hasSource: true,
+            hasHandler: true,
+            out var reason));
+        Assert.AreEqual(
+            IconRequestReason.SourceChanged | IconRequestReason.HandlerAttached,
+            reason);
+    }
+
+    [TestMethod]
+    public void HandlerThenSourceDoesNotRetainAReasonWithoutWork()
+    {
+        var state = default(IconRefreshState);
+        state.Request(hasSource: false, reason: IconRequestReason.HandlerAttached);
+        state.Request(hasSource: true, reason: IconRequestReason.SourceChanged);
+
+        Assert.IsTrue(state.TryConsume(
+            isLoaded: true,
+            hasSource: true,
+            hasHandler: true,
+            out var reason));
+        Assert.AreEqual(IconRequestReason.SourceChanged, reason);
+    }
+
+    [TestMethod]
+    public void PendingRequestSurvivesUntilEveryRequirementIsAvailable()
+    {
+        var state = default(IconRefreshState);
+        state.Request(hasSource: true, reason: IconRequestReason.Loaded);
+
+        Assert.IsFalse(state.TryConsume(isLoaded: false, hasSource: true, hasHandler: true, out _));
+        Assert.IsFalse(state.TryConsume(isLoaded: true, hasSource: false, hasHandler: true, out _));
+        Assert.IsFalse(state.TryConsume(isLoaded: true, hasSource: true, hasHandler: false, out _));
+        Assert.IsTrue(state.TryConsume(isLoaded: true, hasSource: true, hasHandler: true, out var reason));
+        Assert.AreEqual(IconRequestReason.Loaded, reason);
+        Assert.IsFalse(state.TryConsume(isLoaded: true, hasSource: true, hasHandler: true, out _));
+    }
+
+    [TestMethod]
+    public void ClearingSourceDiscardsPendingReasons()
+    {
+        var state = default(IconRefreshState);
+        state.Request(hasSource: true, reason: IconRequestReason.SourceChanged | IconRequestReason.ThemeChanged);
+        state.Request(hasSource: false, reason: IconRequestReason.Retry);
+
+        Assert.IsFalse(state.TryConsume(
+            isLoaded: true,
+            hasSource: true,
+            hasHandler: true,
+            out var reason));
+        Assert.AreEqual(IconRequestReason.None, reason);
+    }
+
+    [TestMethod]
+    public void RetryWaitsForAndCombinesWithAnExternalTrigger()
+    {
+        var state = default(IconRefreshState);
+        state.Request(hasSource: true, reason: IconRequestReason.Retry);
+
+        Assert.IsFalse(state.TryConsume(
+            isLoaded: false,
+            hasSource: true,
+            hasHandler: true,
+            out _));
+
+        state.Request(hasSource: true, reason: IconRequestReason.Loaded);
+
+        Assert.IsTrue(state.TryConsume(
+            isLoaded: true,
+            hasSource: true,
+            hasHandler: true,
+            out var reason));
+        Assert.AreEqual(IconRequestReason.Retry | IconRequestReason.Loaded, reason);
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/Microsoft.CmdPal.UI.UnitTests.csproj
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/Microsoft.CmdPal.UI.UnitTests.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Controls\IconRefreshState.cs" Link="Controls\IconRefreshState.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Controls\IconRequestSite.cs" Link="Controls\IconRequestSite.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\AdaptiveCache`2.cs" Link="Helpers\AdaptiveCache`2.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\AdaptiveCacheRemovalReason.cs" Link="Helpers\AdaptiveCacheRemovalReason.cs" />


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Part 3 of 12 in the CmdPal icon-loading series. Depends on #50182. Next: #50184.

This PR fixes cache identity/lifetime hazards and avoids unnecessary `IconBox` reloads.

- Stops recycling mutable cache entries while readers may still hold them, and gives stream-backed icons stable weak identities.
- Preserves shared in-flight loads and safe cache publication.
- Coalesces refreshes, waits for a usable control/handler, skips unchanged theme/scale, and rejects obsolete completions.

Motivation: wrong or stale icons are correctness failures; unnecessary refreshes also add work during recycling.

### Evidence

Historical adjacent-stage comparison (2026-08-18); shared method and limitations: the diagnostics foundation PR #50181.

- A cold-ish applied average: 11.420 → 6.377 ms (−5.043 ms, −44.2%); all three pairs improved.
- A cold-ish applied p95 bound: ≤33 → ≤16 ms.
- C cold-ish applied average: 10.212 → 8.192 ms (−2.020 ms), but only two of three pairs improved and the ranges overlap.
- B warm process CPU: 111421.875 → 114671.875 ms (+2.9%); the direction was inconsistent, so this is not an established CPU regression.
- Regression tests exercise lookup overlapping eviction, rather than only sequential cache access.

The strongest latency evidence is scenario A. Refresh coalescing changes the request population; these measurements support less icon-pipeline delay, not a measured first-paint improvement.

### Technical notes

- Removing entry reuse is intentional: a lock-free reader can retain an evicted entry. Reusing that mutable object for another key can return the wrong icon.
- A runtime hash code is not a unique identity. Weak stream identities avoid collisions without making the identity table retain every stream forever.
- Refresh coalescing must retain request-version and handler checks. “Same source object” alone does not prove that an asynchronous completion still belongs to the current row.

Implementation: `src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/IconBox.cs`.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #49935
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

