### PR TITLE
CmdPal: Icons (7/n) - Split glyph caches and materialize synchronous sources directly

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/CachedIconSourceProvider.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/CachedIconSourceProvider.cs
@@ -15,25 +15,40 @@ internal sealed class CachedIconSourceProvider : IIconSourceProvider
 {
     private static readonly ConditionalWeakTable<IRandomAccessStreamReference, StreamIdentity> StreamIdentities = new();
 
-    private readonly AdaptiveCache<IconCacheKey, Task<IconSource?>> _cache;
+    private readonly AdaptiveCache<IconCacheKey, Task<IconSource?>> _glyphCache;
+    private readonly AdaptiveCache<IconCacheKey, Task<IconSource?>> _otherCache;
     private readonly ConcurrentDictionary<IconCacheKey, InFlightIconLoad> _inFlight = new();
     private readonly Size _iconSize;
-    private readonly int _cacheSize;
+    private readonly int _glyphCacheSize;
+    private readonly int _otherCacheSize;
     private readonly IIconLoaderService _loader;
 
-    public CachedIconSourceProvider(IIconLoaderService loader, Size iconSize, int cacheSize)
+    public CachedIconSourceProvider(
+        IIconLoaderService loader,
+        Size iconSize,
+        int glyphCacheSize,
+        int otherCacheSize)
     {
         _loader = loader;
         _iconSize = iconSize;
-        _cacheSize = cacheSize;
-        _cache = new AdaptiveCache<IconCacheKey, Task<IconSource?>>(
-            cacheSize,
+        _glyphCacheSize = glyphCacheSize;
+        _otherCacheSize = otherCacheSize;
+        _glyphCache = new AdaptiveCache<IconCacheKey, Task<IconSource?>>(
+            glyphCacheSize,
             TimeSpan.FromMinutes(60),
-            removalCallback: OnCacheEntryRemoved);
+            removalCallback: OnGlyphCacheEntryRemoved);
+        _otherCache = new AdaptiveCache<IconCacheKey, Task<IconSource?>>(
+            otherCacheSize,
+            TimeSpan.FromMinutes(60),
+            removalCallback: OnOtherCacheEntryRemoved);
     }
 
-    public CachedIconSourceProvider(IIconLoaderService loader, int iconSize, int cacheSize)
-        : this(loader, new Size(iconSize, iconSize), cacheSize)
+    public CachedIconSourceProvider(
+        IIconLoaderService loader,
+        int iconSize,
+        int glyphCacheSize,
+        int otherCacheSize)
+        : this(loader, new Size(iconSize, iconSize), glyphCacheSize, otherCacheSize)
     {
     }
 
@@ -44,22 +59,26 @@ internal sealed class CachedIconSourceProvider : IIconSourceProvider
         IIconRequestDemand? demand = null)
     {
         var key = new IconCacheKey(icon, scale);
+        var partition = ClassifyCachePartition(icon.Icon);
+        var cache = GetCache(partition);
+        var cacheSize = GetCacheSize(partition);
 
-        if (_cache.TryGet(key, out var existingTask))
+        if (cache.TryGet(key, out var existingTask))
         {
-            IconLoadDiagnostics.RecordCacheLookup(_iconSize, _cacheSize, hit: true);
+            IconLoadDiagnostics.RecordCacheLookup(_iconSize, partition, cacheSize, hit: true);
             diagnostics.RecordProviderResolution(IconProviderResolution.CacheHit, existingTask);
             return existingTask;
         }
 
-        IconLoadDiagnostics.RecordCacheLookup(_iconSize, _cacheSize, hit: false);
-        return GetOrCreateSlowPath(key, icon, scale, diagnostics, demand);
+        IconLoadDiagnostics.RecordCacheLookup(_iconSize, partition, cacheSize, hit: false);
+        return GetOrCreateSlowPath(key, icon, scale, partition, diagnostics, demand);
     }
 
     private Task<IconSource?> GetOrCreateSlowPath(
         IconCacheKey key,
         IconDataViewModel icon,
         double scale,
+        IconCachePartition partition,
         IconRequestMeasurement diagnostics,
         IIconRequestDemand? demand)
     {
@@ -75,6 +94,8 @@ internal sealed class CachedIconSourceProvider : IIconSourceProvider
 
         var tcs = pending;
         var task = pending.Task;
+        var cache = GetCache(partition);
+        var cacheSize = GetCacheSize(partition);
         IconLoadMeasurement? loadDiagnostics = null;
 
         _ = task.ContinueWith(
@@ -84,11 +105,12 @@ internal sealed class CachedIconSourceProvider : IIconSourceProvider
                 {
                     if (completed.IsCompletedSuccessfully)
                     {
-                        _cache.Add(key, completed);
+                        cache.Add(key, completed);
                         IconLoadDiagnostics.RecordCacheEntryAdded(
                             _iconSize,
-                            _cacheSize,
-                            _cache.ApproximateCount);
+                            partition,
+                            cacheSize,
+                            cache.ApproximateCount);
                     }
                 }
                 finally
@@ -145,7 +167,46 @@ internal sealed class CachedIconSourceProvider : IIconSourceProvider
         return task;
     }
 
+    private static IconCachePartition ClassifyCachePartition(string? iconString)
+    {
+        try
+        {
+            return FontIconGlyphClassifier.IsGlyphCandidate(iconString)
+                ? IconCachePartition.Glyph
+                : IconCachePartition.Other;
+        }
+        catch
+        {
+            // Keep routing consistent with TryLoadGlyph: classifier failures use the
+            // general icon loader and therefore belong in the non-glyph cache.
+            return IconCachePartition.Other;
+        }
+    }
+
+    private AdaptiveCache<IconCacheKey, Task<IconSource?>> GetCache(IconCachePartition partition) =>
+        partition == IconCachePartition.Glyph ? _glyphCache : _otherCache;
+
+    private int GetCacheSize(IconCachePartition partition) =>
+        partition == IconCachePartition.Glyph ? _glyphCacheSize : _otherCacheSize;
+
+    private void OnGlyphCacheEntryRemoved(
+        IconCacheKey key,
+        Task<IconSource?> task,
+        AdaptiveCacheRemovalReason reason,
+        int remainingCount,
+        int capacity) =>
+        OnCacheEntryRemoved(IconCachePartition.Glyph, key, task, reason, remainingCount, capacity);
+
+    private void OnOtherCacheEntryRemoved(
+        IconCacheKey key,
+        Task<IconSource?> task,
+        AdaptiveCacheRemovalReason reason,
+        int remainingCount,
+        int capacity) =>
+        OnCacheEntryRemoved(IconCachePartition.Other, key, task, reason, remainingCount, capacity);
+
     private void OnCacheEntryRemoved(
+        IconCachePartition partition,
         IconCacheKey key,
         Task<IconSource?> task,
         AdaptiveCacheRemovalReason reason,
@@ -156,6 +217,7 @@ internal sealed class CachedIconSourceProvider : IIconSourceProvider
         _ = task;
         IconLoadDiagnostics.RecordCacheEntryRemoved(
             _iconSize,
+            partition,
             capacity,
             remainingCount,
             reason);

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/FontIconGlyphClassifier.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/FontIconGlyphClassifier.cs
@@ -20,6 +20,37 @@ internal static partial class FontIconGlyphClassifier
     private const char TextVariationSelector = '\uFE0E';
     private const char EmojiVariationSelector = '\uFE0F';
 
+    /// <summary>
+    /// Reports whether <paramref name="text" /> is a glyph candidate without resolving
+    /// the font family needed to render it.
+    /// </summary>
+    public static bool IsGlyphCandidate(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return false;
+        }
+
+        if (text.Length == 1)
+        {
+            // Match Classify's compatibility behavior for isolated surrogates.
+            return !char.IsHighSurrogate(text[0]);
+        }
+
+        if (text.Length == 2 && char.IsSurrogatePair(text[0], text[1]))
+        {
+            return true;
+        }
+
+        if (text[0] <= 0x7F && text[1] <= 0x7F)
+        {
+            return false;
+        }
+
+        var textElementLength = StringInfo.GetNextTextElementLength(text.AsSpan());
+        return textElementLength != 0 && textElementLength == text.Length;
+    }
+
     public static FontIconGlyphKind Classify(string? text)
     {
         if (string.IsNullOrEmpty(text))

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconCachePartition.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconCachePartition.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+internal enum IconCachePartition
+{
+    Glyph = 0,
+    Other = 1,
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadDiagnostics.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadDiagnostics.cs
@@ -106,24 +106,34 @@ internal static class IconLoadDiagnostics
         return session.CreateLoad(ClassifyInput(iconString, hasStream), width, height, scale);
     }
 
-    internal static void RecordCacheLookup(Size iconSize, int capacity, bool hit)
+    internal static void RecordCacheLookup(
+        Size iconSize,
+        IconCachePartition partition,
+        int capacity,
+        bool hit)
     {
-        GetCurrentSession()?.RecordCacheLookup(iconSize, capacity, hit);
+        GetCurrentSession()?.RecordCacheLookup(iconSize, partition, capacity, hit);
     }
 
-    internal static void RecordCacheEntryAdded(Size iconSize, int capacity, int entryCount)
+    internal static void RecordCacheEntryAdded(
+        Size iconSize,
+        IconCachePartition partition,
+        int capacity,
+        int entryCount)
     {
-        GetCurrentSession()?.RecordCacheEntryAdded(iconSize, capacity, entryCount);
+        GetCurrentSession()?.RecordCacheEntryAdded(iconSize, partition, capacity, entryCount);
     }
 
     internal static void RecordCacheEntryRemoved(
         Size iconSize,
+        IconCachePartition partition,
         int capacity,
         int entryCount,
         AdaptiveCacheRemovalReason reason)
     {
         GetCurrentSession()?.RecordCacheEntryRemoved(
             iconSize,
+            partition,
             capacity,
             entryCount,
             reason);

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadDiagnosticsSession.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadDiagnosticsSession.cs
@@ -202,23 +202,32 @@ internal sealed class IconLoadDiagnosticsSession
 
     internal void RecordUiProbeRejected() => Interlocked.Increment(ref _uiProbeRejected);
 
-    internal void RecordCacheLookup(Size iconSize, int capacity, bool hit)
+    internal void RecordCacheLookup(
+        Size iconSize,
+        IconCachePartition partition,
+        int capacity,
+        bool hit)
     {
-        GetCacheMeasurements(iconSize, capacity).RecordLookup(hit);
+        GetCacheMeasurements(iconSize, partition, capacity).RecordLookup(hit);
     }
 
-    internal void RecordCacheEntryAdded(Size iconSize, int capacity, int entryCount)
+    internal void RecordCacheEntryAdded(
+        Size iconSize,
+        IconCachePartition partition,
+        int capacity,
+        int entryCount)
     {
-        GetCacheMeasurements(iconSize, capacity).RecordAdded(entryCount);
+        GetCacheMeasurements(iconSize, partition, capacity).RecordAdded(entryCount);
     }
 
     internal void RecordCacheEntryRemoved(
         Size iconSize,
+        IconCachePartition partition,
         int capacity,
         int entryCount,
         AdaptiveCacheRemovalReason reason)
     {
-        GetCacheMeasurements(iconSize, capacity).RecordRemoved(entryCount, reason);
+        GetCacheMeasurements(iconSize, partition, capacity).RecordRemoved(entryCount, reason);
     }
 
     internal bool IsLoadDemanded(long loadId)
@@ -1499,7 +1508,13 @@ internal sealed class IconLoadDiagnosticsSession
                 }
 
                 var height = left.Key.Height.CompareTo(right.Key.Height);
-                return height != 0 ? height : left.Key.Capacity.CompareTo(right.Key.Capacity);
+                if (height != 0)
+                {
+                    return height;
+                }
+
+                var partition = left.Key.Partition.CompareTo(right.Key.Partition);
+                return partition != 0 ? partition : left.Key.Capacity.CompareTo(right.Key.Capacity);
             });
 
         foreach (var (descriptor, measurements) in caches)
@@ -1510,7 +1525,9 @@ internal sealed class IconLoadDiagnosticsSession
                 .Append(descriptor.Width)
                 .Append('x')
                 .Append(descriptor.Height)
-                .Append(", capacity ")
+                .Append(' ')
+                .Append(descriptor.Partition)
+                .Append(" cache, capacity ")
                 .AppendLine(descriptor.Capacity.ToString(CultureInfo.InvariantCulture));
             AppendValue(builder, "Lookups", snapshot.Hits + snapshot.Misses, "    ");
             AppendValue(builder, "Hits", snapshot.Hits, "    ");
@@ -1530,11 +1547,15 @@ internal sealed class IconLoadDiagnosticsSession
         }
     }
 
-    private CacheMeasurements GetCacheMeasurements(Size iconSize, int capacity)
+    private CacheMeasurements GetCacheMeasurements(
+        Size iconSize,
+        IconCachePartition partition,
+        int capacity)
     {
         var descriptor = new CacheDescriptor(
             NormalizeCacheDimension(iconSize.Width),
             NormalizeCacheDimension(iconSize.Height),
+            partition,
             capacity);
         return _cacheMeasurements.GetOrAdd(descriptor, static _ => new CacheMeasurements());
     }
@@ -2268,7 +2289,11 @@ internal sealed class IconLoadDiagnosticsSession
         long StartedAt,
         long ElapsedTicks);
 
-    private readonly record struct CacheDescriptor(int Width, int Height, int Capacity);
+    private readonly record struct CacheDescriptor(
+        int Width,
+        int Height,
+        IconCachePartition Partition,
+        int Capacity);
 
     private readonly record struct CacheMeasurementsSnapshot(
         long Hits,

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoaderService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoaderService.cs
@@ -229,11 +229,15 @@ internal sealed partial class IconLoaderService : IIconLoaderService
                     ? IconDispatcherMaterializationKind.Unknown
                     : GetDispatcherMaterializationKind(preparedIcon);
                 var dispatcherEnqueuedAt = diagnostics?.BeginDispatcherWait(materializationKind) ?? 0;
+
+                // Keep the dispatcher callback synchronous for glyph and URI sources.
+                // The returned ValueTask carries only binary transfer work beyond it.
                 try
                 {
-                    return await _dispatcherQueue
+                    var materialization = await _dispatcherQueue
                         .EnqueueAsync(CreateIconSourceOnDispatcher, LoadingPriorityOnDispatcher)
                         .ConfigureAwait(false);
+                    return await materialization.ConfigureAwait(false);
                 }
                 catch
                 {
@@ -242,14 +246,43 @@ internal sealed partial class IconLoaderService : IIconLoaderService
                     throw;
                 }
 
-                async Task<IconSource?> CreateIconSourceOnDispatcher()
+                ValueTask<IconSource?> CreateIconSourceOnDispatcher()
                 {
                     var dispatcherStartedAt = diagnostics?.DispatcherStarted(dispatcherEnqueuedAt) ?? 0;
+                    var completionOwnedByCallback = true;
+                    try
+                    {
+                        if (IconPathConverter.TryCreateIconSourceSynchronously(preparedIcon, out var result))
+                        {
+                            diagnostics?.SetResult(result);
+                            return ValueTask.FromResult<IconSource?>(result);
+                        }
+
+                        var materializationInner = CompleteAsynchronousMaterializationAsync(dispatcherStartedAt);
+
+                        // The asynchronous continuation now owns the single timing-completion notification.
+                        completionOwnedByCallback = false;
+                        return materializationInner;
+                    }
+                    finally
+                    {
+                        if (completionOwnedByCallback)
+                        {
+                            diagnostics?.DispatcherUiSliceCompleted(
+                                dispatcherStartedAt,
+                                IconDispatcherUiSliceKind.SynchronousCallback);
+                            diagnostics?.DispatcherCompleted(dispatcherStartedAt);
+                        }
+                    }
+                }
+
+                async ValueTask<IconSource?> CompleteAsynchronousMaterializationAsync(long dispatcherStartedAt)
+                {
                     var suspensionStartedAt = 0L;
                     var continuationStartedAt = 0L;
                     try
                     {
-                        var operation = IconPathConverter.CreateIconSourceAsync(preparedIcon);
+                        var operation = IconPathConverter.CompleteIconSourceCreationAsync(preparedIcon);
                         if (operation.IsCompleted)
                         {
                             var synchronousResult = await operation;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconPathConverter.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconPathConverter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Microsoft.UI.Xaml.Controls;
@@ -48,7 +49,35 @@ internal static partial class IconPathConverter
         return PreparedIcon.FromGlyph(glyph, family, targetSize > 0 ? targetSize : 8);
     }
 
-    public static async Task<IconSource> CreateIconSourceAsync(PreparedIcon icon)
+    public static Task<IconSource> CreateIconSourceAsync(PreparedIcon icon)
+    {
+        try
+        {
+            if (TryCreateIconSourceSynchronously(icon, out var iconSource))
+            {
+                return Task.FromResult(iconSource);
+            }
+
+            return CompleteIconSourceCreationAsync(icon);
+        }
+        catch (Exception exception)
+        {
+            // Preserve async exception delivery for invalid callers now that this
+            // entry point no longer has an async state machine.
+            return Task.FromException<IconSource>(exception);
+        }
+    }
+
+    /// <summary>
+    /// Attempts to create an icon source without an asynchronous bitmap transfer.
+    /// </summary>
+    /// <returns>
+    /// <see langword="false"/> only when a populated binary icon must be transferred
+    /// to a <see cref="SoftwareBitmapSource"/> asynchronously.
+    /// </returns>
+    public static bool TryCreateIconSourceSynchronously(
+        PreparedIcon icon,
+        [MaybeNullWhen(false)] out IconSource iconSource)
     {
         try
         {
@@ -60,7 +89,8 @@ internal static partial class IconPathConverter
                         DecodePixelWidth = icon.TargetSize > 0 ? icon.TargetSize : 0,
                         UriSource = icon.Uri!,
                     };
-                    return new ImageIconSource { ImageSource = bitmap };
+                    iconSource = new ImageIconSource { ImageSource = bitmap };
+                    return true;
 
                 case PreparedIconKind.SvgUri:
                     var svg = new SvgImageSource(icon.Uri!);
@@ -69,64 +99,87 @@ internal static partial class IconPathConverter
                         svg.RasterizePixelWidth = icon.TargetSize;
                     }
 
-                    return new ImageIconSource { ImageSource = svg };
+                    iconSource = new ImageIconSource { ImageSource = svg };
+                    return true;
 
                 case PreparedIconKind.Glyph:
-                    return new FontIconSource
+                    iconSource = new FontIconSource
                     {
                         FontFamily = new FontFamily(icon.FontFamily!),
                         FontSize = icon.TargetSize,
                         Glyph = icon.Glyph!,
                     };
+                    return true;
 
                 case PreparedIconKind.Binary:
-                    var softwareBitmap = icon.TakeSoftwareBitmap();
-                    if (softwareBitmap is null)
+                    if (icon.SoftwareBitmap is not null)
                     {
-                        return new ImageIconSource();
+                        iconSource = null!;
+                        return false;
                     }
 
-                    var ownershipTransferred = false;
-                    try
-                    {
-                        var bitmapSource = new SoftwareBitmapSource();
-                        try
-                        {
-                            await bitmapSource.SetBitmapAsync(softwareBitmap);
-
-                            var iconSource = new ImageIconSource { ImageSource = bitmapSource };
-
-                            // SetBitmapAsync can finish before WinUI's AsyncCopyToSurfaceTask.
-                            // Once XAML accepts the bitmap, explicitly closing either object can
-                            // fail-fast that later copy with RO_E_CLOSED. Release both through
-                            // their normal WinRT reference lifetimes instead.
-                            ownershipTransferred = true;
-                            return iconSource;
-                        }
-                        catch
-                        {
-                            // The source has not escaped to a caller or visual tree.
-                            bitmapSource.Dispose();
-                            throw;
-                        }
-                    }
-                    finally
-                    {
-                        if (!ownershipTransferred)
-                        {
-                            softwareBitmap.Dispose();
-                        }
-                    }
+                    iconSource = new ImageIconSource();
+                    return true;
 
                 default:
-                    return CreateEmptyIconSource();
+                    iconSource = CreateEmptyIconSource();
+                    return true;
             }
         }
         catch
         {
-            return icon.Kind == PreparedIconKind.Binary
+            iconSource = icon.Kind == PreparedIconKind.Binary
                 ? new ImageIconSource()
                 : CreateEmptyIconSource();
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Completes icon-source creation after <see cref="TryCreateIconSourceSynchronously"/>
+    /// returned <see langword="false"/> for the same prepared icon.
+    /// </summary>
+    public static Task<IconSource> CompleteIconSourceCreationAsync(PreparedIcon icon) =>
+        icon.TakeSoftwareBitmap() is { } softwareBitmap
+            ? CreateBinaryIconSourceAsync(softwareBitmap)
+            : Task.FromResult<IconSource>(new ImageIconSource());
+
+    private static async Task<IconSource> CreateBinaryIconSourceAsync(SoftwareBitmap softwareBitmap)
+    {
+        var ownershipTransferred = false;
+        try
+        {
+            var bitmapSource = new SoftwareBitmapSource();
+            try
+            {
+                await bitmapSource.SetBitmapAsync(softwareBitmap);
+
+                var iconSource = new ImageIconSource { ImageSource = bitmapSource };
+
+                // SetBitmapAsync can finish before WinUI's AsyncCopyToSurfaceTask.
+                // Once XAML accepts the bitmap, explicitly closing either object can
+                // fail-fast that later copy with RO_E_CLOSED. Release both through
+                // their normal WinRT reference lifetimes instead.
+                ownershipTransferred = true;
+                return iconSource;
+            }
+            catch
+            {
+                // The source has not escaped to a caller or visual tree.
+                bitmapSource.Dispose();
+                throw;
+            }
+        }
+        catch
+        {
+            return new ImageIconSource();
+        }
+        finally
+        {
+            if (!ownershipTransferred)
+            {
+                softwareBitmap.Dispose();
+            }
         }
     }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconProvider.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconProvider.cs
@@ -14,17 +14,6 @@ namespace Microsoft.CmdPal.UI.Helpers;
 /// </summary>
 public static partial class IconProvider
 {
-    /*
-      Memory Usage Considerations (raw estimates):
-      | Icon Size | Per Icon | Count |    Total | Per Icon @ 200% | Total @ 200% | Per Icon @ 300% | Total @ 300% |
-      | --------- | -------: | ----: | -------: | --------------: | -----------: | --------------: | -----------: |
-      | 20×20     |   1.6 KB |  1024 |   1.6 MB |          6.4 KB |       6.4 MB |         14.4 KB |      14.4 MB |
-      | 32×32     |   4.0 KB |   512 |   2.0 MB |           16 KB |       8.0 MB |         36.0 KB |      18.0 MB |
-      | 48×48     |   9.0 KB |   256 |   2.3 MB |           36 KB |       9.0 MB |         81.0 KB |      20.3 MB |
-      | 64×64     |  16.0 KB |    64 |   1.0 MB |           64 KB |       4.0 MB |        144.0 KB |       9.0 MB |
-      | 256×256   | 256.0 KB |    64 |  16.0 MB |            1 MB |      64.0 MB |          2.3 MB |       144 MB |
-    */
-
     private static IIconSourceProvider _provider16 = null!;
     private static IIconSourceProvider _provider20 = null!;
     private static IIconSourceProvider _provider32 = null!;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconServiceRegistration.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconServiceRegistration.cs
@@ -9,6 +9,21 @@ namespace Microsoft.CmdPal.UI.Helpers;
 
 internal static class IconServiceRegistration
 {
+    /*
+      Cached icon-source capacities and raw BGRA estimates for a completely
+      bitmap-backed Other partition:
+      | Icon size | Glyph capacity | Other capacity | Other @ 100% | Other @ 200% | Other @ 300% |
+      | --------- | -------------: | -------------: | -----------: | -----------: | -----------: |
+      | 20×20     |           4096 |           1024 |       1.6 MB |       6.4 MB |      14.4 MB |
+      | 64×64     |           1024 |            256 |       4.0 MB |      16.0 MB |      36.0 MB |
+      | 256×256   |            256 |             64 |      16.0 MB |      64.0 MB |       144 MB |
+
+      Other capacities preserve the previous shared-cache limits. Glyph entries
+      retain no decoded pixel buffer, so their initial capacity is four times larger.
+      This is a heuristic rather than a memory equivalence; use the per-partition
+      diagnostics to tune occupancy and eviction rates from real workloads.
+    */
+
     public static IServiceCollection AddIconServices(this IServiceCollection services, DispatcherQueue dispatcherQueue)
     {
         // Single shared loader
@@ -22,7 +37,11 @@ internal static class IconServiceRegistration
 
         services.AddKeyedSingleton<IIconSourceProvider>(
             WellKnownIconSize.Size20,
-            (_, _) => new CachedIconSourceProvider(loader, 20, 1024));
+            (_, _) => new CachedIconSourceProvider(
+                loader,
+                20,
+                glyphCacheSize: 4096,
+                otherCacheSize: 1024));
 
         services.AddKeyedSingleton<IIconSourceProvider>(
             WellKnownIconSize.Size32,
@@ -30,11 +49,19 @@ internal static class IconServiceRegistration
 
         services.AddKeyedSingleton<IIconSourceProvider>(
             WellKnownIconSize.Size64,
-            (_, _) => new CachedIconSourceProvider(loader, 64, 256));
+            (_, _) => new CachedIconSourceProvider(
+                loader,
+                64,
+                glyphCacheSize: 1024,
+                otherCacheSize: 256));
 
         services.AddKeyedSingleton<IIconSourceProvider>(
             WellKnownIconSize.Size256,
-            (_, _) => new CachedIconSourceProvider(loader, 256, 64));
+            (_, _) => new CachedIconSourceProvider(
+                loader,
+                256,
+                glyphCacheSize: 256,
+                otherCacheSize: 64));
 
         services.AddKeyedSingleton<IIconSourceProvider>(
             WellKnownIconSize.Unbound,

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/CachedIconSourceProviderTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/CachedIconSourceProviderTests.cs
@@ -23,7 +23,7 @@ public partial class CachedIconSourceProviderTests
     public async Task ConcurrentRequestsShareOneInFlightLoad()
     {
         var loader = new ControllableIconLoader();
-        var provider = new CachedIconSourceProvider(loader, new Size(20, 20), cacheSize: 16);
+        var provider = CreateProvider(loader);
         var icon = new IconDataViewModel { Icon = "test" };
         var requests = new ConcurrentBag<Task<IconSource?>>();
 
@@ -46,7 +46,7 @@ public partial class CachedIconSourceProviderTests
     public async Task SuccessfulLoadIsCachedBeforeInFlightEntryIsRemoved()
     {
         var loader = new ControllableIconLoader();
-        var provider = new CachedIconSourceProvider(loader, new Size(20, 20), cacheSize: 16);
+        var provider = CreateProvider(loader);
         var icon = new IconDataViewModel { Icon = "test" };
 
         var first = provider.GetIconSource(icon, 1.0);
@@ -68,7 +68,7 @@ public partial class CachedIconSourceProviderTests
     public async Task SharedInFlightLoadTracksEveryLiveRequest()
     {
         var loader = new ControllableIconLoader();
-        var provider = new CachedIconSourceProvider(loader, new Size(20, 20), cacheSize: 16);
+        var provider = CreateProvider(loader);
         var icon = new IconDataViewModel { Icon = "test" };
         var firstDemand = new IconRequestDemand();
         var secondDemand = new IconRequestDemand();
@@ -108,8 +108,8 @@ public partial class CachedIconSourceProviderTests
             ReturnDirectGlyph = true,
             DirectGlyphResult = glyph,
         };
-        var provider = new CachedIconSourceProvider(loader, new Size(20, 20), cacheSize: 16);
-        var icon = new IconDataViewModel { Icon = "glyph" };
+        var provider = CreateProvider(loader);
+        var icon = new IconDataViewModel { Icon = "\uE700" };
 
         var first = provider.GetIconSource(icon, 1.0);
         var firstResult = await first;
@@ -130,7 +130,7 @@ public partial class CachedIconSourceProviderTests
     public async Task CachedProviderFallsBackWhenLoaderViolatesDirectGlyphContract()
     {
         var loader = new ControllableIconLoader { ReturnDirectGlyph = true };
-        var provider = new CachedIconSourceProvider(loader, new Size(20, 20), cacheSize: 16);
+        var provider = CreateProvider(loader);
 
         var result = provider.GetIconSource(new IconDataViewModel { Icon = "glyph" }, 1.0);
 
@@ -138,6 +138,41 @@ public partial class CachedIconSourceProviderTests
         Assert.AreEqual(1, loader.EnqueueCount);
         loader.CompleteNext(null);
         Assert.IsNull(await result);
+    }
+
+    [TestMethod]
+    [Timeout(5_000)]
+    public async Task GlyphAndOtherEntriesUseIndependentCacheCapacities()
+    {
+        var glyphResult = CreateTestIconSource();
+        var loader = new ControllableIconLoader
+        {
+            ReturnDirectGlyph = true,
+            DirectGlyphResult = glyphResult,
+        };
+        var provider = CreateProvider(loader, glyphCacheSize: 1, otherCacheSize: 1);
+        var glyph = new IconDataViewModel { Icon = "\uE700" };
+        var other = new IconDataViewModel { Icon = "bitmap.png" };
+
+        var glyphLoad = provider.GetIconSource(glyph, 1.0);
+        await glyphLoad;
+
+        loader.ReturnDirectGlyph = false;
+        var otherLoad = provider.GetIconSource(other, 1.0);
+        loader.CompleteNext(null);
+        await otherLoad;
+
+        Assert.IsTrue(
+            SpinWait.SpinUntil(
+                () => GetInFlightCount(provider) == 0 &&
+                    GetCacheCount(provider, "_glyphCache") == 1 &&
+                    GetCacheCount(provider, "_otherCache") == 1,
+                TimeSpan.FromSeconds(2)),
+            "The completed entries were not added to their independent caches.");
+
+        Assert.AreSame(glyphLoad, provider.GetIconSource(glyph, 1.0));
+        Assert.AreSame(otherLoad, provider.GetIconSource(other, 1.0));
+        Assert.AreEqual(1, loader.EnqueueCount);
     }
 
     [TestMethod]
@@ -156,7 +191,7 @@ public partial class CachedIconSourceProviderTests
         Assert.AreEqual(RuntimeHelpers.GetHashCode(firstStream), RuntimeHelpers.GetHashCode(secondStream));
 
         var loader = new ControllableIconLoader();
-        var provider = new CachedIconSourceProvider(loader, new Size(20, 20), cacheSize: 16);
+        var provider = CreateProvider(loader);
         var firstIcon = new IconDataViewModel
         {
             Data = new IconDataStreamReference { Unsafe = firstStream },
@@ -182,7 +217,7 @@ public partial class CachedIconSourceProviderTests
     public async Task FailedLoadIsRemovedAndCanBeRetried()
     {
         var loader = new ControllableIconLoader();
-        var provider = new CachedIconSourceProvider(loader, new Size(20, 20), cacheSize: 16);
+        var provider = CreateProvider(loader);
         var icon = new IconDataViewModel { Icon = "test" };
 
         var failed = provider.GetIconSource(icon, 1.0);
@@ -207,7 +242,7 @@ public partial class CachedIconSourceProviderTests
     public async Task RejectedLoadFaultsAndCanBeRetried()
     {
         var loader = new ControllableIconLoader { AcceptLoads = false };
-        var provider = new CachedIconSourceProvider(loader, new Size(20, 20), cacheSize: 16);
+        var provider = CreateProvider(loader);
         var icon = new IconDataViewModel { Icon = "test" };
 
         var rejected = provider.GetIconSource(icon, 1.0);
@@ -250,7 +285,7 @@ public partial class CachedIconSourceProviderTests
         };
         var provider = new IconSourceProvider(loader, new Size(16, 16));
 
-        var result = await provider.GetIconSource(new IconDataViewModel { Icon = "glyph" }, 1.0);
+        var result = await provider.GetIconSource(new IconDataViewModel { Icon = "\uE700" }, 1.0);
 
         Assert.AreSame(glyph, result);
         Assert.AreEqual(1, loader.GlyphAttemptCount);
@@ -285,6 +320,20 @@ public partial class CachedIconSourceProviderTests
         var countProperty = inFlight.GetType().GetProperty("Count");
         return (int)countProperty!.GetValue(inFlight)!;
     }
+
+    private static int GetCacheCount(CachedIconSourceProvider provider, string fieldName)
+    {
+        var field = typeof(CachedIconSourceProvider).GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+        var cache = field!.GetValue(provider)!;
+        var countProperty = cache.GetType().GetProperty("ApproximateCount", BindingFlags.Instance | BindingFlags.NonPublic);
+        return (int)countProperty!.GetValue(cache)!;
+    }
+
+    private static CachedIconSourceProvider CreateProvider(
+        ControllableIconLoader loader,
+        int glyphCacheSize = 16,
+        int otherCacheSize = 16) =>
+        new(loader, new Size(20, 20), glyphCacheSize, otherCacheSize);
 
     private static (TestStreamReference First, TestStreamReference Second)? FindRuntimeHashCollision()
     {

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/FontIconGlyphClassifierTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/FontIconGlyphClassifierTests.cs
@@ -13,8 +13,8 @@ public class FontIconGlyphClassifierTests
     [TestMethod]
     public void EmptyInputHasNoGlyph()
     {
-        Assert.AreEqual(FontIconGlyphKind.None, FontIconGlyphClassifier.Classify(null));
-        Assert.AreEqual(FontIconGlyphKind.None, FontIconGlyphClassifier.Classify(string.Empty));
+        AssertClassification(null, FontIconGlyphKind.None);
+        AssertClassification(string.Empty, FontIconGlyphKind.None);
     }
 
     [TestMethod]
@@ -23,7 +23,7 @@ public class FontIconGlyphClassifierTests
     [DataRow("\uF8FF")]
     public void FluentPrivateUseCharactersAreSymbols(string text)
     {
-        Assert.AreEqual(FontIconGlyphKind.FluentSymbol, FontIconGlyphClassifier.Classify(text));
+        AssertClassification(text, FontIconGlyphKind.FluentSymbol);
     }
 
     [TestMethod]
@@ -34,7 +34,7 @@ public class FontIconGlyphClassifierTests
     [DataRow("e\u0301")]
     public void SingleNonEmojiGraphemesUseTheGeneralFont(string text)
     {
-        Assert.AreEqual(FontIconGlyphKind.Other, FontIconGlyphClassifier.Classify(text));
+        AssertClassification(text, FontIconGlyphKind.Other);
     }
 
     [TestMethod]
@@ -42,13 +42,13 @@ public class FontIconGlyphClassifierTests
     {
         var text = new string((char)0xDC00, 1);
 
-        Assert.AreEqual(FontIconGlyphKind.Other, FontIconGlyphClassifier.Classify(text));
+        AssertClassification(text, FontIconGlyphKind.Other);
     }
 
     [TestMethod]
     public void IsolatedEmojiVariationSelectorPreservesNativeClassifierBehavior()
     {
-        Assert.AreEqual(FontIconGlyphKind.Emoji, FontIconGlyphClassifier.Classify("\uFE0F"));
+        AssertClassification("\uFE0F", FontIconGlyphKind.Emoji);
     }
 
     [TestMethod]
@@ -60,7 +60,7 @@ public class FontIconGlyphClassifierTests
     [DataRow("\U0001F469\u200D\U0001F4BB")]
     public void EmojiGraphemesUseTheEmojiFont(string text)
     {
-        Assert.AreEqual(FontIconGlyphKind.Emoji, FontIconGlyphClassifier.Classify(text));
+        AssertClassification(text, FontIconGlyphKind.Emoji);
     }
 
     [TestMethod]
@@ -70,7 +70,7 @@ public class FontIconGlyphClassifierTests
     [DataRow("2\u20E3")]
     public void TextPresentationRemainsGeneralText(string text)
     {
-        Assert.AreEqual(FontIconGlyphKind.Other, FontIconGlyphClassifier.Classify(text));
+        AssertClassification(text, FontIconGlyphKind.Other);
     }
 
     [TestMethod]
@@ -80,7 +80,7 @@ public class FontIconGlyphClassifierTests
     [DataRow("\U0001F600\U0001F600")]
     public void InvalidOrMultipleGraphemesAreRejected(string text)
     {
-        Assert.AreEqual(FontIconGlyphKind.Invalid, FontIconGlyphClassifier.Classify(text));
+        AssertClassification(text, FontIconGlyphKind.Invalid);
     }
 
     [TestMethod]
@@ -98,5 +98,13 @@ public class FontIconGlyphClassifierTests
         Assert.AreEqual(
             "Segoe UI",
             FontIconGlyphClassifier.GetFontFamily(FontIconGlyphKind.Invalid, "Custom Font"));
+    }
+
+    private static void AssertClassification(string? text, FontIconGlyphKind expected)
+    {
+        Assert.AreEqual(expected, FontIconGlyphClassifier.Classify(text));
+        Assert.AreEqual(
+            expected is not FontIconGlyphKind.Invalid and not FontIconGlyphKind.None,
+            FontIconGlyphClassifier.IsGlyphCandidate(text));
     }
 }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconLoadDiagnosticsTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconLoadDiagnosticsTests.cs
@@ -414,11 +414,12 @@ public class IconLoadDiagnosticsTests
     {
         IconLoadDiagnostics.Start();
         var size = new global::Windows.Foundation.Size(20, 20);
-        IconLoadDiagnostics.RecordCacheLookup(size, capacity: 16, hit: false);
-        IconLoadDiagnostics.RecordCacheEntryAdded(size, capacity: 16, entryCount: 1);
-        IconLoadDiagnostics.RecordCacheLookup(size, capacity: 16, hit: true);
+        IconLoadDiagnostics.RecordCacheLookup(size, IconCachePartition.Glyph, capacity: 16, hit: false);
+        IconLoadDiagnostics.RecordCacheEntryAdded(size, IconCachePartition.Glyph, capacity: 16, entryCount: 1);
+        IconLoadDiagnostics.RecordCacheLookup(size, IconCachePartition.Glyph, capacity: 16, hit: true);
         IconLoadDiagnostics.RecordCacheEntryRemoved(
             size,
+            IconCachePartition.Glyph,
             capacity: 16,
             entryCount: 0,
             AdaptiveCacheRemovalReason.Explicit);
@@ -431,7 +432,7 @@ public class IconLoadDiagnosticsTests
             $"  Definition: each entry is a cached IconSource task; counts are approximate concurrent observations. Eviction only drops the cache reference.{Environment.NewLine}" +
             $"  A request coalesced with an in-flight load is a cache miss; see Provider resolution for in-flight reuse.{Environment.NewLine}" +
             $"  Capacity means the cache was over its limit when removal was attempted and takes precedence over LowScore; LowScore means score alone caused removal.{Environment.NewLine}" +
-            "  20x20, capacity 16";
+            "  20x20 Glyph cache, capacity 16";
         StringAssert.Contains(report.Text, expectedHeader);
         StringAssert.Contains(report.Text, "    Lookups: 2");
         StringAssert.Contains(report.Text, "    Hits: 1");

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/Microsoft.CmdPal.UI.UnitTests.csproj
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/Microsoft.CmdPal.UI.UnitTests.csproj
@@ -36,6 +36,7 @@
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\FontIconGlyphClassifier.cs" Link="Helpers\Icons\FontIconGlyphClassifier.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\FontIconGlyphKind.cs" Link="Helpers\Icons\FontIconGlyphKind.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\FontIconSizeCalculator.cs" Link="Helpers\Icons\FontIconSizeCalculator.cs" />
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconCachePartition.cs" Link="Helpers\Icons\IconCachePartition.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconLoadDemand.cs" Link="Helpers\Icons\IconLoadDemand.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconLoadDemandStage.cs" Link="Helpers\Icons\IconLoadDemandStage.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconLoadDiagnostics.cs" Link="Helpers\Icons\IconLoadDiagnostics.cs" />


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Part 7 of 12 in the CmdPal icon-loading series. Depends on #50186. Next: #50188.

This PR retains more inexpensive glyph sources and avoids asynchronous machinery when materialization can complete synchronously.

- Gives glyphs and other icons independent AdaptiveCache capacities, preventing mutual eviction.
- Adds and consumes a synchronous materialization API while retaining asynchronous bitmap transfer.
- Preserves cache/in-flight sharing and reports the partitions separately.

Motivation: glyph metadata and bitmap payloads have different storage costs. Separate entry limits improve retention without imposing one common budget.

### Evidence

Historical adjacent-stage comparison (2026-08-18); shared method and limitations: the diagnostics foundation PR #50181.

- B warm applied average: 2.866 → 0.306 ms (−2.560 ms); p95 bound ≤8 → ≤0.5 ms and p99 ≤100 → ≤1 ms. All three pairs improved.
- B warm 20×20 cache removals: 2503 → 0. All 3590 list-row requests hit cache and no materializations were queued in each of the three candidate runs.
- B warm managed allocations: 159176256 → 144702064 bytes (14474192 fewer bytes allocated, not retained-memory savings).
- B warm cumulative measured icon UI time: 1324.927 → 854.928 ms (469.999 ms less across an approximately 178-second pass).
- A warm queued dispatcher callbacks: 646 → 2. The dispatcher-wait average rises 3.832 → 11.632 ms, but now describes only two remaining callbacks—not comparable dispatcher traffic.
- Partition and provider tests cover cache routing and shared in-flight requests.

Improved retention removes the warm queued-work case observed after managed cleanup. The benefit includes a larger glyph entry budget; it is not evidence of a cheaper lookup at equal cache capacity.

### Technical notes

- Partition selection still runs on lookup. It uses a candidate classifier, not source construction or full emoji classification; it is inexpensive, not literally free.
- The measured 20×20 provider changes from 1024 shared entries to 4096 glyph entries plus 1024 other entries. These are entry counts, not a measured byte budget; this is a capacity-policy change, not just a cheaper lookup.
- A returned `ValueTask` is consumed once. The synchronous callback and asynchronous continuation transfer responsibility for the single completion measurement; adding another `finally` notification would double-count it.
- Later SVG-data sources also use asynchronous materialization. The synchronous fast path is not a promise that every protocol is synchronous.

Implementation: `src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/CachedIconSourceProvider.cs`.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #49939
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

