### PR TITLE
CmdPal: Icons (10/n) - Add generated swatch and Unicode initials icons

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/AppIconProtocolProcessor.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/AppIconProtocolProcessor.cs
@@ -28,6 +28,8 @@ internal sealed class AppIconProtocolProcessor : IIconProtocolProcessor
 
     public ReadOnlySpan<string> ProtocolPrefixes => AppIconProtocol.ProtocolPrefixes;
 
+    public string GetCacheIdentity(string value) => value;
+
     public ElementTheme GetCacheTheme(string value, ElementTheme theme) => ElementTheme.Default;
 
     public IconLoadInputKind ClassifyInput(string value) => IconLoadInputKind.SpecializedAppIcon;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/CachedIconSourceProvider.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/CachedIconSourceProvider.cs
@@ -61,8 +61,11 @@ internal sealed class CachedIconSourceProvider : IIconSourceProvider
         ElementTheme theme = ElementTheme.Default)
     {
         var protocolProcessor = IconProtocolRegistry.Find(icon.Icon);
+        var iconIdentity = icon.Icon is { } iconString && protocolProcessor is not null
+            ? protocolProcessor.GetCacheIdentity(iconString)
+            : icon.Icon;
         var cacheTheme = protocolProcessor?.GetCacheTheme(icon.Icon!, theme) ?? ElementTheme.Default;
-        var key = new IconCacheKey(icon, scale, cacheTheme);
+        var key = new IconCacheKey(icon, iconIdentity, scale, cacheTheme);
         var partition = ClassifyCachePartition(icon.Icon, protocolProcessor);
         var cache = GetCache(partition);
         var cacheSize = GetCacheSize(partition);
@@ -256,9 +259,13 @@ internal sealed class CachedIconSourceProvider : IIconSourceProvider
         private readonly int _scale;
         private readonly ElementTheme _theme;
 
-        public IconCacheKey(IconDataViewModel icon, double scale, ElementTheme cacheTheme)
+        public IconCacheKey(
+            IconDataViewModel icon,
+            string? iconIdentity,
+            double scale,
+            ElementTheme cacheTheme)
         {
-            _icon = icon.Icon;
+            _icon = iconIdentity;
             _fontFamily = icon.FontFamily;
             _streamIdentity = icon.Data?.Unsafe is { } stream
                 ? StreamIdentities.GetValue(stream, static _ => new StreamIdentity())

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/GeneratedIconProtocol.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/GeneratedIconProtocol.cs
@@ -1,0 +1,795 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Text;
+using System.Xml;
+using Microsoft.UI.Xaml;
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+/// <summary>
+/// Parses <c>|Swatch|color[|dark]</c> and
+/// <c>|Initials|text|color[|dark][|circle|rounded]</c> icon strings.
+/// Initials accept one to three Unicode text elements. A literal percent sign in
+/// the text token is encoded as <c>%25</c>, and a literal separator as <c>%7C</c>.
+/// Percent encoding keeps this hand-authored protocol legible; the machine-generated
+/// app-icon protocol uses length-prefixed fields instead.
+/// Colors use the XAML #RGB, #ARGB, #RRGGBB, or #AARRGGBB forms.
+/// </summary>
+internal static class GeneratedIconProtocol
+{
+    private const int MaxEncodedInitialsLength = 96;
+    private const int MaxInitialsLength = 32;
+    private const int MaxInitialsTextElements = 3;
+    private const string SwatchPrefix = "|Swatch|";
+    private const string InitialsPrefix = "|Initials|";
+    private static readonly string[] ProtocolPrefixValues = [SwatchPrefix, InitialsPrefix];
+    private static readonly UTF8Encoding StrictUtf8 = new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
+    public static ReadOnlySpan<string> ProtocolPrefixes => ProtocolPrefixValues;
+
+    public static string GetCacheIdentity(string value)
+    {
+        var kind = Classify(value);
+        if (kind == Kind.None)
+        {
+            return value;
+        }
+
+        try
+        {
+            if (kind == Kind.Swatch)
+            {
+                var swatchPayload = value.AsSpan(SwatchPrefix.Length);
+                if (HasCanonicalStyleTokenCasing(swatchPayload)
+                    || !TryParseSwatch(swatchPayload, out _, out _, out _))
+                {
+                    return value;
+                }
+
+                return CanonicalizeStyleTokenCasing(value, SwatchPrefix.Length);
+            }
+
+            var payload = value.AsSpan(InitialsPrefix.Length);
+            var separator = payload.IndexOf('|');
+            if (separator <= 0)
+            {
+                return value;
+            }
+
+            var initialsToken = payload[..separator];
+            var stylePayload = payload[(separator + 1)..];
+            var hasCanonicalInitials = IsCanonicalAsciiInitials(initialsToken);
+            var hasCanonicalStyle = HasCanonicalStyleTokenCasing(stylePayload);
+            if (hasCanonicalInitials && hasCanonicalStyle)
+            {
+                return value;
+            }
+
+            if (!TryParseInitials(
+                payload,
+                out var initials,
+                out _,
+                out _,
+                out _,
+                out _))
+            {
+                return value;
+            }
+
+            if (hasCanonicalInitials)
+            {
+                return CanonicalizeStyleTokenCasing(
+                    value,
+                    InitialsPrefix.Length + separator + 1);
+            }
+
+            // Canonicalize both Unicode representation and token escaping before
+            // cache lookup, so visually identical text cannot occupy two entries.
+            var escapedInitials = EscapeInitialsToken(initials);
+            var identity = InitialsPrefix
+                + escapedInitials
+                + payload[separator..].ToString();
+            return hasCanonicalStyle
+                ? identity
+                : CanonicalizeStyleTokenCasing(
+                    identity,
+                    InitialsPrefix.Length + escapedInitials.Length + 1);
+        }
+        catch
+        {
+            return value;
+        }
+    }
+
+    private static bool IsCanonicalAsciiInitials(ReadOnlySpan<char> value)
+    {
+        if (value.Length is < 1 or > MaxInitialsTextElements)
+        {
+            return false;
+        }
+
+        foreach (var character in value)
+        {
+            if (character is not (>= 'A' and <= 'Z')
+                and not (>= '0' and <= '9'))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool HasCanonicalStyleTokenCasing(ReadOnlySpan<char> payload)
+    {
+        payload = TrimOptionalTrailingSeparator(payload);
+        while (TryReadToken(ref payload, out var token))
+        {
+            if (token.IsEmpty)
+            {
+                continue;
+            }
+
+            if (token[0] == '#')
+            {
+                foreach (var character in token[1..])
+                {
+                    if (character is >= 'a' and <= 'f')
+                    {
+                        return false;
+                    }
+                }
+            }
+            else
+            {
+                foreach (var character in token)
+                {
+                    if (character is >= 'A' and <= 'Z')
+                    {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private static string CanonicalizeStyleTokenCasing(string value, int styleStart) =>
+        string.Create(
+            value.Length,
+            (Value: value, StyleStart: styleStart),
+            static (destination, state) =>
+            {
+                state.Value.AsSpan().CopyTo(destination);
+                var remaining = destination[state.StyleStart..];
+                while (!remaining.IsEmpty)
+                {
+                    var separator = remaining.IndexOf('|');
+                    var token = separator < 0 ? remaining : remaining[..separator];
+                    if (!token.IsEmpty)
+                    {
+                        if (token[0] == '#')
+                        {
+                            for (var index = 1; index < token.Length; index++)
+                            {
+                                if (token[index] is >= 'a' and <= 'f')
+                                {
+                                    token[index] = (char)(token[index] - ('a' - 'A'));
+                                }
+                            }
+                        }
+                        else
+                        {
+                            for (var index = 0; index < token.Length; index++)
+                            {
+                                if (token[index] is >= 'A' and <= 'Z')
+                                {
+                                    token[index] = (char)(token[index] + ('a' - 'A'));
+                                }
+                            }
+                        }
+                    }
+
+                    if (separator < 0)
+                    {
+                        break;
+                    }
+
+                    remaining = remaining[(separator + 1)..];
+                }
+            });
+
+    public static Kind Classify(string? value)
+    {
+        if (value?.StartsWith(SwatchPrefix, StringComparison.Ordinal) == true)
+        {
+            return Kind.Swatch;
+        }
+
+        if (value?.StartsWith(InitialsPrefix, StringComparison.Ordinal) == true)
+        {
+            return Kind.Initials;
+        }
+
+        return Kind.None;
+    }
+
+    public static ElementTheme GetCacheTheme(string? value, ElementTheme theme)
+    {
+        if (!IsThemeDependent(value))
+        {
+            return ElementTheme.Default;
+        }
+
+        return theme == ElementTheme.Dark ? ElementTheme.Dark : ElementTheme.Light;
+    }
+
+    public static bool TryCreateSwatchSvg(string? value, ElementTheme theme, out byte[] svg)
+    {
+        svg = [];
+
+        try
+        {
+            if (Classify(value) != Kind.Swatch
+                || !TryParseSwatch(
+                    value!.AsSpan(SwatchPrefix.Length),
+                    out var light,
+                    out var dark,
+                    out _))
+            {
+                return false;
+            }
+
+            svg = CreateSwatchSvg(SelectColor(light, dark, theme));
+            return true;
+        }
+        catch
+        {
+            svg = [];
+            return false;
+        }
+    }
+
+    public static bool TryCreateInitialsSvg(string? value, ElementTheme theme, out byte[] svg)
+    {
+        svg = [];
+
+        try
+        {
+            if (Classify(value) != Kind.Initials
+                || !TryParseInitials(
+                    value!.AsSpan(InitialsPrefix.Length),
+                    out var initials,
+                    out var light,
+                    out var dark,
+                    out _,
+                    out var shape))
+            {
+                return false;
+            }
+
+            var hasGlyph = InitialsTextRenderer.TryCreatePathData(
+                initials,
+                out var pathData,
+                out var useEvenOddFill);
+            svg = CreateInitialsSvg(
+                hasGlyph ? pathData : null,
+                useEvenOddFill,
+                SelectColor(light, dark, theme),
+                theme,
+                shape);
+            return true;
+        }
+        catch
+        {
+            svg = [];
+            return false;
+        }
+    }
+
+    private static bool IsThemeDependent(string? value)
+    {
+        switch (Classify(value))
+        {
+            case Kind.Swatch:
+                return TryParseSwatch(value!.AsSpan(SwatchPrefix.Length), out _, out _, out var hasDark) && hasDark;
+
+            case Kind.Initials:
+                // Foreground contrast can depend on the surface theme when the
+                // background is translucent. Keep every initials entry isolated
+                // by theme so this cheap discriminator never has to parse it.
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    private static bool TryParseSwatch(
+        ReadOnlySpan<char> payload,
+        out RgbaColor light,
+        out RgbaColor dark,
+        out bool hasDark)
+    {
+        light = default;
+        dark = default;
+        hasDark = false;
+        payload = TrimOptionalTrailingSeparator(payload);
+        if (!TryReadToken(ref payload, out var lightToken) || !TryParseColor(lightToken, out light))
+        {
+            return false;
+        }
+
+        dark = light;
+        if (!payload.IsEmpty)
+        {
+            if (!TryReadToken(ref payload, out var darkToken) || !TryParseColor(darkToken, out dark))
+            {
+                return false;
+            }
+
+            hasDark = true;
+        }
+
+        return payload.IsEmpty;
+    }
+
+    private static bool TryParseInitials(
+        ReadOnlySpan<char> payload,
+        out string initials,
+        out RgbaColor light,
+        out RgbaColor dark,
+        out bool hasDark,
+        out InitialsShape shape)
+    {
+        initials = string.Empty;
+        light = default;
+        dark = default;
+        hasDark = false;
+        shape = InitialsShape.Circle;
+
+        payload = TrimOptionalTrailingSeparator(payload);
+        if (!TryReadToken(ref payload, out var initialsToken)
+            || !TryNormalizeInitials(initialsToken, out initials)
+            || !TryReadToken(ref payload, out var lightToken)
+            || !TryParseColor(lightToken, out light))
+        {
+            return false;
+        }
+
+        dark = light;
+        if (!payload.IsEmpty)
+        {
+            if (!TryReadToken(ref payload, out var nextToken))
+            {
+                return false;
+            }
+
+            if (TryParseColor(nextToken, out var darkColor))
+            {
+                dark = darkColor;
+                hasDark = true;
+                if (!payload.IsEmpty
+                    && (!TryReadToken(ref payload, out var shapeToken) || !TryParseShape(shapeToken, out shape)))
+                {
+                    return false;
+                }
+            }
+            else if (!TryParseShape(nextToken, out shape))
+            {
+                return false;
+            }
+        }
+
+        if (!payload.IsEmpty)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryNormalizeInitials(ReadOnlySpan<char> value, out string initials)
+    {
+        initials = string.Empty;
+        if (value.IsEmpty
+            || value.Length > MaxEncodedInitialsLength
+            || !TryDecodeInitialsToken(value, out var decoded))
+        {
+            return false;
+        }
+
+        decoded = decoded.Trim();
+        if (decoded.Length is < 1 or > MaxInitialsLength)
+        {
+            return false;
+        }
+
+        // Preserve the original ASCII behavior while making canonically equivalent
+        // Unicode spellings share rendering and cache identity.
+        var normalized = decoded
+            .Normalize(NormalizationForm.FormC)
+            .ToUpperInvariant()
+            .Normalize(NormalizationForm.FormC);
+        if (normalized.Length is < 1 or > MaxInitialsLength)
+        {
+            return false;
+        }
+
+        var remaining = normalized.AsSpan();
+        var textElementCount = 0;
+        while (!remaining.IsEmpty)
+        {
+            var textElementLength = StringInfo.GetNextTextElementLength(remaining);
+            if (textElementLength <= 0 || ++textElementCount > MaxInitialsTextElements)
+            {
+                return false;
+            }
+
+            remaining = remaining[textElementLength..];
+        }
+
+        foreach (var rune in normalized.EnumerateRunes())
+        {
+            var category = Rune.GetUnicodeCategory(rune);
+            if (category is UnicodeCategory.Control
+                or UnicodeCategory.LineSeparator
+                or UnicodeCategory.ParagraphSeparator)
+            {
+                return false;
+            }
+        }
+
+        initials = normalized;
+        return true;
+    }
+
+    private static bool TryDecodeInitialsToken(ReadOnlySpan<char> value, out string decoded)
+    {
+        decoded = string.Empty;
+        if (value.IndexOf('%') < 0)
+        {
+            decoded = value.ToString();
+            return true;
+        }
+
+        var builder = new StringBuilder(value.Length);
+        Span<byte> escapedBytes = stackalloc byte[MaxEncodedInitialsLength / 3];
+        for (var index = 0; index < value.Length; index++)
+        {
+            if (value[index] != '%')
+            {
+                builder.Append(value[index]);
+                continue;
+            }
+
+            var byteCount = 0;
+            while (index < value.Length && value[index] == '%')
+            {
+                if (index > value.Length - 3
+                    || !TryParseHexByte(value.Slice(index + 1, 2), out var escapedByte))
+                {
+                    return false;
+                }
+
+                escapedBytes[byteCount++] = escapedByte;
+                index += 3;
+            }
+
+            try
+            {
+                builder.Append(StrictUtf8.GetString(escapedBytes[..byteCount]));
+            }
+            catch (DecoderFallbackException)
+            {
+                return false;
+            }
+
+            index--;
+        }
+
+        decoded = builder.ToString();
+        return true;
+    }
+
+    private static string EscapeInitialsToken(string value)
+    {
+        if (value.AsSpan().IndexOfAny('%', '|') < 0)
+        {
+            return value;
+        }
+
+        // Escape '%' first. Reversing these calls would escape the '%' introduced
+        // for a literal separator and make the canonical token decode incorrectly.
+        return value
+            .Replace("%", "%25", StringComparison.Ordinal)
+            .Replace("|", "%7C", StringComparison.Ordinal);
+    }
+
+    private static bool TryParseShape(ReadOnlySpan<char> value, out InitialsShape shape)
+    {
+        if (value.Equals("circle", StringComparison.OrdinalIgnoreCase))
+        {
+            shape = InitialsShape.Circle;
+            return true;
+        }
+
+        if (value.Equals("rounded", StringComparison.OrdinalIgnoreCase))
+        {
+            shape = InitialsShape.RoundedSquare;
+            return true;
+        }
+
+        shape = default;
+        return false;
+    }
+
+    private static bool TryParseColor(ReadOnlySpan<char> value, out RgbaColor color)
+    {
+        color = default;
+        if (value.IsEmpty || value[0] != '#')
+        {
+            return false;
+        }
+
+        value = value[1..];
+        switch (value.Length)
+        {
+            case 3:
+                if (!TryParseHexDigit(value[0], out var shortRed)
+                    || !TryParseHexDigit(value[1], out var shortGreen)
+                    || !TryParseHexDigit(value[2], out var shortBlue))
+                {
+                    return false;
+                }
+
+                color = new RgbaColor(255, ExpandHexDigit(shortRed), ExpandHexDigit(shortGreen), ExpandHexDigit(shortBlue));
+                return true;
+
+            case 4:
+                if (!TryParseHexDigit(value[0], out var shortAlpha)
+                    || !TryParseHexDigit(value[1], out shortRed)
+                    || !TryParseHexDigit(value[2], out shortGreen)
+                    || !TryParseHexDigit(value[3], out shortBlue))
+                {
+                    return false;
+                }
+
+                color = new RgbaColor(
+                    ExpandHexDigit(shortAlpha),
+                    ExpandHexDigit(shortRed),
+                    ExpandHexDigit(shortGreen),
+                    ExpandHexDigit(shortBlue));
+                return true;
+
+            case 6:
+                if (!TryParseHexByte(value[..2], out var red)
+                    || !TryParseHexByte(value.Slice(2, 2), out var green)
+                    || !TryParseHexByte(value.Slice(4, 2), out var blue))
+                {
+                    return false;
+                }
+
+                color = new RgbaColor(255, red, green, blue);
+                return true;
+
+            case 8:
+                if (!TryParseHexByte(value[..2], out var alpha)
+                    || !TryParseHexByte(value.Slice(2, 2), out red)
+                    || !TryParseHexByte(value.Slice(4, 2), out green)
+                    || !TryParseHexByte(value.Slice(6, 2), out blue))
+                {
+                    return false;
+                }
+
+                color = new RgbaColor(alpha, red, green, blue);
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    private static bool TryParseHexByte(ReadOnlySpan<char> value, out byte result)
+    {
+        if (!TryParseHexDigit(value[0], out var high) || !TryParseHexDigit(value[1], out var low))
+        {
+            result = 0;
+            return false;
+        }
+
+        result = (byte)((high << 4) | low);
+        return true;
+    }
+
+    private static bool TryParseHexDigit(char value, out byte result)
+    {
+        if (value is >= '0' and <= '9')
+        {
+            result = (byte)(value - '0');
+            return true;
+        }
+
+        if (value is >= 'A' and <= 'F')
+        {
+            result = (byte)(value - 'A' + 10);
+            return true;
+        }
+
+        if (value is >= 'a' and <= 'f')
+        {
+            result = (byte)(value - 'a' + 10);
+            return true;
+        }
+
+        result = 0;
+        return false;
+    }
+
+    private static byte ExpandHexDigit(byte value) => (byte)((value << 4) | value);
+
+    private static ReadOnlySpan<char> TrimOptionalTrailingSeparator(ReadOnlySpan<char> value) =>
+        !value.IsEmpty && value[^1] == '|' ? value[..^1] : value;
+
+    private static bool TryReadToken(ref ReadOnlySpan<char> remaining, out ReadOnlySpan<char> token)
+    {
+        if (remaining.IsEmpty)
+        {
+            token = default;
+            return false;
+        }
+
+        var separator = remaining.IndexOf('|');
+        if (separator < 0)
+        {
+            token = remaining;
+            remaining = [];
+        }
+        else
+        {
+            token = remaining[..separator];
+            remaining = remaining[(separator + 1)..];
+        }
+
+        return !token.IsEmpty;
+    }
+
+    private static RgbaColor SelectColor(RgbaColor light, RgbaColor dark, ElementTheme theme) =>
+        theme == ElementTheme.Dark ? dark : light;
+
+    private static byte[] CreateSwatchSvg(RgbaColor color)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = CreateSvgWriter(stream))
+        {
+            WriteSvgStart(writer);
+            writer.WriteStartElement("circle");
+            writer.WriteAttributeString("cx", "16");
+            writer.WriteAttributeString("cy", "16");
+            writer.WriteAttributeString("r", "12");
+            WriteFill(writer, color);
+            writer.WriteEndElement();
+            writer.WriteEndElement();
+        }
+
+        return stream.ToArray();
+    }
+
+    private static byte[] CreateInitialsSvg(
+        string? pathData,
+        bool useEvenOddFill,
+        RgbaColor background,
+        ElementTheme theme,
+        InitialsShape shape)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = CreateSvgWriter(stream))
+        {
+            WriteSvgStart(writer);
+            if (shape == InitialsShape.Circle)
+            {
+                writer.WriteStartElement("circle");
+                writer.WriteAttributeString("cx", "16");
+                writer.WriteAttributeString("cy", "16");
+                writer.WriteAttributeString("r", "15.5");
+            }
+            else
+            {
+                writer.WriteStartElement("rect");
+                writer.WriteAttributeString("x", "0.5");
+                writer.WriteAttributeString("y", "0.5");
+                writer.WriteAttributeString("width", "31");
+                writer.WriteAttributeString("height", "31");
+                writer.WriteAttributeString("rx", "7");
+            }
+
+            WriteFill(writer, background);
+            writer.WriteEndElement();
+
+            if (!string.IsNullOrEmpty(pathData))
+            {
+                writer.WriteStartElement("path");
+                writer.WriteAttributeString("d", pathData);
+                if (useEvenOddFill)
+                {
+                    writer.WriteAttributeString("fill-rule", "evenodd");
+                }
+
+                WriteFill(writer, GetContrastingForeground(background, theme));
+                writer.WriteEndElement();
+            }
+
+            writer.WriteEndElement();
+        }
+
+        return stream.ToArray();
+    }
+
+    private static XmlWriter CreateSvgWriter(Stream stream) =>
+        XmlWriter.Create(
+            stream,
+            new XmlWriterSettings
+            {
+                Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+                OmitXmlDeclaration = true,
+                Indent = false,
+                CloseOutput = false,
+            });
+
+    private static void WriteSvgStart(XmlWriter writer)
+    {
+        writer.WriteStartElement("svg", "http://www.w3.org/2000/svg");
+        writer.WriteAttributeString("viewBox", "0 0 32 32");
+    }
+
+    private static void WriteFill(XmlWriter writer, RgbaColor color)
+    {
+        writer.WriteAttributeString("fill", FormattableString.Invariant($"#{color.R:X2}{color.G:X2}{color.B:X2}"));
+        if (color.A != byte.MaxValue)
+        {
+            writer.WriteAttributeString(
+                "fill-opacity",
+                (color.A / 255d).ToString("0.###", CultureInfo.InvariantCulture));
+        }
+    }
+
+    private static RgbaColor GetContrastingForeground(RgbaColor background, ElementTheme theme)
+    {
+        var surface = theme == ElementTheme.Dark ? (byte)32 : byte.MaxValue;
+        var red = Composite(background.R, background.A, surface);
+        var green = Composite(background.G, background.A, surface);
+        var blue = Composite(background.B, background.A, surface);
+        var luminance = (0.2126 * ToLinear(red)) + (0.7152 * ToLinear(green)) + (0.0722 * ToLinear(blue));
+        return luminance > 0.179
+            ? new RgbaColor(255, 0, 0, 0)
+            : new RgbaColor(255, 255, 255, 255);
+    }
+
+    private static byte Composite(byte foreground, byte alpha, byte background) =>
+        (byte)(((foreground * alpha) + (background * (byte.MaxValue - alpha)) + 127) / byte.MaxValue);
+
+    private static double ToLinear(byte channel)
+    {
+        var value = channel / 255d;
+        return value <= 0.04045 ? value / 12.92 : Math.Pow((value + 0.055) / 1.055, 2.4);
+    }
+
+    internal enum Kind
+    {
+        None,
+        Swatch,
+        Initials,
+    }
+
+    private enum InitialsShape
+    {
+        Circle,
+        RoundedSquare,
+    }
+
+    private readonly record struct RgbaColor(byte A, byte R, byte G, byte B);
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/GeneratedIconProtocol.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/GeneratedIconProtocol.cs
@@ -261,6 +261,16 @@ internal static class GeneratedIconProtocol
 
     public static bool TryCreateInitialsSvg(string? value, ElementTheme theme, out byte[] svg)
     {
+        return TryCreateInitialsSvg(
+            value,
+            theme,
+            InitialsTextRenderer.TryCreatePathData,
+            out svg);
+    }
+
+    internal static bool TryCreateInitialsSvg(
+        string? value, ElementTheme theme, InitialsPathFactory createPathData, out byte[] svg)
+    {
         svg = [];
 
         try
@@ -277,7 +287,7 @@ internal static class GeneratedIconProtocol
                 return false;
             }
 
-            var hasGlyph = InitialsTextRenderer.TryCreatePathData(
+            var hasGlyph = createPathData(
                 initials,
                 out var pathData,
                 out var useEvenOddFill);

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/GeneratedIconProtocol.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/GeneratedIconProtocol.cs
@@ -10,13 +10,17 @@ using Microsoft.UI.Xaml;
 namespace Microsoft.CmdPal.UI.Helpers;
 
 /// <summary>
-/// Parses <c>|Swatch|color[|dark]</c> and
-/// <c>|Initials|text|color[|dark][|circle|rounded]</c> icon strings.
+/// Parses <c>|Swatch|color[|dark][|circle|square]</c> and
+/// <c>|Initials|text|color[|dark][|circle|square]</c> icon strings.
 /// Initials accept one to three Unicode text elements. A literal percent sign in
 /// the text token is encoded as <c>%25</c>, and a literal separator as <c>%7C</c>.
 /// Percent encoding keeps this hand-authored protocol legible; the machine-generated
 /// app-icon protocol uses length-prefixed fields instead.
 /// Colors use the XAML #RGB, #ARGB, #RRGGBB, or #AARRGGBB forms.
+/// Both protocols also accept danger, subtle, info, warning, success, neutral,
+/// dark, normal, or transparent as a semantic color. A semantic color supplies
+/// both light and dark values and may be followed only by an optional shape. Use
+/// two explicit hex colors to customize the light and dark values separately.
 /// </summary>
 internal static class GeneratedIconProtocol
 {
@@ -44,7 +48,7 @@ internal static class GeneratedIconProtocol
             {
                 var swatchPayload = value.AsSpan(SwatchPrefix.Length);
                 if (HasCanonicalStyleTokenCasing(swatchPayload)
-                    || !TryParseSwatch(swatchPayload, out _, out _, out _))
+                    || !TryParseSwatch(swatchPayload, out _, out _, out _, out _))
                 {
                     return value;
                 }
@@ -239,12 +243,13 @@ internal static class GeneratedIconProtocol
                     value!.AsSpan(SwatchPrefix.Length),
                     out var light,
                     out var dark,
-                    out _))
+                    out _,
+                    out var shape))
             {
                 return false;
             }
 
-            svg = CreateSwatchSvg(SelectColor(light, dark, theme));
+            svg = CreateSwatchSvg(SelectColor(light, dark, theme), shape);
             return true;
         }
         catch
@@ -296,7 +301,7 @@ internal static class GeneratedIconProtocol
         switch (Classify(value))
         {
             case Kind.Swatch:
-                return TryParseSwatch(value!.AsSpan(SwatchPrefix.Length), out _, out _, out var hasDark) && hasDark;
+                return TryParseSwatch(value!.AsSpan(SwatchPrefix.Length), out _, out _, out var hasDark, out _) && hasDark;
 
             case Kind.Initials:
                 // Foreground contrast can depend on the surface theme when the
@@ -313,29 +318,59 @@ internal static class GeneratedIconProtocol
         ReadOnlySpan<char> payload,
         out RgbaColor light,
         out RgbaColor dark,
-        out bool hasDark)
+        out bool hasDark,
+        out BackgroundShape shape)
     {
         light = default;
         dark = default;
         hasDark = false;
+        shape = BackgroundShape.Circle;
         payload = TrimOptionalTrailingSeparator(payload);
-        if (!TryReadToken(ref payload, out var lightToken) || !TryParseColor(lightToken, out light))
+        if (!TryReadToken(ref payload, out var lightToken))
         {
             return false;
         }
 
-        dark = light;
-        if (!payload.IsEmpty)
+        if (TryParseSemanticColorPair(lightToken, out light, out dark))
         {
-            if (!TryReadToken(ref payload, out var darkToken) || !TryParseColor(darkToken, out dark))
-            {
-                return false;
-            }
-
-            hasDark = true;
+            hasDark = light != dark;
+            return TryParseOptionalShape(ref payload, out shape);
         }
 
-        return payload.IsEmpty;
+        if (!TryParseColor(lightToken, out light))
+        {
+            return false;
+        }
+
+        return TryParseOptionalDarkAndShape(ref payload, light, out dark, out hasDark, out shape);
+    }
+
+    private static bool TryParseSemanticColorPair(
+        ReadOnlySpan<char> value,
+        out RgbaColor light,
+        out RgbaColor dark)
+    {
+        light = default;
+        dark = default;
+        if (value.IsEmpty || value[0] == '#')
+        {
+            return false;
+        }
+
+        return SemanticIconColor.TryResolvePair(value, out var lightValue, out var darkValue)
+            && TryParseColor(lightValue, out light)
+            && TryParseColor(darkValue, out dark);
+    }
+
+    private static bool TryParseOptionalShape(
+        ref ReadOnlySpan<char> payload,
+        out BackgroundShape shape)
+    {
+        shape = BackgroundShape.Circle;
+        return payload.IsEmpty
+            || (TryReadToken(ref payload, out var shapeToken)
+                && TryParseShape(shapeToken, out shape)
+                && payload.IsEmpty);
     }
 
     private static bool TryParseInitials(
@@ -344,53 +379,34 @@ internal static class GeneratedIconProtocol
         out RgbaColor light,
         out RgbaColor dark,
         out bool hasDark,
-        out InitialsShape shape)
+        out BackgroundShape shape)
     {
         initials = string.Empty;
         light = default;
         dark = default;
         hasDark = false;
-        shape = InitialsShape.Circle;
+        shape = BackgroundShape.Circle;
 
         payload = TrimOptionalTrailingSeparator(payload);
         if (!TryReadToken(ref payload, out var initialsToken)
             || !TryNormalizeInitials(initialsToken, out initials)
-            || !TryReadToken(ref payload, out var lightToken)
-            || !TryParseColor(lightToken, out light))
+            || !TryReadToken(ref payload, out var lightToken))
         {
             return false;
         }
 
-        dark = light;
-        if (!payload.IsEmpty)
+        if (TryParseSemanticColorPair(lightToken, out light, out dark))
         {
-            if (!TryReadToken(ref payload, out var nextToken))
-            {
-                return false;
-            }
-
-            if (TryParseColor(nextToken, out var darkColor))
-            {
-                dark = darkColor;
-                hasDark = true;
-                if (!payload.IsEmpty
-                    && (!TryReadToken(ref payload, out var shapeToken) || !TryParseShape(shapeToken, out shape)))
-                {
-                    return false;
-                }
-            }
-            else if (!TryParseShape(nextToken, out shape))
-            {
-                return false;
-            }
+            hasDark = light != dark;
+            return TryParseOptionalShape(ref payload, out shape);
         }
 
-        if (!payload.IsEmpty)
+        if (!TryParseColor(lightToken, out light))
         {
             return false;
         }
 
-        return true;
+        return TryParseOptionalDarkAndShape(ref payload, light, out dark, out hasDark, out shape);
     }
 
     private static bool TryNormalizeInitials(ReadOnlySpan<char> value, out string initials)
@@ -510,17 +526,55 @@ internal static class GeneratedIconProtocol
             .Replace("|", "%7C", StringComparison.Ordinal);
     }
 
-    private static bool TryParseShape(ReadOnlySpan<char> value, out InitialsShape shape)
+    private static bool TryParseOptionalDarkAndShape(
+        ref ReadOnlySpan<char> payload,
+        RgbaColor light,
+        out RgbaColor dark,
+        out bool hasDark,
+        out BackgroundShape shape)
     {
-        if (value.Equals("circle", StringComparison.OrdinalIgnoreCase))
+        dark = light;
+        hasDark = false;
+        shape = BackgroundShape.Circle;
+        if (payload.IsEmpty)
         {
-            shape = InitialsShape.Circle;
             return true;
         }
 
-        if (value.Equals("rounded", StringComparison.OrdinalIgnoreCase))
+        if (!TryReadToken(ref payload, out var nextToken))
         {
-            shape = InitialsShape.RoundedSquare;
+            return false;
+        }
+
+        if (TryParseColor(nextToken, out var darkColor))
+        {
+            dark = darkColor;
+            hasDark = true;
+            if (!payload.IsEmpty
+                && (!TryReadToken(ref payload, out var shapeToken) || !TryParseShape(shapeToken, out shape)))
+            {
+                return false;
+            }
+        }
+        else if (!TryParseShape(nextToken, out shape))
+        {
+            return false;
+        }
+
+        return payload.IsEmpty;
+    }
+
+    private static bool TryParseShape(ReadOnlySpan<char> value, out BackgroundShape shape)
+    {
+        if (value.Equals("circle", StringComparison.OrdinalIgnoreCase))
+        {
+            shape = BackgroundShape.Circle;
+            return true;
+        }
+
+        if (value.Equals("square", StringComparison.OrdinalIgnoreCase))
+        {
+            shape = BackgroundShape.Square;
             return true;
         }
 
@@ -661,18 +715,13 @@ internal static class GeneratedIconProtocol
     private static RgbaColor SelectColor(RgbaColor light, RgbaColor dark, ElementTheme theme) =>
         theme == ElementTheme.Dark ? dark : light;
 
-    private static byte[] CreateSwatchSvg(RgbaColor color)
+    private static byte[] CreateSwatchSvg(RgbaColor color, BackgroundShape shape)
     {
         using var stream = new MemoryStream();
         using (var writer = CreateSvgWriter(stream))
         {
             WriteSvgStart(writer);
-            writer.WriteStartElement("circle");
-            writer.WriteAttributeString("cx", "16");
-            writer.WriteAttributeString("cy", "16");
-            writer.WriteAttributeString("r", "12");
-            WriteFill(writer, color);
-            writer.WriteEndElement();
+            WriteBackground(writer, color, shape);
             writer.WriteEndElement();
         }
 
@@ -684,31 +733,13 @@ internal static class GeneratedIconProtocol
         bool useEvenOddFill,
         RgbaColor background,
         ElementTheme theme,
-        InitialsShape shape)
+        BackgroundShape shape)
     {
         using var stream = new MemoryStream();
         using (var writer = CreateSvgWriter(stream))
         {
             WriteSvgStart(writer);
-            if (shape == InitialsShape.Circle)
-            {
-                writer.WriteStartElement("circle");
-                writer.WriteAttributeString("cx", "16");
-                writer.WriteAttributeString("cy", "16");
-                writer.WriteAttributeString("r", "15.5");
-            }
-            else
-            {
-                writer.WriteStartElement("rect");
-                writer.WriteAttributeString("x", "0.5");
-                writer.WriteAttributeString("y", "0.5");
-                writer.WriteAttributeString("width", "31");
-                writer.WriteAttributeString("height", "31");
-                writer.WriteAttributeString("rx", "7");
-            }
-
-            WriteFill(writer, background);
-            writer.WriteEndElement();
+            WriteBackground(writer, background, shape);
 
             if (!string.IsNullOrEmpty(pathData))
             {
@@ -729,6 +760,31 @@ internal static class GeneratedIconProtocol
         return stream.ToArray();
     }
 
+    private static void WriteBackground(XmlWriter writer, RgbaColor color, BackgroundShape shape)
+    {
+        // The generated background is the icon, so it fills 31 of the 32 view-box
+        // units. The 0.5-unit guard on each edge keeps antialiased pixels in bounds.
+        if (shape == BackgroundShape.Circle)
+        {
+            writer.WriteStartElement("circle");
+            writer.WriteAttributeString("cx", "16");
+            writer.WriteAttributeString("cy", "16");
+            writer.WriteAttributeString("r", "15.5");
+        }
+        else
+        {
+            writer.WriteStartElement("rect");
+            writer.WriteAttributeString("x", "0.5");
+            writer.WriteAttributeString("y", "0.5");
+            writer.WriteAttributeString("width", "31");
+            writer.WriteAttributeString("height", "31");
+            writer.WriteAttributeString("rx", "7");
+        }
+
+        WriteFill(writer, color);
+        writer.WriteEndElement();
+    }
+
     private static XmlWriter CreateSvgWriter(Stream stream) =>
         XmlWriter.Create(
             stream,
@@ -743,6 +799,9 @@ internal static class GeneratedIconProtocol
     private static void WriteSvgStart(XmlWriter writer)
     {
         writer.WriteStartElement("svg", "http://www.w3.org/2000/svg");
+
+        // The 32x32 view box is a scale-independent design grid; it does not request
+        // a 32-pixel output. The loader rasterizes it for the calling surface's size.
         writer.WriteAttributeString("viewBox", "0 0 32 32");
     }
 
@@ -785,10 +844,10 @@ internal static class GeneratedIconProtocol
         Initials,
     }
 
-    private enum InitialsShape
+    private enum BackgroundShape
     {
         Circle,
-        RoundedSquare,
+        Square,
     }
 
     private readonly record struct RgbaColor(byte A, byte R, byte G, byte B);

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/GeneratedIconProtocolProcessor.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/GeneratedIconProtocolProcessor.cs
@@ -8,10 +8,14 @@ namespace Microsoft.CmdPal.UI.Helpers;
 
 internal sealed class GeneratedIconProtocolProcessor : IIconProtocolProcessor
 {
-    public static GeneratedIconProtocolProcessor Instance { get; } = new();
+    private readonly InitialsPathFactory _createInitialsPathData;
 
-    private GeneratedIconProtocolProcessor()
+    public static GeneratedIconProtocolProcessor Instance { get; } = new(InitialsTextRenderer.TryCreatePathData);
+
+    internal GeneratedIconProtocolProcessor(InitialsPathFactory createInitialsPathData)
     {
+        ArgumentNullException.ThrowIfNull(createInitialsPathData);
+        _createInitialsPathData = createInitialsPathData;
     }
 
     public IconCachePartition CachePartition => IconCachePartition.Other;
@@ -67,7 +71,11 @@ internal sealed class GeneratedIconProtocolProcessor : IIconProtocolProcessor
         return await Task.Run(
             () =>
             {
-                var preparedIcon = GeneratedIconProtocol.TryCreateInitialsSvg(value, theme, out var svg)
+                var preparedIcon = GeneratedIconProtocol.TryCreateInitialsSvg(
+                    value,
+                    theme,
+                    _createInitialsPathData,
+                    out var svg)
                     ? IconPathConverter.PreparedIcon.FromSvgData(svg, targetSize)
                     : IconPathConverter.PreparedIcon.Empty();
                 return IconProtocolProcessingResult.FromPreparedIcon(preparedIcon);

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/GeneratedIconProtocolProcessor.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/GeneratedIconProtocolProcessor.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.UI.Xaml;
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+internal sealed class GeneratedIconProtocolProcessor : IIconProtocolProcessor
+{
+    public static GeneratedIconProtocolProcessor Instance { get; } = new();
+
+    private GeneratedIconProtocolProcessor()
+    {
+    }
+
+    public IconCachePartition CachePartition => IconCachePartition.Other;
+
+    public ReadOnlySpan<string> ProtocolPrefixes => GeneratedIconProtocol.ProtocolPrefixes;
+
+    public string GetCacheIdentity(string value) => GeneratedIconProtocol.GetCacheIdentity(value);
+
+    public ElementTheme GetCacheTheme(string value, ElementTheme theme) =>
+        GeneratedIconProtocol.GetCacheTheme(value, theme);
+
+    public IconLoadInputKind ClassifyInput(string value) =>
+        GeneratedIconProtocol.Classify(value) switch
+        {
+            GeneratedIconProtocol.Kind.Swatch => IconLoadInputKind.GeneratedSwatch,
+            GeneratedIconProtocol.Kind.Initials => IconLoadInputKind.GeneratedInitials,
+            _ => IconLoadInputKind.String,
+        };
+
+    public bool TryPrepareSynchronously(
+        string value,
+        int targetSize,
+        ElementTheme theme,
+        out IconPathConverter.PreparedIcon preparedIcon)
+    {
+        if (GeneratedIconProtocol.Classify(value) == GeneratedIconProtocol.Kind.Initials)
+        {
+            // Font fallback and outline extraction must never run in a synchronous
+            // caller such as the WinUI STA. PrepareAsync owns all initials work.
+            preparedIcon = null!;
+            return false;
+        }
+
+        preparedIcon = GeneratedIconProtocol.TryCreateSwatchSvg(value, theme, out var svg)
+            ? IconPathConverter.PreparedIcon.FromSvgData(svg, targetSize)
+            : IconPathConverter.PreparedIcon.Empty();
+        return true;
+    }
+
+    public async ValueTask<IconProtocolProcessingResult> PrepareAsync(
+        string value,
+        int targetSize,
+        ElementTheme theme)
+    {
+        if (GeneratedIconProtocol.Classify(value) != GeneratedIconProtocol.Kind.Initials)
+        {
+            _ = TryPrepareSynchronously(value, targetSize, theme, out var synchronousIcon);
+            return IconProtocolProcessingResult.FromPreparedIcon(synchronousIcon);
+        }
+
+        // The loader currently calls async processors from a worker, but keep this
+        // boundary independently safe if another caller reaches it from the STA.
+        return await Task.Run(
+            () =>
+            {
+                var preparedIcon = GeneratedIconProtocol.TryCreateInitialsSvg(value, theme, out var svg)
+                    ? IconPathConverter.PreparedIcon.FromSvgData(svg, targetSize)
+                    : IconPathConverter.PreparedIcon.Empty();
+                return IconProtocolProcessingResult.FromPreparedIcon(preparedIcon);
+            }).ConfigureAwait(false);
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IIconProtocolProcessor.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IIconProtocolProcessor.cs
@@ -13,6 +13,8 @@ internal interface IIconProtocolProcessor
 
     ReadOnlySpan<string> ProtocolPrefixes { get; }
 
+    string GetCacheIdentity(string value);
+
     ElementTheme GetCacheTheme(string value, ElementTheme theme);
 
     IconLoadInputKind ClassifyInput(string value);

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadInputKind.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoadInputKind.cs
@@ -11,4 +11,6 @@ internal enum IconLoadInputKind
     ShellBinary,
     Stream,
     SpecializedAppIcon,
+    GeneratedSwatch,
+    GeneratedInitials,
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoaderService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoaderService.cs
@@ -396,6 +396,7 @@ internal sealed partial class IconLoaderService : IIconLoaderService
             IconPathConverter.PreparedIconKind.SvgUri => IconDispatcherMaterializationKind.SvgUri,
             IconPathConverter.PreparedIconKind.Glyph => IconDispatcherMaterializationKind.Glyph,
             IconPathConverter.PreparedIconKind.Binary => IconDispatcherMaterializationKind.Binary,
+            IconPathConverter.PreparedIconKind.SvgData => IconDispatcherMaterializationKind.SvgData,
             _ => IconDispatcherMaterializationKind.Unknown,
         };
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconPathConverter.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconPathConverter.cs
@@ -11,6 +11,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Windows.Graphics.Imaging;
+using Windows.Storage.Streams;
 using DrawingIcon = System.Drawing.Icon;
 using DrawingImageLockMode = System.Drawing.Imaging.ImageLockMode;
 using DrawingPixelFormat = System.Drawing.Imaging.PixelFormat;
@@ -133,8 +134,8 @@ internal static partial class IconPathConverter
     /// Attempts to create an icon source without an asynchronous bitmap transfer.
     /// </summary>
     /// <returns>
-    /// <see langword="false"/> only when a populated binary icon must be transferred
-    /// to a <see cref="SoftwareBitmapSource"/> asynchronously.
+    /// <see langword="false"/> only when generated SVG data or a populated binary icon
+    /// must be transferred to its XAML image source asynchronously.
     /// </returns>
     public static bool TryCreateIconSourceSynchronously(
         PreparedIcon icon,
@@ -163,6 +164,10 @@ internal static partial class IconPathConverter
                     iconSource = new ImageIconSource { ImageSource = svg };
                     return true;
 
+                case PreparedIconKind.SvgData:
+                    iconSource = null!;
+                    return false;
+
                 case PreparedIconKind.Glyph:
                     iconSource = new FontIconSource
                     {
@@ -189,7 +194,7 @@ internal static partial class IconPathConverter
         }
         catch
         {
-            iconSource = icon.Kind == PreparedIconKind.Binary
+            iconSource = icon.Kind is PreparedIconKind.Binary or PreparedIconKind.SvgData
                 ? new ImageIconSource()
                 : CreateEmptyIconSource();
             return true;
@@ -200,10 +205,48 @@ internal static partial class IconPathConverter
     /// Completes icon-source creation after <see cref="TryCreateIconSourceSynchronously"/>
     /// returned <see langword="false"/> for the same prepared icon.
     /// </summary>
-    public static Task<IconSource> CompleteIconSourceCreationAsync(PreparedIcon icon) =>
-        icon.TakeSoftwareBitmap() is { } softwareBitmap
-            ? CreateBinaryIconSourceAsync(softwareBitmap)
-            : Task.FromResult<IconSource>(new ImageIconSource());
+    public static Task<IconSource> CompleteIconSourceCreationAsync(PreparedIcon icon)
+    {
+        if (icon.Kind == PreparedIconKind.Binary)
+        {
+            return icon.TakeSoftwareBitmap() is { } softwareBitmap
+                ? CreateBinaryIconSourceAsync(softwareBitmap)
+                : Task.FromResult<IconSource>(new ImageIconSource());
+        }
+
+        return icon.Kind == PreparedIconKind.SvgData
+            ? CreateSvgIconSourceAsync(icon.SvgData!, icon.TargetSize)
+            : Task.FromResult<IconSource>(CreateEmptyIconSource());
+    }
+
+    private static async Task<IconSource> CreateSvgIconSourceAsync(byte[] svgData, int targetSize)
+    {
+        try
+        {
+            using var stream = new InMemoryRandomAccessStream();
+            using (var writer = new DataWriter(stream))
+            {
+                writer.WriteBytes(svgData);
+                await writer.StoreAsync();
+                writer.DetachStream();
+            }
+
+            stream.Seek(0);
+            var svg = new SvgImageSource();
+            if (targetSize > 0)
+            {
+                svg.RasterizePixelWidth = targetSize;
+                svg.RasterizePixelHeight = targetSize;
+            }
+
+            await svg.SetSourceAsync(stream);
+            return new ImageIconSource { ImageSource = svg };
+        }
+        catch
+        {
+            return new ImageIconSource();
+        }
+    }
 
     private static async Task<IconSource> CreateBinaryIconSourceAsync(SoftwareBitmap softwareBitmap)
     {
@@ -343,6 +386,7 @@ internal static partial class IconPathConverter
             Uri? uri = null,
             string? glyph = null,
             string? fontFamily = null,
+            byte[]? svgData = null,
             SoftwareBitmap? softwareBitmap = null,
             int targetSize = 0)
         {
@@ -350,6 +394,7 @@ internal static partial class IconPathConverter
             Uri = uri;
             Glyph = glyph;
             FontFamily = fontFamily;
+            SvgData = svgData;
             _softwareBitmap = softwareBitmap;
             TargetSize = targetSize;
         }
@@ -362,6 +407,8 @@ internal static partial class IconPathConverter
 
         public string? FontFamily { get; }
 
+        public byte[]? SvgData { get; }
+
         public SoftwareBitmap? SoftwareBitmap => _softwareBitmap;
 
         public int TargetSize { get; }
@@ -373,6 +420,9 @@ internal static partial class IconPathConverter
 
         public static PreparedIcon FromGlyph(string glyph, string fontFamily, int targetSize) =>
             new(PreparedIconKind.Glyph, glyph: glyph, fontFamily: fontFamily, targetSize: targetSize);
+
+        public static PreparedIcon FromSvgData(byte[] svgData, int targetSize) =>
+            new(PreparedIconKind.SvgData, svgData: svgData, targetSize: targetSize);
 
         public static PreparedIcon FromBinary(SoftwareBitmap? bitmap) =>
             new(PreparedIconKind.Binary, softwareBitmap: bitmap);
@@ -393,6 +443,7 @@ internal static partial class IconPathConverter
         Empty,
         BitmapUri,
         SvgUri,
+        SvgData,
         Glyph,
         Binary,
     }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconProtocolRegistry.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconProtocolRegistry.cs
@@ -12,6 +12,7 @@ internal static class IconProtocolRegistry
     private static readonly IIconProtocolProcessor[] Processors =
     [
         AppIconProtocolProcessor.Instance,
+        GeneratedIconProtocolProcessor.Instance,
     ];
 
     static IconProtocolRegistry()

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/InitialsPathFactory.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/InitialsPathFactory.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+/// <summary>
+/// Produces normalized SVG path data for an initials string.
+/// </summary>
+internal delegate bool InitialsPathFactory(
+    string text,
+    out string pathData,
+    out bool useEvenOddFill);

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/InitialsTextRenderer.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/InitialsTextRenderer.cs
@@ -1,0 +1,179 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Numerics;
+using ManagedCommon;
+using Microsoft.Graphics.Canvas;
+using Microsoft.Graphics.Canvas.Geometry;
+using Microsoft.Graphics.Canvas.Text;
+using Windows.UI.Text;
+using WinRT;
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+internal static class InitialsTextRenderer
+{
+    private const float LayoutExtent = 512;
+    private const float NominalFontSize = 100;
+    private const float TargetHeight = 18;
+    private const float TargetWidth = 23;
+    private const float ViewBoxSize = 32;
+
+    // Initials preparation is dispatched to a worker before this is touched. Keep
+    // its software device private so font-outline extraction cannot contend with a
+    // Win2D device used by XAML on the STA.
+    private static Lazy<CanvasDevice> _device = CreateDevice();
+    private static int _outlineFailureLogged;
+
+    public static bool TryCreatePathData(
+        string text,
+        out string pathData,
+        out bool useEvenOddFill)
+    {
+        pathData = string.Empty;
+        useEvenOddFill = false;
+        var device = Volatile.Read(ref _device);
+
+        try
+        {
+            using var format = new CanvasTextFormat
+            {
+                Direction = CanvasTextDirection.LeftToRightThenTopToBottom,
+                FontFamily = "Segoe UI",
+                FontSize = NominalFontSize,
+                FontWeight = new FontWeight { Weight = 600 },
+                LocaleName = CultureInfo.CurrentUICulture.Name,
+                WordWrapping = CanvasWordWrapping.NoWrap,
+            };
+
+            if (!HasFontForEveryCharacter(text, format))
+            {
+                return false;
+            }
+
+            using var layout = new CanvasTextLayout(
+                device.Value,
+                text,
+                format,
+                LayoutExtent,
+                LayoutExtent);
+            using var geometry = CanvasGeometry.CreateText(layout);
+            var bounds = geometry.ComputeBounds();
+            if (bounds.Width <= 0 || bounds.Height <= 0)
+            {
+                return false;
+            }
+
+            var scale = MathF.Min(
+                TargetWidth / (float)bounds.Width,
+                TargetHeight / (float)bounds.Height);
+            var width = (float)bounds.Width * scale;
+            var height = (float)bounds.Height * scale;
+            var transform = Matrix3x2.CreateTranslation(-(float)bounds.X, -(float)bounds.Y)
+                * Matrix3x2.CreateScale(scale)
+                * Matrix3x2.CreateTranslation(
+                    (ViewBoxSize - width) / 2,
+                    (ViewBoxSize - height) / 2);
+
+            using var transformed = geometry.Transform(transform);
+            var receiver = new SvgPathDataReceiver();
+            transformed.SendPathTo(receiver);
+            pathData = receiver.PathData;
+            useEvenOddFill = receiver.UseEvenOddFill;
+            return pathData.Length > 0;
+        }
+        catch (Exception ex)
+        {
+            var failure = ex;
+            try
+            {
+                ResetDeviceIfLost(device, ex.HResult);
+            }
+            catch (Exception resetFailure)
+            {
+                failure = new AggregateException(
+                    "Failed while checking whether the initials rendering device was lost.",
+                    ex,
+                    resetFailure);
+            }
+
+            if (Interlocked.Exchange(ref _outlineFailureLogged, 1) == 0)
+            {
+                Logger.LogError("Initials outline extraction failed; falling back to background tile", failure);
+            }
+
+            pathData = string.Empty;
+            useEvenOddFill = false;
+            return false;
+        }
+    }
+
+    private static Lazy<CanvasDevice> CreateDevice() =>
+        new(
+            static () => new CanvasDevice(forceSoftwareRenderer: true) { LowPriority = true },
+
+            // PublicationOnly deliberately retries transient CanvasDevice factory failures.
+            // Concurrent losing devices use GC-based release, matching the lock-free lifetime
+            // policy used when replacing a lost device.
+            LazyThreadSafetyMode.PublicationOnly);
+
+    private static void ResetDeviceIfLost(Lazy<CanvasDevice> device, int failureHResult)
+    {
+        if (device.IsValueCreated)
+        {
+            var canvasDevice = device.Value;
+            if (canvasDevice.IsDeviceLost(failureHResult) || canvasDevice.IsDeviceLost())
+            {
+                // Do not dispose the lost device here: another worker may still be
+                // unwinding a call through it. Once those calls finish, replacing
+                // the Lazy releases the last long-lived reference without a lock.
+                Interlocked.CompareExchange(ref _device, CreateDevice(), device);
+            }
+        }
+    }
+
+    private static bool HasFontForEveryCharacter(string text, CanvasTextFormat format)
+    {
+        var analyzer = new CanvasTextAnalyzer(
+            text,
+            CanvasTextDirection.LeftToRightThenTopToBottom);
+        try
+        {
+            var mappings = analyzer.GetFonts(format);
+            Span<bool> covered = stackalloc bool[text.Length];
+
+            foreach (var mapping in mappings)
+            {
+                var range = mapping.Key;
+                if (range.CharacterIndex < 0
+                    || range.CharacterCount <= 0
+                    || range.CharacterIndex > text.Length - range.CharacterCount)
+                {
+                    return false;
+                }
+
+                covered.Slice(range.CharacterIndex, range.CharacterCount).Fill(true);
+            }
+
+            foreach (var isCovered in covered)
+            {
+                if (!isCovered)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+        finally
+        {
+            // CanvasTextAnalyzer's projected IDisposable currently queries an IID
+            // the Win2D runtime object does not expose. Releasing its owned object
+            // reference avoids both that InvalidCastException and finalizer-delayed
+            // retention of the analyzer's native state.
+            ((IWinRTObject)analyzer).NativeObject.Dispose();
+        }
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/SemanticIconColor.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/SemanticIconColor.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.UI.Xaml;
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+/// <summary>
+/// Resolves the shared semantic color vocabulary used by generated and themed icons.
+/// </summary>
+internal static class SemanticIconColor
+{
+    public static string GetDefault(ElementTheme theme) =>
+        theme == ElementTheme.Dark ? "#60CDFF" : "#0067C0";
+
+    public static bool IsSemantic(ReadOnlySpan<char> value) =>
+        TryResolvePair(value, out _, out _);
+
+    public static bool TryResolve(
+        ReadOnlySpan<char> value,
+        ElementTheme theme,
+        out string color)
+    {
+        if (!TryResolvePair(value, out var light, out var dark))
+        {
+            color = string.Empty;
+            return false;
+        }
+
+        color = theme == ElementTheme.Dark ? dark : light;
+        return true;
+    }
+
+    public static bool TryResolvePair(
+        ReadOnlySpan<char> value,
+        out string light,
+        out string dark)
+    {
+        if (value.Equals("danger", StringComparison.OrdinalIgnoreCase))
+        {
+            light = "#C42B1C";
+            dark = "#FF99A4";
+            return true;
+        }
+
+        if (value.Equals("subtle", StringComparison.OrdinalIgnoreCase))
+        {
+            light = "#616161";
+            dark = "#C5C5C5";
+            return true;
+        }
+
+        if (value.Equals("info", StringComparison.OrdinalIgnoreCase))
+        {
+            light = "#0067C0";
+            dark = "#60CDFF";
+            return true;
+        }
+
+        if (value.Equals("warning", StringComparison.OrdinalIgnoreCase))
+        {
+            light = "#9D5D00";
+            dark = "#FCE100";
+            return true;
+        }
+
+        if (value.Equals("success", StringComparison.OrdinalIgnoreCase))
+        {
+            light = "#0F7B0F";
+            dark = "#6CCB5F";
+            return true;
+        }
+
+        if (value.Equals("neutral", StringComparison.OrdinalIgnoreCase))
+        {
+            light = "#8A8A8A";
+            dark = "#9D9D9D";
+            return true;
+        }
+
+        if (value.Equals("dark", StringComparison.OrdinalIgnoreCase))
+        {
+            light = "#1B1A19";
+            dark = "#1B1A19";
+            return true;
+        }
+
+        if (value.Equals("normal", StringComparison.OrdinalIgnoreCase))
+        {
+            light = "#000000";
+            dark = "#FFFFFF";
+            return true;
+        }
+
+        if (value.Equals("transparent", StringComparison.OrdinalIgnoreCase))
+        {
+            light = "#00000000";
+            dark = "#00000000";
+            return true;
+        }
+
+        light = string.Empty;
+        dark = string.Empty;
+        return false;
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/SvgPathDataReceiver.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/SvgPathDataReceiver.cs
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Numerics;
+using System.Text;
+using Microsoft.Graphics.Canvas.Geometry;
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+internal sealed partial class SvgPathDataReceiver : ICanvasPathReceiver
+{
+    private readonly StringBuilder _path = new();
+    private bool _includeFigure;
+
+    public string PathData => _path.ToString();
+
+    public bool UseEvenOddFill { get; private set; }
+
+    public void BeginFigure(Vector2 startPoint, CanvasFigureFill figureFill)
+    {
+        _includeFigure = figureFill != CanvasFigureFill.DoesNotAffectFills;
+        if (_includeFigure)
+        {
+            _path.Append('M');
+            AppendPoint(startPoint);
+        }
+    }
+
+    public void AddArc(
+        Vector2 endPoint,
+        float radiusX,
+        float radiusY,
+        float rotationAngle,
+        CanvasSweepDirection sweepDirection,
+        CanvasArcSize arcSize)
+    {
+        if (!_includeFigure)
+        {
+            return;
+        }
+
+        _path.Append('A');
+        AppendNumber(radiusX);
+        _path.Append(' ');
+        AppendNumber(radiusY);
+        _path.Append(' ');
+        AppendNumber(rotationAngle);
+        _path.Append(arcSize == CanvasArcSize.Large ? " 1 " : " 0 ");
+        _path.Append(sweepDirection == CanvasSweepDirection.Clockwise ? "1 " : "0 ");
+        AppendPoint(endPoint);
+    }
+
+    public void AddCubicBezier(Vector2 controlPoint1, Vector2 controlPoint2, Vector2 endPoint)
+    {
+        if (!_includeFigure)
+        {
+            return;
+        }
+
+        _path.Append('C');
+        AppendPoint(controlPoint1);
+        _path.Append(' ');
+        AppendPoint(controlPoint2);
+        _path.Append(' ');
+        AppendPoint(endPoint);
+    }
+
+    public void AddLine(Vector2 endPoint)
+    {
+        if (_includeFigure)
+        {
+            _path.Append('L');
+            AppendPoint(endPoint);
+        }
+    }
+
+    public void AddQuadraticBezier(Vector2 controlPoint, Vector2 endPoint)
+    {
+        if (!_includeFigure)
+        {
+            return;
+        }
+
+        _path.Append('Q');
+        AppendPoint(controlPoint);
+        _path.Append(' ');
+        AppendPoint(endPoint);
+    }
+
+    public void SetFilledRegionDetermination(CanvasFilledRegionDetermination filledRegionDetermination) =>
+        UseEvenOddFill = filledRegionDetermination == CanvasFilledRegionDetermination.Alternate;
+
+    public void SetSegmentOptions(CanvasFigureSegmentOptions figureSegmentOptions)
+    {
+        // Segment options only affect stroking. Initials serialize filled geometry.
+        _ = figureSegmentOptions;
+    }
+
+    public void EndFigure(CanvasFigureLoop figureLoop)
+    {
+        if (_includeFigure && figureLoop == CanvasFigureLoop.Closed)
+        {
+            _path.Append('Z');
+        }
+
+        _includeFigure = false;
+    }
+
+    private void AppendPoint(Vector2 point)
+    {
+        AppendNumber(point.X);
+        _path.Append(' ');
+        AppendNumber(point.Y);
+    }
+
+    private void AppendNumber(float value)
+    {
+        if (MathF.Abs(value) < 0.0005f)
+        {
+            value = 0;
+        }
+
+        _path.Append(value.ToString("0.###", CultureInfo.InvariantCulture));
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/CachedIconSourceProviderTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/CachedIconSourceProviderTests.cs
@@ -215,6 +215,26 @@ public partial class CachedIconSourceProviderTests
 
     [TestMethod]
     [Timeout(5_000)]
+    public async Task CanonicallyEquivalentInitialsShareCacheEntry()
+    {
+        var loader = new ControllableIconLoader();
+        var provider = CreateProvider(loader);
+        var precomposed = new IconDataViewModel { Icon = "|Initials|Å|#0067C0|circle|" };
+        var decomposed = new IconDataViewModel { Icon = "|Initials|A\u030A|#0067C0|circle|" };
+        var percentEncoded = new IconDataViewModel { Icon = "|Initials|%C3%85|#0067C0|circle|" };
+
+        var first = provider.GetIconSource(precomposed, 1.0, theme: ElementTheme.Light);
+        loader.CompleteNext(null);
+        await first;
+        Assert.IsTrue(SpinWait.SpinUntil(() => GetInFlightCount(provider) == 0, TimeSpan.FromSeconds(2)));
+
+        Assert.AreSame(first, provider.GetIconSource(decomposed, 1.0, theme: ElementTheme.Light));
+        Assert.AreSame(first, provider.GetIconSource(percentEncoded, 1.0, theme: ElementTheme.Light));
+        Assert.AreEqual(1, loader.EnqueueCount);
+    }
+
+    [TestMethod]
+    [Timeout(5_000)]
     public async Task FailedLoadIsRemovedAndCanBeRetried()
     {
         var loader = new ControllableIconLoader();

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/GeneratedIconProtocolTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/GeneratedIconProtocolTests.cs
@@ -1,0 +1,259 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+using System.Xml.Linq;
+using Microsoft.CmdPal.UI.Helpers;
+using Microsoft.UI.Xaml;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.UI.UnitTests;
+
+[TestClass]
+public class GeneratedIconProtocolTests
+{
+    [DataTestMethod]
+    [DataRow("|Swatch|#07A|", "#0077AA", null)]
+    [DataRow("|Swatch|#807A|", "#0077AA", "0.533")]
+    [DataRow("|Swatch|#102030", "#102030", null)]
+    [DataRow("|Swatch|#80102030|", "#102030", "0.502")]
+    public void SwatchSupportsXamlHexColorForms(string value, string expectedFill, string? expectedOpacity)
+    {
+        Assert.IsTrue(GeneratedIconProtocol.TryCreateSwatchSvg(value, ElementTheme.Light, out var svg));
+
+        var shape = ParseSvg(svg).Element(SvgName("circle"));
+        Assert.IsNotNull(shape);
+        Assert.AreEqual(expectedFill, shape.Attribute("fill")?.Value);
+        Assert.AreEqual(expectedOpacity, shape.Attribute("fill-opacity")?.Value);
+        Assert.AreEqual("12", shape.Attribute("r")?.Value);
+    }
+
+    [TestMethod]
+    public void ThemeAwareSwatchSelectsThemeColorAndUsesThemeInCacheIdentity()
+    {
+        const string Value = "|Swatch|#FF0067C0|#FF60CDFF|";
+
+        Assert.IsTrue(GeneratedIconProtocol.TryCreateSwatchSvg(Value, ElementTheme.Light, out var lightSvg));
+        Assert.IsTrue(GeneratedIconProtocol.TryCreateSwatchSvg(Value, ElementTheme.Dark, out var darkSvg));
+
+        Assert.AreEqual("#0067C0", GetBackgroundFill(lightSvg));
+        Assert.AreEqual("#60CDFF", GetBackgroundFill(darkSvg));
+        Assert.AreEqual(ElementTheme.Light, GeneratedIconProtocol.GetCacheTheme(Value, ElementTheme.Light));
+        Assert.AreEqual(ElementTheme.Dark, GeneratedIconProtocol.GetCacheTheme(Value, ElementTheme.Dark));
+        Assert.AreEqual(ElementTheme.Light, GeneratedIconProtocol.GetCacheTheme(Value, ElementTheme.Default));
+    }
+
+    [TestMethod]
+    public void SingleColorSwatchSharesCacheIdentityAcrossThemes()
+    {
+        const string Value = "|Swatch|#0067C0|";
+
+        Assert.AreEqual(ElementTheme.Default, GeneratedIconProtocol.GetCacheTheme(Value, ElementTheme.Light));
+        Assert.AreEqual(ElementTheme.Default, GeneratedIconProtocol.GetCacheTheme(Value, ElementTheme.Dark));
+    }
+
+    [TestMethod]
+    public async Task TranslucentInitialsUsesThemeForContrastAndCacheIdentity()
+    {
+        const string Value = "|Initials|AB|#80000000|rounded|";
+
+        var lightSvg = await CreateSvgAsync(Value, ElementTheme.Light);
+        var darkSvg = await CreateSvgAsync(Value, ElementTheme.Dark);
+
+        Assert.AreEqual("#000000", GetForegroundFill(lightSvg));
+        Assert.AreEqual("#FFFFFF", GetForegroundFill(darkSvg));
+        Assert.AreEqual(ElementTheme.Light, GeneratedIconProtocol.GetCacheTheme(Value, ElementTheme.Light));
+        Assert.AreEqual(ElementTheme.Dark, GeneratedIconProtocol.GetCacheTheme(Value, ElementTheme.Dark));
+    }
+
+    [TestMethod]
+    public async Task InitialsSupportsCircleRoundedSquareAndVectorGlyphs()
+    {
+        var circleSvg = await CreateSvgAsync(
+            "|Initials|a|#FFFFFFFF|circle|",
+            ElementTheme.Light);
+        var roundedSvg = await CreateSvgAsync(
+            "|Initials|CP|#FF005FB8|#FF60CDFF|rounded|",
+            ElementTheme.Dark);
+
+        var circle = ParseSvg(circleSvg);
+        Assert.IsNotNull(circle.Element(SvgName("circle")));
+        Assert.IsFalse(string.IsNullOrEmpty(circle.Element(SvgName("path"))?.Attribute("d")?.Value));
+        Assert.AreEqual("#000000", circle.Element(SvgName("path"))?.Attribute("fill")?.Value);
+
+        var rounded = ParseSvg(roundedSvg);
+        Assert.IsNotNull(rounded.Element(SvgName("rect")));
+        Assert.AreEqual("#60CDFF", rounded.Element(SvgName("rect"))?.Attribute("fill")?.Value);
+        Assert.IsFalse(string.IsNullOrEmpty(rounded.Element(SvgName("path"))?.Attribute("d")?.Value));
+    }
+
+    [DataTestMethod]
+    [DataRow("Æ")]
+    [DataRow("Ж")]
+    [DataRow("Ω")]
+    [DataRow("東")]
+    [DataRow("ش")]
+    [DataRow("A\u030A")]
+    [DataRow("👩‍💻")]
+    [DataRow("👩‍💻Å東")]
+    public async Task InitialsSupportsOneToThreeUnicodeTextElements(string initials)
+    {
+        var svg = await CreateSvgAsync($"|Initials|{initials}|#0067C0|circle|", ElementTheme.Light);
+
+        var path = ParseSvg(svg).Element(SvgName("path"));
+        Assert.IsNotNull(path);
+        Assert.IsFalse(string.IsNullOrEmpty(path.Attribute("d")?.Value));
+        Assert.IsFalse(Encoding.UTF8.GetString(svg).Contains("<text", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public async Task InitialsPercentEncodingDistinguishesSeparatorAndPercentText()
+    {
+        const string Separator = "|Initials|A%7CB|#0F7B0F|rounded|";
+        const string Percent = "|Initials|%25|#0F7B0F|rounded|";
+
+        var separatorSvg = await CreateSvgAsync(Separator, ElementTheme.Light);
+        var percentSvg = await CreateSvgAsync(Percent, ElementTheme.Light);
+
+        Assert.IsNotNull(ParseSvg(separatorSvg).Element(SvgName("path")));
+        Assert.IsNotNull(ParseSvg(percentSvg).Element(SvgName("path")));
+        Assert.AreNotEqual(
+            GeneratedIconProtocol.GetCacheIdentity(Separator),
+            GeneratedIconProtocol.GetCacheIdentity(Percent));
+    }
+
+    [TestMethod]
+    public void InitialsCacheIdentityUsesCanonicalUnicodeAndEscaping()
+    {
+        const string Precomposed = "|Initials|Å|#0067C0|circle|";
+        const string Decomposed = "|Initials|A\u030A|#0067C0|circle|";
+        const string EscapedPrecomposed = "|Initials|%C3%85|#0067C0|circle|";
+        const string CanonicalAscii = "|Initials|JP|#0067C0|circle|";
+        const string LowercaseAscii = "|Initials|jp|#0067C0|circle|";
+        const string PaddedAscii = "|Initials| JP |#0067C0|circle|";
+
+        var expected = GeneratedIconProtocol.GetCacheIdentity(Precomposed);
+        Assert.AreEqual(expected, GeneratedIconProtocol.GetCacheIdentity(Decomposed));
+        Assert.AreEqual(expected, GeneratedIconProtocol.GetCacheIdentity(EscapedPrecomposed));
+        StringAssert.Contains(
+            GeneratedIconProtocol.GetCacheIdentity("|Initials|A%7CB|#0067C0|circle|"),
+            "A%7CB");
+        StringAssert.Contains(
+            GeneratedIconProtocol.GetCacheIdentity("|Initials|%25|#0067C0|circle|"),
+            "%25");
+        Assert.AreEqual(
+            GeneratedIconProtocol.GetCacheIdentity(CanonicalAscii),
+            GeneratedIconProtocol.GetCacheIdentity(LowercaseAscii));
+        Assert.AreEqual(
+            GeneratedIconProtocol.GetCacheIdentity(CanonicalAscii),
+            GeneratedIconProtocol.GetCacheIdentity(PaddedAscii));
+    }
+
+    [DataTestMethod]
+    [DataRow("|Swatch|#fff|", "|Swatch|#FFF|")]
+    [DataRow("|Swatch|#abcdef|#a1b2c3|", "|Swatch|#ABCDEF|#A1B2C3|")]
+    [DataRow("|Initials|CP|#fff|CIRCLE|", "|Initials|CP|#FFF|circle|")]
+    [DataRow("|Initials|cp|#abcdef|CIRCLE|", "|Initials|CP|#ABCDEF|circle|")]
+    public void EquivalentGeneratedStyleTokensShareCacheIdentity(string value, string canonical)
+    {
+        Assert.AreEqual(canonical, GeneratedIconProtocol.GetCacheIdentity(value));
+        Assert.AreEqual(
+            GeneratedIconProtocol.GetCacheIdentity(canonical),
+            GeneratedIconProtocol.GetCacheIdentity(value));
+    }
+
+    [DataTestMethod]
+    [DataRow("|Swatch|#FFF|")]
+    [DataRow("|Swatch|#ABCDEF|#A1B2C3|")]
+    [DataRow("|Initials|A|#0067C0|circle|")]
+    [DataRow("|Initials|AB|#0067C0|rounded|")]
+    [DataRow("|Initials|JP|#0067C0|circle|")]
+    [DataRow("|Initials|123|#0067C0|rounded|")]
+    public void CanonicalGeneratedIdentitiesReuseInput(string value)
+    {
+        Assert.AreSame(value, GeneratedIconProtocol.GetCacheIdentity(value));
+    }
+
+    [TestMethod]
+    public async Task MissingInitialsFontDegradesToBackgroundTile()
+    {
+        var svg = await CreateSvgAsync("|Initials|\U0010FFFF|#C42B1C|rounded|", ElementTheme.Light);
+        var root = ParseSvg(svg);
+
+        Assert.IsNotNull(root.Element(SvgName("rect")));
+        Assert.IsNull(root.Element(SvgName("path")));
+    }
+
+    [DataTestMethod]
+    [DataRow(null)]
+    [DataRow("")]
+    [DataRow("|Swatch|")]
+    [DataRow("|Swatch|red|")]
+    [DataRow("|Swatch|#12345|")]
+    [DataRow("|Swatch|#123456|#654321|#ABCDEF|")]
+    [DataRow("|swatch|#123456|")]
+    [DataRow("|Initials||#123456|")]
+    [DataRow("|Initials|TOOLONG|#123456|")]
+    [DataRow("|Initials|ABCD|#123456|")]
+    [DataRow("|Initials|A%|#123456|")]
+    [DataRow("|Initials|A%7|#123456|")]
+    [DataRow("|Initials|A%XX|#123456|")]
+    [DataRow("|Initials|%C3|#123456|")]
+    [DataRow("|Initials|%FF|#123456|")]
+    [DataRow("|Initials|%F0%9F%91|#123456|")]
+    [DataRow("|Initials|AB|#123456|triangle|")]
+    [DataRow("|Initials|AB|#123456|#654321|rounded|extra|")]
+    public async Task InvalidProtocolIsRejected(string? value)
+    {
+        var (success, svg) = await TryCreateSvgAsync(value, ElementTheme.Light);
+        Assert.IsFalse(success);
+        Assert.AreEqual(0, svg.Length);
+    }
+
+    private static async Task<byte[]> CreateSvgAsync(string value, ElementTheme theme)
+    {
+        var (success, svg) = await TryCreateSvgAsync(value, theme);
+        Assert.IsTrue(success);
+        return svg;
+    }
+
+    private static async Task<(bool Success, byte[] Svg)> TryCreateSvgAsync(
+        string? value,
+        ElementTheme theme)
+    {
+        var processor = IconProtocolRegistry.Find(value);
+        if (processor is null)
+        {
+            return (false, []);
+        }
+
+        IconPathConverter.PreparedIcon? preparedIcon;
+        if (!processor.TryPrepareSynchronously(value!, 32, theme, out preparedIcon))
+        {
+            using var result = await processor.PrepareAsync(value!, 32, theme);
+            preparedIcon = result.TakePreparedIcon();
+        }
+
+        using (preparedIcon)
+        {
+            return preparedIcon?.Kind == IconPathConverter.PreparedIconKind.SvgData
+                && preparedIcon.SvgData is { Length: > 0 } svg
+                    ? (true, svg)
+                    : (false, []);
+        }
+    }
+
+    private static XElement ParseSvg(byte[] svg) => XDocument.Parse(Encoding.UTF8.GetString(svg)).Root!;
+
+    private static string? GetBackgroundFill(byte[] svg)
+    {
+        var root = ParseSvg(svg);
+        return (root.Element(SvgName("circle")) ?? root.Element(SvgName("rect")))?.Attribute("fill")?.Value;
+    }
+
+    private static string? GetForegroundFill(byte[] svg) =>
+        ParseSvg(svg).Element(SvgName("path"))?.Attribute("fill")?.Value;
+
+    private static XName SvgName(string localName) => XName.Get(localName, "http://www.w3.org/2000/svg");
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/GeneratedIconProtocolTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/GeneratedIconProtocolTests.cs
@@ -26,13 +26,13 @@ public class GeneratedIconProtocolTests
         Assert.IsNotNull(shape);
         Assert.AreEqual(expectedFill, shape.Attribute("fill")?.Value);
         Assert.AreEqual(expectedOpacity, shape.Attribute("fill-opacity")?.Value);
-        Assert.AreEqual("12", shape.Attribute("r")?.Value);
+        Assert.AreEqual("15.5", shape.Attribute("r")?.Value);
     }
 
     [TestMethod]
     public void ThemeAwareSwatchSelectsThemeColorAndUsesThemeInCacheIdentity()
     {
-        const string Value = "|Swatch|#FF0067C0|#FF60CDFF|";
+        const string Value = "|Swatch|#FF0067C0|#FF60CDFF|square|";
 
         Assert.IsTrue(GeneratedIconProtocol.TryCreateSwatchSvg(Value, ElementTheme.Light, out var lightSvg));
         Assert.IsTrue(GeneratedIconProtocol.TryCreateSwatchSvg(Value, ElementTheme.Dark, out var darkSvg));
@@ -53,10 +53,66 @@ public class GeneratedIconProtocolTests
         Assert.AreEqual(ElementTheme.Default, GeneratedIconProtocol.GetCacheTheme(Value, ElementTheme.Dark));
     }
 
+    [DataTestMethod]
+    [DataRow("danger", "#C42B1C", "#FF99A4", true, null)]
+    [DataRow("subtle", "#616161", "#C5C5C5", true, null)]
+    [DataRow("info", "#0067C0", "#60CDFF", true, null)]
+    [DataRow("warning", "#9D5D00", "#FCE100", true, null)]
+    [DataRow("success", "#0F7B0F", "#6CCB5F", true, null)]
+    [DataRow("neutral", "#8A8A8A", "#9D9D9D", true, null)]
+    [DataRow("dark", "#1B1A19", "#1B1A19", false, null)]
+    [DataRow("normal", "#000000", "#FFFFFF", true, null)]
+    [DataRow("transparent", "#000000", "#000000", false, "0")]
+    public void SwatchSupportsSemanticColors(
+        string semanticColor,
+        string expectedLight,
+        string expectedDark,
+        bool isThemeDependent,
+        string? expectedOpacity)
+    {
+        var value = $"|Swatch|{semanticColor}|square|";
+
+        Assert.IsTrue(GeneratedIconProtocol.TryCreateSwatchSvg(value, ElementTheme.Light, out var lightSvg));
+        Assert.IsTrue(GeneratedIconProtocol.TryCreateSwatchSvg(value, ElementTheme.Dark, out var darkSvg));
+
+        Assert.AreEqual(expectedLight, GetBackgroundFill(lightSvg));
+        Assert.AreEqual(expectedDark, GetBackgroundFill(darkSvg));
+        Assert.AreEqual(expectedOpacity, GetBackgroundOpacity(lightSvg));
+        Assert.AreEqual(expectedOpacity, GetBackgroundOpacity(darkSvg));
+        Assert.IsNotNull(ParseSvg(lightSvg).Element(SvgName("rect")));
+        Assert.AreEqual(
+            isThemeDependent ? ElementTheme.Light : ElementTheme.Default,
+            GeneratedIconProtocol.GetCacheTheme(value, ElementTheme.Light));
+        Assert.AreEqual(
+            isThemeDependent ? ElementTheme.Dark : ElementTheme.Default,
+            GeneratedIconProtocol.GetCacheTheme(value, ElementTheme.Dark));
+    }
+
+    [TestMethod]
+    public async Task InitialsSupportsNormalAndTransparentSemanticBackgrounds()
+    {
+        const string Normal = "|Initials|N|normal|circle|";
+        const string Transparent = "|Initials|T|transparent|square|";
+
+        var normalLight = await CreateSvgAsync(Normal, ElementTheme.Light);
+        var normalDark = await CreateSvgAsync(Normal, ElementTheme.Dark);
+        Assert.AreEqual("#000000", GetBackgroundFill(normalLight));
+        Assert.AreEqual("#FFFFFF", GetBackgroundFill(normalDark));
+        Assert.AreEqual("#FFFFFF", GetForegroundFill(normalLight));
+        Assert.AreEqual("#000000", GetForegroundFill(normalDark));
+
+        var transparentLight = await CreateSvgAsync(Transparent, ElementTheme.Light);
+        var transparentDark = await CreateSvgAsync(Transparent, ElementTheme.Dark);
+        Assert.AreEqual("0", GetBackgroundOpacity(transparentLight));
+        Assert.AreEqual("0", GetBackgroundOpacity(transparentDark));
+        Assert.AreEqual("#000000", GetForegroundFill(transparentLight));
+        Assert.AreEqual("#FFFFFF", GetForegroundFill(transparentDark));
+    }
+
     [TestMethod]
     public async Task TranslucentInitialsUsesThemeForContrastAndCacheIdentity()
     {
-        const string Value = "|Initials|AB|#80000000|rounded|";
+        const string Value = "|Initials|AB|#80000000|square|";
 
         var lightSvg = await CreateSvgAsync(Value, ElementTheme.Light);
         var darkSvg = await CreateSvgAsync(Value, ElementTheme.Dark);
@@ -68,13 +124,13 @@ public class GeneratedIconProtocolTests
     }
 
     [TestMethod]
-    public async Task InitialsSupportsCircleRoundedSquareAndVectorGlyphs()
+    public async Task InitialsSupportsCircleSquareAndVectorGlyphs()
     {
         var circleSvg = await CreateSvgAsync(
             "|Initials|a|#FFFFFFFF|circle|",
             ElementTheme.Light);
-        var roundedSvg = await CreateSvgAsync(
-            "|Initials|CP|#FF005FB8|#FF60CDFF|rounded|",
+        var squareSvg = await CreateSvgAsync(
+            "|Initials|CP|#FF005FB8|#FF60CDFF|square|",
             ElementTheme.Dark);
 
         var circle = ParseSvg(circleSvg);
@@ -82,10 +138,23 @@ public class GeneratedIconProtocolTests
         Assert.IsFalse(string.IsNullOrEmpty(circle.Element(SvgName("path"))?.Attribute("d")?.Value));
         Assert.AreEqual("#000000", circle.Element(SvgName("path"))?.Attribute("fill")?.Value);
 
-        var rounded = ParseSvg(roundedSvg);
-        Assert.IsNotNull(rounded.Element(SvgName("rect")));
-        Assert.AreEqual("#60CDFF", rounded.Element(SvgName("rect"))?.Attribute("fill")?.Value);
-        Assert.IsFalse(string.IsNullOrEmpty(rounded.Element(SvgName("path"))?.Attribute("d")?.Value));
+        var square = ParseSvg(squareSvg);
+        Assert.IsNotNull(square.Element(SvgName("rect")));
+        Assert.AreEqual("#60CDFF", square.Element(SvgName("rect"))?.Attribute("fill")?.Value);
+        Assert.IsFalse(string.IsNullOrEmpty(square.Element(SvgName("path"))?.Attribute("d")?.Value));
+    }
+
+    [TestMethod]
+    public async Task SwatchAndInitialsShareCircleAndSquareBackgroundGeometry()
+    {
+        Assert.IsTrue(GeneratedIconProtocol.TryCreateSwatchSvg("|Swatch|#0067C0|", ElementTheme.Light, out var circleSwatch));
+        var circleInitials = await CreateSvgAsync("|Initials|A|#0067C0|", ElementTheme.Light);
+        Assert.IsTrue(GeneratedIconProtocol.TryCreateSwatchSvg("|Swatch|#0067C0|square|", ElementTheme.Light, out var squareSwatch));
+        var squareInitials = await CreateSvgAsync("|Initials|A|#0067C0|square|", ElementTheme.Light);
+
+        Assert.AreEqual(GetBackgroundGeometry(circleSwatch), GetBackgroundGeometry(circleInitials));
+        Assert.AreEqual(GetBackgroundGeometry(squareSwatch), GetBackgroundGeometry(squareInitials));
+        Assert.AreNotEqual(GetBackgroundGeometry(circleSwatch), GetBackgroundGeometry(squareSwatch));
     }
 
     [DataTestMethod]
@@ -110,8 +179,8 @@ public class GeneratedIconProtocolTests
     [TestMethod]
     public async Task InitialsPercentEncodingDistinguishesSeparatorAndPercentText()
     {
-        const string Separator = "|Initials|A%7CB|#0F7B0F|rounded|";
-        const string Percent = "|Initials|%25|#0F7B0F|rounded|";
+        const string Separator = "|Initials|A%7CB|#0F7B0F|square|";
+        const string Percent = "|Initials|%25|#0F7B0F|square|";
 
         var separatorSvg = await CreateSvgAsync(Separator, ElementTheme.Light);
         var percentSvg = await CreateSvgAsync(Percent, ElementTheme.Light);
@@ -153,8 +222,10 @@ public class GeneratedIconProtocolTests
     [DataTestMethod]
     [DataRow("|Swatch|#fff|", "|Swatch|#FFF|")]
     [DataRow("|Swatch|#abcdef|#a1b2c3|", "|Swatch|#ABCDEF|#A1B2C3|")]
+    [DataRow("|Swatch|INFO|SQUARE|", "|Swatch|info|square|")]
     [DataRow("|Initials|CP|#fff|CIRCLE|", "|Initials|CP|#FFF|circle|")]
     [DataRow("|Initials|cp|#abcdef|CIRCLE|", "|Initials|CP|#ABCDEF|circle|")]
+    [DataRow("|Initials|CP|WARNING|SQUARE|", "|Initials|CP|warning|square|")]
     public void EquivalentGeneratedStyleTokensShareCacheIdentity(string value, string canonical)
     {
         Assert.AreEqual(canonical, GeneratedIconProtocol.GetCacheIdentity(value));
@@ -166,10 +237,12 @@ public class GeneratedIconProtocolTests
     [DataTestMethod]
     [DataRow("|Swatch|#FFF|")]
     [DataRow("|Swatch|#ABCDEF|#A1B2C3|")]
+    [DataRow("|Swatch|info|square|")]
     [DataRow("|Initials|A|#0067C0|circle|")]
-    [DataRow("|Initials|AB|#0067C0|rounded|")]
+    [DataRow("|Initials|AB|#0067C0|square|")]
     [DataRow("|Initials|JP|#0067C0|circle|")]
-    [DataRow("|Initials|123|#0067C0|rounded|")]
+    [DataRow("|Initials|123|#0067C0|square|")]
+    [DataRow("|Initials|CP|warning|square|")]
     public void CanonicalGeneratedIdentitiesReuseInput(string value)
     {
         Assert.AreSame(value, GeneratedIconProtocol.GetCacheIdentity(value));
@@ -178,7 +251,7 @@ public class GeneratedIconProtocolTests
     [TestMethod]
     public async Task MissingInitialsFontDegradesToBackgroundTile()
     {
-        var svg = await CreateSvgAsync("|Initials|\U0010FFFF|#C42B1C|rounded|", ElementTheme.Light);
+        var svg = await CreateSvgAsync("|Initials|\U0010FFFF|#C42B1C|square|", ElementTheme.Light);
         var root = ParseSvg(svg);
 
         Assert.IsNotNull(root.Element(SvgName("rect")));
@@ -191,6 +264,7 @@ public class GeneratedIconProtocolTests
     [DataRow("|Swatch|")]
     [DataRow("|Swatch|red|")]
     [DataRow("|Swatch|#12345|")]
+    [DataRow("|Swatch|#123456|triangle|")]
     [DataRow("|Swatch|#123456|#654321|#ABCDEF|")]
     [DataRow("|swatch|#123456|")]
     [DataRow("|Initials||#123456|")]
@@ -203,7 +277,8 @@ public class GeneratedIconProtocolTests
     [DataRow("|Initials|%FF|#123456|")]
     [DataRow("|Initials|%F0%9F%91|#123456|")]
     [DataRow("|Initials|AB|#123456|triangle|")]
-    [DataRow("|Initials|AB|#123456|#654321|rounded|extra|")]
+    [DataRow("|Initials|AB|unknown|circle|")]
+    [DataRow("|Initials|AB|#123456|#654321|square|extra|")]
     public async Task InvalidProtocolIsRejected(string? value)
     {
         var (success, svg) = await TryCreateSvgAsync(value, ElementTheme.Light);
@@ -252,8 +327,32 @@ public class GeneratedIconProtocolTests
         return (root.Element(SvgName("circle")) ?? root.Element(SvgName("rect")))?.Attribute("fill")?.Value;
     }
 
+    private static string? GetBackgroundOpacity(byte[] svg)
+    {
+        var root = ParseSvg(svg);
+        return (root.Element(SvgName("circle")) ?? root.Element(SvgName("rect")))?.Attribute("fill-opacity")?.Value;
+    }
+
     private static string? GetForegroundFill(byte[] svg) =>
         ParseSvg(svg).Element(SvgName("path"))?.Attribute("fill")?.Value;
+
+    private static string GetBackgroundGeometry(byte[] svg)
+    {
+        var root = ParseSvg(svg);
+        var background = root.Element(SvgName("circle")) ?? root.Element(SvgName("rect"));
+        Assert.IsNotNull(background);
+
+        var geometry = background.Name.LocalName;
+        foreach (var attribute in background.Attributes())
+        {
+            if (attribute.Name.LocalName is not "fill" and not "fill-opacity")
+            {
+                geometry += $"|{attribute.Name.LocalName}={attribute.Value}";
+            }
+        }
+
+        return geometry;
+    }
 
     private static XName SvgName(string localName) => XName.Get(localName, "http://www.w3.org/2000/svg");
 }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/GeneratedIconProtocolTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/GeneratedIconProtocolTests.cs
@@ -13,6 +13,13 @@ namespace Microsoft.CmdPal.UI.UnitTests;
 [TestClass]
 public class GeneratedIconProtocolTests
 {
+    private const string TestInitialsPathData = "M4 4H28V28H4Z";
+
+    // Protocol serialization must not depend on graphics or installed fonts. The
+    // processor integration tests exercise the real renderer and its tile fallback.
+    private static readonly GeneratedIconProtocolProcessor TestProcessor = new(TryCreateTestInitialsPathData);
+    private static readonly IIconProtocolProcessor[] TestProcessors = [TestProcessor];
+
     [DataTestMethod]
     [DataRow("|Swatch|#07A|", "#0077AA", null)]
     [DataRow("|Swatch|#807A|", "#0077AA", "0.533")]
@@ -297,7 +304,7 @@ public class GeneratedIconProtocolTests
         string? value,
         ElementTheme theme)
     {
-        var processor = IconProtocolRegistry.Find(value);
+        var processor = IconProtocolRegistry.Find(value, TestProcessors);
         if (processor is null)
         {
             return (false, []);
@@ -352,6 +359,22 @@ public class GeneratedIconProtocolTests
         }
 
         return geometry;
+    }
+
+    private static bool TryCreateTestInitialsPathData(
+        string text,
+        out string pathData,
+        out bool useEvenOddFill)
+    {
+        useEvenOddFill = false;
+        if (text == "\U0010FFFF")
+        {
+            pathData = string.Empty;
+            return false;
+        }
+
+        pathData = TestInitialsPathData;
+        return true;
     }
 
     private static XName SvgName(string localName) => XName.Get(localName, "http://www.w3.org/2000/svg");

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconLoadDiagnosticsTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconLoadDiagnosticsTests.cs
@@ -246,7 +246,7 @@ public class IconLoadDiagnosticsTests
 
     [DataTestMethod]
     [DataRow("|Swatch|#FF0067C0|", "GeneratedSwatch")]
-    [DataRow("|Initials|CP|#FF005FB8|rounded|", "GeneratedInitials")]
+    [DataRow("|Initials|CP|#FF005FB8|square|", "GeneratedInitials")]
     public void GeneratedIconProtocolUsesSpecificInputKind(string icon, string expectedKind)
     {
         IconLoadDiagnostics.Start();

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconLoadDiagnosticsTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconLoadDiagnosticsTests.cs
@@ -244,6 +244,34 @@ public class IconLoadDiagnosticsTests
         Assert.IsFalse(report.Text.Contains("shell32", StringComparison.OrdinalIgnoreCase));
     }
 
+    [DataTestMethod]
+    [DataRow("|Swatch|#FF0067C0|", "GeneratedSwatch")]
+    [DataRow("|Initials|CP|#FF005FB8|rounded|", "GeneratedInitials")]
+    public void GeneratedIconProtocolUsesSpecificInputKind(string icon, string expectedKind)
+    {
+        IconLoadDiagnostics.Start();
+        var request = IconLoadDiagnostics.BeginRequest(IconRequestReason.SourceChanged, 1.0);
+        var load = IconLoadDiagnostics.CreateLoad(
+            request,
+            icon,
+            hasStream: false,
+            width: 20,
+            height: 20,
+            scale: 1.0);
+
+        Assert.IsNotNull(load);
+        request.RecordProviderResolution(IconProviderResolution.NewLoad, load);
+        load.SetResult(null);
+        load.Complete();
+        request.Complete(IconRequestStatus.Empty);
+
+        var report = IconLoadDiagnostics.StopAndCreateReport();
+
+        Assert.IsNotNull(report);
+        StringAssert.Contains(report.Text, $"  {expectedKind}: 1");
+        Assert.IsFalse(report.Text.Contains(icon, StringComparison.Ordinal));
+    }
+
     [TestMethod]
     [Timeout(5_000)]
     public async Task SchedulerReportCapturesCoordinatorAndWorkerHandoff()

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconPathConverterTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconPathConverterTests.cs
@@ -2,7 +2,9 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Text;
 using Microsoft.CmdPal.UI.Helpers;
+using Microsoft.UI.Xaml;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Windows.Graphics.Imaging;
 
@@ -124,6 +126,18 @@ public class IconPathConverterTests
             [missingExecutable, "|AppIcon|", "not a glyph"],
             null,
             20);
+
+        Assert.AreEqual(IconPathConverter.PreparedIconKind.Empty, prepared.Kind);
+    }
+
+    [TestMethod]
+    public void GeneratedInitialsDoNotShapeInSynchronousConverter()
+    {
+        using var prepared = IconPathConverter.Prepare(
+            "|Initials|CP|#FF005FB8|#FF60CDFF|rounded|",
+            null,
+            20,
+            ElementTheme.Dark);
 
         Assert.AreEqual(IconPathConverter.PreparedIconKind.Empty, prepared.Kind);
     }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconPathConverterTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconPathConverterTests.cs
@@ -134,7 +134,7 @@ public class IconPathConverterTests
     public void GeneratedInitialsDoNotShapeInSynchronousConverter()
     {
         using var prepared = IconPathConverter.Prepare(
-            "|Initials|CP|#FF005FB8|#FF60CDFF|rounded|",
+            "|Initials|CP|#FF005FB8|#FF60CDFF|square|",
             null,
             20,
             ElementTheme.Dark);

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconPresentationStateTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconPresentationStateTests.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CmdPal.UI.Controls;
+using Microsoft.CmdPal.UI.Helpers;
+using Microsoft.UI.Xaml;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.CmdPal.UI.UnitTests;
@@ -63,5 +65,35 @@ public class IconPresentationStateTests
 
         Assert.IsNull(state.RequestFallback);
         Assert.IsNull(state.SelectSource(preferFallbackForResolvedSource: false));
+    }
+
+    [TestMethod]
+    public async Task AsyncInitialsUsesPlacementFallbackUntilResolution()
+    {
+        const string Value = "|Initials|Å|info|circle|";
+        var state = new IconPresentationState<string>
+        {
+            PlacementFallback = "placement",
+        };
+        state.SetResolvedSource("recycled", expectsImageSource: true);
+
+        state.BeginSourceChange();
+        Assert.IsFalse(GeneratedIconProtocolProcessor.Instance.TryPrepareSynchronously(
+            Value,
+            20,
+            ElementTheme.Light,
+            out var synchronousIcon));
+        Assert.IsNull(synchronousIcon);
+        Assert.AreEqual("placement", state.SelectSource(preferFallbackForResolvedSource: false));
+
+        using var result = await GeneratedIconProtocolProcessor.Instance.PrepareAsync(
+            Value,
+            20,
+            ElementTheme.Light);
+        using var preparedIcon = result.TakePreparedIcon();
+        Assert.IsNotNull(preparedIcon);
+        state.SetResolvedSource("initials", expectsImageSource: true);
+
+        Assert.AreEqual("initials", state.SelectSource(preferFallbackForResolvedSource: false));
     }
 }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconProtocolRegistryTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/IconProtocolRegistryTests.cs
@@ -40,6 +40,58 @@ public class IconProtocolRegistryTests
     }
 
     [DataTestMethod]
+    [DataRow("|Swatch|#FF0067C0|", "GeneratedSwatch", true)]
+    [DataRow("|Initials|CP|#FF0067C0|circle|", "GeneratedInitials", false)]
+    public void BuiltInRegistryFindsGeneratedIconProcessor(
+        string value,
+        string inputKind,
+        bool preparesSynchronously)
+    {
+        var processor = IconProtocolRegistry.Find(value);
+
+        Assert.IsNotNull(processor);
+        Assert.AreSame(GeneratedIconProtocolProcessor.Instance, processor);
+        Assert.AreEqual(IconCachePartition.Other, processor.CachePartition);
+        Assert.AreEqual(inputKind, processor.ClassifyInput(value).ToString());
+        Assert.AreEqual(preparesSynchronously, processor.TryPrepareSynchronously(
+            value,
+            20,
+            ElementTheme.Light,
+            out var preparedIcon));
+        using (preparedIcon)
+        {
+            if (preparesSynchronously)
+            {
+                Assert.AreEqual(IconPathConverter.PreparedIconKind.SvgData, preparedIcon!.Kind);
+            }
+            else
+            {
+                Assert.IsNull(preparedIcon);
+            }
+        }
+    }
+
+    [TestMethod]
+    public async Task InitialsPreparationRunsThroughAsyncProcessorPath()
+    {
+        const string Value = "|Initials|CP|#FF0067C0|circle|";
+        var processor = IconProtocolRegistry.Find(Value);
+
+        Assert.IsNotNull(processor);
+        Assert.IsFalse(processor.TryPrepareSynchronously(
+            Value,
+            20,
+            ElementTheme.Light,
+            out var synchronousIcon));
+        Assert.IsNull(synchronousIcon);
+
+        using var result = await processor.PrepareAsync(Value, 20, ElementTheme.Light);
+        using var preparedIcon = result.TakePreparedIcon();
+        Assert.IsNotNull(preparedIcon);
+        Assert.AreEqual(IconPathConverter.PreparedIconKind.SvgData, preparedIcon.Kind);
+    }
+
+    [DataTestMethod]
     [DataRow(null)]
     [DataRow("")]
     [DataRow("\uE700")]
@@ -149,6 +201,8 @@ public class IconProtocolRegistryTests
                 return _prefixes;
             }
         }
+
+        public string GetCacheIdentity(string value) => value;
 
         public ElementTheme GetCacheTheme(string value, ElementTheme theme) => ElementTheme.Default;
 

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/Microsoft.CmdPal.UI.UnitTests.csproj
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/Microsoft.CmdPal.UI.UnitTests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="MSTest" />
+    <PackageReference Include="Microsoft.Graphics.Win2D" />
     <PackageReference Include="System.Drawing.Common" />
   </ItemGroup>
 
@@ -38,6 +39,10 @@
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\FontIconGlyphClassifier.cs" Link="Helpers\Icons\FontIconGlyphClassifier.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\FontIconGlyphKind.cs" Link="Helpers\Icons\FontIconGlyphKind.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\FontIconSizeCalculator.cs" Link="Helpers\Icons\FontIconSizeCalculator.cs" />
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\GeneratedIconProtocol.cs" Link="Helpers\Icons\GeneratedIconProtocol.cs" />
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\GeneratedIconProtocolProcessor.cs" Link="Helpers\Icons\GeneratedIconProtocolProcessor.cs" />
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\InitialsTextRenderer.cs" Link="Helpers\Icons\InitialsTextRenderer.cs" />
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\SvgPathDataReceiver.cs" Link="Helpers\Icons\SvgPathDataReceiver.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconCachePartition.cs" Link="Helpers\Icons\IconCachePartition.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconLoadDemand.cs" Link="Helpers\Icons\IconLoadDemand.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconLoadDemandStage.cs" Link="Helpers\Icons\IconLoadDemandStage.cs" />

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/Microsoft.CmdPal.UI.UnitTests.csproj
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/Microsoft.CmdPal.UI.UnitTests.csproj
@@ -42,6 +42,7 @@
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\GeneratedIconProtocol.cs" Link="Helpers\Icons\GeneratedIconProtocol.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\GeneratedIconProtocolProcessor.cs" Link="Helpers\Icons\GeneratedIconProtocolProcessor.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\InitialsTextRenderer.cs" Link="Helpers\Icons\InitialsTextRenderer.cs" />
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\SemanticIconColor.cs" Link="Helpers\Icons\SemanticIconColor.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\SvgPathDataReceiver.cs" Link="Helpers\Icons\SvgPathDataReceiver.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconCachePartition.cs" Link="Helpers\Icons\IconCachePartition.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\IconLoadDemand.cs" Link="Helpers\Icons\IconLoadDemand.cs" />

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/Microsoft.CmdPal.UI.UnitTests.csproj
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.UnitTests/Microsoft.CmdPal.UI.UnitTests.csproj
@@ -41,6 +41,7 @@
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\FontIconSizeCalculator.cs" Link="Helpers\Icons\FontIconSizeCalculator.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\GeneratedIconProtocol.cs" Link="Helpers\Icons\GeneratedIconProtocol.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\GeneratedIconProtocolProcessor.cs" Link="Helpers\Icons\GeneratedIconProtocolProcessor.cs" />
+    <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\InitialsPathFactory.cs" Link="Helpers\Icons\InitialsPathFactory.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\InitialsTextRenderer.cs" Link="Helpers\Icons\InitialsTextRenderer.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\SemanticIconColor.cs" Link="Helpers\Icons\SemanticIconColor.cs" />
     <Compile Include="..\..\Microsoft.CmdPal.UI\Helpers\Icons\SvgPathDataReceiver.cs" Link="Helpers\Icons\SvgPathDataReceiver.cs" />

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PowerToys/Helpers/ColorSwatchIconFactory.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PowerToys/Helpers/ColorSwatchIconFactory.cs
@@ -2,44 +2,12 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Drawing;
-using System.Drawing.Drawing2D;
-using System.Drawing.Imaging;
-using System.IO;
-using System.Runtime.InteropServices.WindowsRuntime;
 using Microsoft.CommandPalette.Extensions.Toolkit;
-using Windows.Storage.Streams;
 
 namespace PowerToysExtension.Helpers;
 
 internal static class ColorSwatchIconFactory
 {
     public static IconInfo Create(byte r, byte g, byte b, byte a)
-    {
-        try
-        {
-            using var bmp = new Bitmap(32, 32, PixelFormat.Format32bppArgb);
-            using var gfx = Graphics.FromImage(bmp);
-            gfx.SmoothingMode = SmoothingMode.AntiAlias;
-            gfx.Clear(Color.Transparent);
-
-            using var brush = new SolidBrush(Color.FromArgb(a, r, g, b));
-            const int padding = 4;
-            gfx.FillEllipse(brush, padding, padding, bmp.Width - (padding * 2), bmp.Height - (padding * 2));
-
-            using var ms = new MemoryStream();
-            bmp.Save(ms, ImageFormat.Png);
-            var ras = new InMemoryRandomAccessStream();
-            var writer = new DataWriter(ras);
-            writer.WriteBytes(ms.ToArray());
-            writer.StoreAsync().GetResults();
-            ras.Seek(0);
-            return IconInfo.FromStream(ras);
-        }
-        catch
-        {
-            // Fallback to a simple colored glyph when drawing fails.
-            return new IconInfo("\u25CF"); // Black circle glyph
-        }
-    }
+        => new($"|Swatch|#{a:X2}{r:X2}{g:X2}{b:X2}|");
 }

--- a/src/modules/cmdpal/ext/SamplePagesExtension/Pages/SampleIconPage.cs
+++ b/src/modules/cmdpal/ext/SamplePagesExtension/Pages/SampleIconPage.cs
@@ -13,9 +13,14 @@ internal sealed partial class SampleIconPage : ListPage
     private readonly IListItem[] _items =
     [
         BuildIconItem(
-            "|Swatch|#FF0067C0|#FF60CDFF|",
-            "Theme-aware generated swatch",
-            "Uses a compact color protocol instead of an extension-generated bitmap"),
+            "|Swatch|#FF0067C0|#FF60CDFF|square|",
+            "Theme-aware square swatch",
+            "Uses separate light and dark colors with the square background shape"),
+
+        BuildIconItem(
+            "|Swatch|success|circle|",
+            "Semantic success swatch",
+            "Uses a theme-aware semantic color with the circle background shape"),
 
         BuildIconItem(
             "|Initials|A|#FF7A3E9D|circle|",
@@ -23,9 +28,19 @@ internal sealed partial class SampleIconPage : ListPage
             "Uses an automatically contrasting foreground"),
 
         BuildIconItem(
-            "|Initials|CP|#FF005FB8|#FF60CDFF|rounded|",
-            "Theme-aware rounded initials avatar",
+            "|Initials|CP|#FF005FB8|#FF60CDFF|square|",
+            "Theme-aware square initials avatar",
             "Uses separate light and dark background colors"),
+
+        BuildIconItem(
+            "|Initials|N|normal|circle|",
+            "Semantic normal initials avatar",
+            "Uses the normal theme foreground as its background color"),
+
+        BuildIconItem(
+            "|Initials|T|transparent|square|",
+            "Transparent initials avatar",
+            "Uses a transparent square background and a theme-aware foreground"),
 
         /*
          * Quick intro to Unicode in source code:

--- a/src/modules/cmdpal/ext/SamplePagesExtension/Pages/SampleIconPage.cs
+++ b/src/modules/cmdpal/ext/SamplePagesExtension/Pages/SampleIconPage.cs
@@ -12,6 +12,21 @@ internal sealed partial class SampleIconPage : ListPage
 {
     private readonly IListItem[] _items =
     [
+        BuildIconItem(
+            "|Swatch|#FF0067C0|#FF60CDFF|",
+            "Theme-aware generated swatch",
+            "Uses a compact color protocol instead of an extension-generated bitmap"),
+
+        BuildIconItem(
+            "|Initials|A|#FF7A3E9D|circle|",
+            "Generated circular initials avatar",
+            "Uses an automatically contrasting foreground"),
+
+        BuildIconItem(
+            "|Initials|CP|#FF005FB8|#FF60CDFF|rounded|",
+            "Theme-aware rounded initials avatar",
+            "Uses separate light and dark background colors"),
+
         /*
          * Quick intro to Unicode in source code:
          * - Every character has a code point (e.g., U+0041 = 'A').


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Part 10 of 12 in the CmdPal icon-loading series. Depends on #50189. Next: #50191.

This PR lets extensions request color tiles and initials without supplying custom bitmap assets.

- Adds shared circle/rounded-square geometry, hex/semantic colors, and normal/transparent backgrounds.
- Shapes Unicode initials off the STA and canonicalizes cache identity with a fast path for simple canonical inputs.
- Migrates saved-color icons and adds samples, including a 256-color palette.

Motivation: centralize sizing, theme handling, contrast, and fallback behavior instead of duplicating image generation in extensions.

### Examples

```csharp
new IconInfo("|Swatch|#0067C0|");                       // Default circle
new IconInfo("|Swatch|#FF0067C0|#FF60CDFF|square|");   // Light/dark colors
new IconInfo("|Swatch|success|circle|");               // Semantic color
new IconInfo("|Initials|JP|info|square|");
new IconInfo("|Initials|T|transparent|square|");
new IconInfo("|Initials|👩‍💻|info|circle|");             // One grapheme cluster
new IconInfo("|Initials|A%7CB|info|square|");           // Literal A|B
```

Semantic colors are `danger`, `subtle`, `info`, `warning`, `success`, `neutral`, `dark`, `normal`, and `transparent`. Initials accept one to three Unicode text elements.

### Evidence

Historical adjacent-stage comparison (2026-08-18); shared method and limitations: the diagnostics foundation PR #50181. A/B/C are regression checks, not measurements of the new generated-icon workload.

- A cold-ish process CPU: 139109.375 → 139390.625 ms (+0.2%); allocations: 839531672 → 839083632 bytes (−0.1%). Both overlap observed variation and change direction across pairs.
- C warm applied average: 0.141 → 0.229 ms (+0.088 ms); p95 stayed ≤0.25 ms. Two of three pairs actually improved, so the median increase is not a consistent regression.
- Tests cover Unicode/graphemes, escaping, equivalent cache keys, shape geometry, theme colors, and missing-font fallback.
- Focused palette and Unicode/emoji-initials measurements are still needed. These results do not establish that emoji shaping costs the same as ordinary Fluent glyphs.

The justification is the new shared capability and its correctness coverage. These small, inconsistent changes support neither a general performance win nor a demonstrated regression.

### Technical notes

- The 32-unit SVG viewBox is a design coordinate system, not a fixed 32-pixel bitmap. Materialization uses the requested size/scale. `square` means rounded square; both protocols share the background geometry.
- Hex colors use XAML ordering: `#RGB`, `#ARGB`, `#RRGGBB`, or `#AARRGGBB`, not CSS alpha-last forms. Semantic colors choose their own light/dark values.
- Swatch preparation can be synchronous; initials preparation must shape off the STA. Both produce SVG data, whose later source materialization can be asynchronous. Placement fallbacks cover that gap.
- Initials are shaped into vector outlines, not promised as full-color emoji. Missing font coverage produces a background tile; unexpected shaping/interop failures are logged once instead of silently masquerading as unsupported characters.
- Normalize initials to NFC and escape literal `%` before `|` (`%25`, `%7C`). Human-authored initials use readable percent encoding; machine-generated app requests use length prefixes. Canonical simple inputs reuse the original string, and style normalization scans small tokens—not a full visual-equivalence algorithm.

Implementation: `src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/GeneratedIconProtocol.cs`.

## Pictures? Pictures!

<img width="1639" height="1431" alt="image" src="https://github.com/user-attachments/assets/68ea5fb5-c192-4c65-8183-ecdd88e31b48" />

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #49942
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

