### PR TITLE
CmdPal: Icons (6/n) - Clean up managed icon conversion and harden failure handling

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/FontIconGlyphClassifier.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/FontIconGlyphClassifier.cs
@@ -17,8 +17,8 @@ internal static partial class FontIconGlyphClassifier
     private const int EmojiPresentationProperty = 58;
     private const int FluentIconsPrivateUseAreaStart = 0xE700;
     private const int FluentIconsPrivateUseAreaEnd = 0xF8FF;
-    private const int TextVariationSelector = 0xFE0E;
-    private const int EmojiVariationSelector = 0xFE0F;
+    private const char TextVariationSelector = '\uFE0E';
+    private const char EmojiVariationSelector = '\uFE0F';
 
     public static FontIconGlyphKind Classify(string? text)
     {
@@ -41,7 +41,26 @@ internal static partial class FontIconGlyphClassifier
                 return FontIconGlyphKind.FluentSymbol;
             }
 
-            return IsEmoji(text) ? FontIconGlyphKind.Emoji : FontIconGlyphKind.Other;
+            if (char.IsLowSurrogate(character))
+            {
+                return FontIconGlyphKind.Other;
+            }
+
+            // Preserve the native classifier's result for a degenerate standalone VS16.
+            if (character == EmojiVariationSelector)
+            {
+                return FontIconGlyphKind.Emoji;
+            }
+
+            return IsEmojiPresentation(character) ? FontIconGlyphKind.Emoji : FontIconGlyphKind.Other;
+        }
+
+        // A valid surrogate pair is exactly one Unicode scalar and therefore one
+        // grapheme. Avoid general grapheme segmentation and decoding it twice.
+        if (text.Length == 2 && char.IsSurrogatePair(text[0], text[1]))
+        {
+            var codePoint = char.ConvertToUtf32(text[0], text[1]);
+            return IsEmojiPresentation(codePoint) ? FontIconGlyphKind.Emoji : FontIconGlyphKind.Other;
         }
 
         // Two adjacent ASCII characters cannot be the single glyph expected here. This
@@ -90,22 +109,18 @@ internal static partial class FontIconGlyphClassifier
 
     private static bool IsEmoji(string text)
     {
-        foreach (var codePoint in text.EnumerateRunes())
+        var selectorIndex = text.AsSpan().IndexOfAny(TextVariationSelector, EmojiVariationSelector);
+        if (selectorIndex >= 0)
         {
-            if (codePoint.Value == EmojiVariationSelector)
-            {
-                return true;
-            }
-
-            if (codePoint.Value == TextVariationSelector)
-            {
-                return false;
-            }
+            return text[selectorIndex] == EmojiVariationSelector;
         }
 
         var status = Rune.DecodeFromUtf16(text.AsSpan(), out var first, out _);
-        return status == OperationStatus.Done && NativeMethods.HasBinaryProperty(first.Value, EmojiPresentationProperty) != 0;
+        return status == OperationStatus.Done && IsEmojiPresentation(first.Value);
     }
+
+    private static bool IsEmojiPresentation(int codePoint) =>
+        NativeMethods.HasBinaryProperty(codePoint, EmojiPresentationProperty) != 0;
 
     private static partial class NativeMethods
     {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconPathConverter.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconPathConverter.cs
@@ -38,7 +38,7 @@ internal static partial class IconPathConverter
         // Avoid using exception-based URI probing for the common Fluent glyph case.
         if (iconPath[0] < 128 && Uri.TryCreate(iconPath, UriKind.Absolute, out var uri))
         {
-            var isSvg = Path.GetExtension(uri.AbsolutePath).Equals(".svg", StringComparison.OrdinalIgnoreCase);
+            var isSvg = uri.AbsolutePath.EndsWith(".svg", StringComparison.OrdinalIgnoreCase);
             return PreparedIcon.FromUri(uri, isSvg, targetSize);
         }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconPathConverter.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconPathConverter.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Microsoft.UI.Xaml.Controls;
@@ -163,20 +164,43 @@ internal static partial class IconPathConverter
             try
             {
                 var bytesPerRow = checked(bitmap.Width * 4);
-                var pixels = GC.AllocateUninitializedArray<byte>(checked(bytesPerRow * bitmap.Height));
-                for (var row = 0; row < bitmap.Height; row++)
+                var pixelBufferLength = checked(bytesPerRow * bitmap.Height);
+                var pixels = ArrayPool<byte>.Shared.Rent(pixelBufferLength);
+                try
                 {
-                    var source = nint.Add(bitmapData.Scan0, row * bitmapData.Stride);
-                    Marshal.Copy(source, pixels, row * bytesPerRow, bytesPerRow);
-                }
+                    if (bitmapData.Stride == bytesPerRow)
+                    {
+                        Marshal.Copy(bitmapData.Scan0, pixels, 0, pixelBufferLength);
+                    }
+                    else
+                    {
+                        for (var row = 0; row < bitmap.Height; row++)
+                        {
+                            var source = nint.Add(bitmapData.Scan0, row * bitmapData.Stride);
+                            Marshal.Copy(source, pixels, row * bytesPerRow, bytesPerRow);
+                        }
+                    }
 
-                var softwareBitmap = new SoftwareBitmap(
-                    BitmapPixelFormat.Bgra8,
-                    bitmap.Width,
-                    bitmap.Height,
-                    BitmapAlphaMode.Premultiplied);
-                softwareBitmap.CopyFromBuffer(pixels.AsBuffer());
-                return softwareBitmap;
+                    var softwareBitmap = new SoftwareBitmap(
+                        BitmapPixelFormat.Bgra8,
+                        bitmap.Width,
+                        bitmap.Height,
+                        BitmapAlphaMode.Premultiplied);
+                    try
+                    {
+                        softwareBitmap.CopyFromBuffer(pixels.AsBuffer(0, pixelBufferLength));
+                        return softwareBitmap;
+                    }
+                    catch
+                    {
+                        softwareBitmap.Dispose();
+                        throw;
+                    }
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(pixels);
+                }
             }
             finally
             {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconPathParser.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconPathParser.cs
@@ -12,7 +12,7 @@ internal static class IconPathParser
     public static bool TryParseBinaryIconReference(string iconPath, out BinaryIconReference iconReference)
     {
         var commaIndex = iconPath.IndexOf(',');
-        var path = commaIndex < 0 ? iconPath : iconPath[..commaIndex];
+        var path = commaIndex < 0 ? iconPath.AsSpan() : iconPath.AsSpan(0, commaIndex);
 
         if (!path.EndsWith(".exe", StringComparison.Ordinal)
             && !path.EndsWith(".dll", StringComparison.Ordinal)
@@ -33,7 +33,7 @@ internal static class IconPathParser
             }
         }
 
-        iconReference = new(path, index);
+        iconReference = new(commaIndex < 0 ? iconPath : iconPath[..commaIndex], index);
         return true;
     }
 

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/FontIconGlyphClassifierTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/FontIconGlyphClassifierTests.cs
@@ -30,6 +30,7 @@ public class FontIconGlyphClassifierTests
     [DataRow("A")]
     [DataRow("\uE6FF")]
     [DataRow("\uF900")]
+    [DataRow("\U0001D11E")]
     [DataRow("e\u0301")]
     public void SingleNonEmojiGraphemesUseTheGeneralFont(string text)
     {
@@ -45,9 +46,16 @@ public class FontIconGlyphClassifierTests
     }
 
     [TestMethod]
+    public void IsolatedEmojiVariationSelectorPreservesNativeClassifierBehavior()
+    {
+        Assert.AreEqual(FontIconGlyphKind.Emoji, FontIconGlyphClassifier.Classify("\uFE0F"));
+    }
+
+    [TestMethod]
     [DataRow("\u231A")]
     [DataRow("\U0001F600")]
     [DataRow("\u2764\uFE0F")]
+    [DataRow("\u2764\uFE0F\uFE0E")]
     [DataRow("2\uFE0F\u20E3")]
     [DataRow("\U0001F469\u200D\U0001F4BB")]
     public void EmojiGraphemesUseTheEmojiFont(string text)
@@ -58,6 +66,7 @@ public class FontIconGlyphClassifierTests
     [TestMethod]
     [DataRow("\u2764")]
     [DataRow("\u2764\uFE0E")]
+    [DataRow("\u2764\uFE0E\uFE0F")]
     [DataRow("2\u20E3")]
     public void TextPresentationRemainsGeneralText(string text)
     {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Part 6 of 12 in the CmdPal icon-loading series. Depends on #50185. Next: #50187.

This PR cleans up the converted helpers and hardens failure handling without changing their API.

- Pools temporary binary pixel buffers, adds a contiguous-stride copy path, and cleans up failed bitmap conversions.
- Adds fast glyph-classification paths while preserving grapheme and emoji behavior.
- Uses spans and suffix checks to avoid unnecessary path/extension strings.

Motivation: make the managed implementation safer and cheaper to maintain, while removing identifiable allocations and copying. Scheduling and cache policy remain separate changes.

### Evidence

Historical adjacent-stage comparison (2026-08-18); shared method and limitations: the diagnostics foundation PR #50181. This is cleanup and hardening with targeted allocation/copy reductions, not a standalone snappiness claim.

- A cold-ish applied average: 3.450 → 5.221 ms (+1.771 ms). Run ranges overlap (3.208–6.716 versus 4.881–6.319 ms), so the median alone does not identify a cleanup-induced regression.
- B warm applied average: 2.181 → 2.866 ms (+0.685 ms), worse in all three pairs; p95 stayed ≤8 ms, but the median p99 bound rose ≤33 → ≤100 ms.
- B warm queue-wait average: 0.863 → 2.399 ms; dispatcher-wait average: 6.265 → 7.908 ms.
- B warm preparation average: 0.204 → 0.199 ms; cumulative measured icon UI time: 1325.415 → 1324.927 ms. Neither shows increased measured work corresponding to the extra delay.
- B warm process CPU: 113515.625 → 109625.000 ms (−3.4%). There were no binary inputs in these runs, so they do not measure the buffer-pooling improvement.
- Existing glyph, parser, and conversion tests exercise the optimized paths.

The extra delay is localized to waiting; no individual cleanup edit has been established as its cause. The following cache/materialization PR #50187 mitigates this warm case: applied average falls to 0.306 ms, p99 to ≤1 ms, and all 3590 list-row requests hit cache with no queued materializations in each of three runs. That is measured mitigation, not proof of the original cause or an explanation of every cold result.

### Technical notes

- `ArrayPool.Shared` reduces allocation frequency; it is not a fixed retained-memory budget. Renting and returning buffers correctly does not prove a process-memory reduction.
- The stride shortcut applies only to a compatible contiguous layout; the row-copy path remains for other layouts.
- “Starts with ASCII” cannot reject every emoji: keycap sequences contain ASCII plus combining code points. Fast paths must preserve the full grapheme rules.
- Removing a substring on rejected binary references is useful for comma-containing URI payloads. It does not change successful binary-path parsing.

Implementation: `src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/FontIconGlyphClassifier.cs`.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #49938
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

