### PR TITLE
[Peek] Update folder preview to be more robust, show more info, include scanning status and report errors

### DIFF
--- a/src/modules/peek/Peek.Common/Helpers/ReadableStringHelper.cs
+++ b/src/modules/peek/Peek.Common/Helpers/ReadableStringHelper.cs
@@ -62,6 +62,34 @@ namespace Peek.Common.Helpers
             return formattedString;
         }
 
+        public static string FormatFolderContents(ulong files, ulong directories, bool isScanning, bool isPartial)
+        {
+            var resourceLoader = ResourceLoaderInstance.ResourceLoader;
+
+            if (isScanning && files == 0 && directories == 0)
+            {
+                return resourceLoader.GetString("UnsupportedFile_FolderContains_Scanning");
+            }
+
+            string formattedFiles = (files == 1)
+                ? resourceLoader.GetString("UnsupportedFile_FolderFileCount_Single")
+                : string.Format(CultureInfo.CurrentCulture, resourceLoader.GetString("UnsupportedFile_FolderFileCount_Plural"), files);
+
+            string formattedDirectories = (directories == 1)
+                ? resourceLoader.GetString("UnsupportedFile_FolderDirectoryCount_Single")
+                : string.Format(CultureInfo.CurrentCulture, resourceLoader.GetString("UnsupportedFile_FolderDirectoryCount_Plural"), directories);
+
+            string result = $"{formattedFiles}, {formattedDirectories}";
+
+            if (isPartial)
+            {
+                string incomplete = resourceLoader.GetString("UnsupportedFile_FolderContains_Incomplete");
+                result += $" ({incomplete})";
+            }
+
+            return result;
+        }
+
         public static int GetPrecision(int index, double number)
         {
             int numberOfDigits = MathHelper.NumberOfDigits((int)number);

--- a/src/modules/peek/Peek.FilePreviewer/Controls/UnsupportedFilePreview/InformationalPreviewControl.xaml
+++ b/src/modules/peek/Peek.FilePreviewer/Controls/UnsupportedFilePreview/InformationalPreviewControl.xaml
@@ -5,6 +5,7 @@
     x:Class="Peek.FilePreviewer.Controls.InformationalPreviewControl"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:conv="using:Peek.Common.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
@@ -42,11 +43,40 @@
                     <ToolTip Content="{x:Bind FormatFileType(Source.FileType), Mode=OneWay}" />
                 </ToolTipService.ToolTip>
             </TextBlock>
-            <TextBlock Text="{x:Bind FormatFileSize(Source.FileSize), Mode=OneWay}">
+            <TextBlock Text="{x:Bind FormatFileSize(Source.FileSize), Mode=OneWay}" Typography.NumeralAlignment="Tabular">
                 <ToolTipService.ToolTip>
                     <ToolTip Content="{x:Bind FormatFileSize(Source.FileSize), Mode=OneWay}" />
                 </ToolTipService.ToolTip>
             </TextBlock>
+            <StackPanel
+                Orientation="Horizontal"
+                Spacing="8"
+                Visibility="{x:Bind conv:VisibilityConverter.Convert(Source.IsFolder), Mode=OneWay}">
+                <TextBlock
+                    VerticalAlignment="Center"
+                    Text="{x:Bind FormatFolderContains(Source.FolderContents), Mode=OneWay}"
+                    Typography.NumeralAlignment="Tabular">
+                    <ToolTipService.ToolTip>
+                        <ToolTip Content="{x:Bind FormatFolderContains(Source.FolderContents), Mode=OneWay}" />
+                    </ToolTipService.ToolTip>
+                </TextBlock>
+                <ProgressRing
+                    Width="14"
+                    Height="14"
+                    VerticalAlignment="Center"
+                    IsActive="{x:Bind Source.IsScanning, Mode=OneWay}"
+                    Visibility="{x:Bind conv:VisibilityConverter.Convert(Source.IsScanning), Mode=OneWay}" />
+                <FontIcon
+                    VerticalAlignment="Center"
+                    FontSize="12"
+                    Foreground="{ThemeResource SystemFillColorCautionBrush}"
+                    Glyph="&#xE7BA;"
+                    Visibility="{x:Bind conv:VisibilityConverter.Convert(Source.IsError), Mode=OneWay}">
+                    <ToolTipService.ToolTip>
+                        <ToolTip Content="{x:Bind FormatFolderContains(Source.FolderContents), Mode=OneWay}" />
+                    </ToolTipService.ToolTip>
+                </FontIcon>
+            </StackPanel>
             <TextBlock Text="{x:Bind FormatFileDateModified(Source.DateModified), Mode=OneWay}">
                 <ToolTipService.ToolTip>
                     <ToolTip Content="{x:Bind FormatFileDateModified(Source.DateModified), Mode=OneWay}" />

--- a/src/modules/peek/Peek.FilePreviewer/Controls/UnsupportedFilePreview/InformationalPreviewControl.xaml.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Controls/UnsupportedFilePreview/InformationalPreviewControl.xaml.cs
@@ -33,6 +33,8 @@ namespace Peek.FilePreviewer.Controls
 
         public string FormatFileSize(string? fileSize) => ReadableStringHelper.FormatResourceString("UnsupportedFile_FileSize", fileSize);
 
+        public string FormatFolderContains(string? folderContents) => ReadableStringHelper.FormatResourceString("UnsupportedFile_FolderContains", folderContents);
+
         public string FormatFileDateModified(string? fileDateModified) => ReadableStringHelper.FormatResourceString("UnsupportedFile_DateModified", fileDateModified);
     }
 }

--- a/src/modules/peek/Peek.FilePreviewer/Models/FolderScanProgress.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Models/FolderScanProgress.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Peek.FilePreviewer.Models
+{
+    public readonly record struct FolderScanProgress(ulong TotalBytes, ulong FileCount, ulong DirectoryCount, FolderScanState State);
+}

--- a/src/modules/peek/Peek.FilePreviewer/Models/FolderScanState.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Models/FolderScanState.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Peek.FilePreviewer.Models
+{
+    public enum FolderScanState
+    {
+        Idle,
+        Scanning,
+        Completed,
+        PartialError,
+    }
+}

--- a/src/modules/peek/Peek.FilePreviewer/Models/UnsupportedFilePreviewData.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Models/UnsupportedFilePreviewData.cs
@@ -22,6 +22,21 @@ namespace Peek.FilePreviewer.Models
         private string? fileSize;
 
         [ObservableProperty]
+        private string? folderContents;
+
+        [ObservableProperty]
+        private bool isFolder;
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(IsScanning))]
+        [NotifyPropertyChangedFor(nameof(IsError))]
+        private FolderScanState folderScanState = FolderScanState.Idle;
+
+        public bool IsScanning => FolderScanState == FolderScanState.Scanning;
+
+        public bool IsError => FolderScanState == FolderScanState.PartialError;
+
+        [ObservableProperty]
         private string? dateModified;
     }
 }

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/UnsupportedFilePreviewer/UnsupportedFilePreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/UnsupportedFilePreviewer/UnsupportedFilePreviewer.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Globalization;
 using System.IO;
-using System.Linq;
+using System.IO.Enumeration;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -24,11 +24,6 @@ namespace Peek.FilePreviewer.Previewers
 {
     public partial class UnsupportedFilePreviewer : ObservableObject, IUnsupportedFilePreviewer
     {
-        /// <summary>
-        /// The number of files to scan between updates when calculating folder size.
-        /// </summary>
-        private const int FolderEnumerationChunkSize = 100;
-
         /// <summary>
         /// The maximum view updates per second when enumerating a folder's contents.
         /// </summary>
@@ -52,7 +47,12 @@ namespace Peek.FilePreviewer.Previewers
 
         static UnsupportedFilePreviewer()
         {
-            FolderEnumerationOptions = new() { RecurseSubdirectories = true, AttributesToSkip = FileAttributes.ReparsePoint };
+            FolderEnumerationOptions = new()
+            {
+                RecurseSubdirectories = true,
+                AttributesToSkip = FileAttributes.ReparsePoint,
+                IgnoreInaccessible = true,
+            };
         }
 
         public UnsupportedFilePreviewer(IFileSystemItem file)
@@ -76,17 +76,24 @@ namespace Peek.FilePreviewer.Previewers
                 {
                     Preview.FileName = Item.Name;
                     Preview.DateModified = Item.DateModified?.ToString(CultureInfo.CurrentCulture);
+                    Preview.IsFolder = Item is FolderItem;
 
                     State = PreviewState.Loaded;
 
                     await LoadIconPreviewAsync(cancellationToken);
                 });
 
-                var progress = new Progress<string>(update =>
+                var progress = new Progress<FolderScanProgress>(update =>
                 {
                     Dispatcher.TryEnqueue(() =>
                     {
-                        Preview.FileSize = update;
+                        Preview.FileSize = ReadableStringHelper.BytesToReadableString(update.TotalBytes);
+                        Preview.FolderContents = ReadableStringHelper.FormatFolderContents(
+                            update.FileCount,
+                            update.DirectoryCount,
+                            update.State == FolderScanState.Scanning,
+                            update.State == FolderScanState.PartialError);
+                        Preview.FolderScanState = update.State;
                     });
                 });
 
@@ -118,52 +125,77 @@ namespace Peek.FilePreviewer.Previewers
                 DefaultIcon;
         }
 
-        private async Task LoadDisplayInfoAsync(IProgress<string> sizeProgress, CancellationToken cancellationToken)
+        private async Task LoadDisplayInfoAsync(IProgress<FolderScanProgress> sizeProgress, CancellationToken cancellationToken)
         {
             string type = await Item.GetContentTypeAsync();
 
             Dispatcher.TryEnqueue(() => Preview.FileType = type);
 
-            if (Item is FolderItem folderItem)
+            if (Item is FolderItem)
             {
                 await Task.Run(() => CalculateFolderSizeWithProgress(Item.Path, sizeProgress, cancellationToken), cancellationToken);
             }
             else
             {
-                ReportProgress(sizeProgress, Item.FileSizeBytes);
+                sizeProgress.Report(new FolderScanProgress(Item.FileSizeBytes, 0, 0, FolderScanState.Completed));
             }
         }
 
-        private void CalculateFolderSizeWithProgress(string path, IProgress<string> progress, CancellationToken cancellationToken)
+        private void CalculateFolderSizeWithProgress(string path, IProgress<FolderScanProgress> progress, CancellationToken cancellationToken)
         {
             ulong folderSize = 0;
+            ulong fileCount = 0;
+            ulong directoryCount = 0;
+            bool hadError = false;
+
             TimeSpan updateInterval = TimeSpan.FromMilliseconds(1000 / MaxUpdateFps);
-            DateTime nextUpdate = DateTime.UtcNow + updateInterval;
 
-            var files = new DirectoryInfo(path).EnumerateFiles("*", FolderEnumerationOptions);
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            TimeSpan nextUpdate = updateInterval;
 
-            foreach (var chunk in files.Chunk(FolderEnumerationChunkSize))
+            try
             {
-                cancellationToken.ThrowIfCancellationRequested();
+                var enumerable = new FileSystemEnumerable<(long Length, bool IsDirectory)>(
+                    path,
+                    (ref FileSystemEntry entry) => (entry.Length, entry.IsDirectory),
+                    FolderEnumerationOptions);
 
-                if (DateTime.Now >= nextUpdate)
+                foreach (var (length, isDirectory) in enumerable)
                 {
-                    ReportProgress(progress, folderSize);
-                    nextUpdate = DateTime.UtcNow + updateInterval;
-                }
+                    cancellationToken.ThrowIfCancellationRequested();
 
-                foreach (var file in chunk)
-                {
-                    folderSize += (ulong)file.Length;
+                    if (isDirectory)
+                    {
+                        directoryCount++;
+                    }
+                    else
+                    {
+                        fileCount++;
+                        if (length > 0)
+                        {
+                            folderSize += (ulong)length;
+                        }
+                    }
+
+                    if (stopwatch.Elapsed >= nextUpdate)
+                    {
+                        progress.Report(new FolderScanProgress(folderSize, fileCount, directoryCount, FolderScanState.Scanning));
+                        nextUpdate = stopwatch.Elapsed + updateInterval;
+                    }
                 }
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception)
+            {
+                hadError = true;
+                Logger.LogDebug("Error calculating folder size for directory: " + path);
+            }
 
-            ReportProgress(progress, folderSize);
-        }
-
-        private void ReportProgress(IProgress<string> progress, ulong size)
-        {
-            progress.Report(ReadableStringHelper.BytesToReadableString(size));
+            var finalState = hadError ? FolderScanState.PartialError : FolderScanState.Completed;
+            progress.Report(new FolderScanProgress(folderSize, fileCount, directoryCount, finalState));
         }
     }
 }

--- a/src/modules/peek/Peek.UI/Strings/en-us/Resources.resw
+++ b/src/modules/peek/Peek.UI/Strings/en-us/Resources.resw
@@ -149,6 +149,34 @@
     <value>Size: {0}</value>
     <comment>File Size label for the unsupported files view. {0} is the size.</comment>
   </data>
+  <data name="UnsupportedFile_FolderContains" xml:space="preserve">
+    <value>Contains: {0}</value>
+    <comment>Contains label for folder contents. {0} is the formatted folder contents description.</comment>
+  </data>
+  <data name="UnsupportedFile_FolderFileCount_Single" xml:space="preserve">
+    <value>1 file</value>
+    <comment>Single file count</comment>
+  </data>
+  <data name="UnsupportedFile_FolderFileCount_Plural" xml:space="preserve">
+    <value>{0:N0} files</value>
+    <comment>{0:N0} is the plural file count.</comment>
+  </data>
+  <data name="UnsupportedFile_FolderDirectoryCount_Single" xml:space="preserve">
+    <value>1 folder</value>
+    <comment>Single directory/folder count</comment>
+  </data>
+  <data name="UnsupportedFile_FolderDirectoryCount_Plural" xml:space="preserve">
+    <value>{0:N0} folders</value>
+    <comment>{0:N0} is the plural directory/folder count.</comment>
+  </data>
+  <data name="UnsupportedFile_FolderContains_Scanning" xml:space="preserve">
+    <value>Scanning...</value>
+    <comment>Status text shown while folder content enumeration is in progress.</comment>
+  </data>
+  <data name="UnsupportedFile_FolderContains_Incomplete" xml:space="preserve">
+    <value>incomplete</value>
+    <comment>Short tag appended to folder contents when enumeration encounters an error.</comment>
+  </data>
   <data name="UnsupportedFile_DateModified" xml:space="preserve">
     <value>Date Modified: {0}</value>
     <comment>Date Modified label for the unsupported files view. {0} is the date.</comment>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #50174
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

This updates the folder preview in Peek to:

1. Show the file and sub-folder count, like Explorer's property page
2. Show a spinner while the enumeration is in progress
3. Replace the spinner with a warning icon when there was an error and add "incomplete" to the counts instead of navigating to the default Peek error display
4. Add `IgnoreInaccessible = true` to the `FolderEnumerationOptions`, which automatically skips inaccessible folders instead of raising an error
5. Fix an issue with comparing UTC and non-UTC `DateTime`s which could freeze the updating counts or update them too often
6. Reduce the scan's allocations by more than 60% by using `FileSystemEnumerable` instead of `DirectoryInfo.EnumerateFiles()`. This is because `FileInfo`/`DirectoryInfo` objects are no longer created for each iteration
7. Use `Typography.NumeralAlignment="Tabular"` to present numeric counts, significantly improving the readability of the fields during iteration and removing the alignment jitter
8. Remove LINQ-based chunking. This was not actually required because the file enumeration itself was lazy
9. Check the cancellation token every iteration instead of once per 100-file chunk

### Screenshots and video
#### Scan in progress
<img width="833" height="677" alt="Screenshot 2026-08-27 230826" src="https://github.com/user-attachments/assets/e6f0ad16-3815-4e0e-b7b2-a7d89b9e43f2" />

#### Incomplete scan display
<img width="833" height="677" alt="Screenshot 2026-08-28 024556" src="https://github.com/user-attachments/assets/2787ddc4-7e2e-455b-aa70-bb6b2bf0cfaf" />

#### Screen recording
https://github.com/user-attachments/assets/4bbe677a-c5dd-4f01-98f3-b8f74a15fb22

## Validation Steps Performed

- All Peek unit tests pass:
<img width="308" height="47" alt="image" src="https://github.com/user-attachments/assets/76c33d98-3028-466a-a0f1-068d50de5872" />

- Tested a variety of small and large folders with differing contents and access
- Benchmarked the new approach against the existing enumeration method to confirm memory and timing did not regress

```
// * Summary *

BenchmarkDotNet v0.14.0, Windows 11 (10.0.26200.9168)
11th Gen Intel Core i5-1135G7 2.40GHz, 1 CPU, 8 logical and 4 physical cores
.NET SDK 10.0.400
  [Host]     : .NET 9.0.19 (9.0.1926.36724), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
  Job-ARTJAD : .NET 9.0.19 (9.0.1926.36724), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI

IterationCount=5  WarmupCount=3

| Method                                     | Mean    | Error   | StdDev  | Ratio | Gen0       | Gen1      | Gen2      | Allocated | Alloc Ratio |
|------------------------------------------- |--------:|--------:|--------:|------:|-----------:|----------:|----------:|----------:|------------:|
| 'Old: DirectoryInfo + Chunk'               | 11.13 s | 0.297 s | 0.046 s |  1.00 | 26000.0000 | 9000.0000 | 5000.0000 | 128.23 MB |        1.00 |
| 'New: FileSystemEnumerable'                | 10.97 s | 0.394 s | 0.102 s |  0.99 | 10000.0000 | 6000.0000 | 3000.0000 |  47.51 MB |        0.37 |
| 'P/Invoke: FindFirstFileExW + LARGE_FETCH' | 12.25 s | 0.106 s | 0.016 s |  1.10 | 10000.0000 | 1000.0000 |         - |  44.99 MB |        0.35 |
```
