### PR TITLE
CmdPal: Icons (4/n) - Prioritize live icon requests and load glyphs directly

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/IconBox.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/IconBox.cs
@@ -27,6 +27,7 @@ public partial class IconBox : ContentControl
     private IconRefreshState _refreshState;
     private long _requestVersion;
     private IconRequestMeasurement _activeRequestDiagnostics;
+    private IIconRequestDemand? _activeRequestDemand;
     private long _diagnosticId;
     private IconRequestSite _derivedRequestSite;
     private bool _hasDerivedRequestSite;
@@ -206,13 +207,51 @@ public partial class IconBox : ContentControl
 
     private void OnUnloaded(object sender, RoutedEventArgs e)
     {
+        // ListView recycling can deliver an Unloaded event after the same template
+        // instance has already been rebound, loaded, and arranged for a new item.
+        // No matching Loaded event follows that stale notification, so invalidating
+        // the new request here would leave the previous icon in the visible row.
+        if (_activeRequestDemand is not null && IsLoaded && IsWithinXamlRootBounds())
+        {
+            return;
+        }
+
         if (XamlRoot is not null)
         {
             XamlRoot.Changed -= OnXamlRootChanged;
         }
 
+        if (_activeRequestDemand is not null)
+        {
+            AdvanceRequestVersion();
+            MarkRefreshPending(IconRequestReason.Loaded);
+        }
+
         _hasDerivedRequestSite = false;
         _derivedRequestSite = IconRequestSite.Unknown;
+    }
+
+    private bool IsWithinXamlRootBounds()
+    {
+        var xamlRoot = XamlRoot;
+        if (xamlRoot is null || ActualWidth <= 0 || ActualHeight <= 0)
+        {
+            return false;
+        }
+
+        try
+        {
+            var bounds = TransformToVisual(null).TransformBounds(new Rect(0, 0, ActualWidth, ActualHeight));
+            var rootSize = xamlRoot.Size;
+            return bounds.Right > 0
+                && bounds.Bottom > 0
+                && bounds.Left < rootSize.Width
+                && bounds.Top < rootSize.Height;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
     }
 
     private void OnXamlRootChanged(XamlRoot sender, XamlRootChangedEventArgs args)
@@ -270,26 +309,35 @@ public partial class IconBox : ContentControl
     {
         _activeRequestDiagnostics.Invalidate();
         _activeRequestDiagnostics = default;
+        _activeRequestDemand?.Release();
+        _activeRequestDemand = null;
         return ++_requestVersion;
     }
 
-    private void TrackActiveRequest(long requestVersion, IconRequestMeasurement diagnostics)
+    private void TrackActiveRequest(
+        long requestVersion,
+        IconRequestMeasurement diagnostics,
+        IIconRequestDemand demand)
     {
         if (requestVersion == _requestVersion)
         {
             _activeRequestDiagnostics = diagnostics;
+            _activeRequestDemand = demand;
         }
         else
         {
             diagnostics.Invalidate();
+            demand.Release();
         }
     }
 
-    private void ClearActiveRequest(long requestVersion)
+    private void ClearActiveRequest(long requestVersion, IIconRequestDemand demand)
     {
-        if (requestVersion == _requestVersion)
+        demand.Release();
+        if (requestVersion == _requestVersion && ReferenceEquals(_activeRequestDemand, demand))
         {
             _activeRequestDiagnostics = default;
+            _activeRequestDemand = null;
         }
     }
 
@@ -430,6 +478,7 @@ public partial class IconBox : ContentControl
         IconRequestReason reason)
     {
         var diagnostics = default(IconRequestMeasurement);
+        SourceRequestedEventArgs? eventArgs = null;
 
         try
         {
@@ -440,11 +489,11 @@ public partial class IconBox : ContentControl
             diagnostics = IconLoadDiagnostics.IsRecording
                 ? IconLoadDiagnostics.BeginRequest(reason, scale, iconBox.GetDiagnosticOrigin())
                 : default;
-            iconBox.TrackActiveRequest(requestVersion, diagnostics);
-            var eventArgs = new SourceRequestedEventArgs(sourceKey, iconBox._lastTheme, scale)
+            eventArgs = new SourceRequestedEventArgs(sourceKey, iconBox._lastTheme, scale)
             {
                 Diagnostics = diagnostics,
             };
+            iconBox.TrackActiveRequest(requestVersion, diagnostics, eventArgs);
             await sourceRequested.InvokeAsync(iconBox, eventArgs);
 
             // After the await:
@@ -482,7 +531,10 @@ public partial class IconBox : ContentControl
         }
         finally
         {
-            iconBox.ClearActiveRequest(requestVersion);
+            if (eventArgs is not null)
+            {
+                iconBox.ClearActiveRequest(requestVersion, eventArgs);
+            }
         }
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SourceRequestedEventArgs.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SourceRequestedEventArgs.cs
@@ -12,8 +12,10 @@ namespace Microsoft.CmdPal.UI.Controls;
 /// <summary>
 /// See <see cref="IconBox.SourceRequested"/> event.
 /// </summary>
-public class SourceRequestedEventArgs(object? key, ElementTheme requestedTheme, double scale = 1.0) : DeferredEventArgs
+public class SourceRequestedEventArgs(object? key, ElementTheme requestedTheme, double scale = 1.0) : DeferredEventArgs, IIconRequestDemand
 {
+    private IconRequestDemandState _demandState;
+
     public object? Key { get; private set; } = key;
 
     public IconSource? Value { get; set; }
@@ -23,4 +25,8 @@ public class SourceRequestedEventArgs(object? key, ElementTheme requestedTheme, 
     public double Scale => scale;
 
     internal IconRequestMeasurement Diagnostics { get; set; }
+
+    void IIconRequestDemand.Attach(IconLoadDemand loadDemand) => _demandState.Attach(loadDemand);
+
+    void IIconRequestDemand.Release() => _demandState.Release();
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/CachedIconSourceProvider.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/CachedIconSourceProvider.cs
@@ -16,7 +16,7 @@ internal sealed class CachedIconSourceProvider : IIconSourceProvider
     private static readonly ConditionalWeakTable<IRandomAccessStreamReference, StreamIdentity> StreamIdentities = new();
 
     private readonly AdaptiveCache<IconCacheKey, Task<IconSource?>> _cache;
-    private readonly ConcurrentDictionary<IconCacheKey, Task<IconSource?>> _inFlight = new();
+    private readonly ConcurrentDictionary<IconCacheKey, InFlightIconLoad> _inFlight = new();
     private readonly Size _iconSize;
     private readonly int _cacheSize;
     private readonly IIconLoaderService _loader;
@@ -37,7 +37,11 @@ internal sealed class CachedIconSourceProvider : IIconSourceProvider
     {
     }
 
-    public Task<IconSource?> GetIconSource(IconDataViewModel icon, double scale, IconRequestMeasurement diagnostics = default)
+    public Task<IconSource?> GetIconSource(
+        IconDataViewModel icon,
+        double scale,
+        IconRequestMeasurement diagnostics = default,
+        IIconRequestDemand? demand = null)
     {
         var key = new IconCacheKey(icon, scale);
 
@@ -49,25 +53,28 @@ internal sealed class CachedIconSourceProvider : IIconSourceProvider
         }
 
         IconLoadDiagnostics.RecordCacheLookup(_iconSize, _cacheSize, hit: false);
-        return GetOrCreateSlowPath(key, icon, scale, diagnostics);
+        return GetOrCreateSlowPath(key, icon, scale, diagnostics, demand);
     }
 
     private Task<IconSource?> GetOrCreateSlowPath(
         IconCacheKey key,
         IconDataViewModel icon,
         double scale,
-        IconRequestMeasurement diagnostics)
+        IconRequestMeasurement diagnostics,
+        IIconRequestDemand? demand)
     {
-        var tcs = new TaskCompletionSource<IconSource?>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var task = tcs.Task;
+        var candidate = new InFlightIconLoad();
 
-        var pending = _inFlight.GetOrAdd(key, task);
-        if (!ReferenceEquals(pending, task))
+        var pending = _inFlight.GetOrAdd(key, candidate);
+        if (!ReferenceEquals(pending, candidate))
         {
-            diagnostics.RecordProviderResolution(IconProviderResolution.InFlight, pending);
-            return pending;
+            pending.Demand.Attach(demand);
+            diagnostics.RecordProviderResolution(IconProviderResolution.InFlight, pending.Task);
+            return pending.Task;
         }
 
+        var tcs = pending;
+        var task = pending.Task;
         IconLoadMeasurement? loadDiagnostics = null;
 
         _ = task.ContinueWith(
@@ -86,7 +93,7 @@ internal sealed class CachedIconSourceProvider : IIconSourceProvider
                 }
                 finally
                 {
-                    _inFlight.TryRemove(new KeyValuePair<IconCacheKey, Task<IconSource?>>(key, completed));
+                    _inFlight.TryRemove(new KeyValuePair<IconCacheKey, InFlightIconLoad>(key, pending));
                 }
             },
             CancellationToken.None,
@@ -113,6 +120,8 @@ internal sealed class CachedIconSourceProvider : IIconSourceProvider
                 return task;
             }
 
+            pending.Demand.Attach(demand);
+
             if (!_loader.TryEnqueueLoad(
                     icon.Icon,
                     icon.FontFamily,
@@ -121,7 +130,8 @@ internal sealed class CachedIconSourceProvider : IIconSourceProvider
                     scale,
                     tcs,
                     IconLoadPriority.Low,
-                    loadDiagnostics))
+                    loadDiagnostics,
+                    pending.Demand))
             {
                 tcs.TrySetException(new ObjectDisposedException(nameof(IIconLoaderService)));
             }
@@ -149,6 +159,18 @@ internal sealed class CachedIconSourceProvider : IIconSourceProvider
             capacity,
             remainingCount,
             reason);
+    }
+
+    private sealed class InFlightIconLoad : TaskCompletionSource<IconSource?>
+    {
+        private IconLoadDemand? _demand;
+
+        public InFlightIconLoad()
+            : base(TaskCreationOptions.RunContinuationsAsynchronously)
+        {
+        }
+
+        public IconLoadDemand Demand => LazyInitializer.EnsureInitialized(ref _demand);
     }
 
     private readonly struct IconCacheKey : IEquatable<IconCacheKey>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/CachedIconSourceProvider.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/CachedIconSourceProvider.cs
@@ -106,6 +106,13 @@ internal sealed class CachedIconSourceProvider : IIconSourceProvider
             loadDiagnostics?.RegisterTask(task);
             diagnostics.RecordProviderResolution(IconProviderResolution.NewLoad, loadDiagnostics);
 
+            if (_loader.TryLoadGlyph(icon.Icon, icon.FontFamily, _iconSize, scale, out var glyph) && glyph is not null)
+            {
+                loadDiagnostics?.CompleteDirectGlyph(glyph);
+                tcs.TrySetResult(glyph);
+                return task;
+            }
+
             if (!_loader.TryEnqueueLoad(
                     icon.Icon,
                     icon.FontFamily,

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/FontIconSizeCalculator.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/FontIconSizeCalculator.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Windows.Foundation;
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+internal static class FontIconSizeCalculator
+{
+    private const int MinimumFallbackSize = 8;
+
+    public static int Calculate(Size iconSize, double scale, int defaultSize)
+    {
+        var scaledSize = iconSize.IsEmpty
+            ? iconSize
+            : new Size(iconSize.Width * scale, iconSize.Height * scale);
+        var targetSize = scaledSize.IsEmpty
+            ? defaultSize
+            : (int)Math.Max(scaledSize.Width, scaledSize.Height);
+        return targetSize > 0 ? targetSize : MinimumFallbackSize;
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IIconLoaderService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IIconLoaderService.cs
@@ -26,5 +26,6 @@ internal interface IIconLoaderService : IAsyncDisposable
         double scale,
         TaskCompletionSource<IconSource?> tcs,
         IconLoadPriority priority,
-        IconLoadMeasurement? diagnostics = null);
+        IconLoadMeasurement? diagnostics = null,
+        IconLoadDemand? demand = null);
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IIconLoaderService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IIconLoaderService.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Xaml.Controls;
 using Windows.Foundation;
 using Windows.Storage.Streams;
@@ -10,6 +11,13 @@ namespace Microsoft.CmdPal.UI.Helpers;
 
 internal interface IIconLoaderService : IAsyncDisposable
 {
+    bool TryLoadGlyph(
+        string? iconString,
+        string? fontFamily,
+        Size iconSize,
+        double scale,
+        [MaybeNullWhen(false)] out IconSource result);
+
     bool TryEnqueueLoad(
         string? iconString,
         string? fontFamily,

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IIconRequestDemand.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IIconRequestDemand.cs
@@ -4,13 +4,9 @@
 
 namespace Microsoft.CmdPal.UI.Helpers;
 
-internal enum IconLoadDemandStage
+internal interface IIconRequestDemand
 {
-    Unlinked,
-    BeforeEnqueue,
-    Queued,
-    WorkerActive,
-    Completed,
-    Rejected,
-    Abandoned,
+    void Attach(IconLoadDemand loadDemand);
+
+    void Release();
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IIconSourceProvider.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IIconSourceProvider.cs
@@ -9,5 +9,9 @@ namespace Microsoft.CmdPal.UI.Helpers;
 
 internal interface IIconSourceProvider
 {
-    Task<IconSource?> GetIconSource(IconDataViewModel icon, double scale, IconRequestMeasurement diagnostics = default);
+    Task<IconSource?> GetIconSource(
+        IconDataViewModel icon,
+        double scale,
+        IconRequestMeasurement diagnostics = default,
+        IIconRequestDemand? demand = null);
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadDemand.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadDemand.cs
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+/// <summary>
+/// Aggregates all live UI requests sharing one icon load.
+/// </summary>
+internal sealed class IconLoadDemand
+{
+    private int _liveRequesters;
+    private IObserver? _observer;
+
+    internal interface IObserver
+    {
+        // This is an invalidation, not a state snapshot. Notifications may overtake
+        // one another, so observers must read current state.
+        void OnDemandChanged();
+    }
+
+    public bool IsDemanded => Volatile.Read(ref _liveRequesters) > 0;
+
+    public static IconLoadDemand CreateDemanded()
+    {
+        var demand = new IconLoadDemand();
+        demand.AddRequester();
+        return demand;
+    }
+
+    public void Attach(IIconRequestDemand? requestDemand)
+    {
+        if (requestDemand is null)
+        {
+            AddRequester();
+        }
+        else
+        {
+            requestDemand.Attach(this);
+        }
+    }
+
+    /// <summary>
+    /// Installs the single queue observer that owns this load while it is queued.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The demand already has a queue observer. One load demand cannot represent
+    /// more than one queued work item at a time.
+    /// </exception>
+    public void Subscribe(IObserver observer)
+    {
+        Debug.Assert(Volatile.Read(ref _observer) is null, "An icon load can be queued only once.");
+        if (Interlocked.CompareExchange(ref _observer, observer, null) is not null)
+        {
+            throw new InvalidOperationException("The icon load already has a queue observer.");
+        }
+    }
+
+    public void Unsubscribe(IObserver observer)
+    {
+        Interlocked.CompareExchange(ref _observer, null, observer);
+    }
+
+    internal void AddRequester()
+    {
+        if (Interlocked.Increment(ref _liveRequesters) == 1)
+        {
+            Volatile.Read(ref _observer)?.OnDemandChanged();
+        }
+    }
+
+    internal void RemoveRequester()
+    {
+        while (true)
+        {
+            var liveRequesters = Volatile.Read(ref _liveRequesters);
+            Debug.Assert(liveRequesters > 0, "A released icon request must be attached to the load.");
+            if (liveRequesters == 0)
+            {
+                return;
+            }
+
+            var remainingRequesters = liveRequesters - 1;
+            if (Interlocked.CompareExchange(ref _liveRequesters, remainingRequesters, liveRequesters) == liveRequesters)
+            {
+                if (remainingRequesters == 0)
+                {
+                    Volatile.Read(ref _observer)?.OnDemandChanged();
+                }
+
+                return;
+            }
+        }
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadDiagnostics.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadDiagnostics.cs
@@ -247,6 +247,22 @@ internal static class IconLoadDiagnostics
         return new DemandedIdleCapacityMeasurement(session, startedAt);
     }
 
+    internal static SpeculativeDispatchDeferralMeasurement? BeginSpeculativeDispatchDeferral(
+        int speculativeQueueDepth,
+        int workerCount,
+        int reservedWorkerSlots)
+    {
+        var session = Volatile.Read(ref _activeSession);
+        if (session is null)
+        {
+            return null;
+        }
+
+        var startedAt = Stopwatch.GetTimestamp();
+        session.RecordSpeculativeDispatchDeferralStarted(speculativeQueueDepth, workerCount, reservedWorkerSlots);
+        return new SpeculativeDispatchDeferralMeasurement(session, startedAt, workerCount);
+    }
+
     private static IconLoadInputKind ClassifyInput(string? iconString, bool hasStream)
     {
         if (!string.IsNullOrEmpty(iconString))
@@ -412,6 +428,42 @@ internal static class IconLoadDiagnostics
             if (Interlocked.Exchange(ref _completed, 1) == 0)
             {
                 _session.RecordDemandedIdleCapacityCompleted(Stopwatch.GetTimestamp() - _startedAt);
+            }
+        }
+    }
+
+    internal sealed class SpeculativeDispatchDeferralMeasurement
+    {
+        private readonly IconLoadDiagnosticsSession _session;
+        private readonly long _startedAt;
+        private readonly int _workerCount;
+        private int _completed;
+
+        public SpeculativeDispatchDeferralMeasurement(
+            IconLoadDiagnosticsSession session,
+            long startedAt,
+            int workerCount)
+        {
+            _session = session;
+            _startedAt = startedAt;
+            _workerCount = workerCount;
+        }
+
+        public bool IsForActiveSession => ReferenceEquals(_session, Volatile.Read(ref _activeSession));
+
+        public void Observe(int speculativeQueueDepth, int reservedWorkerSlots)
+        {
+            _session.RecordSpeculativeDispatchDeferralObserved(
+                speculativeQueueDepth,
+                _workerCount,
+                reservedWorkerSlots);
+        }
+
+        public void Complete()
+        {
+            if (Interlocked.Exchange(ref _completed, 1) == 0)
+            {
+                _session.RecordSpeculativeDispatchDeferralCompleted(Stopwatch.GetTimestamp() - _startedAt);
             }
         }
     }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadDiagnostics.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadDiagnostics.cs
@@ -219,6 +219,34 @@ internal static class IconLoadDiagnostics
         return ReferenceEquals(session, Volatile.Read(ref _etwSession));
     }
 
+    internal static SchedulerCommandMeasurement? BeginSchedulerCommand(IconLoadQueue.QueueCommandKind kind)
+    {
+        var session = GetCurrentSession();
+        if (session is null)
+        {
+            return null;
+        }
+
+        var publishedAt = Stopwatch.GetTimestamp();
+        session.RecordSchedulerCommandPublished(kind);
+        return new SchedulerCommandMeasurement(session, kind, publishedAt);
+    }
+
+    internal static DemandedIdleCapacityMeasurement? BeginDemandedIdleCapacity(
+        int demandedQueueDepth,
+        int availableWorkerSlots)
+    {
+        var session = GetCurrentSession();
+        if (session is null)
+        {
+            return null;
+        }
+
+        var startedAt = Stopwatch.GetTimestamp();
+        session.RecordDemandedIdleCapacityStarted(demandedQueueDepth, availableWorkerSlots);
+        return new DemandedIdleCapacityMeasurement(session, startedAt);
+    }
+
     private static IconLoadInputKind ClassifyInput(string? iconString, bool hasStream)
     {
         if (!string.IsNullOrEmpty(iconString))
@@ -263,6 +291,128 @@ internal static class IconLoadDiagnostics
         catch
         {
             return IconLoadResultKind.Other;
+        }
+    }
+
+    internal sealed class SchedulerCommandMeasurement
+    {
+        private readonly IconLoadDiagnosticsSession _session;
+        private readonly IconLoadQueue.QueueCommandKind _kind;
+        private readonly long _publishedAt;
+        private int _processed;
+        private int _dispatched;
+
+        public SchedulerCommandMeasurement(
+            IconLoadDiagnosticsSession session,
+            IconLoadQueue.QueueCommandKind kind,
+            long publishedAt)
+        {
+            _session = session;
+            _kind = kind;
+            _publishedAt = publishedAt;
+        }
+
+        public void Processed()
+        {
+            if (Interlocked.Exchange(ref _processed, 1) == 0)
+            {
+                _session.RecordSchedulerCommandProcessed(
+                    _kind,
+                    Stopwatch.GetTimestamp() - _publishedAt);
+            }
+        }
+
+        public SchedulerWakeMeasurement CreateWakeMeasurement()
+        {
+            return new SchedulerWakeMeasurement(_session, _kind, _publishedAt);
+        }
+
+        public void WorkerDispatched(bool demanded)
+        {
+            if (Interlocked.Exchange(ref _dispatched, 1) == 0)
+            {
+                _session.RecordWorkerDispatched(
+                    demanded,
+                    Stopwatch.GetTimestamp() - _publishedAt);
+            }
+        }
+    }
+
+    internal sealed class SchedulerWakeMeasurement
+    {
+        private readonly IconLoadDiagnosticsSession _session;
+        private readonly IconLoadQueue.QueueCommandKind _triggerKind;
+        private readonly long _signaledAt;
+        private long _wakeTicks = -1;
+        private int _woke;
+        private int _completed;
+
+        public SchedulerWakeMeasurement(
+            IconLoadDiagnosticsSession session,
+            IconLoadQueue.QueueCommandKind triggerKind,
+            long signaledAt)
+        {
+            _session = session;
+            _triggerKind = triggerKind;
+            _signaledAt = signaledAt;
+        }
+
+        public void Woke(long wokeAt)
+        {
+            if (Interlocked.Exchange(ref _woke, 1) == 0)
+            {
+                var wakeTicks = Math.Max(0, wokeAt - _signaledAt);
+                Volatile.Write(ref _wakeTicks, wakeTicks);
+                _session.RecordSchedulerCoordinatorWoke(_triggerKind, wakeTicks);
+            }
+        }
+
+        public void BatchCompleted(
+            int commandCount,
+            int dispatchedWorkItemCount,
+            long drainTicks,
+            long passTicks)
+        {
+            if (Interlocked.Exchange(ref _completed, 1) == 0)
+            {
+                var wakeTicks = Volatile.Read(ref _wakeTicks);
+                Debug.Assert(wakeTicks >= 0, "A scheduler batch must wake before it completes.");
+                _session.RecordSchedulerBatchCompleted(
+                    _triggerKind,
+                    wakeTicks,
+                    commandCount,
+                    dispatchedWorkItemCount,
+                    drainTicks,
+                    passTicks);
+            }
+        }
+    }
+
+    internal sealed class DemandedIdleCapacityMeasurement
+    {
+        private readonly IconLoadDiagnosticsSession _session;
+        private readonly long _startedAt;
+        private int _completed;
+
+        public DemandedIdleCapacityMeasurement(IconLoadDiagnosticsSession session, long startedAt)
+        {
+            _session = session;
+            _startedAt = startedAt;
+        }
+
+        public bool IsForActiveSession => IsCurrentSession(_session);
+
+        public void Observe(int demandedQueueDepth, int availableWorkerSlots)
+        {
+            _session.RecordDemandedIdleCapacityObserved(demandedQueueDepth, availableWorkerSlots);
+        }
+
+        public void Complete()
+        {
+            if (Interlocked.Exchange(ref _completed, 1) == 0)
+            {
+                _session.RecordDemandedIdleCapacityCompleted(Stopwatch.GetTimestamp() - _startedAt);
+            }
         }
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadDiagnosticsSession.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadDiagnosticsSession.cs
@@ -30,6 +30,7 @@ internal sealed class IconLoadDiagnosticsSession
     private readonly long[] _inputKinds = new long[Enum.GetValues<IconLoadInputKind>().Length];
     private readonly long[] _resultKinds = new long[Enum.GetValues<IconLoadResultKind>().Length];
     private readonly DiagnosticHistogram[][] _requestLatencyByResolutionAndResult = CreateRequestMeasurements();
+    private readonly DiagnosticHistogram[] _appliedRequestLatencyByResolution = CreateResolutionMeasurements();
     private readonly DiagnosticHistogram _requestLatency = new();
     private readonly DiagnosticHistogram _loadLatency = new();
     private readonly DiagnosticHistogram _directGlyphLatency = new();
@@ -37,6 +38,8 @@ internal sealed class IconLoadDiagnosticsSession
     private readonly DiagnosticHistogram _queueLatency = new();
     private readonly DiagnosticHistogram _demandedQueueLatency = new();
     private readonly DiagnosticHistogram _speculativeQueueLatency = new();
+    private readonly DiagnosticHistogram _demandArrivalToWorkerStartWithActiveSpeculative = new();
+    private readonly DiagnosticHistogram _directlyBlockedDemandArrivalToWorkerStart = new();
     private readonly DiagnosticHistogram _backgroundPreparationLatency = new();
     private readonly DiagnosticHistogram _dispatcherWaitLatency = new();
     private readonly DiagnosticHistogram _dispatcherWorkLatency = new();
@@ -51,6 +54,18 @@ internal sealed class IconLoadDiagnosticsSession
     private readonly ConcurrentQueue<DispatcherOutlierSample> _dispatcherOutliers = new();
     private readonly DiagnosticHistogram _uiProbeWaitLatency = new();
     private readonly DiagnosticHistogram _elementUpdateLatency = new();
+    private readonly long[] _schedulerCommandsPublished = new long[Enum.GetValues<IconLoadQueue.QueueCommandKind>().Length];
+    private readonly long[] _schedulerCommandsProcessed = new long[Enum.GetValues<IconLoadQueue.QueueCommandKind>().Length];
+    private readonly DiagnosticHistogram[] _schedulerCommandLatency = CreateSchedulerCommandMeasurements();
+    private readonly DiagnosticHistogram _schedulerSignalToWakeLatency = new();
+    private readonly DiagnosticHistogram _schedulerEmptyBatchSignalToWakeLatency = new();
+    private readonly DiagnosticHistogram[] _schedulerSignalToWakeLatencyByCommandKind = CreateSchedulerCommandMeasurements();
+    private readonly DiagnosticHistogram _schedulerBatchDrainLatency = new();
+    private readonly DiagnosticHistogram _schedulerPassLatency = new();
+    private readonly DiagnosticHistogram _workerReadyToDispatchLatency = new();
+    private readonly DiagnosticHistogram _workerReadyToDemandedDispatchLatency = new();
+    private readonly DiagnosticHistogram _workerReadyToSpeculativeDispatchLatency = new();
+    private readonly DiagnosticHistogram _demandedIdleCapacityDuration = new();
     private readonly InputKindMeasurements[] _inputKindMeasurements = CreateInputKindMeasurements();
     private readonly ElementKindMeasurements[] _elementKindMeasurements = CreateElementKindMeasurements();
     private readonly ConditionalWeakTable<Task<IconSource?>, IconLoadMeasurement> _loadsByTask = new();
@@ -63,6 +78,9 @@ internal sealed class IconLoadDiagnosticsSession
     private readonly ConcurrentDictionary<RequestOriginKey, RequestOriginMeasurements> _requestOriginMeasurements = new();
     private readonly long[] _invalidatedRequestLoadStages = new long[Enum.GetValues<IconLoadDemandStage>().Length];
     private readonly long[] _capacityInterferingSpeculativeStartsByInputKind = new long[Enum.GetValues<IconLoadInputKind>().Length];
+    private readonly long[] _currentActiveSpeculativeWorkersByInputKind = new long[Enum.GetValues<IconLoadInputKind>().Length];
+    private readonly long[] _speculativeWorkerOccupancyAtDemandArrivalsByInputKind = new long[Enum.GetValues<IconLoadInputKind>().Length];
+    private readonly long[] _directlyBlockedDemandArrivalsByInputKind = new long[Enum.GetValues<IconLoadInputKind>().Length];
     private readonly long _processCpuStartedTicks;
     private readonly long _managedAllocatedBytesStarted;
     private readonly long _gcPauseStartedTicks;
@@ -86,6 +104,7 @@ internal sealed class IconLoadDiagnosticsSession
     private long _requestsStarted;
     private long _loadsCreated;
     private long _loadsRejected;
+    private long _loadsAbandonedBeforeStart;
     private long _directGlyphLoads;
     private long _currentHighQueueDepth;
     private long _currentLowQueueDepth;
@@ -103,6 +122,26 @@ internal sealed class IconLoadDiagnosticsSession
     private long _capacityInterferingSpeculativeStarts;
     private long _demandedLoadsBeyondCapacityAtSpeculativeStarts;
     private long _maximumDemandedLoadsBeyondCapacityAtSpeculativeStart;
+    private long _currentActiveDemandedWorkers;
+    private long _currentActiveSpeculativeWorkers;
+    private long _maximumActiveSpeculativeWorkers;
+    private long _demandedQueueArrivals;
+    private long _demandedArrivalsWithActiveSpeculativeWorkers;
+    private long _speculativeWorkerOccupancyAtDemandArrivals;
+    private long _maximumSpeculativeWorkersAtDemandArrival;
+    private long _demandedArrivalsDirectlyBlockedBySpeculativeCapacity;
+    private long _currentSchedulerCommandBacklog;
+    private long _maximumSchedulerCommandBacklog;
+    private long _schedulerBatchesCompleted;
+    private long _schedulerEmptyBatches;
+    private long _schedulerCommandsDrained;
+    private long _maximumSchedulerBatchSize;
+    private long _schedulerWorkItemsDispatched;
+    private long _maximumSchedulerDispatchCount;
+    private long _demandedIdleCapacityIntervalsStarted;
+    private long _currentDemandedIdleCapacityIntervals;
+    private long _maximumDemandedQueueDepthWithIdleCapacity;
+    private long _maximumAvailableWorkerSlotsWithDemandedWork;
     private long _activeWorkers;
     private long _maximumActiveWorkers;
     private long _dispatcherEnqueuedDemanded;
@@ -179,6 +218,101 @@ internal sealed class IconLoadDiagnosticsSession
     internal bool IsLoadDemanded(long loadId)
     {
         return _loadDemandStates.TryGetValue(loadId, out var demandState) && demandState.IsDemanded;
+    }
+
+    public void RecordSchedulerCommandPublished(IconLoadQueue.QueueCommandKind kind)
+    {
+        Interlocked.Increment(ref _schedulerCommandsPublished[(int)kind]);
+        var backlog = Interlocked.Increment(ref _currentSchedulerCommandBacklog);
+        UpdateMaximum(ref _maximumSchedulerCommandBacklog, backlog);
+    }
+
+    public void RecordSchedulerCommandProcessed(IconLoadQueue.QueueCommandKind kind, long elapsedTicks)
+    {
+        Interlocked.Increment(ref _schedulerCommandsProcessed[(int)kind]);
+        _schedulerCommandLatency[(int)kind].Record(elapsedTicks);
+        var backlog = Interlocked.Decrement(ref _currentSchedulerCommandBacklog);
+        Debug.Assert(backlog >= 0, "A processed scheduler command must have been published in the same diagnostic session.");
+        IconLoadEventSource.Log.SchedulerCommandProcessed(
+            Id,
+            (int)kind,
+            ToMicroseconds(elapsedTicks),
+            Math.Max(0, backlog));
+    }
+
+    public void RecordSchedulerCoordinatorWoke(IconLoadQueue.QueueCommandKind triggerKind, long elapsedTicks)
+    {
+        IconLoadEventSource.Log.SchedulerCoordinatorWoke(
+            Id,
+            (int)triggerKind,
+            ToMicroseconds(elapsedTicks));
+    }
+
+    public void RecordSchedulerBatchCompleted(
+        IconLoadQueue.QueueCommandKind triggerKind,
+        long wakeTicks,
+        int commandCount,
+        int dispatchedWorkItemCount,
+        long drainTicks,
+        long passTicks)
+    {
+        Interlocked.Increment(ref _schedulerBatchesCompleted);
+        if (commandCount == 0)
+        {
+            Interlocked.Increment(ref _schedulerEmptyBatches);
+            _schedulerEmptyBatchSignalToWakeLatency.Record(wakeTicks);
+        }
+        else
+        {
+            _schedulerSignalToWakeLatency.Record(wakeTicks);
+            _schedulerSignalToWakeLatencyByCommandKind[(int)triggerKind].Record(wakeTicks);
+            _schedulerBatchDrainLatency.Record(drainTicks);
+            _schedulerPassLatency.Record(passTicks);
+        }
+
+        Interlocked.Add(ref _schedulerCommandsDrained, commandCount);
+        Interlocked.Add(ref _schedulerWorkItemsDispatched, dispatchedWorkItemCount);
+        UpdateMaximum(ref _maximumSchedulerBatchSize, commandCount);
+        UpdateMaximum(ref _maximumSchedulerDispatchCount, dispatchedWorkItemCount);
+        IconLoadEventSource.Log.SchedulerBatchCompleted(
+            Id,
+            commandCount,
+            dispatchedWorkItemCount,
+            ToMicroseconds(drainTicks),
+            ToMicroseconds(passTicks));
+    }
+
+    public void RecordWorkerDispatched(bool demanded, long elapsedTicks)
+    {
+        _workerReadyToDispatchLatency.Record(elapsedTicks);
+        (demanded
+            ? _workerReadyToDemandedDispatchLatency
+            : _workerReadyToSpeculativeDispatchLatency).Record(elapsedTicks);
+        IconLoadEventSource.Log.WorkerReadyToDispatchCompleted(
+            Id,
+            demanded ? 1 : 0,
+            ToMicroseconds(elapsedTicks));
+    }
+
+    public void RecordDemandedIdleCapacityStarted(int demandedQueueDepth, int availableWorkerSlots)
+    {
+        Interlocked.Increment(ref _demandedIdleCapacityIntervalsStarted);
+        Interlocked.Increment(ref _currentDemandedIdleCapacityIntervals);
+        RecordDemandedIdleCapacityObserved(demandedQueueDepth, availableWorkerSlots);
+    }
+
+    public void RecordDemandedIdleCapacityObserved(int demandedQueueDepth, int availableWorkerSlots)
+    {
+        UpdateMaximum(ref _maximumDemandedQueueDepthWithIdleCapacity, demandedQueueDepth);
+        UpdateMaximum(ref _maximumAvailableWorkerSlotsWithDemandedWork, availableWorkerSlots);
+    }
+
+    public void RecordDemandedIdleCapacityCompleted(long elapsedTicks)
+    {
+        var activeIntervals = Interlocked.Decrement(ref _currentDemandedIdleCapacityIntervals);
+        Debug.Assert(activeIntervals >= 0, "A demanded-idle-capacity interval must start before it completes.");
+        _demandedIdleCapacityDuration.Record(elapsedTicks);
+        IconLoadEventSource.Log.DemandedIdleCapacityCompleted(Id, ToMicroseconds(elapsedTicks));
     }
 
     public IconRequestMeasurement BeginRequest(IconRequestReason reason, double scale, IconRequestOrigin origin)
@@ -283,7 +417,11 @@ internal sealed class IconLoadDiagnosticsSession
         {
             lock (requestState.SyncRoot)
             {
-                requestState.OriginMeasurements.RecordCompleted(status, resultKind, elapsedTicks);
+                requestState.OriginMeasurements.RecordCompleted(
+                    status,
+                    resultKind,
+                    requestState.Resolution,
+                    elapsedTicks);
 
                 if (status == IconRequestStatus.Stale && !requestState.Invalidated)
                 {
@@ -307,6 +445,11 @@ internal sealed class IconLoadDiagnosticsSession
                 if (requestState.Resolution is { } resolution)
                 {
                     _requestLatencyByResolutionAndResult[(int)resolution][(int)resultKind].Record(elapsedTicks);
+                    if (status == IconRequestStatus.Applied)
+                    {
+                        _appliedRequestLatencyByResolution[(int)resolution].Record(elapsedTicks);
+                    }
+
                     IconLoadEventSource.Log.RequestAttributed(
                         Id,
                         requestId,
@@ -367,7 +510,7 @@ internal sealed class IconLoadDiagnosticsSession
             remainingLiveRequesters);
     }
 
-    public void RecordLoadEnqueued(long loadId, IconLoadPriority priority)
+    public void RecordLoadEnqueued(long loadId, IconLoadPriority priority, int workerCount)
     {
         ref var currentDepth = ref (priority == IconLoadPriority.High
             ? ref _currentHighQueueDepth
@@ -380,22 +523,28 @@ internal sealed class IconLoadDiagnosticsSession
         UpdateMaximum(ref maximumDepth, depth);
         if (_loadDemandStates.TryGetValue(loadId, out var demandState))
         {
-            demandState.MarkEnqueued();
+            demandState.MarkEnqueued(workerCount);
         }
 
         IconLoadEventSource.Log.LoadEnqueued(Id, loadId, (int)priority, depth);
     }
 
-    private void RecordDemandQueueEnqueued(long loadId, bool demanded)
+    private DemandedQueueArrival? RecordDemandQueueEnqueued(
+        long loadId,
+        IconLoadInputKind inputKind,
+        bool demanded,
+        int workerCount)
     {
         long demandedDepth;
         long speculativeDepth;
+        DemandedQueueArrival? demandArrival = null;
         lock (_queueDemandLock)
         {
             if (demanded)
             {
                 _currentDemandedQueueDepth++;
                 _maximumDemandedQueueDepth = Math.Max(_maximumDemandedQueueDepth, _currentDemandedQueueDepth);
+                demandArrival = RecordDemandArrival(inputKind, workerCount);
             }
             else
             {
@@ -416,12 +565,41 @@ internal sealed class IconLoadDiagnosticsSession
             (int)transition,
             demandedDepth,
             speculativeDepth);
+        return demandArrival;
     }
 
-    private void RecordQueuedDemandTransition(long loadId, bool becameDemanded)
+    private void RecordDemandQueueAbandoned(bool demanded)
+    {
+        lock (_queueDemandLock)
+        {
+            if (demanded)
+            {
+                Debug.Assert(_currentDemandedQueueDepth > 0, "An abandoned demanded load must still be queued.");
+                if (_currentDemandedQueueDepth > 0)
+                {
+                    _currentDemandedQueueDepth--;
+                }
+            }
+            else
+            {
+                Debug.Assert(_currentSpeculativeQueueDepth > 0, "An abandoned speculative load must still be queued.");
+                if (_currentSpeculativeQueueDepth > 0)
+                {
+                    _currentSpeculativeQueueDepth--;
+                }
+            }
+        }
+    }
+
+    private DemandedQueueArrival? RecordQueuedDemandTransition(
+        long loadId,
+        IconLoadInputKind inputKind,
+        bool becameDemanded,
+        int workerCount)
     {
         long demandedDepth;
         long speculativeDepth;
+        DemandedQueueArrival? demandArrival = null;
         lock (_queueDemandLock)
         {
             if (becameDemanded)
@@ -431,6 +609,7 @@ internal sealed class IconLoadDiagnosticsSession
                 _currentDemandedQueueDepth++;
                 _queuedDemandPromotions++;
                 _maximumDemandedQueueDepth = Math.Max(_maximumDemandedQueueDepth, _currentDemandedQueueDepth);
+                demandArrival = RecordDemandArrival(inputKind, workerCount);
             }
             else
             {
@@ -451,15 +630,60 @@ internal sealed class IconLoadDiagnosticsSession
             (int)(becameDemanded ? IconLoadQueueDemandTransition.Promoted : IconLoadQueueDemandTransition.Demoted),
             demandedDepth,
             speculativeDepth);
+        return demandArrival;
+    }
+
+    private DemandedQueueArrival RecordDemandArrival(IconLoadInputKind inputKind, int workerCount)
+    {
+        Debug.Assert(Monitor.IsEntered(_queueDemandLock), "Demand arrival accounting requires the queue-demand lock.");
+
+        var activeSpeculativeWorkers = _currentActiveSpeculativeWorkers;
+        var activeDemandedWorkers = _currentActiveDemandedWorkers;
+        var remainingWorkerCapacity = Math.Max(
+            0,
+            workerCount - activeDemandedWorkers - activeSpeculativeWorkers);
+        var capacityWithoutSpeculativeWorkers = Math.Max(0, workerCount - activeDemandedWorkers);
+        var directlyBlockedBySpeculativeCapacity = activeSpeculativeWorkers > 0
+            && _currentDemandedQueueDepth > remainingWorkerCapacity
+            && _currentDemandedQueueDepth <= capacityWithoutSpeculativeWorkers;
+
+        _demandedQueueArrivals++;
+        if (activeSpeculativeWorkers > 0)
+        {
+            _demandedArrivalsWithActiveSpeculativeWorkers++;
+            _speculativeWorkerOccupancyAtDemandArrivals += activeSpeculativeWorkers;
+            _maximumSpeculativeWorkersAtDemandArrival = Math.Max(
+                _maximumSpeculativeWorkersAtDemandArrival,
+                activeSpeculativeWorkers);
+
+            for (var i = 0; i < _currentActiveSpeculativeWorkersByInputKind.Length; i++)
+            {
+                _speculativeWorkerOccupancyAtDemandArrivalsByInputKind[i] +=
+                    _currentActiveSpeculativeWorkersByInputKind[i];
+            }
+        }
+
+        if (directlyBlockedBySpeculativeCapacity)
+        {
+            _demandedArrivalsDirectlyBlockedBySpeculativeCapacity++;
+            _directlyBlockedDemandArrivalsByInputKind[(int)inputKind]++;
+        }
+
+        return new DemandedQueueArrival(
+            Stopwatch.GetTimestamp(),
+            activeSpeculativeWorkers,
+            directlyBlockedBySpeculativeCapacity);
     }
 
     private void RecordDemandWorkerStarted(
         long loadId,
         IconLoadInputKind inputKind,
         bool demanded,
+        long startedAt,
         long queueTicks,
         long activeWorkers,
-        int workerCount)
+        int workerCount,
+        DemandedQueueArrival? demandArrival)
     {
         long demandedDepth;
         long speculativeDepth;
@@ -471,12 +695,18 @@ internal sealed class IconLoadDiagnosticsSession
                 Debug.Assert(_currentDemandedQueueDepth > 0, "A demanded worker start requires a demanded queued load.");
                 _currentDemandedQueueDepth--;
                 _demandedWorkerStarts++;
+                _currentActiveDemandedWorkers++;
             }
             else
             {
                 Debug.Assert(_currentSpeculativeQueueDepth > 0, "A speculative worker start requires a speculative queued load.");
                 _currentSpeculativeQueueDepth--;
                 _speculativeWorkerStarts++;
+                _currentActiveSpeculativeWorkers++;
+                _currentActiveSpeculativeWorkersByInputKind[(int)inputKind]++;
+                _maximumActiveSpeculativeWorkers = Math.Max(
+                    _maximumActiveSpeculativeWorkers,
+                    _currentActiveSpeculativeWorkers);
             }
 
             demandedDepth = _currentDemandedQueueDepth;
@@ -503,10 +733,22 @@ internal sealed class IconLoadDiagnosticsSession
         if (demanded)
         {
             _demandedQueueLatency.Record(queueTicks);
+            _inputKindMeasurements[(int)inputKind].DemandedQueueLatency.Record(queueTicks);
         }
         else
         {
             _speculativeQueueLatency.Record(queueTicks);
+            _inputKindMeasurements[(int)inputKind].SpeculativeQueueLatency.Record(queueTicks);
+        }
+
+        if (demanded && demandArrival is { SpeculativeWorkersAtArrival: > 0 } arrival)
+        {
+            var demandArrivalToWorkerStartTicks = Math.Max(0, startedAt - arrival.ArrivedAt);
+            _demandArrivalToWorkerStartWithActiveSpeculative.Record(demandArrivalToWorkerStartTicks);
+            if (arrival.DirectlyBlockedBySpeculativeCapacity)
+            {
+                _directlyBlockedDemandArrivalToWorkerStart.Record(demandArrivalToWorkerStartTicks);
+            }
         }
 
         IconLoadEventSource.Log.LoadDemandAtWorkerStart(
@@ -520,6 +762,70 @@ internal sealed class IconLoadDiagnosticsSession
             demandedBeyondCapacity);
     }
 
+    private void RecordActiveWorkerDemandTransition(IconLoadInputKind inputKind, bool becameDemanded)
+    {
+        lock (_queueDemandLock)
+        {
+            if (becameDemanded)
+            {
+                Debug.Assert(_currentActiveSpeculativeWorkers > 0, "An active promotion requires a speculative worker.");
+                if (_currentActiveSpeculativeWorkers > 0)
+                {
+                    _currentActiveSpeculativeWorkers--;
+                }
+
+                if (_currentActiveSpeculativeWorkersByInputKind[(int)inputKind] > 0)
+                {
+                    _currentActiveSpeculativeWorkersByInputKind[(int)inputKind]--;
+                }
+
+                _currentActiveDemandedWorkers++;
+            }
+            else
+            {
+                Debug.Assert(_currentActiveDemandedWorkers > 0, "An active demotion requires a demanded worker.");
+                if (_currentActiveDemandedWorkers > 0)
+                {
+                    _currentActiveDemandedWorkers--;
+                }
+
+                _currentActiveSpeculativeWorkers++;
+                _currentActiveSpeculativeWorkersByInputKind[(int)inputKind]++;
+                _maximumActiveSpeculativeWorkers = Math.Max(
+                    _maximumActiveSpeculativeWorkers,
+                    _currentActiveSpeculativeWorkers);
+            }
+        }
+    }
+
+    private void RecordActiveWorkerCompleted(IconLoadInputKind inputKind, bool demanded)
+    {
+        lock (_queueDemandLock)
+        {
+            if (demanded)
+            {
+                Debug.Assert(_currentActiveDemandedWorkers > 0, "A demanded completion requires an active demanded worker.");
+                if (_currentActiveDemandedWorkers > 0)
+                {
+                    _currentActiveDemandedWorkers--;
+                }
+            }
+            else
+            {
+                Debug.Assert(_currentActiveSpeculativeWorkers > 0, "A speculative completion requires an active speculative worker.");
+                if (_currentActiveSpeculativeWorkers > 0)
+                {
+                    _currentActiveSpeculativeWorkers--;
+                }
+
+                if (_currentActiveSpeculativeWorkersByInputKind[(int)inputKind] > 0)
+                {
+                    _currentActiveSpeculativeWorkersByInputKind[(int)inputKind]--;
+                }
+            }
+        }
+    }
+
     public void RecordLoadRejected(long loadId)
     {
         Interlocked.Increment(ref _loadsRejected);
@@ -529,6 +835,20 @@ internal sealed class IconLoadDiagnosticsSession
         }
 
         IconLoadEventSource.Log.LoadRejected(Id, loadId);
+    }
+
+    public void RecordLoadAbandoned(long loadId, IconLoadPriority priority)
+    {
+        ref var currentDepth = ref (priority == IconLoadPriority.High
+            ? ref _currentHighQueueDepth
+            : ref _currentLowQueueDepth);
+        var remainingDepth = Interlocked.Decrement(ref currentDepth);
+        Debug.Assert(remainingDepth >= 0, "An abandoned icon load must have been counted as queued.");
+        Interlocked.Increment(ref _loadsAbandonedBeforeStart);
+        if (_loadDemandStates.TryGetValue(loadId, out var demandState))
+        {
+            demandState.MarkAbandoned();
+        }
     }
 
     public void RecordWorkerStarted(
@@ -866,6 +1186,7 @@ internal sealed class IconLoadDiagnosticsSession
         builder.AppendLine("Loads");
         AppendValue(builder, "Created", Volatile.Read(ref _loadsCreated));
         AppendValue(builder, "Rejected", Volatile.Read(ref _loadsRejected));
+        AppendValue(builder, "Abandoned before worker start", Volatile.Read(ref _loadsAbandonedBeforeStart));
         AppendValue(builder, "Direct glyph loads", Volatile.Read(ref _directGlyphLoads));
         AppendValue(builder, "Active at stop", Math.Max(0, Volatile.Read(ref _activeWorkers)));
         AppendValue(builder, "Maximum active workers", Volatile.Read(ref _maximumActiveWorkers));
@@ -882,6 +1203,10 @@ internal sealed class IconLoadDiagnosticsSession
 
         builder.AppendLine("Dispatcher materialization");
         AppendDispatcherMeasurements(builder);
+        builder.AppendLine();
+
+        builder.AppendLine("Scheduler coordination");
+        AppendSchedulerMeasurements(builder);
         builder.AppendLine();
 
         builder.AppendLine("Load demand");
@@ -1187,6 +1512,86 @@ internal sealed class IconLoadDiagnosticsSession
             : 0;
     }
 
+    private void AppendSchedulerMeasurements(StringBuilder builder)
+    {
+        builder.AppendLine("  Definition: the command backlog is work published to the lock-free coordinator but not yet processed during this diagnostic session.");
+        builder.AppendLine("  Commands published by kind");
+        AppendEnumCounts<IconLoadQueue.QueueCommandKind>(builder, _schedulerCommandsPublished, "    ");
+        builder.AppendLine("  Commands processed by kind");
+        AppendEnumCounts<IconLoadQueue.QueueCommandKind>(builder, _schedulerCommandsProcessed, "    ");
+        AppendValue(
+            builder,
+            "Commands outstanding at stop",
+            Math.Max(0, Volatile.Read(ref _currentSchedulerCommandBacklog)));
+        AppendValue(builder, "Maximum command backlog", Volatile.Read(ref _maximumSchedulerCommandBacklog));
+        builder.AppendLine("  Publish to coordinator processing by command kind");
+
+        var commandKinds = Enum.GetValues<IconLoadQueue.QueueCommandKind>();
+        for (var i = 0; i < commandKinds.Length; i++)
+        {
+            _schedulerCommandLatency[i].Append(builder, commandKinds[i].ToString(), "    ");
+        }
+
+        builder.AppendLine("  Coordinator wake and batch processing");
+        builder.AppendLine("    Definition: the first command to complete the current signal triggers the next coordinator pass; later pulses coalesce. If the coordinator is still processing, latency includes the remainder of that pass. Drain time excludes worker dispatch.");
+        builder.AppendLine("    Empty batches occur when the preceding pass already consumed the triggering command; their signal-to-pass-start latency is reported separately.");
+        _schedulerSignalToWakeLatency.Append(builder, "Signal to coordinator pass start for non-empty batches", "    ");
+        _schedulerEmptyBatchSignalToWakeLatency.Append(builder, "Signal to coordinator pass start for empty coalesced batches", "    ");
+        builder.AppendLine("    Non-empty batch signal to coordinator pass start by triggering command kind");
+        for (var i = 0; i < commandKinds.Length; i++)
+        {
+            _schedulerSignalToWakeLatencyByCommandKind[i].Append(
+                builder,
+                commandKinds[i].ToString(),
+                "      ");
+        }
+
+        var batchesCompleted = Volatile.Read(ref _schedulerBatchesCompleted);
+        var emptyBatches = Volatile.Read(ref _schedulerEmptyBatches);
+        var nonEmptyBatches = Math.Max(0, batchesCompleted - emptyBatches);
+        var commandsDrained = Volatile.Read(ref _schedulerCommandsDrained);
+        var workItemsDispatched = Volatile.Read(ref _schedulerWorkItemsDispatched);
+        AppendValue(builder, "Batches completed", batchesCompleted, "    ");
+        AppendValue(builder, "Empty batches", emptyBatches, "    ");
+        AppendValue(builder, "Commands drained", commandsDrained, "    ");
+        AppendAverage(builder, "Average commands per non-empty batch", commandsDrained, nonEmptyBatches, "    ");
+        AppendValue(builder, "Maximum commands in one batch", Volatile.Read(ref _maximumSchedulerBatchSize), "    ");
+        AppendValue(builder, "Work items dispatched", workItemsDispatched, "    ");
+        AppendAverage(builder, "Average work items dispatched per non-empty batch", workItemsDispatched, nonEmptyBatches, "    ");
+        AppendValue(builder, "Maximum work items dispatched in one batch", Volatile.Read(ref _maximumSchedulerDispatchCount), "    ");
+        _schedulerBatchDrainLatency.Append(builder, "Non-empty batch command drain wall time", "    ");
+        _schedulerPassLatency.Append(builder, "Non-empty batch pass-start-to-dispatch-complete wall time", "    ");
+
+        builder.AppendLine("  Worker handoff");
+        builder.AppendLine("    Definition: measured from a worker publishing readiness until the coordinator assigns work to that worker slot; this includes ordinary idle time before work arrives.");
+        _workerReadyToDispatchLatency.Append(builder, "Ready to work dispatch", "    ");
+        _workerReadyToDemandedDispatchLatency.Append(builder, "Ready to demanded work dispatch", "    ");
+        _workerReadyToSpeculativeDispatchLatency.Append(builder, "Ready to speculative work dispatch", "    ");
+        builder.AppendLine("  Demanded work queued while worker capacity was available");
+        builder.AppendLine("    Definition: a coordinator-state interval with at least one demanded queued load and at least one worker-ready slot. It normally spans command draining before dispatch.");
+        AppendValue(
+            builder,
+            "Intervals started",
+            Volatile.Read(ref _demandedIdleCapacityIntervalsStarted),
+            "    ");
+        AppendValue(
+            builder,
+            "Intervals active at stop",
+            Math.Max(0, Volatile.Read(ref _currentDemandedIdleCapacityIntervals)),
+            "    ");
+        AppendValue(
+            builder,
+            "Maximum demanded queue depth during an interval",
+            Volatile.Read(ref _maximumDemandedQueueDepthWithIdleCapacity),
+            "    ");
+        AppendValue(
+            builder,
+            "Maximum available worker slots during an interval",
+            Volatile.Read(ref _maximumAvailableWorkerSlotsWithDemandedWork),
+            "    ");
+        _demandedIdleCapacityDuration.Append(builder, "Interval duration", "    ");
+    }
+
     private void AppendLoadDemandMeasurements(StringBuilder builder)
     {
         var linkedRequests = 0L;
@@ -1296,7 +1701,17 @@ internal sealed class IconLoadDiagnosticsSession
         long capacityInterferingSpeculativeStarts;
         long demandedLoadsBeyondCapacityAtSpeculativeStarts;
         long maximumDemandedLoadsBeyondCapacityAtSpeculativeStart;
+        long currentActiveDemandedWorkers;
+        long currentActiveSpeculativeWorkers;
+        long maximumActiveSpeculativeWorkers;
+        long demandedQueueArrivals;
+        long demandedArrivalsWithActiveSpeculativeWorkers;
+        long speculativeWorkerOccupancyAtDemandArrivals;
+        long maximumSpeculativeWorkersAtDemandArrival;
+        long demandedArrivalsDirectlyBlockedBySpeculativeCapacity;
         long[] capacityInterferingSpeculativeStartsByInputKind;
+        long[] speculativeWorkerOccupancyAtDemandArrivalsByInputKind;
+        long[] directlyBlockedDemandArrivalsByInputKind;
 
         lock (_queueDemandLock)
         {
@@ -1312,11 +1727,21 @@ internal sealed class IconLoadDiagnosticsSession
             capacityInterferingSpeculativeStarts = _capacityInterferingSpeculativeStarts;
             demandedLoadsBeyondCapacityAtSpeculativeStarts = _demandedLoadsBeyondCapacityAtSpeculativeStarts;
             maximumDemandedLoadsBeyondCapacityAtSpeculativeStart = _maximumDemandedLoadsBeyondCapacityAtSpeculativeStart;
+            currentActiveDemandedWorkers = _currentActiveDemandedWorkers;
+            currentActiveSpeculativeWorkers = _currentActiveSpeculativeWorkers;
+            maximumActiveSpeculativeWorkers = _maximumActiveSpeculativeWorkers;
+            demandedQueueArrivals = _demandedQueueArrivals;
+            demandedArrivalsWithActiveSpeculativeWorkers = _demandedArrivalsWithActiveSpeculativeWorkers;
+            speculativeWorkerOccupancyAtDemandArrivals = _speculativeWorkerOccupancyAtDemandArrivals;
+            maximumSpeculativeWorkersAtDemandArrival = _maximumSpeculativeWorkersAtDemandArrival;
+            demandedArrivalsDirectlyBlockedBySpeculativeCapacity = _demandedArrivalsDirectlyBlockedBySpeculativeCapacity;
             capacityInterferingSpeculativeStartsByInputKind = [.. _capacityInterferingSpeculativeStartsByInputKind];
+            speculativeWorkerOccupancyAtDemandArrivalsByInputKind = [.. _speculativeWorkerOccupancyAtDemandArrivalsByInputKind];
+            directlyBlockedDemandArrivalsByInputKind = [.. _directlyBlockedDemandArrivalsByInputKind];
         }
 
         builder.AppendLine("  Demand-aware queue view");
-        builder.AppendLine("    Definition: demanded means at least one live IconBox request; speculative means none. Measurement only; scheduling is unchanged.");
+        builder.AppendLine("    Definition: demanded means at least one live IconBox request; speculative means none. Queue scheduling prefers demanded work; worker count is unchanged.");
         AppendValue(builder, "Demanded loads queued at stop", currentDemandedQueueDepth, "    ");
         AppendValue(builder, "Speculative loads queued at stop", currentSpeculativeQueueDepth, "    ");
         AppendValue(builder, "Maximum demanded queue depth", maximumDemandedQueueDepth, "    ");
@@ -1325,12 +1750,35 @@ internal sealed class IconLoadDiagnosticsSession
         AppendValue(builder, "Queued promotions after demand returned", queuedDemandPromotions, "    ");
         AppendValue(builder, "Workers started demanded", demandedWorkerStarts, "    ");
         AppendValue(builder, "Workers started speculative", speculativeWorkerStarts, "    ");
+        AppendValue(builder, "Active demanded workers at stop", currentActiveDemandedWorkers, "    ");
+        AppendValue(builder, "Active speculative workers at stop", currentActiveSpeculativeWorkers, "    ");
+        AppendValue(builder, "Maximum active speculative workers", maximumActiveSpeculativeWorkers, "    ");
         AppendValue(builder, "Speculative starts with demanded loads queued", speculativeStartsWithDemandedLoadsQueued, "    ");
         AppendValue(builder, "Speculative starts leaving demanded loads beyond remaining worker capacity", capacityInterferingSpeculativeStarts, "    ");
         AppendValue(builder, "Demanded loads beyond remaining capacity across those starts", demandedLoadsBeyondCapacityAtSpeculativeStarts, "    ");
         AppendValue(builder, "Maximum demanded loads beyond remaining capacity at one start", maximumDemandedLoadsBeyondCapacityAtSpeculativeStart, "    ");
         builder.AppendLine("    Capacity-interfering speculative starts by input kind");
         AppendEnumCounts<IconLoadInputKind>(builder, capacityInterferingSpeculativeStartsByInputKind, "      ");
+        builder.AppendLine("    Demanded arrivals and active speculative capacity");
+        builder.AppendLine("      Directly blocked means the arriving load's queue position could use capacity occupied by speculative workers and would fit if those workers were absent.");
+        AppendValue(builder, "Demanded queue arrivals", demandedQueueArrivals, "      ");
+        AppendValue(builder, "Arrivals with active speculative workers", demandedArrivalsWithActiveSpeculativeWorkers, "      ");
+        AppendValue(builder, "Sum of active speculative workers observed at those arrivals", speculativeWorkerOccupancyAtDemandArrivals, "      ");
+        AppendValue(builder, "Maximum speculative workers active at one demanded arrival", maximumSpeculativeWorkersAtDemandArrival, "      ");
+        AppendValue(builder, "Arrivals directly blocked by speculative worker capacity", demandedArrivalsDirectlyBlockedBySpeculativeCapacity, "      ");
+        builder.AppendLine("      Speculative worker occupancy observed at demanded arrivals by speculative input kind");
+        AppendEnumCounts<IconLoadInputKind>(builder, speculativeWorkerOccupancyAtDemandArrivalsByInputKind, "        ");
+        builder.AppendLine("      Directly blocked demanded arrivals by demanded input kind");
+        AppendEnumCounts<IconLoadInputKind>(builder, directlyBlockedDemandArrivalsByInputKind, "        ");
+        builder.AppendLine("      Timing samples include affected arrivals that were still demanded when their worker started.");
+        _demandArrivalToWorkerStartWithActiveSpeculative.Append(
+            builder,
+            "Demand arrival to worker start with speculative workers active",
+            "      ");
+        _directlyBlockedDemandArrivalToWorkerStart.Append(
+            builder,
+            "Directly blocked demand arrival to worker start",
+            "      ");
         _demandedQueueLatency.Append(builder, "Demanded queue wait", "    ");
         _speculativeQueueLatency.Append(builder, "Speculative queue wait", "    ");
     }
@@ -1351,6 +1799,8 @@ internal sealed class IconLoadDiagnosticsSession
             measurements.LoadLatency.Append(builder, "Enqueue to completion", "    ");
             measurements.DirectGlyphLatency.Append(builder, "Direct glyph construction", "    ");
             measurements.QueueLatency.Append(builder, "Queue wait", "    ");
+            measurements.DemandedQueueLatency.Append(builder, "Demanded queue wait", "    ");
+            measurements.SpeculativeQueueLatency.Append(builder, "Speculative queue wait", "    ");
             measurements.BackgroundPreparationLatency.Append(builder, "Background preparation", "    ");
             measurements.DispatcherWaitLatency.Append(builder, "Dispatcher wait", "    ");
             measurements.DispatcherWorkLatency.Append(builder, "Dispatcher callback wall time", "    ");
@@ -1418,6 +1868,9 @@ internal sealed class IconLoadDiagnosticsSession
             builder.Append("    Unattributed completed requests: ")
                 .AppendLine(unattributedRequests.ToString(CultureInfo.InvariantCulture));
         }
+
+        builder.AppendLine("  Applied request to completion by provider resolution");
+        AppendResolutionMeasurements(builder, _appliedRequestLatencyByResolution, "    ");
     }
 
     private void AppendRequestOriginMeasurements(StringBuilder builder)
@@ -1546,6 +1999,28 @@ internal sealed class IconLoadDiagnosticsSession
         return measurements;
     }
 
+    private static DiagnosticHistogram[] CreateResolutionMeasurements()
+    {
+        var measurements = new DiagnosticHistogram[Enum.GetValues<IconProviderResolution>().Length];
+        for (var i = 0; i < measurements.Length; i++)
+        {
+            measurements[i] = new DiagnosticHistogram();
+        }
+
+        return measurements;
+    }
+
+    private static DiagnosticHistogram[] CreateSchedulerCommandMeasurements()
+    {
+        var measurements = new DiagnosticHistogram[Enum.GetValues<IconLoadQueue.QueueCommandKind>().Length];
+        for (var i = 0; i < measurements.Length; i++)
+        {
+            measurements[i] = new DiagnosticHistogram();
+        }
+
+        return measurements;
+    }
+
     private static ElementKindMeasurements[] CreateElementKindMeasurements()
     {
         var measurements = new ElementKindMeasurements[Enum.GetValues<IconLoadResultKind>().Length];
@@ -1567,9 +2042,38 @@ internal sealed class IconLoadDiagnosticsSession
         }
     }
 
+    private static void AppendResolutionMeasurements(
+        StringBuilder builder,
+        DiagnosticHistogram[] measurements,
+        string indentation)
+    {
+        var resolutions = Enum.GetValues<IconProviderResolution>();
+        for (var i = 0; i < resolutions.Length; i++)
+        {
+            measurements[i].Append(builder, resolutions[i].ToString(), indentation);
+        }
+    }
+
     private static void AppendValue(StringBuilder builder, string name, long value, string indentation = "  ")
     {
         builder.Append(indentation).Append(name).Append(": ").AppendLine(value.ToString(CultureInfo.InvariantCulture));
+    }
+
+    private static void AppendAverage(
+        StringBuilder builder,
+        string name,
+        long total,
+        long count,
+        string indentation)
+    {
+        builder.Append(indentation).Append(name).Append(": ");
+        if (count == 0)
+        {
+            builder.AppendLine("n/a");
+            return;
+        }
+
+        builder.AppendLine((total / (double)count).ToString("0.###", CultureInfo.InvariantCulture));
     }
 
     private static long Sum(long[] values)
@@ -1787,6 +2291,11 @@ internal sealed class IconLoadDiagnosticsSession
         bool StartedWithoutLiveRequester,
         long WithoutRequesterElapsedTicks);
 
+    private readonly record struct DemandedQueueArrival(
+        long ArrivedAt,
+        long SpeculativeWorkersAtArrival,
+        bool DirectlyBlockedBySpeculativeCapacity);
+
     private readonly record struct LoadCompletionDemandResult(
         bool CompletedWithoutLiveRequester,
         long WithoutRequesterElapsedTicks);
@@ -1817,6 +2326,7 @@ internal sealed class IconLoadDiagnosticsSession
         private readonly long[] _providerResolutions = new long[Enum.GetValues<IconProviderResolution>().Length];
         private readonly long[] _resultKinds = new long[Enum.GetValues<IconLoadResultKind>().Length];
         private readonly DiagnosticHistogram[] _requestLatencyByStatus = CreateStatusMeasurements();
+        private readonly DiagnosticHistogram[] _appliedRequestLatencyByResolution = CreateResolutionMeasurements();
         private readonly DiagnosticHistogram _requestLatency = new();
         private readonly ConcurrentDictionary<long, byte> _iconBoxIds = new();
         private long _requestsStarted;
@@ -1835,12 +2345,20 @@ internal sealed class IconLoadDiagnosticsSession
             Interlocked.Increment(ref _providerResolutions[(int)resolution]);
         }
 
-        public void RecordCompleted(IconRequestStatus status, IconLoadResultKind resultKind, long elapsedTicks)
+        public void RecordCompleted(
+            IconRequestStatus status,
+            IconLoadResultKind resultKind,
+            IconProviderResolution? resolution,
+            long elapsedTicks)
         {
             Interlocked.Increment(ref _requestStatuses[(int)status]);
             Interlocked.Increment(ref _resultKinds[(int)resultKind]);
             _requestLatency.Record(elapsedTicks);
             _requestLatencyByStatus[(int)status].Record(elapsedTicks);
+            if (status == IconRequestStatus.Applied && resolution is { } appliedResolution)
+            {
+                _appliedRequestLatencyByResolution[(int)appliedResolution].Record(elapsedTicks);
+            }
         }
 
         public void Append(StringBuilder builder)
@@ -1875,6 +2393,9 @@ internal sealed class IconLoadDiagnosticsSession
             {
                 builder.AppendLine("      no completed requests");
             }
+
+            builder.AppendLine("    Applied request to completion by provider resolution");
+            AppendResolutionMeasurements(builder, _appliedRequestLatencyByResolution, "      ");
         }
 
         private void AppendNonzeroResultKinds(StringBuilder builder)
@@ -1957,6 +2478,8 @@ internal sealed class IconLoadDiagnosticsSession
         private bool _completedWithoutLiveRequester;
         private long _withoutRequesterToCompletionTicks = -1;
         private int _cacheHitsAfterUnrequestedCompletion;
+        private int _workerCount = 1;
+        private DemandedQueueArrival? _pendingDemandArrival;
 
         public LoadDemandState(IconLoadDiagnosticsSession session, long loadId, IconLoadInputKind inputKind)
         {
@@ -1988,7 +2511,9 @@ internal sealed class IconLoadDiagnosticsSession
 
                 var tracksLiveRequester = false;
                 if (resolution is IconProviderResolution.NewLoad or IconProviderResolution.InFlight
-                    && _stage is not IconLoadDemandStage.Completed and not IconLoadDemandStage.Rejected)
+                    && _stage is not IconLoadDemandStage.Completed
+                        and not IconLoadDemandStage.Rejected
+                        and not IconLoadDemandStage.Abandoned)
                 {
                     if (requesterInvalidated)
                     {
@@ -2009,9 +2534,20 @@ internal sealed class IconLoadDiagnosticsSession
                     }
                 }
 
-                if (!wasDemanded && _liveRequesters > 0 && _stage == IconLoadDemandStage.Queued)
+                if (!wasDemanded && _liveRequesters > 0)
                 {
-                    _session.RecordQueuedDemandTransition(_loadId, becameDemanded: true);
+                    if (_stage == IconLoadDemandStage.Queued)
+                    {
+                        _pendingDemandArrival = _session.RecordQueuedDemandTransition(
+                            _loadId,
+                            _inputKind,
+                            becameDemanded: true,
+                            _workerCount);
+                    }
+                    else if (_stage == IconLoadDemandStage.WorkerActive)
+                    {
+                        _session.RecordActiveWorkerDemandTransition(_inputKind, becameDemanded: true);
+                    }
                 }
 
                 return new LoadResolutionResult(
@@ -2038,9 +2574,21 @@ internal sealed class IconLoadDiagnosticsSession
                     BeginWithoutRequester(invalidatedAt);
                 }
 
-                if (wasDemanded && _liveRequesters == 0 && _stage == IconLoadDemandStage.Queued)
+                if (wasDemanded && _liveRequesters == 0)
                 {
-                    _session.RecordQueuedDemandTransition(_loadId, becameDemanded: false);
+                    if (_stage == IconLoadDemandStage.Queued)
+                    {
+                        _pendingDemandArrival = null;
+                        _session.RecordQueuedDemandTransition(
+                            _loadId,
+                            _inputKind,
+                            becameDemanded: false,
+                            _workerCount);
+                    }
+                    else if (_stage == IconLoadDemandStage.WorkerActive)
+                    {
+                        _session.RecordActiveWorkerDemandTransition(_inputKind, becameDemanded: false);
+                    }
                 }
 
                 return new LoadRequestInvalidationResult(_stage, _liveRequesters);
@@ -2051,9 +2599,15 @@ internal sealed class IconLoadDiagnosticsSession
         {
             lock (_lock)
             {
+                var wasDemanded = _liveRequesters > 0;
                 if (_liveRequesters > 0)
                 {
                     _liveRequesters--;
+                }
+
+                if (wasDemanded && _liveRequesters == 0 && _stage == IconLoadDemandStage.WorkerActive)
+                {
+                    _session.RecordActiveWorkerDemandTransition(_inputKind, becameDemanded: false);
                 }
             }
         }
@@ -2062,7 +2616,9 @@ internal sealed class IconLoadDiagnosticsSession
         {
             if (_liveRequesters != 0
                 || _withoutRequester
-                || _stage is IconLoadDemandStage.Completed or IconLoadDemandStage.Rejected)
+                || _stage is IconLoadDemandStage.Completed
+                    or IconLoadDemandStage.Rejected
+                    or IconLoadDemandStage.Abandoned)
             {
                 return;
             }
@@ -2083,14 +2639,19 @@ internal sealed class IconLoadDiagnosticsSession
             }
         }
 
-        public void MarkEnqueued()
+        public void MarkEnqueued(int workerCount)
         {
             lock (_lock)
             {
                 if (_stage == IconLoadDemandStage.BeforeEnqueue)
                 {
+                    _workerCount = Math.Max(1, workerCount);
                     _stage = IconLoadDemandStage.Queued;
-                    _session.RecordDemandQueueEnqueued(_loadId, _liveRequesters > 0);
+                    _pendingDemandArrival = _session.RecordDemandQueueEnqueued(
+                        _loadId,
+                        _inputKind,
+                        _liveRequesters > 0,
+                        _workerCount);
                 }
             }
         }
@@ -2103,6 +2664,20 @@ internal sealed class IconLoadDiagnosticsSession
                 if (_stage == IconLoadDemandStage.BeforeEnqueue)
                 {
                     _stage = IconLoadDemandStage.Rejected;
+                }
+            }
+        }
+
+        public void MarkAbandoned()
+        {
+            lock (_lock)
+            {
+                Debug.Assert(_stage == IconLoadDemandStage.Queued, "Only accepted queued work can be abandoned.");
+                if (_stage == IconLoadDemandStage.Queued)
+                {
+                    _session.RecordDemandQueueAbandoned(_liveRequesters > 0);
+                    _pendingDemandArrival = null;
+                    _stage = IconLoadDemandStage.Abandoned;
                 }
             }
         }
@@ -2121,12 +2696,17 @@ internal sealed class IconLoadDiagnosticsSession
                         _loadId,
                         _inputKind,
                         _liveRequesters > 0,
+                        startedAt,
                         queueTicks,
                         activeWorkers,
-                        workerCount);
+                        workerCount,
+                        _pendingDemandArrival);
+                    _pendingDemandArrival = null;
                 }
 
-                if (_stage is not IconLoadDemandStage.Completed and not IconLoadDemandStage.Rejected)
+                if (_stage is not IconLoadDemandStage.Completed
+                    and not IconLoadDemandStage.Rejected
+                    and not IconLoadDemandStage.Abandoned)
                 {
                     _stage = IconLoadDemandStage.WorkerActive;
                 }
@@ -2147,6 +2727,11 @@ internal sealed class IconLoadDiagnosticsSession
         {
             lock (_lock)
             {
+                if (_stage == IconLoadDemandStage.WorkerActive)
+                {
+                    _session.RecordActiveWorkerCompleted(_inputKind, _liveRequesters > 0);
+                }
+
                 _stage = IconLoadDemandStage.Completed;
                 _resultKind = resultKind;
                 if (_withoutRequester && _liveRequesters == 0)
@@ -2191,6 +2776,10 @@ internal sealed class IconLoadDiagnosticsSession
         public DiagnosticHistogram DirectGlyphLatency { get; } = new();
 
         public DiagnosticHistogram QueueLatency { get; } = new();
+
+        public DiagnosticHistogram DemandedQueueLatency { get; } = new();
+
+        public DiagnosticHistogram SpeculativeQueueLatency { get; } = new();
 
         public DiagnosticHistogram BackgroundPreparationLatency { get; } = new();
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadDiagnosticsSession.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadDiagnosticsSession.cs
@@ -33,6 +33,7 @@ internal sealed class IconLoadDiagnosticsSession
     private readonly DiagnosticHistogram _requestLatency = new();
     private readonly DiagnosticHistogram _loadLatency = new();
     private readonly DiagnosticHistogram _directGlyphLatency = new();
+    private readonly DiagnosticHistogram[] _directGlyphLatencyByResultKind = CreateResultMeasurements();
     private readonly DiagnosticHistogram _queueLatency = new();
     private readonly DiagnosticHistogram _demandedQueueLatency = new();
     private readonly DiagnosticHistogram _speculativeQueueLatency = new();
@@ -753,6 +754,7 @@ internal sealed class IconLoadDiagnosticsSession
         Interlocked.Increment(ref _directGlyphLoads);
         Interlocked.Increment(ref _resultKinds[(int)resultKind]);
         _directGlyphLatency.Record(elapsedTicks);
+        _directGlyphLatencyByResultKind[(int)resultKind].Record(elapsedTicks);
         _inputKindMeasurements[(int)inputKind].DirectGlyphLatency.Record(elapsedTicks);
         RecordDemandCompletion(loadId, resultKind);
         IconLoadEventSource.Log.DirectGlyphLoadCompleted(Id, loadId, (int)resultKind, ToMicroseconds(elapsedTicks));
@@ -871,6 +873,7 @@ internal sealed class IconLoadDiagnosticsSession
         AppendValue(builder, "Maximum low queue depth", Volatile.Read(ref _maximumLowQueueDepth));
         _loadLatency.Append(builder, "Enqueue to completion");
         _directGlyphLatency.Append(builder, "Direct glyph construction");
+        AppendDirectGlyphResultMeasurements(builder);
         _queueLatency.Append(builder, "Queue wait");
         _backgroundPreparationLatency.Append(builder, "Background preparation");
         _dispatcherWaitLatency.Append(builder, "Dispatcher wait");
@@ -1356,6 +1359,28 @@ internal sealed class IconLoadDiagnosticsSession
         }
     }
 
+    private void AppendDirectGlyphResultMeasurements(StringBuilder builder)
+    {
+        var resultKinds = Enum.GetValues<IconLoadResultKind>();
+        var wroteHeader = false;
+        for (var i = 0; i < resultKinds.Length; i++)
+        {
+            var measurement = _directGlyphLatencyByResultKind[i];
+            if (measurement.Count == 0)
+            {
+                continue;
+            }
+
+            if (!wroteHeader)
+            {
+                builder.AppendLine("  Direct glyph construction by result kind");
+                wroteHeader = true;
+            }
+
+            measurement.Append(builder, resultKinds[i].ToString(), "    ");
+        }
+    }
+
     private void AppendRequestMeasurements(StringBuilder builder)
     {
         builder.AppendLine("  Request to completion by resolution and result");
@@ -1505,6 +1530,17 @@ internal sealed class IconLoadDiagnosticsSession
             {
                 measurements[resolutionIndex][resultIndex] = new DiagnosticHistogram();
             }
+        }
+
+        return measurements;
+    }
+
+    private static DiagnosticHistogram[] CreateResultMeasurements()
+    {
+        var measurements = new DiagnosticHistogram[Enum.GetValues<IconLoadResultKind>().Length];
+        for (var i = 0; i < measurements.Length; i++)
+        {
+            measurements[i] = new DiagnosticHistogram();
         }
 
         return measurements;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadDiagnosticsSession.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadDiagnosticsSession.cs
@@ -66,6 +66,7 @@ internal sealed class IconLoadDiagnosticsSession
     private readonly DiagnosticHistogram _workerReadyToDemandedDispatchLatency = new();
     private readonly DiagnosticHistogram _workerReadyToSpeculativeDispatchLatency = new();
     private readonly DiagnosticHistogram _demandedIdleCapacityDuration = new();
+    private readonly DiagnosticHistogram _speculativeDispatchDeferralDuration = new();
     private readonly InputKindMeasurements[] _inputKindMeasurements = CreateInputKindMeasurements();
     private readonly ElementKindMeasurements[] _elementKindMeasurements = CreateElementKindMeasurements();
     private readonly ConditionalWeakTable<Task<IconSource?>, IconLoadMeasurement> _loadsByTask = new();
@@ -142,6 +143,11 @@ internal sealed class IconLoadDiagnosticsSession
     private long _currentDemandedIdleCapacityIntervals;
     private long _maximumDemandedQueueDepthWithIdleCapacity;
     private long _maximumAvailableWorkerSlotsWithDemandedWork;
+    private long _speculativeDispatchDeferralIntervalsStarted;
+    private long _currentSpeculativeDispatchDeferralIntervals;
+    private long _maximumSpeculativeQueueDepthDuringDeferral;
+    private long _maximumWorkerCountDuringSpeculativeDispatchDeferral;
+    private long _maximumReservedWorkerSlotsDuringDeferral;
     private long _activeWorkers;
     private long _maximumActiveWorkers;
     private long _dispatcherEnqueuedDemanded;
@@ -313,6 +319,34 @@ internal sealed class IconLoadDiagnosticsSession
         Debug.Assert(activeIntervals >= 0, "A demanded-idle-capacity interval must start before it completes.");
         _demandedIdleCapacityDuration.Record(elapsedTicks);
         IconLoadEventSource.Log.DemandedIdleCapacityCompleted(Id, ToMicroseconds(elapsedTicks));
+    }
+
+    public void RecordSpeculativeDispatchDeferralStarted(
+        int speculativeQueueDepth,
+        int workerCount,
+        int reservedWorkerSlots)
+    {
+        Interlocked.Increment(ref _speculativeDispatchDeferralIntervalsStarted);
+        Interlocked.Increment(ref _currentSpeculativeDispatchDeferralIntervals);
+        RecordSpeculativeDispatchDeferralObserved(speculativeQueueDepth, workerCount, reservedWorkerSlots);
+    }
+
+    public void RecordSpeculativeDispatchDeferralObserved(
+        int speculativeQueueDepth,
+        int workerCount,
+        int reservedWorkerSlots)
+    {
+        UpdateMaximum(ref _maximumSpeculativeQueueDepthDuringDeferral, speculativeQueueDepth);
+        UpdateMaximum(ref _maximumWorkerCountDuringSpeculativeDispatchDeferral, workerCount);
+        UpdateMaximum(ref _maximumReservedWorkerSlotsDuringDeferral, reservedWorkerSlots);
+    }
+
+    public void RecordSpeculativeDispatchDeferralCompleted(long elapsedTicks)
+    {
+        var activeIntervals = Interlocked.Decrement(ref _currentSpeculativeDispatchDeferralIntervals);
+        Debug.Assert(activeIntervals >= 0, "A speculative-dispatch-deferral interval must start before it completes.");
+        _speculativeDispatchDeferralDuration.Record(elapsedTicks);
+        IconLoadEventSource.Log.SpeculativeDispatchDeferralCompleted(Id, ToMicroseconds(elapsedTicks));
     }
 
     public IconRequestMeasurement BeginRequest(IconRequestReason reason, double scale, IconRequestOrigin origin)
@@ -1590,6 +1624,34 @@ internal sealed class IconLoadDiagnosticsSession
             Volatile.Read(ref _maximumAvailableWorkerSlotsWithDemandedWork),
             "    ");
         _demandedIdleCapacityDuration.Append(builder, "Interval duration", "    ");
+        builder.AppendLine("  Speculative dispatch deferred by the demand reserve");
+        builder.AppendLine("    Definition: a coordinator-state interval with speculative work queued, no demanded work queued, and a worker-ready slot deliberately retained for a future live request.");
+        AppendValue(
+            builder,
+            "Intervals started",
+            Volatile.Read(ref _speculativeDispatchDeferralIntervalsStarted),
+            "    ");
+        AppendValue(
+            builder,
+            "Intervals active at stop",
+            Math.Max(0, Volatile.Read(ref _currentSpeculativeDispatchDeferralIntervals)),
+            "    ");
+        AppendValue(
+            builder,
+            "Maximum speculative queue depth during an interval",
+            Volatile.Read(ref _maximumSpeculativeQueueDepthDuringDeferral),
+            "    ");
+        AppendValue(
+            builder,
+            "Maximum configured worker count during an interval",
+            Volatile.Read(ref _maximumWorkerCountDuringSpeculativeDispatchDeferral),
+            "    ");
+        AppendValue(
+            builder,
+            "Maximum worker-ready slots retained during an interval",
+            Volatile.Read(ref _maximumReservedWorkerSlotsDuringDeferral),
+            "    ");
+        _speculativeDispatchDeferralDuration.Append(builder, "Interval duration", "    ");
     }
 
     private void AppendLoadDemandMeasurements(StringBuilder builder)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadEventSource.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadEventSource.cs
@@ -280,6 +280,74 @@ internal sealed partial class IconLoadEventSource : EventSource
             demandedBeyondCapacity);
     }
 
+    // Event IDs follow the final grouped diagnostics schema and intentionally remain sparse so
+    // independently reviewable layers can land without changing an event's published identity.
+    [Event(22, Level = EventLevel.Informational)]
+    public void SchedulerCommandProcessed(long sessionId, int commandKind, long elapsedMicroseconds, long backlog)
+    {
+        if (!IsEnabled())
+        {
+            return;
+        }
+
+        WriteEvent(22, sessionId, commandKind, elapsedMicroseconds, backlog);
+    }
+
+    [Event(23, Level = EventLevel.Informational)]
+    public void WorkerReadyToDispatchCompleted(long sessionId, int demanded, long elapsedMicroseconds)
+    {
+        if (!IsEnabled())
+        {
+            return;
+        }
+
+        WriteEvent(23, sessionId, demanded, elapsedMicroseconds);
+    }
+
+    [Event(24, Level = EventLevel.Informational)]
+    public void DemandedIdleCapacityCompleted(long sessionId, long elapsedMicroseconds)
+    {
+        if (!IsEnabled())
+        {
+            return;
+        }
+
+        WriteEvent(24, sessionId, elapsedMicroseconds);
+    }
+
+    [Event(25, Level = EventLevel.Informational)]
+    public void SchedulerCoordinatorWoke(long sessionId, int triggerKind, long elapsedMicroseconds)
+    {
+        if (!IsEnabled())
+        {
+            return;
+        }
+
+        WriteEvent(25, sessionId, triggerKind, elapsedMicroseconds);
+    }
+
+    [Event(26, Level = EventLevel.Informational)]
+    public void SchedulerBatchCompleted(
+        long sessionId,
+        int commandCount,
+        int dispatchedWorkItemCount,
+        long drainMicroseconds,
+        long passMicroseconds)
+    {
+        if (!IsEnabled())
+        {
+            return;
+        }
+
+        WriteEvent(
+            26,
+            sessionId,
+            commandCount,
+            dispatchedWorkItemCount,
+            drainMicroseconds,
+            passMicroseconds);
+    }
+
     [Event(34, Level = EventLevel.Warning)]
     public void DispatcherWaitFailed(long sessionId, long loadId, long elapsedMicroseconds)
     {
@@ -324,8 +392,6 @@ internal sealed partial class IconLoadEventSource : EventSource
         WriteEvent(36, sessionId, loadId, materializationKind, isDemanded, elapsedMicroseconds);
     }
 
-    // Event IDs follow the final grouped diagnostics schema and intentionally remain sparse so
-    // independently reviewable layers can land without changing an event's published identity.
     [Event(37, Level = EventLevel.Informational)]
     public void UiResponsivenessProbeCompleted(long sessionId, long elapsedMicroseconds)
     {
@@ -347,6 +413,16 @@ internal sealed partial class IconLoadEventSource : EventSource
         SetEventData(&data[0], &value1, sizeof(long));
         SetEventData(&data[1], &value2, sizeof(long));
         WritePrimitiveEvent(eventId, 2, data);
+    }
+
+    [NonEvent]
+    private unsafe void WriteEvent(int eventId, long value1, int value2, long value3)
+    {
+        EventData* data = stackalloc EventData[3];
+        SetEventData(&data[0], &value1, sizeof(long));
+        SetEventData(&data[1], &value2, sizeof(int));
+        SetEventData(&data[2], &value3, sizeof(long));
+        WritePrimitiveEvent(eventId, 3, data);
     }
 
     [NonEvent]
@@ -414,6 +490,17 @@ internal sealed partial class IconLoadEventSource : EventSource
     }
 
     [NonEvent]
+    private unsafe void WriteEvent(int eventId, long value1, int value2, long value3, long value4)
+    {
+        EventData* data = stackalloc EventData[4];
+        SetEventData(&data[0], &value1, sizeof(long));
+        SetEventData(&data[1], &value2, sizeof(int));
+        SetEventData(&data[2], &value3, sizeof(long));
+        SetEventData(&data[3], &value4, sizeof(long));
+        WritePrimitiveEvent(eventId, 4, data);
+    }
+
+    [NonEvent]
     private unsafe void WriteEvent(int eventId, long value1, int value2, bool value3, long value4)
     {
         var boolValue3 = value3 ? 1 : 0;
@@ -455,6 +542,18 @@ internal sealed partial class IconLoadEventSource : EventSource
         EventData* data = stackalloc EventData[5];
         SetEventData(&data[0], &value1, sizeof(long));
         SetEventData(&data[1], &value2, sizeof(long));
+        SetEventData(&data[2], &value3, sizeof(int));
+        SetEventData(&data[3], &value4, sizeof(long));
+        SetEventData(&data[4], &value5, sizeof(long));
+        WritePrimitiveEvent(eventId, 5, data);
+    }
+
+    [NonEvent]
+    private unsafe void WriteEvent(int eventId, long value1, int value2, int value3, long value4, long value5)
+    {
+        EventData* data = stackalloc EventData[5];
+        SetEventData(&data[0], &value1, sizeof(long));
+        SetEventData(&data[1], &value2, sizeof(int));
         SetEventData(&data[2], &value3, sizeof(int));
         SetEventData(&data[3], &value4, sizeof(long));
         SetEventData(&data[4], &value5, sizeof(long));

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadEventSource.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadEventSource.cs
@@ -403,6 +403,17 @@ internal sealed partial class IconLoadEventSource : EventSource
         WriteEvent(37, sessionId, elapsedMicroseconds);
     }
 
+    [Event(38, Level = EventLevel.Informational)]
+    public void SpeculativeDispatchDeferralCompleted(long sessionId, long elapsedMicroseconds)
+    {
+        if (!IsEnabled())
+        {
+            return;
+        }
+
+        WriteEvent(38, sessionId, elapsedMicroseconds);
+    }
+
     // These exact overloads intentionally shadow EventSource.WriteEvent(params object?[]).
     // The params overload allocates an array and boxes values while ETW is enabled, which
     // would make the icon diagnostics measurably perturb the paths they are observing.

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadMeasurement.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadMeasurement.cs
@@ -45,13 +45,13 @@ internal sealed class IconLoadMeasurement
         InputKind = inputKind;
     }
 
-    public void Enqueued(IconLoadPriority priority)
+    public void Enqueued(IconLoadPriority priority, int workerCount = 1)
     {
         _queuePriority = (int)priority;
         _enqueuedAt = Stopwatch.GetTimestamp();
         try
         {
-            Session.RecordLoadEnqueued(Id, priority);
+            Session.RecordLoadEnqueued(Id, priority, Math.Max(1, workerCount));
             var published = PublishEnqueueState(EnqueueState.Enqueued);
             Debug.Assert(published, "A load can only be enqueued once.");
         }
@@ -237,9 +237,18 @@ internal sealed class IconLoadMeasurement
         if (Interlocked.Exchange(ref _completed, 1) == 0)
         {
             var enqueuedAt = Volatile.Read(ref _enqueuedAt);
-            if (enqueuedAt != 0 && Volatile.Read(ref _started) != 0)
+            if (enqueuedAt == 0)
+            {
+                return;
+            }
+
+            if (Volatile.Read(ref _started) != 0)
             {
                 Session.RecordLoadCompleted(Id, InputKind, IconLoadResultKind.Failed, Stopwatch.GetTimestamp() - enqueuedAt);
+            }
+            else
+            {
+                Session.RecordLoadAbandoned(Id, (IconLoadPriority)_queuePriority);
             }
         }
     }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadQueue.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadQueue.cs
@@ -1,0 +1,763 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Threading.Channels;
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+/// <summary>
+/// Orders icon work by live UI demand, then by the existing high/low priority.
+/// </summary>
+internal sealed class IconLoadQueue
+{
+    private const int HighPriorityCapacity = 32;
+
+    // UI requesters only publish commands. A dedicated background coordinator is
+    // the sole owner of the linked lists, so the WinUI thread never waits on scheduler state.
+    private readonly ConcurrentQueue<QueueCommand> _commands = new();
+    private readonly SingleConsumerSignal _commandSignal = new();
+    private readonly Channel<Operation> _readyWork;
+    private readonly LinkedList<WorkItem> _demandedHigh = new();
+    private readonly LinkedList<WorkItem> _demandedLow = new();
+    private readonly LinkedList<WorkItem> _speculativeHigh = new();
+    private readonly LinkedList<WorkItem> _speculativeLow = new();
+    private readonly Queue<IconLoadDiagnostics.SchedulerCommandMeasurement?> _availableWorkerMeasurements = new();
+    private readonly TaskCompletionSource<bool> _schedulerCompletion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly Thread _schedulerThread;
+    private readonly int _workerCount;
+
+    private TaskCompletionSource<bool>? _faultedEnqueuePublishersDrained;
+    private int _accepting = 1;
+    private int _activeDequeuers;
+    private int _activeEnqueuePublishers;
+    private int _completionCommandPublished;
+    private int _coordinatorFailed;
+    private int _highPriorityCount;
+
+    // Accessed only by the background coordinator.
+    private int _availableWorkerSlots;
+    private bool _completionRequested;
+    private IconLoadDiagnostics.DemandedIdleCapacityMeasurement? _demandedIdleCapacityMeasurement;
+
+    public IconLoadQueue(int workerCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(workerCount, 1);
+        _workerCount = workerCount;
+        _readyWork = Channel.CreateUnbounded<Operation>(new UnboundedChannelOptions
+        {
+            SingleReader = false,
+            SingleWriter = true,
+            AllowSynchronousContinuations = false,
+        });
+        _schedulerThread = new Thread(ProcessCommands)
+        {
+            IsBackground = true,
+            Name = "CmdPal.IconLoadCoordinator",
+        };
+        _schedulerThread.Start();
+    }
+
+    public Task Completion => _schedulerCompletion.Task;
+
+    public bool TryEnqueue(
+        Operation operation,
+        IconLoadPriority requestedPriority,
+        IconLoadDemand demand,
+        out IconLoadPriority actualPriority)
+    {
+        actualPriority = requestedPriority;
+        Interlocked.Increment(ref _activeEnqueuePublishers);
+
+        var highPriorityReserved = false;
+        WorkItem? item = null;
+        try
+        {
+            if (Volatile.Read(ref _accepting) == 0)
+            {
+                return false;
+            }
+
+            if (requestedPriority == IconLoadPriority.High)
+            {
+                highPriorityReserved = TryReserveHighPriority();
+                if (!highPriorityReserved)
+                {
+                    actualPriority = IconLoadPriority.Low;
+                }
+            }
+
+            item = new WorkItem(this, operation, demand, actualPriority);
+            demand.Subscribe(item);
+            operation.Enqueued(actualPriority, _workerCount);
+            Publish(QueueCommand.Enqueue(item));
+            return true;
+        }
+        catch
+        {
+            if (item is not null)
+            {
+                item.ReleaseQueueOwnership();
+            }
+            else if (highPriorityReserved)
+            {
+                ReleaseHighPriority();
+            }
+
+            throw;
+        }
+        finally
+        {
+            EnqueuePublisherFinished();
+        }
+    }
+
+    /// <summary>
+    /// Waits for the next work item assigned to one background consumer.
+    /// </summary>
+    /// <remarks>
+    /// The number of simultaneous callers must not exceed the worker count supplied
+    /// to the constructor. Each consumer may have only one outstanding call.
+    /// </remarks>
+    public async ValueTask<Operation?> DequeueAsync()
+    {
+        var activeDequeuers = Interlocked.Increment(ref _activeDequeuers);
+        if (activeDequeuers > _workerCount)
+        {
+            Interlocked.Decrement(ref _activeDequeuers);
+            throw new InvalidOperationException("The icon queue has more active consumers than configured workers.");
+        }
+
+        try
+        {
+            Publish(QueueCommand.WorkerReady());
+
+            try
+            {
+                return await _readyWork.Reader.ReadAsync().ConfigureAwait(false);
+            }
+            catch (ChannelClosedException ex) when (ex.InnerException is null)
+            {
+                return null;
+            }
+        }
+        finally
+        {
+            Interlocked.Decrement(ref _activeDequeuers);
+        }
+    }
+
+    public void Complete()
+    {
+        if (Interlocked.Exchange(ref _accepting, 0) == 0)
+        {
+            return;
+        }
+
+        TryPublishCompletion();
+    }
+
+    private void EnqueuePublisherFinished()
+    {
+        var activePublishers = Interlocked.Decrement(ref _activeEnqueuePublishers);
+        Debug.Assert(activePublishers >= 0, "An enqueue publisher must be registered before it finishes.");
+        if (activePublishers == 0 && Volatile.Read(ref _accepting) == 0)
+        {
+            if (Volatile.Read(ref _coordinatorFailed) != 0)
+            {
+                Volatile.Read(ref _faultedEnqueuePublishersDrained)?.TrySetResult(true);
+            }
+            else
+            {
+                TryPublishCompletion();
+            }
+        }
+    }
+
+    private void TryPublishCompletion()
+    {
+        if (Volatile.Read(ref _activeEnqueuePublishers) == 0
+            && Interlocked.CompareExchange(ref _completionCommandPublished, 1, 0) == 0)
+        {
+            // Every accepted producer publishes its Enqueue command before decrementing
+            // the active count, so Complete cannot overtake accepted work.
+            Publish(QueueCommand.Complete());
+        }
+    }
+
+    private bool TryReserveHighPriority()
+    {
+        while (true)
+        {
+            var count = Volatile.Read(ref _highPriorityCount);
+            if (count >= HighPriorityCapacity)
+            {
+                return false;
+            }
+
+            if (Interlocked.CompareExchange(ref _highPriorityCount, count + 1, count) == count)
+            {
+                return true;
+            }
+        }
+    }
+
+    private void ReleaseHighPriority()
+    {
+        var count = Interlocked.Decrement(ref _highPriorityCount);
+        Debug.Assert(count >= 0, "A high-priority reservation must be released exactly once.");
+    }
+
+    private void Publish(QueueCommand command)
+    {
+        _commands.Enqueue(command);
+        _commandSignal.Pulse(command.Measurement);
+    }
+
+    internal void FailForTesting(Exception failure)
+    {
+        ArgumentNullException.ThrowIfNull(failure);
+        Publish(QueueCommand.Fault(failure));
+    }
+
+    internal bool CoordinatorFailedForTesting => Volatile.Read(ref _coordinatorFailed) != 0;
+
+    private void ProcessCommands()
+    {
+        Exception? failure = null;
+        QueueCommand? commandBeingProcessed = null;
+        try
+        {
+            while (true)
+            {
+                var wakeMeasurement = _commandSignal.Wait();
+                var measureBatch = wakeMeasurement is not null;
+                var drainStartedAt = 0L;
+                if (measureBatch)
+                {
+                    var wokeAt = Stopwatch.GetTimestamp();
+                    wakeMeasurement!.Woke(wokeAt);
+                    drainStartedAt = Stopwatch.GetTimestamp();
+                }
+
+                var commandCount = 0;
+                while (_commands.TryDequeue(out var command))
+                {
+                    commandBeingProcessed = command;
+                    if (measureBatch)
+                    {
+                        commandCount++;
+                    }
+
+                    command.Measurement?.Processed();
+                    Apply(command);
+                    if (command.Measurement is not null || _demandedIdleCapacityMeasurement is not null)
+                    {
+                        UpdateDemandedIdleCapacityMeasurement();
+                    }
+
+                    commandBeingProcessed = null;
+                }
+
+                var drainTicks = measureBatch ? Stopwatch.GetTimestamp() - drainStartedAt : 0;
+                var dispatchedWorkItemCount = DispatchAvailableWorkers();
+                if (_demandedIdleCapacityMeasurement is not null)
+                {
+                    UpdateDemandedIdleCapacityMeasurement();
+                }
+
+                if (measureBatch)
+                {
+                    wakeMeasurement!.BatchCompleted(
+                        commandCount,
+                        dispatchedWorkItemCount,
+                        drainTicks,
+                        Stopwatch.GetTimestamp() - drainStartedAt);
+                }
+
+                if (_completionRequested && !HasQueuedWork())
+                {
+                    return;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            failure = ex;
+            WaitForEnqueuePublishersAfterFailure();
+        }
+        finally
+        {
+            try
+            {
+                CompleteDemandedIdleCapacityMeasurement();
+            }
+            catch (Exception ex)
+            {
+                failure = failure is null ? ex : new AggregateException(failure, ex);
+                WaitForEnqueuePublishersAfterFailure();
+            }
+
+            try
+            {
+                if (failure is null)
+                {
+                    ReleaseQueuedItems();
+                }
+                else
+                {
+                    failure = FailAcceptedWork(failure, commandBeingProcessed);
+                }
+            }
+            catch (Exception ex)
+            {
+                failure = failure is null ? ex : new AggregateException(failure, ex);
+                WaitForEnqueuePublishersAfterFailure();
+            }
+
+            _commandSignal.Close();
+            _readyWork.Writer.TryComplete(failure);
+            if (failure is null)
+            {
+                _schedulerCompletion.TrySetResult(true);
+            }
+            else
+            {
+                // An exception escaping a raw background thread terminates the process.
+                // Preserve the previous Task-based fault contract instead.
+                _schedulerCompletion.TrySetException(failure);
+            }
+        }
+    }
+
+    private void WaitForEnqueuePublishersAfterFailure()
+    {
+        var publisherWaiter = Volatile.Read(ref _faultedEnqueuePublishersDrained);
+        if (publisherWaiter is null)
+        {
+            var newWaiter = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            publisherWaiter = Interlocked.CompareExchange(
+                ref _faultedEnqueuePublishersDrained,
+                newWaiter,
+                null) ?? newWaiter;
+        }
+
+        // Only the dedicated coordinator waits. Producers, including the WinUI STA,
+        // retain their existing lock-free publication path and merely signal the waiter.
+        Volatile.Write(ref _coordinatorFailed, 1);
+        Interlocked.Exchange(ref _accepting, 0);
+        if (Volatile.Read(ref _activeEnqueuePublishers) == 0)
+        {
+            publisherWaiter.TrySetResult(true);
+        }
+
+        publisherWaiter.Task.GetAwaiter().GetResult();
+    }
+
+    private void Apply(QueueCommand command)
+    {
+        if (command.Failure is not null)
+        {
+            throw command.Failure;
+        }
+
+        switch (command.Kind)
+        {
+            case QueueCommandKind.Enqueue:
+                Enqueue(command.Item!);
+                break;
+            case QueueCommandKind.DemandChanged:
+                OnDemandChanged(command.Item!);
+                break;
+            case QueueCommandKind.WorkerReady:
+                _availableWorkerSlots++;
+                _availableWorkerMeasurements.Enqueue(command.Measurement);
+                Debug.Assert(_availableWorkerSlots <= _workerCount, "Each worker can publish only one available slot.");
+                break;
+            case QueueCommandKind.Complete:
+                _completionRequested = true;
+                break;
+            default:
+                throw new UnreachableException();
+        }
+    }
+
+    private void Enqueue(WorkItem item)
+    {
+        Debug.Assert(!_completionRequested, "Completion cannot overtake an accepted enqueue.");
+        item.IsDemanded = item.Demand.IsDemanded;
+        item.Node = GetQueue(item.IsDemanded, item.Priority).AddLast(item);
+    }
+
+    private void OnDemandChanged(WorkItem item)
+    {
+        // Clear the coalescing flag before sampling demand. A transition racing
+        // after this write can then publish the follow-up invalidation needed to
+        // correct the sampled state; moving this below the read can lose it.
+        item.DemandChangeDequeued();
+        if (item.Node is not { List: not null } node)
+        {
+            return;
+        }
+
+        // Notifications are invalidations and may overtake one another. Read the
+        // current aggregate state instead of trusting a state captured by the caller.
+        var isDemanded = item.Demand.IsDemanded;
+        if (item.IsDemanded == isDemanded)
+        {
+            return;
+        }
+
+        node.List.Remove(node);
+        item.IsDemanded = isDemanded;
+
+        // Ordered by the start of the current demand period: losing every requester
+        // relinquishes the position, so an item cannot starve while continuously demanded.
+        GetQueue(isDemanded, item.Priority).AddLast(node);
+    }
+
+    private int DispatchAvailableWorkers()
+    {
+        var dispatchedWorkItemCount = 0;
+        while (_availableWorkerSlots > 0 && RemoveNext() is { } item)
+        {
+            try
+            {
+                _availableWorkerSlots--;
+                dispatchedWorkItemCount++;
+                var workerMeasurement = _availableWorkerMeasurements.Dequeue();
+                item.ReleaseQueueOwnership();
+
+                workerMeasurement?.WorkerDispatched(item.IsDemanded);
+                if (!_readyWork.Writer.TryWrite(item.Operation))
+                {
+                    throw new InvalidOperationException("The icon worker channel was closed unexpectedly.");
+                }
+
+                item.MarkDispatched();
+            }
+            catch (Exception ex)
+            {
+                item.Fail(ex);
+                throw;
+            }
+        }
+
+        return dispatchedWorkItemCount;
+    }
+
+    private void UpdateDemandedIdleCapacityMeasurement()
+    {
+        var hasDemandedWorkWithIdleCapacity = _availableWorkerSlots > 0
+            && (_demandedHigh.Count != 0 || _demandedLow.Count != 0);
+        if (!hasDemandedWorkWithIdleCapacity)
+        {
+            CompleteDemandedIdleCapacityMeasurement();
+            return;
+        }
+
+        if (_demandedIdleCapacityMeasurement is null
+            || !_demandedIdleCapacityMeasurement.IsForActiveSession)
+        {
+            CompleteDemandedIdleCapacityMeasurement();
+            _demandedIdleCapacityMeasurement = IconLoadDiagnostics.BeginDemandedIdleCapacity(
+                _demandedHigh.Count + _demandedLow.Count,
+                _availableWorkerSlots);
+            return;
+        }
+
+        _demandedIdleCapacityMeasurement.Observe(
+            _demandedHigh.Count + _demandedLow.Count,
+            _availableWorkerSlots);
+    }
+
+    private void CompleteDemandedIdleCapacityMeasurement()
+    {
+        _demandedIdleCapacityMeasurement?.Complete();
+        _demandedIdleCapacityMeasurement = null;
+    }
+
+    // Strict order by design: speculative work may starve while demanded work keeps
+    // arriving, since no live request is waiting on it.
+    private WorkItem? RemoveNext()
+    {
+        return RemoveFirst(_demandedHigh)
+            ?? RemoveFirst(_demandedLow)
+            ?? RemoveFirst(_speculativeHigh)
+            ?? RemoveFirst(_speculativeLow);
+    }
+
+    private bool HasQueuedWork()
+    {
+        return _demandedHigh.Count != 0
+            || _demandedLow.Count != 0
+            || _speculativeHigh.Count != 0
+            || _speculativeLow.Count != 0;
+    }
+
+    private LinkedList<WorkItem> GetQueue(bool isDemanded, IconLoadPriority priority)
+    {
+        return (isDemanded, priority) switch
+        {
+            (true, IconLoadPriority.High) => _demandedHigh,
+            (true, IconLoadPriority.Low) => _demandedLow,
+            (false, IconLoadPriority.High) => _speculativeHigh,
+            _ => _speculativeLow,
+        };
+    }
+
+    private void ReleaseQueuedItems()
+    {
+        ReleaseQueuedItems(_demandedHigh);
+        ReleaseQueuedItems(_demandedLow);
+        ReleaseQueuedItems(_speculativeHigh);
+        ReleaseQueuedItems(_speculativeLow);
+    }
+
+    private void ReleaseQueuedItems(LinkedList<WorkItem> queue)
+    {
+        while (RemoveFirst(queue) is { } item)
+        {
+            item.ReleaseQueueOwnership();
+        }
+    }
+
+    private Exception FailAcceptedWork(Exception failure, QueueCommand? commandBeingProcessed)
+    {
+        Exception? cleanupFailure = null;
+        if (commandBeingProcessed is { Kind: QueueCommandKind.Enqueue, Item: { } activeItem })
+        {
+            TryFail(activeItem);
+        }
+
+        while (_commands.TryDequeue(out var command))
+        {
+            if (command is { Kind: QueueCommandKind.Enqueue, Item: { } item })
+            {
+                TryFail(item);
+            }
+        }
+
+        FailQueuedItems(_demandedHigh);
+        FailQueuedItems(_demandedLow);
+        FailQueuedItems(_speculativeHigh);
+        FailQueuedItems(_speculativeLow);
+        return cleanupFailure is null ? failure : new AggregateException(failure, cleanupFailure);
+
+        void FailQueuedItems(LinkedList<WorkItem> queue)
+        {
+            while (RemoveFirst(queue) is { } item)
+            {
+                TryFail(item);
+            }
+        }
+
+        void TryFail(WorkItem item)
+        {
+            try
+            {
+                item.Fail(failure);
+            }
+            catch (Exception ex)
+            {
+                cleanupFailure = cleanupFailure is null ? ex : new AggregateException(cleanupFailure, ex);
+            }
+        }
+    }
+
+    private static WorkItem? RemoveFirst(LinkedList<WorkItem> queue)
+    {
+        if (queue.First is not { } node)
+        {
+            return null;
+        }
+
+        queue.RemoveFirst();
+        node.Value.Node = null;
+        return node.Value;
+    }
+
+    internal enum QueueCommandKind
+    {
+        Enqueue,
+        DemandChanged,
+        WorkerReady,
+        Complete,
+    }
+
+    private readonly record struct QueueCommand(
+        QueueCommandKind Kind,
+        WorkItem? Item,
+        IconLoadDiagnostics.SchedulerCommandMeasurement? Measurement,
+        Exception? Failure)
+    {
+        public static QueueCommand Enqueue(WorkItem item) =>
+            new(
+                QueueCommandKind.Enqueue,
+                item,
+                IconLoadDiagnostics.BeginSchedulerCommand(QueueCommandKind.Enqueue),
+                null);
+
+        public static QueueCommand DemandChanged(WorkItem item) =>
+            new(
+                QueueCommandKind.DemandChanged,
+                item,
+                IconLoadDiagnostics.BeginSchedulerCommand(QueueCommandKind.DemandChanged),
+                null);
+
+        public static QueueCommand WorkerReady() =>
+            new(
+                QueueCommandKind.WorkerReady,
+                null,
+                IconLoadDiagnostics.BeginSchedulerCommand(QueueCommandKind.WorkerReady),
+                null);
+
+        public static QueueCommand Complete() =>
+            new(
+                QueueCommandKind.Complete,
+                null,
+                IconLoadDiagnostics.BeginSchedulerCommand(QueueCommandKind.Complete),
+                null);
+
+        public static QueueCommand Fault(Exception failure) =>
+            new(
+                QueueCommandKind.Complete,
+                null,
+                null,
+                failure);
+    }
+
+    private sealed class WorkItem : IconLoadDemand.IObserver
+    {
+        private readonly IconLoadQueue _owner;
+        private int _demandChangeQueued;
+        private int _queueOwnershipReleased;
+        private int _terminal;
+
+        public WorkItem(IconLoadQueue owner, Operation operation, IconLoadDemand demand, IconLoadPriority priority)
+        {
+            _owner = owner;
+            Operation = operation;
+            Demand = demand;
+            Priority = priority;
+        }
+
+        public Operation Operation { get; }
+
+        public IconLoadDemand Demand { get; }
+
+        public IconLoadPriority Priority { get; }
+
+        public LinkedListNode<WorkItem>? Node { get; set; }
+
+        public bool IsDemanded { get; set; }
+
+        public void ReleaseQueueOwnership()
+        {
+            if (Interlocked.Exchange(ref _queueOwnershipReleased, 1) != 0)
+            {
+                return;
+            }
+
+            Demand.Unsubscribe(this);
+            if (Priority == IconLoadPriority.High)
+            {
+                _owner.ReleaseHighPriority();
+            }
+        }
+
+        public void MarkDispatched()
+        {
+            var wasTerminal = Interlocked.Exchange(ref _terminal, 1);
+            Debug.Assert(wasTerminal == 0, "An icon load operation can be dispatched only once.");
+        }
+
+        public void Fail(Exception failure)
+        {
+            ReleaseQueueOwnership();
+            if (Interlocked.Exchange(ref _terminal, 1) == 0)
+            {
+                Operation.Fail(failure);
+            }
+        }
+
+        public void OnDemandChanged()
+        {
+            if (Interlocked.CompareExchange(ref _demandChangeQueued, 1, 0) == 0)
+            {
+                _owner.Publish(QueueCommand.DemandChanged(this));
+            }
+        }
+
+        public void DemandChangeDequeued() => Volatile.Write(ref _demandChangeQueued, 0);
+    }
+
+    internal abstract class Operation
+    {
+        public virtual void Enqueued(IconLoadPriority priority, int workerCount)
+        {
+        }
+
+        public abstract Task ExecuteAsync();
+
+        public abstract void Fail(Exception failure);
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Design",
+        "CA1001:Types that own disposable fields should be disposable",
+        Justification = "The coordinator closes the handle before completing; late lock-free publishers are ignored.")]
+    private sealed class SingleConsumerSignal
+    {
+        private readonly AutoResetEvent _waitHandle = new(initialState: false);
+        private IconLoadDiagnostics.SchedulerCommandMeasurement? _triggerMeasurement;
+        private int _closed;
+        private int _signaled;
+
+        public void Pulse(IconLoadDiagnostics.SchedulerCommandMeasurement? measurement)
+        {
+            if (Volatile.Read(ref _closed) != 0)
+            {
+                return;
+            }
+
+            // Only the first publisher enters the kernel. Later publications coalesce
+            // behind the already-signaled pass and remain visible in _commands.
+            if (Interlocked.CompareExchange(ref _signaled, 1, 0) != 0)
+            {
+                return;
+            }
+
+            Volatile.Write(ref _triggerMeasurement, measurement);
+            try
+            {
+                _waitHandle.Set();
+            }
+            catch (ObjectDisposedException) when (Volatile.Read(ref _closed) != 0)
+            {
+                // A worker or stale demand notification raced coordinator shutdown.
+            }
+        }
+
+        public IconLoadDiagnostics.SchedulerWakeMeasurement? Wait()
+        {
+            _waitHandle.WaitOne();
+            var triggerMeasurement = Interlocked.Exchange(ref _triggerMeasurement, null);
+
+            // Reset before draining. A new publication either signals the following
+            // pass or races early enough to be consumed by the pass about to begin.
+            Volatile.Write(ref _signaled, 0);
+            return triggerMeasurement?.CreateWakeMeasurement();
+        }
+
+        public void Close()
+        {
+            if (Interlocked.Exchange(ref _closed, 1) == 0)
+            {
+                _waitHandle.Dispose();
+            }
+        }
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadQueue.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadQueue.cs
@@ -27,6 +27,7 @@ internal sealed class IconLoadQueue
     private readonly Queue<IconLoadDiagnostics.SchedulerCommandMeasurement?> _availableWorkerMeasurements = new();
     private readonly TaskCompletionSource<bool> _schedulerCompletion = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly Thread _schedulerThread;
+    private readonly int _workerSlotsReservedForDemand;
     private readonly int _workerCount;
 
     private TaskCompletionSource<bool>? _faultedEnqueuePublishersDrained;
@@ -41,11 +42,18 @@ internal sealed class IconLoadQueue
     private int _availableWorkerSlots;
     private bool _completionRequested;
     private IconLoadDiagnostics.DemandedIdleCapacityMeasurement? _demandedIdleCapacityMeasurement;
+    private IconLoadDiagnostics.SpeculativeDispatchDeferralMeasurement? _speculativeDispatchDeferralMeasurement;
 
     public IconLoadQueue(int workerCount)
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(workerCount, 1);
         _workerCount = workerCount;
+
+        // Keep one consumer waiting for live demand while only speculative work is
+        // queued. At two workers this deliberately halves speculative concurrency:
+        // reserving no slot would let non-preemptible speculative loads occupy all
+        // capacity. A single-worker queue must still make progress.
+        _workerSlotsReservedForDemand = workerCount > 1 ? 1 : 0;
         _readyWork = Channel.CreateUnbounded<Operation>(new UnboundedChannelOptions
         {
             SingleReader = false,
@@ -253,9 +261,12 @@ internal sealed class IconLoadQueue
 
                     command.Measurement?.Processed();
                     Apply(command);
-                    if (command.Measurement is not null || _demandedIdleCapacityMeasurement is not null)
+                    if (command.Measurement is not null
+                        || _demandedIdleCapacityMeasurement is not null
+                        || _speculativeDispatchDeferralMeasurement is not null)
                     {
                         UpdateDemandedIdleCapacityMeasurement();
+                        UpdateSpeculativeDispatchDeferralMeasurement();
                     }
 
                     commandBeingProcessed = null;
@@ -267,6 +278,10 @@ internal sealed class IconLoadQueue
                 {
                     UpdateDemandedIdleCapacityMeasurement();
                 }
+
+                // Dispatch can consume the last non-reserved slot and begin a
+                // deferral interval without another command changing state.
+                UpdateSpeculativeDispatchDeferralMeasurement();
 
                 if (measureBatch)
                 {
@@ -293,6 +308,7 @@ internal sealed class IconLoadQueue
             try
             {
                 CompleteDemandedIdleCapacityMeasurement();
+                CompleteSpeculativeDispatchDeferralMeasurement();
             }
             catch (Exception ex)
             {
@@ -421,7 +437,7 @@ internal sealed class IconLoadQueue
     private int DispatchAvailableWorkers()
     {
         var dispatchedWorkItemCount = 0;
-        while (_availableWorkerSlots > 0 && RemoveNext() is { } item)
+        while (CanDispatchNextWorkItem() && RemoveNext() is { } item)
         {
             try
             {
@@ -446,6 +462,24 @@ internal sealed class IconLoadQueue
         }
 
         return dispatchedWorkItemCount;
+    }
+
+    private bool CanDispatchNextWorkItem()
+    {
+        if (_availableWorkerSlots == 0)
+        {
+            return false;
+        }
+
+        if (_demandedHigh.Count != 0 || _demandedLow.Count != 0)
+        {
+            return true;
+        }
+
+        // Speculative work uses at most workerCount - 1 consumers. Because a
+        // consumer publishes WorkerReady only after its previous load completes,
+        // retaining this slot also bounds the number of active speculative loads.
+        return _availableWorkerSlots > _workerSlotsReservedForDemand;
     }
 
     private void UpdateDemandedIdleCapacityMeasurement()
@@ -477,6 +511,43 @@ internal sealed class IconLoadQueue
     {
         _demandedIdleCapacityMeasurement?.Complete();
         _demandedIdleCapacityMeasurement = null;
+    }
+
+    private void UpdateSpeculativeDispatchDeferralMeasurement()
+    {
+        var speculativeQueueDepth = _speculativeHigh.Count + _speculativeLow.Count;
+        var reserveIsDeferringWork = _workerSlotsReservedForDemand > 0
+            && _availableWorkerSlots > 0
+            && _availableWorkerSlots <= _workerSlotsReservedForDemand
+            && _demandedHigh.Count == 0
+            && _demandedLow.Count == 0
+            && speculativeQueueDepth > 0;
+        if (!reserveIsDeferringWork)
+        {
+            CompleteSpeculativeDispatchDeferralMeasurement();
+            return;
+        }
+
+        if (_speculativeDispatchDeferralMeasurement is null
+            || !_speculativeDispatchDeferralMeasurement.IsForActiveSession)
+        {
+            CompleteSpeculativeDispatchDeferralMeasurement();
+            _speculativeDispatchDeferralMeasurement = IconLoadDiagnostics.BeginSpeculativeDispatchDeferral(
+                speculativeQueueDepth,
+                _workerCount,
+                _availableWorkerSlots);
+            return;
+        }
+
+        _speculativeDispatchDeferralMeasurement.Observe(
+            speculativeQueueDepth,
+            _availableWorkerSlots);
+    }
+
+    private void CompleteSpeculativeDispatchDeferralMeasurement()
+    {
+        _speculativeDispatchDeferralMeasurement?.Complete();
+        _speculativeDispatchDeferralMeasurement = null;
     }
 
     // Strict order by design: speculative work may starve while demanded work keeps

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoaderService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoaderService.cs
@@ -2,12 +2,14 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Channels;
 using CommunityToolkit.WinUI;
 using ManagedCommon;
 using Microsoft.Terminal.UI;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Windows.Foundation;
 using Windows.Storage.Streams;
@@ -28,6 +30,10 @@ internal sealed partial class IconLoaderService : IIconLoaderService
     private readonly Channel<Func<Task>> _lowPriorityQueue = Channel.CreateUnbounded<Func<Task>>();
     private readonly Task[] _workers;
     private readonly DispatcherQueue _dispatcherQueue;
+    private FontFamily? _fluentIconFontFamily;
+    private FontFamily? _emojiFontFamily;
+    private FontFamily? _generalFontFamily;
+    private int _directGlyphFailureLogged;
 
     public IconLoaderService(DispatcherQueue dispatcherQueue)
     {
@@ -38,6 +44,71 @@ internal sealed partial class IconLoaderService : IIconLoaderService
         {
             _workers[i] = Task.Run(ProcessQueueAsync);
         }
+    }
+
+    public bool TryLoadGlyph(
+        string? iconString,
+        string? fontFamily,
+        Size iconSize,
+        double scale,
+        [MaybeNullWhen(false)] out IconSource result)
+    {
+        result = null;
+
+        // IconSource is a XAML object. If a caller ever reaches the provider away from
+        // the UI thread, preserve the existing dispatcher-based path.
+        if (!_dispatcherQueue.HasThreadAccess || string.IsNullOrEmpty(iconString))
+        {
+            return false;
+        }
+
+        try
+        {
+            var glyphKind = FontIconGlyphClassifier.Classify(iconString);
+            if (glyphKind is FontIconGlyphKind.Invalid or FontIconGlyphKind.None)
+            {
+                return false;
+            }
+
+            result = new FontIconSource
+            {
+                FontFamily = GetOrCreateFontFamily(glyphKind, fontFamily),
+                FontSize = FontIconSizeCalculator.Calculate(iconSize, scale, DefaultIconSize),
+                Glyph = iconString,
+            };
+            return true;
+        }
+        catch (Exception ex)
+        {
+            // The general converter has its own fallback behavior. Let it handle any
+            // input that cannot be represented by this narrow glyph fast path.
+            if (Interlocked.Exchange(ref _directGlyphFailureLogged, 1) == 0)
+            {
+                Logger.LogError("Direct glyph construction failed; falling back to queued icon loading", ex);
+            }
+
+            result = null;
+            return false;
+        }
+    }
+
+    private FontFamily GetOrCreateFontFamily(FontIconGlyphKind glyphKind, string? requestedFontFamily)
+    {
+        if (!string.IsNullOrEmpty(requestedFontFamily))
+        {
+            return new FontFamily(requestedFontFamily);
+        }
+
+        // TryLoadGlyph gates this method to the service's dispatcher thread, so these
+        // XAML objects can be reused without a lock or cross-STA sharing.
+        return glyphKind switch
+        {
+            FontIconGlyphKind.FluentSymbol =>
+                _fluentIconFontFamily ??= new FontFamily("Segoe Fluent Icons, Segoe MDL2 Assets"),
+            FontIconGlyphKind.Emoji =>
+                _emojiFontFamily ??= new FontFamily("Segoe UI Emoji, Segoe UI"),
+            _ => _generalFontFamily ??= new FontFamily("Segoe UI"),
+        };
     }
 
     public bool TryEnqueueLoad(

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoaderService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoaderService.cs
@@ -1,9 +1,8 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Channels;
 using CommunityToolkit.WinUI;
 using ManagedCommon;
 using Microsoft.Terminal.UI;
@@ -26,8 +25,7 @@ internal sealed partial class IconLoaderService : IIconLoaderService
 
     private static readonly int WorkerCount = Math.Clamp(Environment.ProcessorCount / 2, 1, MaxWorkerCount);
 
-    private readonly Channel<Func<Task>> _highPriorityQueue = Channel.CreateBounded<Func<Task>>(32);
-    private readonly Channel<Func<Task>> _lowPriorityQueue = Channel.CreateUnbounded<Func<Task>>();
+    private readonly IconLoadQueue _queue = new(WorkerCount);
     private readonly Task[] _workers;
     private readonly DispatcherQueue _dispatcherQueue;
     private FontFamily? _fluentIconFontFamily;
@@ -44,6 +42,12 @@ internal sealed partial class IconLoaderService : IIconLoaderService
         {
             _workers[i] = Task.Run(ProcessQueueAsync);
         }
+
+        _ = _queue.Completion.ContinueWith(
+            static task => Logger.LogError("Icon load scheduler failed", task.Exception!),
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 
     public bool TryLoadGlyph(
@@ -119,101 +123,50 @@ internal sealed partial class IconLoaderService : IIconLoaderService
         double scale,
         TaskCompletionSource<IconSource?> tcs,
         IconLoadPriority priority = IconLoadPriority.Low,
-        IconLoadMeasurement? diagnostics = null)
+        IconLoadMeasurement? diagnostics = null,
+        IconLoadDemand? demand = null)
     {
-        if (priority == IconLoadPriority.High)
+        demand ??= IconLoadDemand.CreateDemanded();
+        var operation = new IconLoadOperation(
+            this,
+            iconString,
+            fontFamily,
+            streamRef,
+            iconSize,
+            scale,
+            tcs,
+            diagnostics);
+        if (_queue.TryEnqueue(operation, priority, demand, out var actualPriority))
         {
-            var highPriorityWorkItem = () => LoadAndCompleteAsync(iconString, fontFamily, streamRef, iconSize, scale, tcs, diagnostics);
-            if (_highPriorityQueue.Writer.TryWrite(highPriorityWorkItem))
-            {
-                RecordEnqueued(diagnostics, IconLoadPriority.High);
-                return true;
-            }
-
 #if DEBUG
-            Logger.LogDebug("High priority icon queue full, falling back to low priority");
+            if (priority == IconLoadPriority.High && actualPriority == IconLoadPriority.Low)
+            {
+                Logger.LogDebug("High priority icon queue full, falling back to low priority");
+            }
 #endif
-        }
-
-        var lowPriorityWorkItem = () => LoadAndCompleteAsync(iconString, fontFamily, streamRef, iconSize, scale, tcs, diagnostics);
-        if (_lowPriorityQueue.Writer.TryWrite(lowPriorityWorkItem))
-        {
-            RecordEnqueued(diagnostics, IconLoadPriority.Low);
             return true;
         }
 
         diagnostics?.Rejected();
         return false;
-
-        static void RecordEnqueued(IconLoadMeasurement? diagnostics, IconLoadPriority actualPriority)
-        {
-            try
-            {
-                diagnostics?.Enqueued(actualPriority);
-            }
-            catch (Exception ex)
-            {
-                // Diagnostics must not fail work that was already published to the loader queue.
-                Logger.LogError("Failed to record icon load enqueue diagnostics", ex);
-            }
-        }
     }
 
     public async ValueTask DisposeAsync()
     {
-        _highPriorityQueue.Writer.Complete();
-        _lowPriorityQueue.Writer.Complete();
-
-        await Task.WhenAll(_workers).ConfigureAwait(false);
+        _queue.Complete();
+        var tasks = new Task[_workers.Length + 1];
+        _workers.CopyTo(tasks, 0);
+        tasks[^1] = _queue.Completion;
+        await Task.WhenAll(tasks).ConfigureAwait(false);
     }
 
     private async Task ProcessQueueAsync()
     {
-        while (true)
-        {
-            Func<Task>? workItem;
-
-            if (_highPriorityQueue.Reader.TryRead(out workItem))
-            {
-                await ExecuteWork(workItem).ConfigureAwait(false);
-                continue;
-            }
-
-            var highWait = _highPriorityQueue.Reader.WaitToReadAsync().AsTask();
-            var lowWait = _lowPriorityQueue.Reader.WaitToReadAsync().AsTask();
-
-            await Task.WhenAny(highWait, lowWait).ConfigureAwait(false);
-
-            // Check if both channels are completed (disposal)
-            if (_highPriorityQueue.Reader.Completion.IsCompleted &&
-                _lowPriorityQueue.Reader.Completion.IsCompleted)
-            {
-                // Drain any remaining items
-                while (_highPriorityQueue.Reader.TryRead(out workItem))
-                {
-                    await ExecuteWork(workItem).ConfigureAwait(false);
-                }
-
-                while (_lowPriorityQueue.Reader.TryRead(out workItem))
-                {
-                    await ExecuteWork(workItem).ConfigureAwait(false);
-                }
-
-                break;
-            }
-
-            if (_highPriorityQueue.Reader.TryRead(out workItem) ||
-                _lowPriorityQueue.Reader.TryRead(out workItem))
-            {
-                await ExecuteWork(workItem).ConfigureAwait(false);
-            }
-        }
-
-        static async Task ExecuteWork(Func<Task> workItem)
+        while (await _queue.DequeueAsync().ConfigureAwait(false) is { } operation)
         {
             try
             {
-                await workItem().ConfigureAwait(false);
+                await operation.ExecuteAsync().ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -406,5 +359,74 @@ internal sealed partial class IconLoaderService : IIconLoaderService
             ? DefaultIconSize
             : (int)Math.Max(size.Width, size.Height);
         return IconPathConverter.IconSourceMUX(iconString, fontFamily, iconSize);
+    }
+
+    private sealed class IconLoadOperation : IconLoadQueue.Operation
+    {
+        private readonly IconLoaderService _owner;
+        private readonly string? _iconString;
+        private readonly string? _fontFamily;
+        private readonly IRandomAccessStreamReference? _streamRef;
+        private readonly Size _iconSize;
+        private readonly double _scale;
+        private readonly TaskCompletionSource<IconSource?> _completion;
+        private readonly IconLoadMeasurement? _diagnostics;
+
+        public IconLoadOperation(
+            IconLoaderService owner,
+            string? iconString,
+            string? fontFamily,
+            IRandomAccessStreamReference? streamRef,
+            Size iconSize,
+            double scale,
+            TaskCompletionSource<IconSource?> completion,
+            IconLoadMeasurement? diagnostics)
+        {
+            _owner = owner;
+            _iconString = iconString;
+            _fontFamily = fontFamily;
+            _streamRef = streamRef;
+            _iconSize = iconSize;
+            _scale = scale;
+            _completion = completion;
+            _diagnostics = diagnostics;
+        }
+
+        public override void Enqueued(IconLoadPriority priority, int workerCount)
+        {
+            try
+            {
+                _diagnostics?.Enqueued(priority, workerCount);
+            }
+            catch (Exception ex)
+            {
+                // Diagnostics must not fail work that the loader is about to publish.
+                Logger.LogError("Failed to record icon load enqueue diagnostics", ex);
+            }
+        }
+
+        public override Task ExecuteAsync() =>
+            _owner.LoadAndCompleteAsync(
+                _iconString,
+                _fontFamily,
+                _streamRef,
+                _iconSize,
+                _scale,
+                _completion,
+                _diagnostics);
+
+        public override void Fail(Exception failure)
+        {
+            try
+            {
+                _diagnostics?.Fail();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError("Failed to record abandoned icon load diagnostics", ex);
+            }
+
+            _completion.TrySetException(failure);
+        }
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconProvider.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconProvider.cs
@@ -55,11 +55,16 @@ public static partial class IconProvider
         {
             args.Value = args.Key switch
             {
-                IconDataViewModel iconData => await service.GetIconSource(iconData, args.Scale, args.Diagnostics),
+                IconDataViewModel iconData => await service.GetIconSource(
+                    iconData,
+                    args.Scale,
+                    args.Diagnostics,
+                    args),
                 IconInfoViewModel iconInfo => await service.GetIconSource(
                     args.Theme == Microsoft.UI.Xaml.ElementTheme.Light ? iconInfo.Light : iconInfo.Dark,
                     args.Scale,
-                    args.Diagnostics),
+                    args.Diagnostics,
+                    args),
                 _ => null,
             };
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconRequestDemand.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconRequestDemand.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+/// <summary>
+/// Represents one UI request's live interest in an icon load.
+/// </summary>
+/// <remarks>
+/// Only unit tests construct this. It keeps <see cref="IconRequestDemandState"/> — the state
+/// machine SourceRequestedEventArgs uses in production — testable without linking XAML types
+/// into the test project.
+/// </remarks>
+internal sealed class IconRequestDemand : IIconRequestDemand
+{
+    private IconRequestDemandState _state;
+
+    public void Attach(IconLoadDemand loadDemand) => _state.Attach(loadDemand);
+
+    public void Release() => _state.Release();
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconRequestDemandState.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconRequestDemandState.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+internal struct IconRequestDemandState
+{
+    private IconLoadDemand? _loadDemand;
+    private int _released;
+
+    public void Attach(IconLoadDemand loadDemand)
+    {
+        loadDemand.AddRequester();
+        if (Volatile.Read(ref _released) != 0)
+        {
+            loadDemand.RemoveRequester();
+            return;
+        }
+
+        var existing = Interlocked.CompareExchange(ref _loadDemand, loadDemand, null);
+        Debug.Assert(existing is null, "An icon request can track only one load.");
+        if (existing is not null)
+        {
+            loadDemand.RemoveRequester();
+            return;
+        }
+
+        if (Volatile.Read(ref _released) != 0
+            && ReferenceEquals(Interlocked.CompareExchange(ref _loadDemand, null, loadDemand), loadDemand))
+        {
+            loadDemand.RemoveRequester();
+        }
+    }
+
+    public void Release()
+    {
+        if (Interlocked.Exchange(ref _released, 1) != 0)
+        {
+            return;
+        }
+
+        Interlocked.Exchange(ref _loadDemand, null)?.RemoveRequester();
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconSourceProvider.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconSourceProvider.cs
@@ -26,7 +26,11 @@ internal sealed class IconSourceProvider : IIconSourceProvider
     {
     }
 
-    public Task<IconSource?> GetIconSource(IconDataViewModel icon, double scale, IconRequestMeasurement diagnostics = default)
+    public Task<IconSource?> GetIconSource(
+        IconDataViewModel icon,
+        double scale,
+        IconRequestMeasurement diagnostics = default,
+        IIconRequestDemand? demand = null)
     {
         var tcs = new TaskCompletionSource<IconSource?>(TaskCreationOptions.RunContinuationsAsynchronously);
         IconLoadMeasurement? loadDiagnostics = null;
@@ -50,6 +54,9 @@ internal sealed class IconSourceProvider : IIconSourceProvider
                 return tcs.Task;
             }
 
+            var loadDemand = new IconLoadDemand();
+            loadDemand.Attach(demand);
+
             if (!_loader.TryEnqueueLoad(
                     icon.Icon,
                     icon.FontFamily,
@@ -58,7 +65,8 @@ internal sealed class IconSourceProvider : IIconSourceProvider
                     scale,
                     tcs,
                     _isPriority ? IconLoadPriority.High : IconLoadPriority.Low,
-                    loadDiagnostics))
+                    loadDiagnostics,
+                    loadDemand))
             {
                 tcs.TrySetException(new ObjectDisposedException(nameof(IIconLoaderService)));
             }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconSourceProvider.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconSourceProvider.cs
@@ -43,6 +43,13 @@ internal sealed class IconSourceProvider : IIconSourceProvider
                 scale);
             diagnostics.RecordProviderResolution(IconProviderResolution.NewLoad, loadDiagnostics);
 
+            if (_loader.TryLoadGlyph(icon.Icon, icon.FontFamily, _iconSize, scale, out var glyph) && glyph is not null)
+            {
+                loadDiagnostics?.CompleteDirectGlyph(glyph);
+                tcs.TrySetResult(glyph);
+                return tcs.Task;
+            }
+
             if (!_loader.TryEnqueueLoad(
                     icon.Icon,
                     icon.FontFamily,

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/CachedIconSourceProviderTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/CachedIconSourceProviderTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.CmdPal.UI.Helpers;
@@ -60,6 +61,48 @@ public partial class CachedIconSourceProviderTests
 
         Assert.AreSame(first, cached);
         Assert.AreEqual(1, loader.EnqueueCount);
+    }
+
+    [TestMethod]
+    [Timeout(5_000)]
+    public async Task SuccessfulDirectGlyphLoadIsCachedWithoutQueueing()
+    {
+        var glyph = CreateTestIconSource();
+        var loader = new ControllableIconLoader
+        {
+            ReturnDirectGlyph = true,
+            DirectGlyphResult = glyph,
+        };
+        var provider = new CachedIconSourceProvider(loader, new Size(20, 20), cacheSize: 16);
+        var icon = new IconDataViewModel { Icon = "glyph" };
+
+        var first = provider.GetIconSource(icon, 1.0);
+        var firstResult = await first;
+
+        Assert.IsTrue(
+            SpinWait.SpinUntil(() => GetInFlightCount(provider) == 0, TimeSpan.FromSeconds(2)),
+            "The direct glyph load was not retired from the in-flight dictionary.");
+
+        var cached = provider.GetIconSource(icon, 1.0);
+
+        Assert.AreSame(glyph, firstResult);
+        Assert.AreSame(first, cached);
+        Assert.AreEqual(1, loader.GlyphAttemptCount);
+        Assert.AreEqual(0, loader.EnqueueCount);
+    }
+
+    [TestMethod]
+    public async Task CachedProviderFallsBackWhenLoaderViolatesDirectGlyphContract()
+    {
+        var loader = new ControllableIconLoader { ReturnDirectGlyph = true };
+        var provider = new CachedIconSourceProvider(loader, new Size(20, 20), cacheSize: 16);
+
+        var result = provider.GetIconSource(new IconDataViewModel { Icon = "glyph" }, 1.0);
+
+        Assert.AreEqual(1, loader.GlyphAttemptCount);
+        Assert.AreEqual(1, loader.EnqueueCount);
+        loader.CompleteNext(null);
+        Assert.IsNull(await result);
     }
 
     [TestMethod]
@@ -161,6 +204,45 @@ public partial class CachedIconSourceProviderTests
         Assert.AreEqual(1, loader.EnqueueCount);
     }
 
+    [TestMethod]
+    public async Task UncachedProviderLoadsGlyphDirectlyWithoutQueueing()
+    {
+        var glyph = CreateTestIconSource();
+        var loader = new ControllableIconLoader
+        {
+            ReturnDirectGlyph = true,
+            DirectGlyphResult = glyph,
+        };
+        var provider = new IconSourceProvider(loader, new Size(16, 16));
+
+        var result = await provider.GetIconSource(new IconDataViewModel { Icon = "glyph" }, 1.0);
+
+        Assert.AreSame(glyph, result);
+        Assert.AreEqual(1, loader.GlyphAttemptCount);
+        Assert.AreEqual(0, loader.EnqueueCount);
+    }
+
+    [TestMethod]
+    public async Task UncachedProviderFallsBackWhenLoaderViolatesDirectGlyphContract()
+    {
+        var loader = new ControllableIconLoader { ReturnDirectGlyph = true };
+        var provider = new IconSourceProvider(loader, new Size(16, 16));
+
+        var result = provider.GetIconSource(new IconDataViewModel { Icon = "glyph" }, 1.0);
+
+        Assert.AreEqual(1, loader.GlyphAttemptCount);
+        Assert.AreEqual(1, loader.EnqueueCount);
+        loader.CompleteNext(null);
+        Assert.IsNull(await result);
+    }
+
+    private static IconSource CreateTestIconSource()
+    {
+        // The unit-test process does not initialize WinUI. Providers treat a completed
+        // IconSource opaquely, so use a non-activated projection only as an identity token.
+        return (IconSource)RuntimeHelpers.GetUninitializedObject(typeof(FontIconSource));
+    }
+
     private static int GetInFlightCount(CachedIconSourceProvider provider)
     {
         var field = typeof(CachedIconSourceProvider).GetField("_inFlight", BindingFlags.Instance | BindingFlags.NonPublic);
@@ -199,10 +281,29 @@ public partial class CachedIconSourceProviderTests
     {
         private readonly ConcurrentQueue<TaskCompletionSource<IconSource?>> _pending = new();
         private int _enqueueCount;
+        private int _glyphAttemptCount;
 
         public bool AcceptLoads { get; set; } = true;
 
+        public bool ReturnDirectGlyph { get; set; }
+
+        public IconSource? DirectGlyphResult { get; set; }
+
         public int EnqueueCount => Volatile.Read(ref _enqueueCount);
+
+        public int GlyphAttemptCount => Volatile.Read(ref _glyphAttemptCount);
+
+        public bool TryLoadGlyph(
+            string? iconString,
+            string? fontFamily,
+            Size iconSize,
+            double scale,
+            [MaybeNullWhen(false)] out IconSource result)
+        {
+            Interlocked.Increment(ref _glyphAttemptCount);
+            result = DirectGlyphResult!;
+            return ReturnDirectGlyph;
+        }
 
         public bool TryEnqueueLoad(
             string? iconString,

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/CachedIconSourceProviderTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/CachedIconSourceProviderTests.cs
@@ -65,6 +65,41 @@ public partial class CachedIconSourceProviderTests
 
     [TestMethod]
     [Timeout(5_000)]
+    public async Task SharedInFlightLoadTracksEveryLiveRequest()
+    {
+        var loader = new ControllableIconLoader();
+        var provider = new CachedIconSourceProvider(loader, new Size(20, 20), cacheSize: 16);
+        var icon = new IconDataViewModel { Icon = "test" };
+        var firstDemand = new IconRequestDemand();
+        var secondDemand = new IconRequestDemand();
+
+        var first = provider.GetIconSource(icon, 1.0, demand: firstDemand);
+        var second = provider.GetIconSource(icon, 1.0, demand: secondDemand);
+
+        Assert.AreSame(first, second);
+        Assert.IsNotNull(loader.LastDemand);
+        Assert.IsTrue(loader.LastDemand.IsDemanded);
+
+        firstDemand.Release();
+        Assert.IsTrue(loader.LastDemand.IsDemanded);
+
+        secondDemand.Release();
+        Assert.IsFalse(loader.LastDemand.IsDemanded);
+
+        var returnedDemand = new IconRequestDemand();
+        var returned = provider.GetIconSource(icon, 1.0, demand: returnedDemand);
+        Assert.AreSame(first, returned);
+        Assert.IsTrue(loader.LastDemand.IsDemanded);
+
+        returnedDemand.Release();
+        Assert.IsFalse(loader.LastDemand.IsDemanded);
+
+        loader.CompleteNext(null);
+        await Task.WhenAll(first, second, returned);
+    }
+
+    [TestMethod]
+    [Timeout(5_000)]
     public async Task SuccessfulDirectGlyphLoadIsCachedWithoutQueueing()
     {
         var glyph = CreateTestIconSource();
@@ -293,6 +328,8 @@ public partial class CachedIconSourceProviderTests
 
         public int GlyphAttemptCount => Volatile.Read(ref _glyphAttemptCount);
 
+        public IconLoadDemand? LastDemand { get; private set; }
+
         public bool TryLoadGlyph(
             string? iconString,
             string? fontFamily,
@@ -313,9 +350,11 @@ public partial class CachedIconSourceProviderTests
             double scale,
             TaskCompletionSource<IconSource?> tcs,
             IconLoadPriority priority,
-            IconLoadMeasurement? diagnostics = null)
+            IconLoadMeasurement? diagnostics = null,
+            IconLoadDemand? demand = null)
         {
             Interlocked.Increment(ref _enqueueCount);
+            LastDemand = demand;
             if (!AcceptLoads)
             {
                 return false;

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/FontIconSizeCalculatorTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/FontIconSizeCalculatorTests.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.UI.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Foundation;
+
+namespace Microsoft.CmdPal.UI.UnitTests;
+
+[TestClass]
+public class FontIconSizeCalculatorTests
+{
+    [TestMethod]
+    public void EmptySizeUsesDefaultSize()
+    {
+        Assert.AreEqual(256, FontIconSizeCalculator.Calculate(Size.Empty, scale: 1, defaultSize: 256));
+    }
+
+    [TestMethod]
+    public void SizeIsScaledBeforeSelectingLargestDimension()
+    {
+        Assert.AreEqual(30, FontIconSizeCalculator.Calculate(new Size(16, 20), scale: 1.5, defaultSize: 256));
+    }
+
+    [TestMethod]
+    [DataRow(0, 0, 1)]
+    [DataRow(0.5, 0.5, 1)]
+    [DataRow(16, 16, 0)]
+    public void NonPositiveTargetUsesMinimumFallback(double width, double height, double scale)
+    {
+        Assert.AreEqual(8, FontIconSizeCalculator.Calculate(new Size(width, height), scale, defaultSize: 256));
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconLoadDiagnosticsTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconLoadDiagnosticsTests.cs
@@ -280,6 +280,58 @@ public class IconLoadDiagnosticsTests
     }
 
     [TestMethod]
+    [Timeout(5_000)]
+    public async Task SchedulerReportCapturesSpeculativeDemandReserve()
+    {
+        IconLoadDiagnostics.Start();
+        var queue = new IconLoadQueue(workerCount: 4);
+        var speculativeWork = new TestOperation();
+        var demandedWork = new TestOperation();
+        var speculativeDemand = IconLoadDemand.CreateDemanded();
+        speculativeDemand.RemoveRequester();
+
+        Assert.IsTrue(queue.TryEnqueue(
+            speculativeWork,
+            IconLoadPriority.Low,
+            speculativeDemand,
+            out _));
+
+        var reservedDequeue = queue.DequeueAsync().AsTask();
+        Assert.IsTrue(queue.TryEnqueue(
+            demandedWork,
+            IconLoadPriority.Low,
+            IconLoadDemand.CreateDemanded(),
+            out _));
+        Assert.AreSame(demandedWork, await reservedDequeue);
+
+        var firstReadyWorker = queue.DequeueAsync().AsTask();
+        var secondReadyWorker = queue.DequeueAsync().AsTask();
+        var speculativeDequeue = await Task.WhenAny(firstReadyWorker, secondReadyWorker);
+        Assert.AreSame(speculativeWork, await speculativeDequeue);
+
+        queue.Complete();
+        var remainingDequeue = ReferenceEquals(speculativeDequeue, firstReadyWorker)
+            ? secondReadyWorker
+            : firstReadyWorker;
+        Assert.IsNull(await remainingDequeue);
+        await queue.Completion;
+
+        var report = IconLoadDiagnostics.StopAndCreateReport();
+
+        Assert.IsNotNull(report);
+        var reserveBlock =
+            $"  Speculative dispatch deferred by the demand reserve{Environment.NewLine}" +
+            $"    Definition: a coordinator-state interval with speculative work queued, no demanded work queued, and a worker-ready slot deliberately retained for a future live request.{Environment.NewLine}" +
+            $"    Intervals started: 2{Environment.NewLine}" +
+            $"    Intervals active at stop: 0{Environment.NewLine}" +
+            $"    Maximum speculative queue depth during an interval: 1{Environment.NewLine}" +
+            $"    Maximum configured worker count during an interval: 4{Environment.NewLine}" +
+            $"    Maximum worker-ready slots retained during an interval: 1{Environment.NewLine}" +
+            $"    Interval duration: count=2";
+        StringAssert.Contains(report.Text, reserveBlock);
+    }
+
+    [TestMethod]
     public void SchedulerReportSeparatesEmptyCoalescedBatchWakeLatency()
     {
         IconLoadDiagnostics.Start();

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconLoadDiagnosticsTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconLoadDiagnosticsTests.cs
@@ -202,10 +202,14 @@ public class IconLoadDiagnosticsTests
         request.Complete(IconRequestStatus.Empty);
 
         var report = IconLoadDiagnostics.StopAndCreateReport();
+        var directGlyphResults =
+            $"  Direct glyph construction by result kind{Environment.NewLine}" +
+            $"    Empty: count=1";
 
         Assert.IsNotNull(report);
         StringAssert.Contains(report.Text, "Direct glyph loads: 1");
         StringAssert.Contains(report.Text, "Direct glyph construction: count=1");
+        StringAssert.Contains(report.Text, directGlyphResults);
         StringAssert.Contains(report.Text, "Active at stop: 0");
         StringAssert.Contains(report.Text, "Maximum active workers: 0");
         StringAssert.Contains(report.Text, "Enqueue to completion: no samples");

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconLoadDiagnosticsTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconLoadDiagnosticsTests.cs
@@ -218,6 +218,146 @@ public class IconLoadDiagnosticsTests
     }
 
     [TestMethod]
+    [Timeout(5_000)]
+    public async Task SchedulerReportCapturesCoordinatorAndWorkerHandoff()
+    {
+        using var coordinatorThreadListener = new CoordinatorThreadListener();
+        IconLoadDiagnostics.Start();
+        var queue = new IconLoadQueue(workerCount: 1);
+        var work = new TestOperation();
+
+        var dequeue = queue.DequeueAsync().AsTask();
+        Assert.IsTrue(queue.TryEnqueue(
+            work,
+            IconLoadPriority.Low,
+            IconLoadDemand.CreateDemanded(),
+            out _));
+
+        Assert.AreSame(work, await dequeue);
+        Assert.IsFalse(await coordinatorThreadListener.IsThreadPoolThread);
+        queue.Complete();
+        await queue.Completion;
+
+        var report = IconLoadDiagnostics.StopAndCreateReport();
+
+        Assert.IsNotNull(report);
+        var publishedCommands =
+            $"  Commands published by kind{Environment.NewLine}" +
+            $"    Enqueue: 1{Environment.NewLine}" +
+            $"    DemandChanged: 0{Environment.NewLine}" +
+            $"    WorkerReady: 1{Environment.NewLine}" +
+            $"    Complete: 1";
+        var processedCommands =
+            $"  Commands processed by kind{Environment.NewLine}" +
+            $"    Enqueue: 1{Environment.NewLine}" +
+            $"    DemandChanged: 0{Environment.NewLine}" +
+            $"    WorkerReady: 1{Environment.NewLine}" +
+            $"    Complete: 1";
+
+        StringAssert.Contains(report.Text, "Scheduler coordination");
+        StringAssert.Contains(report.Text, publishedCommands);
+        StringAssert.Contains(report.Text, processedCommands);
+        StringAssert.Contains(report.Text, "Commands outstanding at stop: 0");
+        StringAssert.Contains(report.Text, "    Enqueue: count=1");
+        StringAssert.Contains(report.Text, "    WorkerReady: count=1");
+        StringAssert.Contains(report.Text, "  Coordinator wake and batch processing");
+        StringAssert.Contains(report.Text, "    Signal to coordinator pass start for non-empty batches: count=");
+
+        // Complete may be drained by a batch whose wake was triggered by another command.
+        // Its publication and processing are asserted above instead of its trigger attribution.
+        StringAssert.Contains(report.Text, "    Commands drained: 3");
+        StringAssert.Contains(report.Text, "    Work items dispatched: 1");
+        StringAssert.Contains(report.Text, "    Non-empty batch command drain wall time: count=");
+        StringAssert.Contains(report.Text, "    Non-empty batch pass-start-to-dispatch-complete wall time: count=");
+        StringAssert.Contains(report.Text, "    Ready to work dispatch: count=1");
+        StringAssert.Contains(report.Text, "    Ready to demanded work dispatch: count=1");
+        StringAssert.Contains(report.Text, "    Ready to speculative work dispatch: no samples");
+        StringAssert.Contains(report.Text, "    Intervals started: 1");
+        StringAssert.Contains(report.Text, "    Intervals active at stop: 0");
+        StringAssert.Contains(report.Text, "    Maximum demanded queue depth during an interval: 1");
+        StringAssert.Contains(report.Text, "    Maximum available worker slots during an interval: 1");
+        StringAssert.Contains(report.Text, "    Interval duration: count=1");
+    }
+
+    [TestMethod]
+    public void SchedulerReportSeparatesEmptyCoalescedBatchWakeLatency()
+    {
+        IconLoadDiagnostics.Start();
+        var command = IconLoadDiagnostics.BeginSchedulerCommand(IconLoadQueue.QueueCommandKind.Enqueue);
+
+        Assert.IsNotNull(command);
+        var wake = command.CreateWakeMeasurement();
+        command.Processed();
+        wake.Woke(System.Diagnostics.Stopwatch.GetTimestamp());
+        wake.BatchCompleted(
+            commandCount: 0,
+            dispatchedWorkItemCount: 0,
+            drainTicks: 0,
+            passTicks: 0);
+
+        var report = IconLoadDiagnostics.StopAndCreateReport();
+
+        Assert.IsNotNull(report);
+        StringAssert.Contains(report.Text, "    Signal to coordinator pass start for non-empty batches: no samples");
+        StringAssert.Contains(report.Text, "    Signal to coordinator pass start for empty coalesced batches: count=1");
+        StringAssert.Contains(report.Text, "    Batches completed: 1");
+        StringAssert.Contains(report.Text, "    Empty batches: 1");
+        StringAssert.Contains(report.Text, "    Commands drained: 0");
+    }
+
+    [TestMethod]
+    [Timeout(5_000)]
+    public async Task SchedulerMeasurementsRemainPairedWithConcurrentPublishersAndWorkers()
+    {
+        const int WorkerCount = 4;
+        const int WorkItemCount = 128;
+
+        IconLoadDiagnostics.Start();
+        var queue = new IconLoadQueue(WorkerCount);
+        var work = new TestOperation[WorkItemCount];
+        var accepted = 0;
+
+        Parallel.For(0, WorkItemCount, i =>
+        {
+            work[i] = new TestOperation();
+            if (queue.TryEnqueue(
+                work[i],
+                IconLoadPriority.Low,
+                IconLoadDemand.CreateDemanded(),
+                out _))
+            {
+                Interlocked.Increment(ref accepted);
+            }
+        });
+
+        Assert.AreEqual(WorkItemCount, accepted);
+        for (var i = 0; i < WorkItemCount; i += WorkerCount)
+        {
+            var dequeued = await Task.WhenAll(
+                queue.DequeueAsync().AsTask(),
+                queue.DequeueAsync().AsTask(),
+                queue.DequeueAsync().AsTask(),
+                queue.DequeueAsync().AsTask());
+            Assert.IsTrue(dequeued.All(item => item is not null));
+        }
+
+        queue.Complete();
+        await queue.Completion;
+
+        var report = IconLoadDiagnostics.StopAndCreateReport();
+
+        Assert.IsNotNull(report);
+        StringAssert.Contains(report.Text, $"    Enqueue: {WorkItemCount}");
+        StringAssert.Contains(report.Text, $"    WorkerReady: {WorkItemCount}");
+        StringAssert.Contains(report.Text, "    Complete: 1");
+        StringAssert.Contains(report.Text, "Commands outstanding at stop: 0");
+        StringAssert.Contains(report.Text, $"    Commands drained: {(WorkItemCount * 2) + 1}");
+        StringAssert.Contains(report.Text, $"    Work items dispatched: {WorkItemCount}");
+        StringAssert.Contains(report.Text, $"    Ready to work dispatch: count={WorkItemCount}");
+        StringAssert.Contains(report.Text, $"    Ready to demanded work dispatch: count={WorkItemCount}");
+    }
+
+    [TestMethod]
     public void CacheReportTracksLookupsOccupancyAndRemovalReasons()
     {
         IconLoadDiagnostics.Start();
@@ -521,6 +661,112 @@ public class IconLoadDiagnosticsTests
         StringAssert.Contains(report.Text, "      String: 1");
         StringAssert.Contains(report.Text, "Demanded queue wait: count=2");
         StringAssert.Contains(report.Text, "Speculative queue wait: count=2");
+
+        var stringInputMeasurements = GetTextBetween(
+            report.Text,
+            "  String: 4",
+            "  ShellBinary: 0");
+        StringAssert.Contains(stringInputMeasurements, "    Demanded queue wait: count=2");
+        StringAssert.Contains(stringInputMeasurements, "    Speculative queue wait: count=2");
+    }
+
+    [TestMethod]
+    public void DemandArrivalReportCapturesActiveSpeculativeCapacity()
+    {
+        IconLoadDiagnostics.Start();
+
+        var activeRequest = IconLoadDiagnostics.BeginRequest(IconRequestReason.SourceChanged, 1.0);
+        var activeLoad = IconLoadDiagnostics.CreateLoad(
+            activeRequest,
+            "active.png",
+            hasStream: false,
+            width: 20,
+            height: 20,
+            scale: 1.0);
+        Assert.IsNotNull(activeLoad);
+        activeRequest.RecordProviderResolution(IconProviderResolution.NewLoad, activeLoad);
+        activeLoad.Enqueued(IconLoadPriority.Low, workerCount: 1);
+        StartWorker(activeLoad, workerCount: 1);
+
+        activeRequest.Invalidate();
+        activeRequest.Complete(IconRequestStatus.Stale);
+
+        var demandedRequest = IconLoadDiagnostics.BeginRequest(IconRequestReason.SourceChanged, 1.0);
+        var demandedLoad = IconLoadDiagnostics.CreateLoad(
+            demandedRequest,
+            "demanded.png",
+            hasStream: false,
+            width: 20,
+            height: 20,
+            scale: 1.0);
+        Assert.IsNotNull(demandedLoad);
+        demandedRequest.RecordProviderResolution(IconProviderResolution.NewLoad, demandedLoad);
+        demandedLoad.Enqueued(IconLoadPriority.Low, workerCount: 1);
+
+        activeLoad.SetResult(null);
+        activeLoad.Complete();
+        StartWorker(demandedLoad, workerCount: 1);
+        demandedLoad.SetResult(null);
+        demandedLoad.Complete();
+        demandedRequest.Complete(IconRequestStatus.Empty);
+
+        var report = IconLoadDiagnostics.StopAndCreateReport();
+
+        Assert.IsNotNull(report);
+        var speculativeOccupancyBlock =
+            $"      Speculative worker occupancy observed at demanded arrivals by speculative input kind{Environment.NewLine}" +
+            $"        Empty: 0{Environment.NewLine}" +
+            $"        String: 1";
+        var directlyBlockedBlock =
+            $"      Directly blocked demanded arrivals by demanded input kind{Environment.NewLine}" +
+            $"        Empty: 0{Environment.NewLine}" +
+            $"        String: 1";
+
+        StringAssert.Contains(report.Text, "Active demanded workers at stop: 0");
+        StringAssert.Contains(report.Text, "Active speculative workers at stop: 0");
+        StringAssert.Contains(report.Text, "Maximum active speculative workers: 1");
+        StringAssert.Contains(report.Text, "Demanded queue arrivals: 2");
+        StringAssert.Contains(report.Text, "Arrivals with active speculative workers: 1");
+        StringAssert.Contains(report.Text, "Sum of active speculative workers observed at those arrivals: 1");
+        StringAssert.Contains(report.Text, "Maximum speculative workers active at one demanded arrival: 1");
+        StringAssert.Contains(report.Text, "Arrivals directly blocked by speculative worker capacity: 1");
+        StringAssert.Contains(report.Text, speculativeOccupancyBlock);
+        StringAssert.Contains(report.Text, directlyBlockedBlock);
+        StringAssert.Contains(report.Text, "Demand arrival to worker start with speculative workers active: count=1");
+        StringAssert.Contains(report.Text, "Directly blocked demand arrival to worker start: count=1");
+    }
+
+    [TestMethod]
+    [Timeout(5_000)]
+    public void ConcurrentActiveInvalidationAndCompletionDoNotLeakWorkerDemand()
+    {
+        IconLoadDiagnostics.Start();
+
+        for (var i = 0; i < 500; i++)
+        {
+            var request = IconLoadDiagnostics.BeginRequest(IconRequestReason.SourceChanged, 1.0);
+            var load = IconLoadDiagnostics.CreateLoad(
+                request,
+                "bitmap.png",
+                hasStream: false,
+                width: 20,
+                height: 20,
+                scale: 1.0);
+            Assert.IsNotNull(load);
+            request.RecordProviderResolution(IconProviderResolution.NewLoad, load);
+            load.Enqueued(IconLoadPriority.Low, workerCount: 1);
+            StartWorker(load, workerCount: 1);
+            load.SetResult(null);
+
+            Parallel.Invoke(request.Invalidate, load.Complete);
+            request.Complete(IconRequestStatus.Stale);
+        }
+
+        var report = IconLoadDiagnostics.StopAndCreateReport();
+
+        Assert.IsNotNull(report);
+        StringAssert.Contains(report.Text, "Active demanded workers at stop: 0");
+        StringAssert.Contains(report.Text, "Active speculative workers at stop: 0");
     }
 
     [TestMethod]
@@ -614,6 +860,16 @@ public class IconLoadDiagnosticsTests
         StringAssert.Contains(report.Text, "      Empty: 3");
         StringAssert.Contains(report.Text, "      Applied: count=2");
         StringAssert.Contains(report.Text, "      Stale: count=1");
+        var globalAppliedResolutionBlock =
+            $"  Applied request to completion by provider resolution{Environment.NewLine}" +
+            $"    NewLoad: no samples{Environment.NewLine}" +
+            $"    CacheHit: count=2";
+        var originAppliedResolutionBlock =
+            $"    Applied request to completion by provider resolution{Environment.NewLine}" +
+            $"      NewLoad: no samples{Environment.NewLine}" +
+            $"      CacheHit: count=2";
+        StringAssert.Contains(report.Text, globalAppliedResolutionBlock);
+        StringAssert.Contains(report.Text, originAppliedResolutionBlock);
         StringAssert.Contains(report.Text, "Individual process-local IconBox IDs are available in RequestOrigin ETW events.");
     }
 
@@ -691,6 +947,37 @@ public class IconLoadDiagnosticsTests
     }
 
     [TestMethod]
+    public void AbandonedQueuedLoadRetiresQueueAndDemandAccounting()
+    {
+        IconLoadDiagnostics.Start();
+        var request = IconLoadDiagnostics.BeginRequest(IconRequestReason.SourceChanged, 1.0);
+        var load = IconLoadDiagnostics.CreateLoad(
+            request,
+            "bitmap.png",
+            hasStream: false,
+            width: 20,
+            height: 20,
+            scale: 1.0);
+
+        Assert.IsNotNull(load);
+        request.RecordProviderResolution(IconProviderResolution.NewLoad, load);
+        load.Enqueued(IconLoadPriority.Low);
+        load.Fail();
+        request.Invalidate();
+        request.Complete(IconRequestStatus.Failed);
+
+        var report = IconLoadDiagnostics.StopAndCreateReport();
+
+        Assert.IsNotNull(report);
+        StringAssert.Contains(report.Text, "Abandoned before worker start: 1");
+        StringAssert.Contains(report.Text, "Active at stop: 0");
+        StringAssert.Contains(report.Text, "Demanded loads queued at stop: 0");
+        StringAssert.Contains(report.Text, "Speculative loads queued at stop: 0");
+        StringAssert.Contains(report.Text, "    Abandoned: 1");
+        StringAssert.Contains(report.Text, "Enqueue to completion: no samples");
+    }
+
+    [TestMethod]
     public void CompletionWithoutEnqueueDoesNotRecordAbsoluteTimestamp()
     {
         IconLoadDiagnostics.Start();
@@ -761,8 +1048,28 @@ public class IconLoadDiagnosticsTests
             request.Invalidate();
             request.Complete(IconRequestStatus.Stale);
 
+            var schedulerCommand = IconLoadDiagnostics.BeginSchedulerCommand(IconLoadQueue.QueueCommandKind.Enqueue);
+            Assert.IsNotNull(schedulerCommand);
+            var wake = schedulerCommand.CreateWakeMeasurement();
+            schedulerCommand.Processed();
+            schedulerCommand.WorkerDispatched(demanded: true);
+            wake.Woke(Stopwatch.GetTimestamp());
+            wake.BatchCompleted(commandCount: 1, dispatchedWorkItemCount: 1, drainTicks: 1, passTicks: 2);
+
+            var idleCapacity = IconLoadDiagnostics.BeginDemandedIdleCapacity(
+                demandedQueueDepth: 1,
+                availableWorkerSlots: 1);
+            Assert.IsNotNull(idleCapacity);
+            Assert.IsTrue(idleCapacity.IsForActiveSession);
+            idleCapacity.Complete();
+
             CollectionAssert.Contains(listener.EventIds.ToArray(), 1);
             CollectionAssert.Contains(listener.EventIds.ToArray(), 4);
+            CollectionAssert.Contains(listener.EventIds.ToArray(), 22);
+            CollectionAssert.Contains(listener.EventIds.ToArray(), 23);
+            CollectionAssert.Contains(listener.EventIds.ToArray(), 24);
+            CollectionAssert.Contains(listener.EventIds.ToArray(), 25);
+            CollectionAssert.Contains(listener.EventIds.ToArray(), 26);
         }
 
         var inactiveRequest = IconLoadDiagnostics.BeginRequest(IconRequestReason.SourceChanged, 1.0);
@@ -806,6 +1113,47 @@ public class IconLoadDiagnosticsTests
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
             EventIds.Enqueue(eventData.EventId);
+        }
+    }
+
+    private static string GetTextBetween(string value, string start, string end)
+    {
+        var startIndex = value.IndexOf(start, StringComparison.Ordinal);
+        Assert.IsTrue(startIndex >= 0, $"Missing report section start: {start}");
+        var endIndex = value.IndexOf(end, startIndex + start.Length, StringComparison.Ordinal);
+        Assert.IsTrue(endIndex > startIndex, $"Missing report section end: {end}");
+        return value[startIndex..endIndex];
+    }
+
+    private sealed class CoordinatorThreadListener : EventListener
+    {
+        private readonly TaskCompletionSource<bool> _isThreadPoolThread = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<bool> IsThreadPoolThread => _isThreadPoolThread.Task;
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            if (eventSource.Name == "Microsoft.PowerToys.CmdPal.IconLoading")
+            {
+                EnableEvents(eventSource, EventLevel.Informational);
+            }
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            if (eventData.EventName == nameof(IconLoadEventSource.SchedulerCoordinatorWoke))
+            {
+                _isThreadPoolThread.TrySetResult(Thread.CurrentThread.IsThreadPoolThread);
+            }
+        }
+    }
+
+    private sealed class TestOperation : IconLoadQueue.Operation
+    {
+        public override Task ExecuteAsync() => Task.CompletedTask;
+
+        public override void Fail(Exception failure)
+        {
         }
     }
 }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconLoadEventSourceTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconLoadEventSourceTests.cs
@@ -51,8 +51,9 @@ public sealed class IconLoadEventSourceTests
         log.DispatcherUiSliceCompleted(11, 14, 52, 53, isDemanded: true, 54);
         log.DispatcherAsyncSuspensionCompleted(11, 14, 55, isDemanded: false, 56);
         log.UiResponsivenessProbeCompleted(11, 57);
+        log.SpeculativeDispatchDeferralCompleted(11, 69);
 
-        Assert.AreEqual(30, listener.Events.Count);
+        Assert.AreEqual(31, listener.Events.Count);
         Assert.IsFalse(listener.Events.Any(e => e.EventId == 0), listener.GetEventSourceErrors());
 
         CollectionAssert.AreEqual(
@@ -88,6 +89,9 @@ public sealed class IconLoadEventSourceTests
         CollectionAssert.AreEqual(
             new object?[] { 11L, 14L, 55, false, 56L },
             listener.GetEvent(36).Payload!.ToArray());
+        CollectionAssert.AreEqual(
+            new object?[] { 11L, 69L },
+            listener.GetEvent(38).Payload!.ToArray());
     }
 
     private sealed class CollectingEventListener : EventListener

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconLoadEventSourceTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconLoadEventSourceTests.cs
@@ -42,12 +42,17 @@ public sealed class IconLoadEventSourceTests
         log.RequestOrigin(11, 12, 42, 43, "ListItem / SingleRow");
         log.LoadQueueDemandChanged(11, 14, 44, 45, 46);
         log.LoadDemandAtWorkerStart(11, 14, 1, 47, 48, 49, 4, 50);
+        log.SchedulerCommandProcessed(11, 58, 59, 60);
+        log.WorkerReadyToDispatchCompleted(11, 1, 61);
+        log.DemandedIdleCapacityCompleted(11, 62);
+        log.SchedulerCoordinatorWoke(11, 63, 64);
+        log.SchedulerBatchCompleted(11, 65, 66, 67, 68);
         log.DispatcherWaitFailed(11, 14, 51);
         log.DispatcherUiSliceCompleted(11, 14, 52, 53, isDemanded: true, 54);
         log.DispatcherAsyncSuspensionCompleted(11, 14, 55, isDemanded: false, 56);
         log.UiResponsivenessProbeCompleted(11, 57);
 
-        Assert.AreEqual(25, listener.Events.Count);
+        Assert.AreEqual(30, listener.Events.Count);
         Assert.IsFalse(listener.Events.Any(e => e.EventId == 0), listener.GetEventSourceErrors());
 
         CollectionAssert.AreEqual(
@@ -62,6 +67,21 @@ public sealed class IconLoadEventSourceTests
         CollectionAssert.AreEqual(
             new object?[] { 11L, 14L, 1, 47L, 48L, 49L, 4, 50L },
             listener.GetEvent(21).Payload!.ToArray());
+        CollectionAssert.AreEqual(
+            new object?[] { 11L, 58, 59L, 60L },
+            listener.GetEvent(22).Payload!.ToArray());
+        CollectionAssert.AreEqual(
+            new object?[] { 11L, 1, 61L },
+            listener.GetEvent(23).Payload!.ToArray());
+        CollectionAssert.AreEqual(
+            new object?[] { 11L, 62L },
+            listener.GetEvent(24).Payload!.ToArray());
+        CollectionAssert.AreEqual(
+            new object?[] { 11L, 63, 64L },
+            listener.GetEvent(25).Payload!.ToArray());
+        CollectionAssert.AreEqual(
+            new object?[] { 11L, 65, 66, 67L, 68L },
+            listener.GetEvent(26).Payload!.ToArray());
         CollectionAssert.AreEqual(
             new object?[] { 11L, 14L, 52, 53, true, 54L },
             listener.GetEvent(35).Payload!.ToArray());

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconLoadQueueTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconLoadQueueTests.cs
@@ -146,6 +146,89 @@ public class IconLoadQueueTests
     }
 
     [TestMethod]
+    [DataRow(2)]
+    [DataRow(4)]
+    [Timeout(5_000)]
+    public async Task SpeculativeWorkLeavesOneWorkerAvailableForDemand(int workerCount)
+    {
+        var queue = new IconLoadQueue(workerCount);
+        var releaseSpeculativeWork = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var speculativeCapacityFilled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var demandedWorkStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var speculativeStarts = 0;
+        var workers = new Task[workerCount];
+
+        for (var i = 0; i < workers.Length; i++)
+        {
+            workers[i] = RunWorkerAsync(queue);
+        }
+
+        try
+        {
+            for (var i = 0; i < workerCount; i++)
+            {
+                var speculativeDemand = IconLoadDemand.CreateDemanded();
+                speculativeDemand.RemoveRequester();
+                Assert.IsTrue(queue.TryEnqueue(
+                    new TestOperation(async () =>
+                    {
+                        if (Interlocked.Increment(ref speculativeStarts) == workerCount - 1)
+                        {
+                            speculativeCapacityFilled.TrySetResult(true);
+                        }
+
+                        await releaseSpeculativeWork.Task;
+                    }),
+                    IconLoadPriority.Low,
+                    speculativeDemand,
+                    out _));
+            }
+
+            await speculativeCapacityFilled.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+            Assert.IsTrue(queue.TryEnqueue(
+                new TestOperation(() =>
+                {
+                    demandedWorkStarted.TrySetResult(true);
+                    return Task.CompletedTask;
+                }),
+                IconLoadPriority.Low,
+                IconLoadDemand.CreateDemanded(),
+                out _));
+
+            await demandedWorkStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+            Assert.AreEqual(workerCount - 1, Volatile.Read(ref speculativeStarts));
+        }
+        finally
+        {
+            queue.Complete();
+            releaseSpeculativeWork.TrySetResult(true);
+            await Task.WhenAll(workers);
+            await queue.Completion;
+        }
+
+        Assert.AreEqual(workerCount, speculativeStarts);
+    }
+
+    [TestMethod]
+    [Timeout(5_000)]
+    public async Task SingleWorkerStillProcessesSpeculativeWork()
+    {
+        var queue = new IconLoadQueue(workerCount: 1);
+        var work = new TestOperation();
+        var speculativeDemand = IconLoadDemand.CreateDemanded();
+        speculativeDemand.RemoveRequester();
+
+        var dequeue = queue.DequeueAsync().AsTask();
+        Assert.IsTrue(queue.TryEnqueue(work, IconLoadPriority.Low, speculativeDemand, out _));
+
+        Assert.AreSame(work, await dequeue);
+        queue.Complete();
+        Assert.IsNull(await queue.DequeueAsync());
+        await queue.Completion;
+    }
+
+    [TestMethod]
     [Timeout(10_000)]
     public async Task DemandChurnDuringDequeueRunsEveryWorkExactlyOnce()
     {

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconLoadQueueTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconLoadQueueTests.cs
@@ -1,0 +1,377 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.UI.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.UI.UnitTests;
+
+[TestClass]
+public class IconLoadQueueTests
+{
+    [TestMethod]
+    [Timeout(5_000)]
+    public async Task DemandedWorkRunsBeforeSpeculativeHighPriorityWork()
+    {
+        var queue = new IconLoadQueue(workerCount: 1);
+        var speculativeDemand = IconLoadDemand.CreateDemanded();
+        speculativeDemand.RemoveRequester();
+        var demanded = IconLoadDemand.CreateDemanded();
+        var speculativeWork = new TestOperation();
+        var demandedWork = new TestOperation();
+
+        Assert.IsTrue(queue.TryEnqueue(
+            speculativeWork,
+            IconLoadPriority.High,
+            speculativeDemand,
+            out var speculativePriority));
+        Assert.AreEqual(IconLoadPriority.High, speculativePriority);
+        Assert.IsTrue(queue.TryEnqueue(
+            demandedWork,
+            IconLoadPriority.Low,
+            demanded,
+            out var demandedPriority));
+        Assert.AreEqual(IconLoadPriority.Low, demandedPriority);
+
+        Assert.AreSame(demandedWork, await queue.DequeueAsync());
+        Assert.AreSame(speculativeWork, await queue.DequeueAsync());
+        queue.Complete();
+        await queue.Completion;
+    }
+
+    [TestMethod]
+    [Timeout(5_000)]
+    public async Task DemandLossMovesQueuedWorkBehindLiveRequests()
+    {
+        var queue = new IconLoadQueue(workerCount: 1);
+        var firstRequest = new IconRequestDemand();
+        var firstDemand = new IconLoadDemand();
+        firstDemand.Attach(firstRequest);
+        var secondDemand = IconLoadDemand.CreateDemanded();
+        var firstWork = new TestOperation();
+        var secondWork = new TestOperation();
+
+        Assert.IsTrue(queue.TryEnqueue(firstWork, IconLoadPriority.Low, firstDemand, out _));
+        Assert.IsTrue(queue.TryEnqueue(secondWork, IconLoadPriority.Low, secondDemand, out _));
+
+        firstRequest.Release();
+
+        Assert.AreSame(secondWork, await queue.DequeueAsync());
+        Assert.AreSame(firstWork, await queue.DequeueAsync());
+        queue.Complete();
+        await queue.Completion;
+    }
+
+    [TestMethod]
+    [Timeout(5_000)]
+    public async Task ReturnedDemandPromotesQueuedWork()
+    {
+        var queue = new IconLoadQueue(workerCount: 1);
+        var promotedDemand = new IconLoadDemand();
+        var speculativeDemand = new IconLoadDemand();
+        var promotedWork = new TestOperation();
+        var speculativeWork = new TestOperation();
+
+        Assert.IsTrue(queue.TryEnqueue(promotedWork, IconLoadPriority.Low, promotedDemand, out _));
+        Assert.IsTrue(queue.TryEnqueue(speculativeWork, IconLoadPriority.Low, speculativeDemand, out _));
+
+        var returnedRequest = new IconRequestDemand();
+        promotedDemand.Attach(returnedRequest);
+
+        Assert.AreSame(promotedWork, await queue.DequeueAsync());
+        Assert.AreSame(speculativeWork, await queue.DequeueAsync());
+        queue.Complete();
+        await queue.Completion;
+    }
+
+    [TestMethod]
+    [Timeout(5_000)]
+    public async Task HighPriorityRemainsFirstWithinDemandClass()
+    {
+        var queue = new IconLoadQueue(workerCount: 1);
+        var lowDemand = IconLoadDemand.CreateDemanded();
+        var highDemand = IconLoadDemand.CreateDemanded();
+        var lowWork = new TestOperation();
+        var highWork = new TestOperation();
+
+        Assert.IsTrue(queue.TryEnqueue(lowWork, IconLoadPriority.Low, lowDemand, out _));
+        Assert.IsTrue(queue.TryEnqueue(highWork, IconLoadPriority.High, highDemand, out _));
+
+        Assert.AreSame(highWork, await queue.DequeueAsync());
+        Assert.AreSame(lowWork, await queue.DequeueAsync());
+        queue.Complete();
+        await queue.Completion;
+    }
+
+    [TestMethod]
+    [Timeout(5_000)]
+    public async Task CompletionDrainsQueuedWorkBeforeStoppingWorkers()
+    {
+        var queue = new IconLoadQueue(workerCount: 2);
+        var firstWork = new TestOperation();
+        var secondWork = new TestOperation();
+
+        Assert.IsTrue(queue.TryEnqueue(
+            firstWork,
+            IconLoadPriority.Low,
+            IconLoadDemand.CreateDemanded(),
+            out _));
+        Assert.IsTrue(queue.TryEnqueue(
+            secondWork,
+            IconLoadPriority.Low,
+            IconLoadDemand.CreateDemanded(),
+            out _));
+
+        queue.Complete();
+
+        Assert.AreSame(firstWork, await queue.DequeueAsync());
+        Assert.AreSame(secondWork, await queue.DequeueAsync());
+        Assert.IsNull(await queue.DequeueAsync());
+        await queue.Completion;
+    }
+
+    [TestMethod]
+    [Timeout(5_000)]
+    public async Task DequeueRejectsMoreConcurrentConsumersThanConfigured()
+    {
+        var queue = new IconLoadQueue(workerCount: 1);
+        var firstDequeue = queue.DequeueAsync().AsTask();
+
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(async () => await queue.DequeueAsync());
+
+        queue.Complete();
+        Assert.IsNull(await firstDequeue);
+        await queue.Completion;
+    }
+
+    [TestMethod]
+    [Timeout(10_000)]
+    public async Task DemandChurnDuringDequeueRunsEveryWorkExactlyOnce()
+    {
+        const int WorkerCount = 4;
+        const int ItemCount = 256;
+        var queue = new IconLoadQueue(WorkerCount);
+        var demands = new IconLoadDemand[ItemCount];
+        var executionCounts = new int[ItemCount];
+        var startedCount = 0;
+        var firstBatchStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstBatch = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        for (var i = 0; i < ItemCount; i++)
+        {
+            var index = i;
+            demands[index] = IconLoadDemand.CreateDemanded();
+            Assert.IsTrue(queue.TryEnqueue(
+                new TestOperation(async () =>
+                {
+                    var started = Interlocked.Increment(ref startedCount);
+                    if (started <= WorkerCount)
+                    {
+                        if (started == WorkerCount)
+                        {
+                            firstBatchStarted.TrySetResult(true);
+                        }
+
+                        await releaseFirstBatch.Task;
+                    }
+
+                    Interlocked.Increment(ref executionCounts[index]);
+                }),
+                IconLoadPriority.Low,
+                demands[index],
+                out _));
+        }
+
+        var workers = new Task[WorkerCount];
+        for (var i = 0; i < workers.Length; i++)
+        {
+            workers[i] = RunWorkerAsync(queue);
+        }
+
+        await firstBatchStarted.Task;
+        await Task.Run(() =>
+        {
+            Parallel.For(0, ItemCount, i =>
+            {
+                for (var cycle = 0; cycle < 20; cycle++)
+                {
+                    demands[i].RemoveRequester();
+                    demands[i].AddRequester();
+                }
+            });
+        });
+
+        queue.Complete();
+        releaseFirstBatch.TrySetResult(true);
+        await Task.WhenAll(workers);
+        await queue.Completion;
+
+        for (var i = 0; i < executionCounts.Length; i++)
+        {
+            Assert.AreEqual(1, executionCounts[i], $"Work item {i} ran an unexpected number of times.");
+        }
+    }
+
+    [TestMethod]
+    [Timeout(10_000)]
+    public async Task CompletionRacingEnqueueDoesNotLoseAcceptedWork()
+    {
+        const int RoundCount = 10;
+        const int WorkerCount = 4;
+        const int ProducerCount = 8;
+        const int AttemptsPerProducer = 128;
+
+        for (var round = 0; round < RoundCount; round++)
+        {
+            var queue = new IconLoadQueue(WorkerCount);
+            var start = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var attempts = 0;
+            var accepted = 0;
+            var executed = 0;
+
+            var workers = new Task[WorkerCount];
+            for (var i = 0; i < workers.Length; i++)
+            {
+                workers[i] = RunWorkerAsync(queue);
+            }
+
+            var producers = new Task[ProducerCount];
+            for (var i = 0; i < producers.Length; i++)
+            {
+                producers[i] = Task.Run(async () =>
+                {
+                    await start.Task;
+                    for (var attempt = 0; attempt < AttemptsPerProducer; attempt++)
+                    {
+                        if (queue.TryEnqueue(
+                            new TestOperation(() =>
+                            {
+                                Interlocked.Increment(ref executed);
+                                return Task.CompletedTask;
+                            }),
+                            IconLoadPriority.Low,
+                            IconLoadDemand.CreateDemanded(),
+                            out _))
+                        {
+                            Interlocked.Increment(ref accepted);
+                        }
+
+                        Interlocked.Increment(ref attempts);
+                        Thread.Yield();
+                    }
+                });
+            }
+
+            var completion = Task.Run(async () =>
+            {
+                await start.Task;
+                SpinWait.SpinUntil(() => Volatile.Read(ref attempts) >= 32, TimeSpan.FromSeconds(1));
+                queue.Complete();
+            });
+
+            start.TrySetResult(true);
+            await Task.WhenAll(producers);
+            await completion;
+            await Task.WhenAll(workers);
+            await queue.Completion;
+
+            Assert.AreEqual(accepted, executed, $"Accepted work was lost in round {round}.");
+        }
+    }
+
+    [TestMethod]
+    [Timeout(5_000)]
+    public async Task CoordinatorFaultFailsQueuedOperationExactlyOnce()
+    {
+        var queue = new IconLoadQueue(workerCount: 1);
+        var demand = IconLoadDemand.CreateDemanded();
+        var operation = new TestOperation();
+        var failure = new InvalidOperationException("Injected coordinator failure.");
+
+        Assert.IsTrue(queue.TryEnqueue(operation, IconLoadPriority.High, demand, out _));
+        queue.FailForTesting(failure);
+
+        Assert.AreSame(failure, await operation.Failure.WaitAsync(TimeSpan.FromSeconds(2)));
+        Assert.AreEqual(1, operation.FailureCount);
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(async () => await queue.Completion);
+
+        var retryQueue = new IconLoadQueue(workerCount: 1);
+        var retry = new TestOperation();
+        Assert.IsTrue(retryQueue.TryEnqueue(retry, IconLoadPriority.High, demand, out _));
+        Assert.AreSame(retry, await retryQueue.DequeueAsync());
+        retryQueue.Complete();
+        Assert.IsNull(await retryQueue.DequeueAsync());
+        await retryQueue.Completion;
+    }
+
+    [TestMethod]
+    [Timeout(5_000)]
+    public async Task CoordinatorFaultWaitsForAcceptedPublisherAndFailsItsOperation()
+    {
+        var queue = new IconLoadQueue(workerCount: 1);
+        using var enqueueEntered = new ManualResetEventSlim();
+        using var resumeEnqueue = new ManualResetEventSlim();
+        var operation = new TestOperation(
+            enqueued: (_, _) =>
+            {
+                enqueueEntered.Set();
+                resumeEnqueue.Wait();
+            });
+        var failure = new InvalidOperationException("Injected coordinator failure.");
+
+        var publisher = Task.Run(() =>
+            queue.TryEnqueue(operation, IconLoadPriority.Low, IconLoadDemand.CreateDemanded(), out _));
+        Assert.IsTrue(enqueueEntered.Wait(TimeSpan.FromSeconds(2)));
+
+        queue.FailForTesting(failure);
+        Assert.IsTrue(
+            SpinWait.SpinUntil(() => queue.CoordinatorFailedForTesting, TimeSpan.FromSeconds(2)),
+            "The coordinator did not observe the injected failure.");
+        Assert.IsFalse(queue.Completion.IsCompleted, "The coordinator must wait for the accepted publisher.");
+
+        resumeEnqueue.Set();
+        Assert.IsTrue(await publisher);
+        Assert.AreSame(failure, await operation.Failure.WaitAsync(TimeSpan.FromSeconds(2)));
+        Assert.AreEqual(1, operation.FailureCount);
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(async () => await queue.Completion);
+    }
+
+    private static async Task RunWorkerAsync(IconLoadQueue queue)
+    {
+        while (await queue.DequeueAsync() is { } operation)
+        {
+            await operation.ExecuteAsync();
+        }
+    }
+
+    private sealed class TestOperation : IconLoadQueue.Operation
+    {
+        private readonly Func<Task> _execute;
+        private readonly Action<IconLoadPriority, int>? _enqueued;
+        private readonly TaskCompletionSource<Exception> _failure = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _failureCount;
+
+        public TestOperation(
+            Func<Task>? execute = null,
+            Action<IconLoadPriority, int>? enqueued = null)
+        {
+            _execute = execute ?? (() => Task.CompletedTask);
+            _enqueued = enqueued;
+        }
+
+        public Task<Exception> Failure => _failure.Task;
+
+        public int FailureCount => Volatile.Read(ref _failureCount);
+
+        public override void Enqueued(IconLoadPriority priority, int workerCount) => _enqueued?.Invoke(priority, workerCount);
+
+        public override Task ExecuteAsync() => _execute();
+
+        public override void Fail(Exception failure)
+        {
+            Interlocked.Increment(ref _failureCount);
+            _failure.TrySetResult(failure);
+        }
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconRequestDemandTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconRequestDemandTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.UI.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.UI.UnitTests;
+
+[TestClass]
+public class IconRequestDemandTests
+{
+    [TestMethod]
+    public void ReleaseBeforeAttachLeavesLoadSpeculative()
+    {
+        var request = new IconRequestDemand();
+        var load = new IconLoadDemand();
+
+        request.Release();
+        request.Attach(load);
+
+        Assert.IsFalse(load.IsDemanded);
+    }
+
+    [TestMethod]
+    [Timeout(5_000)]
+    public void ConcurrentAttachAndReleaseNeverLeaksDemand()
+    {
+        for (var i = 0; i < 1_000; i++)
+        {
+            var request = new IconRequestDemand();
+            var load = new IconLoadDemand();
+
+            Parallel.Invoke(
+                () => request.Attach(load),
+                request.Release);
+
+            Assert.IsFalse(load.IsDemanded);
+        }
+    }
+
+    [TestMethod]
+    [Timeout(5_000)]
+    public void DelayedNotificationObservesCurrentDemand()
+    {
+        var load = new IconLoadDemand();
+        using var firstNotificationStarted = new ManualResetEventSlim();
+        using var resumeFirstNotification = new ManualResetEventSlim();
+        var observer = new DelayedObserver(load, firstNotificationStarted, resumeFirstNotification);
+        load.Subscribe(observer);
+        Assert.IsFalse(load.IsDemanded);
+
+        var addRequester = Task.Run(load.AddRequester);
+        try
+        {
+            Assert.IsTrue(firstNotificationStarted.Wait(TimeSpan.FromSeconds(2)));
+            load.RemoveRequester();
+        }
+        finally
+        {
+            resumeFirstNotification.Set();
+            addRequester.GetAwaiter().GetResult();
+        }
+
+        Assert.IsFalse(observer.LastObservedDemand);
+        load.Unsubscribe(observer);
+    }
+
+    private sealed class DelayedObserver(
+        IconLoadDemand demand,
+        ManualResetEventSlim firstNotificationStarted,
+        ManualResetEventSlim resumeFirstNotification) : IconLoadDemand.IObserver
+    {
+        private int _notificationCount;
+        private int _lastObservedDemand;
+
+        public bool LastObservedDemand => Volatile.Read(ref _lastObservedDemand) != 0;
+
+        public void OnDemandChanged()
+        {
+            if (Interlocked.Increment(ref _notificationCount) == 1)
+            {
+                firstNotificationStarted.Set();
+                resumeFirstNotification.Wait();
+            }
+
+            Volatile.Write(ref _lastObservedDemand, demand.IsDemanded ? 1 : 0);
+        }
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/Microsoft.CmdPal.UI.UnitTests.csproj
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/Microsoft.CmdPal.UI.UnitTests.csproj
@@ -31,6 +31,7 @@
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\CachedIconSourceProvider.cs" Link="Helpers\Icons\CachedIconSourceProvider.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconDispatcherMaterializationKind.cs" Link="Helpers\Icons\IconDispatcherMaterializationKind.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconDispatcherUiSliceKind.cs" Link="Helpers\Icons\IconDispatcherUiSliceKind.cs" />
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\FontIconSizeCalculator.cs" Link="Helpers\Icons\FontIconSizeCalculator.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconLoadDemandStage.cs" Link="Helpers\Icons\IconLoadDemandStage.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconLoadDiagnostics.cs" Link="Helpers\Icons\IconLoadDiagnostics.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconLoadDiagnosticsReport.cs" Link="Helpers\Icons\IconLoadDiagnosticsReport.cs" />

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/Microsoft.CmdPal.UI.UnitTests.csproj
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/Microsoft.CmdPal.UI.UnitTests.csproj
@@ -32,6 +32,7 @@
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconDispatcherMaterializationKind.cs" Link="Helpers\Icons\IconDispatcherMaterializationKind.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconDispatcherUiSliceKind.cs" Link="Helpers\Icons\IconDispatcherUiSliceKind.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\FontIconSizeCalculator.cs" Link="Helpers\Icons\FontIconSizeCalculator.cs" />
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconLoadDemand.cs" Link="Helpers\Icons\IconLoadDemand.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconLoadDemandStage.cs" Link="Helpers\Icons\IconLoadDemandStage.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconLoadDiagnostics.cs" Link="Helpers\Icons\IconLoadDiagnostics.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconLoadDiagnosticsReport.cs" Link="Helpers\Icons\IconLoadDiagnosticsReport.cs" />
@@ -41,15 +42,19 @@
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconLoadMeasurement.cs" Link="Helpers\Icons\IconLoadMeasurement.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconLoadPriority.cs" Link="Helpers\Icons\IconLoadPriority.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconLoadQueueDemandTransition.cs" Link="Helpers\Icons\IconLoadQueueDemandTransition.cs" />
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconLoadQueue.cs" Link="Helpers\Icons\IconLoadQueue.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconLoadResultKind.cs" Link="Helpers\Icons\IconLoadResultKind.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconProviderResolution.cs" Link="Helpers\Icons\IconProviderResolution.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconRequestMeasurement.cs" Link="Helpers\Icons\IconRequestMeasurement.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconRequestOrigin.cs" Link="Helpers\Icons\IconRequestOrigin.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconRequestReason.cs" Link="Helpers\Icons\IconRequestReason.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconRequestStatus.cs" Link="Helpers\Icons\IconRequestStatus.cs" />
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconRequestDemand.cs" Link="Helpers\Icons\IconRequestDemand.cs" />
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconRequestDemandState.cs" Link="Helpers\Icons\IconRequestDemandState.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconSourceProvider.cs" Link="Helpers\Icons\IconSourceProvider.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconUiResponsivenessProbe.cs" Link="Helpers\Icons\IconUiResponsivenessProbe.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IIconLoaderService.cs" Link="Helpers\Icons\IIconLoaderService.cs" />
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IIconRequestDemand.cs" Link="Helpers\Icons\IIconRequestDemand.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IIconSourceProvider.cs" Link="Helpers\Icons\IIconSourceProvider.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Part 4 of 12 in the CmdPal icon-loading series. Depends on #50183. Next: #50185.

This PR gives live requests precedence and removes unnecessary queueing for glyph cache misses.

- Keeps caching/in-flight sharing, but constructs eligible glyph sources directly on the UI thread.
- Sends demand changes through a lock-free command queue to a dedicated coordinator.
- Keeps the extraction-worker count unchanged and reserves capacity from speculative work.

Motivation: inexpensive list/context-menu glyphs should not wait behind image work, and off-screen work should not occupy every slot.

### Evidence

Historical adjacent-stage comparison (2026-08-18); shared method and limitations: the diagnostics foundation PR #50181.

- B cold-ish applied average: 19.951 → 4.978 ms (−14.973 ms, −75.0%); all three pairs improved.
- B cold-ish new-load glyph latency: 30.575 → 0.402 ms; p99 bound ≤500 → ≤1 ms.
- A cold-ish queued dispatcher callbacks: 3504 → 673 (2831 fewer); all three pairs decreased.
- A cold-ish demanded queue-wait average: 2.285 → 13.544 ms. Cheap glyphs have left this population, so the aggregate is no longer like-for-like; remaining image delays still need their own assessment.
- Queue tests cover demand transitions, capacity limits, and scheduler faults.

The evidence supports removing glyph queueing and reducing dispatcher traffic, rather than a universal improvement for every remaining icon type.

### Technical notes

- Direct glyph loading still uses the cache. “Cheap to construct” does not mean “free to construct repeatedly,” and XAML objects still require the correct STA.
- The coordinator is a control thread, not an additional extraction worker. The STA publishes notifications without acquiring the scheduler's state lock.
- Losing demand does not cancel a shared load. Speculative work may still populate the cache, but is allowed to starve while live demand continues.
- Queue order follows the current continuous demand period. Losing every requester relinquishes that position; returning demand does not keep an old place indefinitely.

Implementation: `src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadQueue.cs`.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #49936
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

