### PR TITLE
[Settings] Fix Simplified Chinese Quick Access translation

### DIFF
--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -6506,6 +6506,7 @@ Text uses the current drawing color.</value>
   </data>
   <data name="GeneralPage_EnableQuickAccess.Description" xml:space="preserve">
     <value>Fast access to quick actions and module toggles</value>
+    <comment>Simplified Chinese: translate the full string as "快速操作和模块切换", not "快速访问快速作和模块切换".</comment>
   </data>
   <data name="GeneralPage_QuickAccessShortcut.Header" xml:space="preserve">
     <value>Activation shortcut</value>


### PR DESCRIPTION
## Summary of the Pull Request

Adds Simplified Chinese translator guidance for the General page Quick Access description so the complete translation uses `快速操作和模块切换` instead of the incorrect `快速访问快速作和模块切换`.

## PR Checklist

- [x] Closes: #50172
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

Issue #50172 reports that the Simplified Chinese translation of `GeneralPage_EnableQuickAccess.Description` is rendered as `快速访问快速作和模块切换`. The intended Simplified Chinese translation is `快速操作和模块切换`.

PowerToys localized resources are generated through the Touchdown localization pipeline, so this PR adds an explicit translator comment to the English resource entry. The English value, resource key, XAML, Traditional Chinese and other locales, and runtime behavior remain unchanged.

## Validation Steps Performed

- Parsed the modified `Resources.resw` successfully as XML.
- Verified the affected entry contains only Simplified Chinese guidance with the exact intended translation.
- Confirmed the diff changes only the translator comment and passes `git diff --check`.
- No build or automated tests were run because this is a translator-comment-only localization change with no runtime impact.