### PR TITLE
CmdPal: Icons (9/n) - Prevent stale recycled icons and reuse image presenters

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Assets/Icons/AppIconFallback.svg
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Assets/Icons/AppIconFallback.svg
@@ -1,0 +1,3 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="4" y="4" width="24" height="24" rx="5" fill="#808080" fill-opacity="0.35"/>
+</svg>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/IconBox.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/IconBox.cs
@@ -20,6 +20,7 @@ public partial class IconBox : ContentControl
 {
     private const double DefaultIconFontSize = 16.0;
     private static long _nextDiagnosticId;
+    private readonly IconPresentationState<IconSource> _presentation = new();
 
     private double _lastScale;
     private ElementTheme _lastTheme;
@@ -55,6 +56,33 @@ public partial class IconBox : ContentControl
     // Using a DependencyProperty as the backing store for Source.  This enables animation, styling, binding, etc...
     public static readonly DependencyProperty SourceProperty =
         DependencyProperty.Register(nameof(Source), typeof(IconSource), typeof(IconBox), new PropertyMetadata(null, OnSourcePropertyChanged));
+
+    /// <summary>
+    /// Gets or sets the source displayed while <see cref="SourceKey"/> is being resolved or cannot produce an icon.
+    /// A placement fallback takes precedence over a fallback supplied by the source provider.
+    /// </summary>
+    public IconSource? FallbackSource
+    {
+        get => (IconSource?)GetValue(FallbackSourceProperty);
+        set => SetValue(FallbackSourceProperty, value);
+    }
+
+    public static readonly DependencyProperty FallbackSourceProperty =
+        DependencyProperty.Register(nameof(FallbackSource), typeof(IconSource), typeof(IconBox), new PropertyMetadata(null, OnFallbackSourcePropertyChanged));
+
+    /// <summary>
+    /// Gets or sets a value indicating whether an image-oriented request that resolves to a
+    /// font icon should use <see cref="FallbackSource"/> instead. This is intended for image
+    /// placements, such as application hero images, where a glyph is not appropriate.
+    /// </summary>
+    public bool PreferFallbackSourceForFontIcons
+    {
+        get => (bool)GetValue(PreferFallbackSourceForFontIconsProperty);
+        set => SetValue(PreferFallbackSourceForFontIconsProperty, value);
+    }
+
+    public static readonly DependencyProperty PreferFallbackSourceForFontIconsProperty =
+        DependencyProperty.Register(nameof(PreferFallbackSourceForFontIcons), typeof(bool), typeof(IconBox), new PropertyMetadata(false, OnPreferFallbackSourceForFontIconsPropertyChanged));
 
     /// <summary>
     /// Gets or sets a value to use as the <see cref="SourceKey"/> to retrieve an <see cref="IconSource"/> to set as the <see cref="Source"/>.
@@ -451,6 +479,28 @@ public partial class IconBox : ContentControl
         }
     }
 
+    private static void OnFallbackSourcePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not IconBox self)
+        {
+            return;
+        }
+
+        self._presentation.PlacementFallback = e.NewValue as IconSource;
+        if (self.SourceKey is not null)
+        {
+            self.UpdatePresentedSource();
+        }
+    }
+
+    private static void OnPreferFallbackSourceForFontIconsPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is IconBox self && self.SourceKey is not null)
+        {
+            self.UpdatePresentedSource();
+        }
+    }
+
     private static void OnSourceKeyPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
         if (d is not IconBox self)
@@ -459,6 +509,7 @@ public partial class IconBox : ContentControl
         }
 
         self.AdvanceRequestVersion();
+        self._presentation.BeginSourceChange();
 
         if (e.NewValue is null)
         {
@@ -467,6 +518,9 @@ public partial class IconBox : ContentControl
             return;
         }
 
+        // A recycled IconBox must stop presenting the preceding item's icon before
+        // the replacement request has a chance to yield or enter the load queue.
+        self.UpdatePresentedSource();
         self.RequestRefresh(IconRequestReason.SourceChanged);
     }
 
@@ -494,7 +548,13 @@ public partial class IconBox : ContentControl
                 Diagnostics = diagnostics,
             };
             iconBox.TrackActiveRequest(requestVersion, diagnostics, eventArgs);
-            await sourceRequested.InvokeAsync(iconBox, eventArgs);
+            var invocation = sourceRequested.InvokeAsync(iconBox, eventArgs);
+            if (!invocation.IsCompleted)
+            {
+                iconBox.SetRequestFallback(requestVersion, sourceKey, eventArgs.FallbackSource);
+            }
+
+            await invocation;
 
             // After the await:
             // Is the icon we're looking up now, the one we still
@@ -509,7 +569,9 @@ public partial class IconBox : ContentControl
                 return;
             }
 
-            iconBox.Source = eventArgs.Value;
+            iconBox._presentation.SetRequestFallback(eventArgs.FallbackSource);
+            iconBox._presentation.SetResolvedSource(eventArgs.Value, eventArgs.ExpectsImageSource);
+            iconBox.UpdatePresentedSource();
             diagnostics.Complete(
                 eventArgs.Value is null ? IconRequestStatus.Empty : IconRequestStatus.Applied,
                 eventArgs.Value);
@@ -536,5 +598,30 @@ public partial class IconBox : ContentControl
                 iconBox.ClearActiveRequest(requestVersion, eventArgs);
             }
         }
+    }
+
+    private void SetRequestFallback(long requestVersion, object sourceKey, IconSource? fallbackSource)
+    {
+        if (requestVersion != _requestVersion || !ReferenceEquals(sourceKey, SourceKey))
+        {
+            return;
+        }
+
+        _presentation.SetRequestFallback(fallbackSource);
+        UpdatePresentedSource();
+    }
+
+    private void UpdatePresentedSource()
+    {
+        var resolvedSource = _presentation.ResolvedSource;
+
+        // Replacing a valid glyph requires both opt-ins: the placement must prefer
+        // an image fallback, and the provider must identify this as an image request.
+        // This keeps app hero images image-only without replacing emoji or other glyph heroes.
+        var preferFallback = resolvedSource is null
+            || (PreferFallbackSourceForFontIcons && _presentation.ResolvedSourceExpectsImage && resolvedSource is FontIconSource)
+            || resolvedSource is BitmapIconSource { UriSource: null }
+            || resolvedSource is ImageIconSource { ImageSource: null };
+        Source = _presentation.SelectSource(preferFallback);
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/IconBox.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/IconBox.cs
@@ -29,6 +29,16 @@ public partial class IconBox : ContentControl
     private long _requestVersion;
     private IconRequestMeasurement _activeRequestDiagnostics;
     private IIconRequestDemand? _activeRequestDemand;
+
+    // ImageIconSource does not render through IconSourceElement. Reassigning Source on
+    // one realized Image left recycled rows intermittently blank in testing. Keep a
+    // stable Grid and alternate inactive Image slots so Source changes occur only on a
+    // collapsed element before it is shown.
+    private Grid? _imagePresenter;
+    private Image? _firstImageSlot;
+    private Image? _secondImageSlot;
+    private Image? _activeImageSlot;
+    private bool _imagePresenterDisabled;
     private long _diagnosticId;
     private IconRequestSite _derivedRequestSite;
     private bool _hasDerivedRequestSite;
@@ -429,11 +439,18 @@ public partial class IconBox : ContentControl
         switch (e.NewValue)
         {
             case null:
-                self.Content = null;
+                var imagePresenterWasActive = ReferenceEquals(self.Content, self._imagePresenter);
+                self.ClearImagePresenter();
+                if (!imagePresenterWasActive)
+                {
+                    self.Content = null;
+                }
+
                 self.Padding = default;
                 break;
             case FontIconSource fontIcon:
                 var fontElementStartedAt = IconLoadDiagnostics.BeginElementUpdate();
+                self.ClearImagePresenter();
                 self.UpdateLastFontSize();
                 fontIcon.FontSize = self._lastFontSize;
                 if (self.Content is IconSourceElement iconSourceElement)
@@ -452,6 +469,7 @@ public partial class IconBox : ContentControl
                 break;
             case BitmapIconSource bitmapIcon:
                 var bitmapElementStartedAt = IconLoadDiagnostics.BeginElementUpdate();
+                self.ClearImagePresenter();
                 if (self.Content is IconSourceElement iconSourceElement2)
                 {
                     iconSourceElement2.IconSource = bitmapIcon;
@@ -467,8 +485,16 @@ public partial class IconBox : ContentControl
 
                 break;
 
+            case ImageIconSource imageIcon:
+                var imageElementStartedAt = IconLoadDiagnostics.BeginElementUpdate();
+                var reusedImagePresenter = self.PresentImageIconSource(imageIcon);
+                IconLoadDiagnostics.RecordElementUpdate(reusedImagePresenter, imageIcon, imageElementStartedAt);
+                self.Padding = default;
+                break;
+
             case IconSource source:
                 var sourceElementStartedAt = IconLoadDiagnostics.BeginElementUpdate();
+                self.ClearImagePresenter();
                 self.Content = source.CreateIconElement();
                 IconLoadDiagnostics.RecordElementUpdate(reused: false, source, sourceElementStartedAt);
                 self.Padding = default;
@@ -477,6 +503,134 @@ public partial class IconBox : ContentControl
             default:
                 throw new InvalidOperationException($"New value of {e.NewValue} is not of type IconSource.");
         }
+    }
+
+    private bool PresentImageIconSource(ImageIconSource source)
+    {
+        if (_imagePresenterDisabled)
+        {
+            Content = source.CreateIconElement();
+            return false;
+        }
+
+        if (source.ImageSource is null)
+        {
+            var imagePresenterWasActive = ReferenceEquals(Content, _imagePresenter);
+            ClearImagePresenter();
+            if (!imagePresenterWasActive)
+            {
+                Content = null;
+            }
+
+            return _imagePresenter is not null;
+        }
+
+        var reused = _imagePresenter is not null;
+
+        try
+        {
+            var presenter = EnsureImagePresenter();
+            var nextSlot = ReferenceEquals(_activeImageSlot, _firstImageSlot)
+                ? EnsureSecondImageSlot()
+                : _firstImageSlot!;
+            var previousSlot = _activeImageSlot;
+
+            if (previousSlot is not null)
+            {
+                previousSlot.Visibility = Visibility.Collapsed;
+            }
+
+            nextSlot.Source = source.ImageSource;
+            nextSlot.Visibility = Visibility.Visible;
+
+            if (previousSlot is not null)
+            {
+                previousSlot.Source = null;
+            }
+
+            _activeImageSlot = nextSlot;
+            if (!ReferenceEquals(Content, presenter))
+            {
+                Content = presenter;
+            }
+
+            return reused;
+        }
+        catch (Exception ex)
+        {
+            DisableImagePresenter();
+            Logger.LogError($"Failed to update reusable image presenter ({GetDiagnosticDescription()})", ex);
+            Content = source.CreateIconElement();
+            return false;
+        }
+    }
+
+    private Grid EnsureImagePresenter()
+    {
+        if (_imagePresenter is not null)
+        {
+            return _imagePresenter;
+        }
+
+        var presenter = new Grid
+        {
+            IsHitTestVisible = false,
+        };
+        var firstSlot = CreateImageSlot();
+        presenter.Children.Add(firstSlot);
+
+        _imagePresenter = presenter;
+        _firstImageSlot = firstSlot;
+        return presenter;
+    }
+
+    private Image EnsureSecondImageSlot()
+    {
+        if (_secondImageSlot is not null)
+        {
+            return _secondImageSlot;
+        }
+
+        var secondSlot = CreateImageSlot();
+        _imagePresenter!.Children.Add(secondSlot);
+        _secondImageSlot = secondSlot;
+        return secondSlot;
+    }
+
+    private static Image CreateImageSlot()
+    {
+        return new Image
+        {
+            IsHitTestVisible = false,
+            Stretch = Stretch.Uniform,
+            Visibility = Visibility.Collapsed,
+        };
+    }
+
+    private void ClearImagePresenter()
+    {
+        _activeImageSlot?.Visibility = Visibility.Collapsed;
+        _firstImageSlot?.Source = null;
+        _secondImageSlot?.Source = null;
+        _activeImageSlot = null;
+    }
+
+    private void DisableImagePresenter()
+    {
+        try
+        {
+            ClearImagePresenter();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError($"Failed to clear reusable image presenter ({GetDiagnosticDescription()})", ex);
+        }
+
+        _imagePresenter = null;
+        _firstImageSlot = null;
+        _secondImageSlot = null;
+        _activeImageSlot = null;
+        _imagePresenterDisabled = true;
     }
 
     private static void OnFallbackSourcePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -518,9 +672,15 @@ public partial class IconBox : ContentControl
             return;
         }
 
-        // A recycled IconBox must stop presenting the preceding item's icon before
-        // the replacement request has a chance to yield or enter the load queue.
-        self.UpdatePresentedSource();
+        // Keep the preceding source only while a replacement has a chance to resolve
+        // synchronously in Refresh. RequestIconFromSource presents the fallback before
+        // an asynchronous suspension, so the preceding item can never reach another frame.
+        // If no request can start now, clear it immediately instead.
+        if (!self.IsLoaded || self._sourceRequested is null)
+        {
+            self.UpdatePresentedSource();
+        }
+
         self.RequestRefresh(IconRequestReason.SourceChanged);
     }
 
@@ -582,6 +742,17 @@ public partial class IconBox : ContentControl
 
             if (requestVersion == iconBox._requestVersion)
             {
+                // A synchronous provider failure occurs before the pending-source path
+                // gets a chance to clear the preceding item.
+                try
+                {
+                    iconBox.UpdatePresentedSource();
+                }
+                catch (Exception presentationException)
+                {
+                    Logger.LogError($"Failed to clear icon after a request failure ({iconBox.GetDiagnosticDescription()})", presentationException);
+                }
+
                 // Do not dispatch immediately: a deterministic failure would recurse forever.
                 // Keep the request pending for the next external lifecycle or source trigger.
                 iconBox.MarkRefreshPending(IconRequestReason.Retry);

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/IconPresentationState`1.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/IconPresentationState`1.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CmdPal.UI.Controls;
+
+internal sealed class IconPresentationState<T>
+    where T : class
+{
+    public T? PlacementFallback { get; set; }
+
+    public T? RequestFallback { get; private set; }
+
+    public T? ResolvedSource { get; private set; }
+
+    public bool HasResolvedSource { get; private set; }
+
+    public bool ResolvedSourceExpectsImage { get; private set; }
+
+    public void BeginSourceChange()
+    {
+        RequestFallback = null;
+        ResolvedSource = null;
+        HasResolvedSource = false;
+        ResolvedSourceExpectsImage = false;
+    }
+
+    public void SetRequestFallback(T? source) => RequestFallback = source;
+
+    public void SetResolvedSource(T? source, bool expectsImageSource)
+    {
+        ResolvedSource = source;
+        HasResolvedSource = true;
+        ResolvedSourceExpectsImage = expectsImageSource;
+    }
+
+    public T? SelectSource(bool preferFallbackForResolvedSource)
+    {
+        var fallback = PlacementFallback ?? RequestFallback;
+        return !HasResolvedSource || (preferFallbackForResolvedSource && fallback is not null)
+            ? fallback
+            : ResolvedSource;
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SourceRequestedEventArgs.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SourceRequestedEventArgs.cs
@@ -20,6 +20,19 @@ public class SourceRequestedEventArgs(object? key, ElementTheme requestedTheme, 
 
     public IconSource? Value { get; set; }
 
+    /// <summary>
+    /// Gets or sets an optional source to display while <see cref="Value"/> is being resolved.
+    /// Handlers should set this before their first asynchronous suspension so the control can present it immediately.
+    /// </summary>
+    public IconSource? FallbackSource { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this request is expected to resolve to an image.
+    /// This lets image-oriented placements reject a glyph produced by a final fallback path
+    /// without affecting ordinary glyph requests.
+    /// </summary>
+    internal bool ExpectsImageSource { get; set; }
+
     public ElementTheme Theme => requestedTheme;
 
     public double Scale => scale;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconProvider.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconProvider.cs
@@ -5,7 +5,11 @@
 using ManagedCommon;
 using Microsoft.CmdPal.UI.Controls;
 using Microsoft.CmdPal.UI.ViewModels;
+using Microsoft.CommandPalette.Extensions.Toolkit;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media.Imaging;
 
 namespace Microsoft.CmdPal.UI.Helpers;
 
@@ -14,12 +18,15 @@ namespace Microsoft.CmdPal.UI.Helpers;
 /// </summary>
 public static partial class IconProvider
 {
+    private static readonly Uri AppIconFallbackUri = new("ms-appx:///Assets/Icons/AppIconFallback.svg");
+
     private static IIconSourceProvider _provider16 = null!;
     private static IIconSourceProvider _provider20 = null!;
     private static IIconSourceProvider _provider32 = null!;
     private static IIconSourceProvider _provider64 = null!;
     private static IIconSourceProvider _provider256 = null!;
     private static IIconSourceProvider _providerUnbound = null!;
+    private static ImageIconSource? _appIconFallbackSource;
 
     public static void Initialize(IServiceProvider serviceProvider)
     {
@@ -42,22 +49,29 @@ public static partial class IconProvider
 
         try
         {
-            args.Value = args.Key switch
+            var iconData = args.Key switch
             {
-                IconDataViewModel iconData => await service.GetIconSource(
+                IconDataViewModel value => value,
+                IconInfoViewModel value => value.IconForTheme(args.Theme == ElementTheme.Light),
+                _ => null,
+            };
+            if (iconData is not null && AppIconProtocol.IsProtocol(iconData.Icon))
+            {
+                args.FallbackSource = _appIconFallbackSource ??= new ImageIconSource
+                {
+                    ImageSource = new SvgImageSource(AppIconFallbackUri),
+                };
+                args.ExpectsImageSource = true;
+            }
+
+            args.Value = iconData is null
+                ? null
+                : await service.GetIconSource(
                     iconData,
                     args.Scale,
                     args.Diagnostics,
                     args,
-                    args.Theme),
-                IconInfoViewModel iconInfo => await service.GetIconSource(
-                    args.Theme == Microsoft.UI.Xaml.ElementTheme.Light ? iconInfo.Light : iconInfo.Dark,
-                    args.Scale,
-                    args.Diagnostics,
-                    args,
-                    args.Theme),
-                _ => null,
-            };
+                    args.Theme);
         }
         catch (Exception ex)
         {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Microsoft.CmdPal.UI.csproj
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Microsoft.CmdPal.UI.csproj
@@ -234,6 +234,10 @@
     <Content Update="..\Microsoft.CmdPal.UI.ViewModels\Assets\template.zip">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Update="Assets\Icons\AppIconFallback.svg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <DeploymentContent>true</DeploymentContent>
+    </Content>
     <Content Update="Assets\StoreLogo.dark.svg">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Content>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml
@@ -507,10 +507,17 @@
                             HorizontalAlignment="Left"
                             AutomationProperties.AccessibilityView="Raw"
                             DiagnosticScope="HeroImage"
+                            PreferFallbackSourceForFontIcons="True"
                             RequestSite="Details"
                             SourceKey="{x:Bind ViewModel.Details.HeroImage, Mode=OneWay}"
                             SourceRequested="{x:Bind help:IconProvider.SourceRequested64}"
-                            Visibility="{x:Bind HasHeroImage, Mode=OneWay}" />
+                            Visibility="{x:Bind HasHeroImage, Mode=OneWay}">
+                            <cpcontrols:IconBox.FallbackSource>
+                                <BitmapIconSource
+                                    ShowAsMonochrome="False"
+                                    UriSource="ms-appx:///Assets/Icons/ExtensionIconPlaceholder.png" />
+                            </cpcontrols:IconBox.FallbackSource>
+                        </cpcontrols:IconBox>
 
                         <TextBlock
                             Grid.Row="1"

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionPage.xaml
@@ -63,7 +63,13 @@
                                         DiagnosticScope="ExtensionSummary"
                                         RequestSite="Settings"
                                         SourceKey="{x:Bind ViewModel.Icon, Mode=OneWay}"
-                                        SourceRequested="{x:Bind helpers:IconProvider.SourceRequested20}" />
+                                        SourceRequested="{x:Bind helpers:IconProvider.SourceRequested20}">
+                                        <cpcontrols:IconBox.FallbackSource>
+                                            <BitmapIconSource
+                                                ShowAsMonochrome="False"
+                                                UriSource="ms-appx:///Assets/Icons/ExtensionIconPlaceholder.png" />
+                                        </cpcontrols:IconBox.FallbackSource>
+                                    </cpcontrols:IconBox>
                                 </cpcontrols:ContentIcon.Content>
                             </cpcontrols:ContentIcon>
                         </controls:SettingsCard.HeaderIcon>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionsPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionsPage.xaml
@@ -156,7 +156,13 @@
                                                             DiagnosticScope="ExtensionList"
                                                             RequestSite="Settings"
                                                             SourceKey="{x:Bind Icon, Mode=OneWay}"
-                                                            SourceRequested="{x:Bind helpers:IconProvider.SourceRequested20}" />
+                                                            SourceRequested="{x:Bind helpers:IconProvider.SourceRequested20}">
+                                                            <cpcontrols:IconBox.FallbackSource>
+                                                                <BitmapIconSource
+                                                                    ShowAsMonochrome="False"
+                                                                    UriSource="ms-appx:///Assets/Icons/ExtensionIconPlaceholder.png" />
+                                                            </cpcontrols:IconBox.FallbackSource>
+                                                        </cpcontrols:IconBox>
                                                     </controls:Case>
                                                     <controls:Case Value="False">
                                                         <Image

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconPresentationStateTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconPresentationStateTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CmdPal.UI.UnitTests;
 public class IconPresentationStateTests
 {
     [TestMethod]
-    public void SourceChangeImmediatelyReplacesResolvedSourceWithPlacementFallback()
+    public void SourceChangeResetsResolvedSourceToPlacementFallback()
     {
         var state = new IconPresentationState<string>
         {

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconPresentationStateTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconPresentationStateTests.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.UI.Controls;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.UI.UnitTests;
+
+[TestClass]
+public class IconPresentationStateTests
+{
+    [TestMethod]
+    public void SourceChangeImmediatelyReplacesResolvedSourceWithPlacementFallback()
+    {
+        var state = new IconPresentationState<string>
+        {
+            PlacementFallback = "placement",
+        };
+        state.SetResolvedSource("preceding item", expectsImageSource: true);
+
+        Assert.IsTrue(state.ResolvedSourceExpectsImage);
+
+        state.BeginSourceChange();
+
+        Assert.AreEqual("placement", state.SelectSource(preferFallbackForResolvedSource: false));
+        Assert.IsFalse(state.HasResolvedSource);
+        Assert.IsFalse(state.ResolvedSourceExpectsImage);
+    }
+
+    [TestMethod]
+    public void PlacementFallbackTakesPrecedenceOverRequestFallback()
+    {
+        var state = new IconPresentationState<string>
+        {
+            PlacementFallback = "placement",
+        };
+        state.SetRequestFallback("request");
+
+        Assert.AreEqual("placement", state.SelectSource(preferFallbackForResolvedSource: false));
+    }
+
+    [TestMethod]
+    public void ResolvedSourceReplacesFallbackUnlessPlacementPrefersFallback()
+    {
+        var state = new IconPresentationState<string>
+        {
+            PlacementFallback = "fallback",
+        };
+        state.SetResolvedSource("resolved", expectsImageSource: false);
+
+        Assert.AreEqual("resolved", state.SelectSource(preferFallbackForResolvedSource: false));
+        Assert.AreEqual("fallback", state.SelectSource(preferFallbackForResolvedSource: true));
+    }
+
+    [TestMethod]
+    public void NewSourceDoesNotRetainPreviousRequestFallback()
+    {
+        var state = new IconPresentationState<string>();
+        state.SetRequestFallback("preceding request");
+
+        state.BeginSourceChange();
+
+        Assert.IsNull(state.RequestFallback);
+        Assert.IsNull(state.SelectSource(preferFallbackForResolvedSource: false));
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/Microsoft.CmdPal.UI.UnitTests.csproj
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/Microsoft.CmdPal.UI.UnitTests.csproj
@@ -28,6 +28,7 @@
     <Compile Include="..\..\Microsoft.CmdPal.UI\Controls\IconRefreshState.cs" Link="Controls\IconRefreshState.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\AppIconProtocolProcessor.cs" Link="Helpers\Icons\AppIconProtocolProcessor.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Controls\IconRequestSite.cs" Link="Controls\IconRequestSite.cs" />
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Controls\IconPresentationState`1.cs" Link="Controls\IconPresentationState`1.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\AdaptiveCache`2.cs" Link="Helpers\AdaptiveCache`2.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\AdaptiveCacheRemovalReason.cs" Link="Helpers\AdaptiveCacheRemovalReason.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\BinaryIconReference.cs" Link="Helpers\Icons\BinaryIconReference.cs" />


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Part 9 of 12 in the CmdPal icon-loading series. Depends on #50188. Next: #50190.

This PR clears previous-item presentation immediately and reduces image-control churn.

- Adds placement-owned fallbacks and resets resolved/request-specific fallback state when the source changes.
- Alternates inactive Image slots in a stable Grid instead of rebuilding the image subtree.
- Keeps app-image fallback policy separate from valid glyph/emoji hero rendering.

Motivation: a recycled row must not show another item's icon while loading, and repeated image updates should reuse presentation where WinUI permits it.

### Evidence

Historical adjacent-stage comparison (2026-08-18); shared method and limitations: the diagnostics foundation PR #50181.

- C cold-ish icon-element update average: 0.188 → 0.074 ms (−0.114 ms); all three pairs decreased.
- C cold-ish elements created: 454 → 84; elements reused: 0 → 382.
- C cold-ish cumulative measured icon UI time: 119.588 → 67.655 ms (51.933 ms less across an approximately 28-second search scenario).
- C cold-ish applied average: 8.402 → 8.483 ms (+0.081 ms), inconsistent across pairs; no request-latency benefit is established.
- Presentation-state tests cover reset and asynchronous fallback transitions. Final visual recycling still needs a UI smoke test.

The measurable benefit is less control construction and cumulative UI work, alongside the stale-icon correctness fix. A 0.114 ms update saving is not a claim that the app feels 61% faster.

### Technical notes

- Two lazily created image slots are an intentional workaround for observed blank/stale results when reusing one presenter. They are not a claim that all WinUI icon elements can safely be reused.
- Request-specific fallback state must be reset together with the resolved source. Clearing only the displayed source can retain the previous item's fallback.
- Recycled controls must not explicitly dispose shared cached image resources; those may still be used by other controls or deferred WinUI copies.
- Ordinary glyphs and emojis remain valid hero sources. The shared bitmap placeholder is an app-icon policy, not a blanket ban on glyphs in details.

Implementation: `src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/IconBox.cs`.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #49941
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

