### PR TITLE
fix(common): handle packaged context menu servicing shutdown

### DIFF
--- a/src/common/utils/context_menu_lifecycle.h
+++ b/src/common/utils/context_menu_lifecycle.h
@@ -1,0 +1,379 @@
+#pragma once
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include <appmodel.h>
+
+#include <atomic>
+#include <cwchar>
+#include <new>
+
+// Packaged COM surrogates do not own a top-level window, so package servicing has
+// no WM_CLOSE target and eventually reports HANG_QUIESCE. This helper adds one
+// process-lifetime window to a package-dedicated surrogate. An extra module
+// reference keeps the window procedure valid after COM considers the server
+// unloadable.
+namespace context_menu_lifecycle
+{
+    using initialization_callback = void (*)(HRESULT) noexcept;
+
+    struct activity_token
+    {
+        void* monitor = nullptr;
+        bool accepted = true;
+
+        explicit operator bool() const noexcept
+        {
+            return accepted;
+        }
+    };
+
+    namespace details
+    {
+        struct monitor_state
+        {
+            HMODULE module = nullptr;
+            PCWSTR window_class_name = nullptr;
+            DWORD shutdown_grace_ms = 0;
+            initialization_callback report_initialization = nullptr;
+            std::atomic_uint64_t activity_state = 0;
+            HANDLE initialization_event = nullptr;
+            HRESULT initialization_result = E_UNEXPECTED;
+        };
+
+        constexpr uint64_t shutdown_requested_bit = uint64_t{ 1 } << 63;
+        constexpr uint64_t active_operations_mask = ~shutdown_requested_bit;
+
+        struct initialization_parameters
+        {
+            const void* module_address = nullptr;
+            PCWSTR package_family_name_prefix = nullptr;
+            PCWSTR window_class_name = nullptr;
+            DWORD shutdown_grace_ms = 0;
+            initialization_callback report_initialization = nullptr;
+        };
+
+        inline std::atomic<monitor_state*>& state()
+        {
+            static std::atomic<monitor_state*> value = nullptr;
+            return value;
+        }
+
+        inline INIT_ONCE& initialization_once()
+        {
+            static INIT_ONCE value = INIT_ONCE_STATIC_INIT;
+            return value;
+        }
+
+        inline HRESULT& initialization_result()
+        {
+            static HRESULT value = E_UNEXPECTED;
+            return value;
+        }
+
+        inline void report(monitor_state* state, HRESULT result) noexcept
+        {
+            if (state->report_initialization)
+            {
+                state->report_initialization(result);
+            }
+        }
+
+        inline bool is_expected_package_host(PCWSTR package_family_name_prefix) noexcept
+        {
+            WCHAR package_family_name[PACKAGE_FAMILY_NAME_MAX_LENGTH + 1]{};
+            UINT32 package_family_name_length = ARRAYSIZE(package_family_name);
+            if (GetCurrentPackageFamilyName(&package_family_name_length, package_family_name) != ERROR_SUCCESS)
+            {
+                return false;
+            }
+
+            const size_t prefix_length = wcslen(package_family_name_prefix);
+            return wcsncmp(package_family_name, package_family_name_prefix, prefix_length) == 0;
+        }
+
+        inline void terminate_after_active_operations(monitor_state* state) noexcept
+        {
+            state->activity_state.fetch_or(shutdown_requested_bit, std::memory_order_acq_rel);
+            const ULONGLONG deadline = GetTickCount64() + state->shutdown_grace_ms;
+            while ((state->activity_state.load(std::memory_order_acquire) & active_operations_mask) != 0 &&
+                   GetTickCount64() < deadline)
+            {
+                Sleep(50);
+            }
+
+            TerminateProcess(GetCurrentProcess(), ERROR_SUCCESS);
+        }
+
+        inline LRESULT CALLBACK window_proc(HWND window, UINT message, WPARAM wparam, LPARAM lparam)
+        {
+            if (message == WM_NCCREATE)
+            {
+                const auto create = reinterpret_cast<CREATESTRUCTW*>(lparam);
+                SetWindowLongPtrW(window, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(create->lpCreateParams));
+            }
+
+            const auto state = reinterpret_cast<monitor_state*>(GetWindowLongPtrW(window, GWLP_USERDATA));
+            switch (message)
+            {
+            case WM_QUERYENDSESSION:
+                return TRUE;
+            case WM_ENDSESSION:
+                if (!wparam)
+                {
+                    return 0;
+                }
+                [[fallthrough]];
+            case WM_CLOSE:
+                if (state)
+                {
+                    terminate_after_active_operations(state);
+                }
+                else
+                {
+                    TerminateProcess(GetCurrentProcess(), ERROR_SUCCESS);
+                }
+                return 0;
+            case WM_DESTROY:
+                PostQuitMessage(0);
+                return 0;
+            default:
+                return DefWindowProcW(window, message, wparam, lparam);
+            }
+        }
+
+        inline DWORD WINAPI monitor_thread(void* parameter)
+        {
+            const auto state = static_cast<monitor_state*>(parameter);
+            WNDCLASSW window_class{};
+            window_class.lpfnWndProc = window_proc;
+            window_class.hInstance = state->module;
+            window_class.lpszClassName = state->window_class_name;
+
+            const ATOM window_class_atom = RegisterClassW(&window_class);
+            if (!window_class_atom && GetLastError() != ERROR_CLASS_ALREADY_EXISTS)
+            {
+                state->initialization_result = HRESULT_FROM_WIN32(GetLastError());
+                SetEvent(state->initialization_event);
+                return 0;
+            }
+
+            const HWND window = CreateWindowExW(
+                WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW,
+                state->window_class_name,
+                L"",
+                WS_POPUP,
+                0,
+                0,
+                0,
+                0,
+                nullptr,
+                nullptr,
+                state->module,
+                state);
+            if (!window)
+            {
+                const DWORD error = GetLastError();
+                if (window_class_atom)
+                {
+                    UnregisterClassW(state->window_class_name, state->module);
+                }
+                state->initialization_result = HRESULT_FROM_WIN32(error);
+                SetEvent(state->initialization_event);
+                return 0;
+            }
+
+            state->initialization_result = S_OK;
+            SetEvent(state->initialization_event);
+
+            MSG message{};
+            while (GetMessageW(&message, nullptr, 0, 0) > 0)
+            {
+                TranslateMessage(&message);
+                DispatchMessageW(&message);
+            }
+
+            return 0;
+        }
+
+        inline BOOL CALLBACK initialize(PINIT_ONCE, void* parameter, void**)
+        {
+            const auto parameters = static_cast<initialization_parameters*>(parameter);
+            if (!is_expected_package_host(parameters->package_family_name_prefix))
+            {
+                initialization_result() = S_FALSE;
+                return TRUE;
+            }
+
+            HMODULE module = nullptr;
+            if (!GetModuleHandleExW(
+                    GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+                    reinterpret_cast<LPCWSTR>(parameters->module_address),
+                    &module))
+            {
+                initialization_result() = HRESULT_FROM_WIN32(GetLastError());
+                if (parameters->report_initialization)
+                {
+                    parameters->report_initialization(initialization_result());
+                }
+                SetLastError(HRESULT_CODE(initialization_result()));
+                return FALSE;
+            }
+
+            auto monitor = new (std::nothrow) monitor_state{};
+            if (!monitor)
+            {
+                initialization_result() = E_OUTOFMEMORY;
+                if (parameters->report_initialization)
+                {
+                    parameters->report_initialization(initialization_result());
+                }
+                FreeLibrary(module);
+                SetLastError(ERROR_OUTOFMEMORY);
+                return FALSE;
+            }
+
+            monitor->module = module;
+            monitor->window_class_name = parameters->window_class_name;
+            monitor->shutdown_grace_ms = parameters->shutdown_grace_ms;
+            monitor->report_initialization = parameters->report_initialization;
+            monitor->initialization_event = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+            if (!monitor->initialization_event)
+            {
+                initialization_result() = HRESULT_FROM_WIN32(GetLastError());
+                report(monitor, initialization_result());
+                FreeLibrary(module);
+                delete monitor;
+                SetLastError(HRESULT_CODE(initialization_result()));
+                return FALSE;
+            }
+
+            const HANDLE thread = CreateThread(nullptr, 0, monitor_thread, monitor, 0, nullptr);
+            if (!thread)
+            {
+                initialization_result() = HRESULT_FROM_WIN32(GetLastError());
+                report(monitor, initialization_result());
+                CloseHandle(monitor->initialization_event);
+                FreeLibrary(module);
+                delete monitor;
+                SetLastError(HRESULT_CODE(initialization_result()));
+                return FALSE;
+            }
+
+            const DWORD wait_result = WaitForSingleObject(monitor->initialization_event, 5000);
+            if (wait_result != WAIT_OBJECT_0)
+            {
+                initialization_result() = wait_result == WAIT_TIMEOUT ? HRESULT_FROM_WIN32(ERROR_TIMEOUT) : HRESULT_FROM_WIN32(GetLastError());
+                report(monitor, initialization_result());
+                state().store(monitor, std::memory_order_release);
+                CloseHandle(thread);
+                return TRUE;
+            }
+
+            initialization_result() = monitor->initialization_result;
+            CloseHandle(monitor->initialization_event);
+            monitor->initialization_event = nullptr;
+            if (FAILED(initialization_result()))
+            {
+                WaitForSingleObject(thread, INFINITE);
+                CloseHandle(thread);
+                report(monitor, initialization_result());
+                FreeLibrary(module);
+                delete monitor;
+                SetLastError(HRESULT_CODE(initialization_result()));
+                return FALSE;
+            }
+
+            state().store(monitor, std::memory_order_release);
+            CloseHandle(thread);
+            report(monitor, S_OK);
+            return TRUE;
+        }
+    }
+
+    inline HRESULT ensure_servicing_window(
+        const void* module_address,
+        PCWSTR package_family_name_prefix,
+        PCWSTR window_class_name,
+        DWORD shutdown_grace_ms,
+        initialization_callback report_initialization = nullptr) noexcept
+    {
+        // The string arguments are retained for the process lifetime and must
+        // therefore point to static storage.
+        details::initialization_parameters parameters{
+            module_address,
+            package_family_name_prefix,
+            window_class_name,
+            shutdown_grace_ms,
+            report_initialization
+        };
+
+        const BOOL initialized = InitOnceExecuteOnce(
+            &details::initialization_once(),
+            details::initialize,
+            &parameters,
+            nullptr);
+        if (!initialized)
+        {
+            return details::initialization_result();
+        }
+
+        return details::initialization_result();
+    }
+
+    inline activity_token begin_activity() noexcept
+    {
+        if (const auto monitor = details::state().load(std::memory_order_acquire))
+        {
+            auto current_state = monitor->activity_state.load(std::memory_order_acquire);
+            while ((current_state & details::shutdown_requested_bit) == 0)
+            {
+                if (monitor->activity_state.compare_exchange_weak(
+                        current_state,
+                        current_state + 1,
+                        std::memory_order_acq_rel,
+                        std::memory_order_acquire))
+                {
+                    return { monitor, true };
+                }
+            }
+
+            return { nullptr, false };
+        }
+
+        return {};
+    }
+
+    inline void end_activity(activity_token token) noexcept
+    {
+        if (const auto monitor = static_cast<details::monitor_state*>(token.monitor))
+        {
+            monitor->activity_state.fetch_sub(1, std::memory_order_acq_rel);
+        }
+    }
+
+    class activity_guard
+    {
+    public:
+        activity_guard() noexcept :
+            token(begin_activity())
+        {
+        }
+
+        activity_guard(const activity_guard&) = delete;
+        activity_guard& operator=(const activity_guard&) = delete;
+
+        explicit operator bool() const noexcept
+        {
+            return static_cast<bool>(token);
+        }
+
+        ~activity_guard()
+        {
+            end_activity(token);
+        }
+
+    private:
+        activity_token token;
+    };
+}

--- a/src/modules/FileLocksmith/FileLocksmithContextMenu/dllmain.cpp
+++ b/src/modules/FileLocksmith/FileLocksmithContextMenu/dllmain.cpp
@@ -2,6 +2,7 @@
 #include "pch.h"
 
 #include <common/telemetry/EtwTrace/EtwTrace.h>
+#include <common/utils/context_menu_lifecycle.h>
 #include <common/utils/process_path.h>
 #include <common/utils/resources.h>
 #include <common/utils/elevation.h>
@@ -22,6 +23,19 @@ using namespace Microsoft::WRL;
 
 HINSTANCE g_hInst = 0;
 Shared::Trace::ETWTrace trace(L"FileLocksmithContextMenu");
+
+namespace
+{
+    void ensure_servicing_window()
+    {
+        context_menu_lifecycle::ensure_servicing_window(
+            &g_hInst,
+            L"Microsoft.PowerToys.FileLocksmithContextMenu_",
+            L"PowerToys.FileLocksmithContextMenu.ServicingWindow",
+            5000,
+            Trace::ServicingWindowInitialization);
+    }
+}
 
 BOOL APIENTRY DllMain( HMODULE hModule,
                        DWORD  ul_reason_for_call,
@@ -93,6 +107,12 @@ public:
 
     IFACEMETHODIMP Invoke(_In_opt_ IShellItemArray* selection, _In_opt_ IBindCtx*) noexcept
     {
+        context_menu_lifecycle::activity_guard activity;
+        if (!activity)
+        {
+            return HRESULT_FROM_WIN32(ERROR_SHUTDOWN_IN_PROGRESS);
+        }
+
         trace.UpdateState(true);
 
         Trace::Invoked();
@@ -190,6 +210,7 @@ CoCreatableClassWrlCreatorMapInclude(FileLocksmithContextMenuCommand)
 
 STDAPI DllGetActivationFactory(_In_ HSTRING activatableClassId, _COM_Outptr_ IActivationFactory** factory)
 {
+    ensure_servicing_window();
     return Module<ModuleType::InProc>::GetModule().GetActivationFactory(activatableClassId, factory);
 }
 
@@ -200,5 +221,6 @@ STDAPI DllCanUnloadNow()
 
 STDAPI DllGetClassObject(_In_ REFCLSID rclsid, _In_ REFIID riid, _COM_Outptr_ void** instance)
 {
+    ensure_servicing_window();
     return Module<InProc>::GetModule().GetClassObject(rclsid, riid, instance);
 }

--- a/src/modules/FileLocksmith/FileLocksmithLib/Trace.cpp
+++ b/src/modules/FileLocksmith/FileLocksmithLib/Trace.cpp
@@ -50,6 +50,16 @@ void Trace::QueryContextMenuError(_In_ HRESULT hr) noexcept
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
 }
 
+void Trace::ServicingWindowInitialization(_In_ HRESULT hr) noexcept
+{
+    TraceLoggingWriteWrapper(
+        g_hProvider,
+        "FileLocksmith_ServicingWindowInitialization",
+        ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
+        TraceLoggingHResult(hr),
+        TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
+}
+
 void Trace::CLICommand(_In_ PCWSTR commandName, _In_ bool successful) noexcept
 {
     TraceLoggingWriteWrapper(

--- a/src/modules/FileLocksmith/FileLocksmithLib/Trace.h
+++ b/src/modules/FileLocksmith/FileLocksmithLib/Trace.h
@@ -11,5 +11,6 @@ public:
     static void Invoked() noexcept;
     static void InvokedRet(_In_ HRESULT hr) noexcept;
     static void QueryContextMenuError(_In_ HRESULT hr) noexcept;
+    static void ServicingWindowInitialization(_In_ HRESULT hr) noexcept;
     static void CLICommand(_In_ PCWSTR commandName, _In_ bool successful) noexcept;
 };

--- a/src/modules/FileLocksmith/Tests/FileLocksmith.UITests/FileLocksmithContextMenuTests.cs
+++ b/src/modules/FileLocksmith/Tests/FileLocksmith.UITests/FileLocksmithContextMenuTests.cs
@@ -2,6 +2,10 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+
 using Microsoft.PowerToys.UITest.Next;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Win32;
@@ -21,6 +25,7 @@ public sealed class FileLocksmithContextMenuTests : UITestBase
         @"Software\Classes\AllFileSystemObjects\ShellEx\ContextMenuHandlers\FileLocksmithExt";
 
     private const string ModernPackageName = "FileLocksmithContextMenu";
+    private const string ServicingWindowClassName = "PowerToys.FileLocksmithContextMenu.ServicingWindow";
 
     private static readonly string[] ShellIntegrationModules =
     {
@@ -224,6 +229,59 @@ public sealed class FileLocksmithContextMenuTests : UITestBase
         }
     }
 
+    /// <summary>
+    /// Packaged Win32 servicing can only request shutdown from a GUI process through a top-level
+    /// window. Verify the package-dedicated COM surrogate exposes that window, exits on WM_CLOSE,
+    /// and can be activated again by Explorer.
+    /// </summary>
+    [TestMethod("FileLocksmith.ContextMenu.ServicingShutdown")]
+    [TestCategory("File Locksmith")]
+    public void ContextMenuSurrogateHandlesServicingShutdown()
+    {
+        if (!ExplorerHelper.IsWindows11OrNewer)
+        {
+            Assert.Inconclusive("The packaged File Locksmith context-menu surrogate exists only on Windows 11.");
+        }
+
+        RequireDefaultTier();
+        var fixture = CreateFixture();
+        var selection = new[] { fixture.TargetPath };
+        var explorer = ExplorerHelper.OpenFolder(fixture.TargetFolder);
+        var initialProbe = ExplorerHelper.ProbeCommand(
+            explorer,
+            () => ExplorerHelper.OpenFolder(fixture.TargetFolder),
+            selection,
+            ContextMenuTier.Default,
+            FileLocksmithConstants.ContextMenuCaption,
+            expectedCommand: true,
+            siblingCaption: null,
+            TestContext);
+        Assert.IsTrue(initialProbe.Succeeded, "Explorer did not activate the File Locksmith context-menu surrogate.");
+
+        using var surrogate = WaitForModernContextMenuSurrogate(timeoutMS: 10_000);
+        Assert.IsNotNull(surrogate, "The File Locksmith package-specific dllhost process was not found.");
+
+        var servicingWindow = WaitForServicingWindow(surrogate!.Id, timeoutMS: 5_000);
+        Assert.AreNotEqual(
+            IntPtr.Zero,
+            servicingWindow,
+            "The File Locksmith context-menu surrogate has no top-level servicing window.");
+
+        Assert.IsTrue(PostMessageW(servicingWindow, WmClose, IntPtr.Zero, IntPtr.Zero), "WM_CLOSE could not be posted.");
+        Assert.IsTrue(surrogate.WaitForExit(5_000), "The context-menu surrogate did not exit after WM_CLOSE.");
+
+        var reactivationProbe = ExplorerHelper.ProbeCommand(
+            initialProbe.Explorer,
+            () => ExplorerHelper.OpenFolder(fixture.TargetFolder),
+            selection,
+            ContextMenuTier.Default,
+            FileLocksmithConstants.ContextMenuCaption,
+            expectedCommand: true,
+            siblingCaption: null,
+            TestContext);
+        Assert.IsTrue(reactivationProbe.Succeeded, "Explorer could not reactivate the context-menu surrogate.");
+    }
+
     private static bool ClassicHandlerRegistered()
     {
         using var key = Registry.CurrentUser.OpenSubKey(ClassicHandlerKeyPath);
@@ -292,6 +350,122 @@ public sealed class FileLocksmithContextMenuTests : UITestBase
             return false;
         }
     }
+
+    private static Process? WaitForModernContextMenuSurrogate(int timeoutMS)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromMilliseconds(timeoutMS);
+        do
+        {
+            foreach (var process in Process.GetProcessesByName("dllhost"))
+            {
+                if (GetPackageFullName(process.Id)?.Contains(ModernPackageName, StringComparison.OrdinalIgnoreCase) == true)
+                {
+                    return process;
+                }
+
+                process.Dispose();
+            }
+
+            Thread.Sleep(200);
+        }
+        while (DateTime.UtcNow < deadline);
+
+        return null;
+    }
+
+    private static string? GetPackageFullName(int processId)
+    {
+        var process = OpenProcess(ProcessQueryLimitedInformation, false, processId);
+        if (process == IntPtr.Zero)
+        {
+            return null;
+        }
+
+        try
+        {
+            uint length = 0;
+            if (GetPackageFullName(process, ref length, null) != ErrorInsufficientBuffer)
+            {
+                return null;
+            }
+
+            var packageFullName = new StringBuilder(checked((int)length));
+            return GetPackageFullName(process, ref length, packageFullName) == ErrorSuccess
+                ? packageFullName.ToString()
+                : null;
+        }
+        finally
+        {
+            CloseHandle(process);
+        }
+    }
+
+    private static IntPtr WaitForServicingWindow(int processId, int timeoutMS)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromMilliseconds(timeoutMS);
+        do
+        {
+            IntPtr match = IntPtr.Zero;
+            EnumWindows(
+                (window, _) =>
+                {
+                    if (GetWindowThreadProcessId(window, out var ownerProcessId) != 0 && ownerProcessId == processId)
+                    {
+                        var className = new StringBuilder(256);
+                        if (GetClassNameW(window, className, className.Capacity) > 0 &&
+                            className.ToString().Equals(ServicingWindowClassName, StringComparison.Ordinal))
+                        {
+                            match = window;
+                            return false;
+                        }
+                    }
+
+                    return true;
+                },
+                IntPtr.Zero);
+
+            if (match != IntPtr.Zero)
+            {
+                return match;
+            }
+
+            Thread.Sleep(100);
+        }
+        while (DateTime.UtcNow < deadline);
+
+        return IntPtr.Zero;
+    }
+
+    private const int ErrorSuccess = 0;
+    private const int ErrorInsufficientBuffer = 122;
+    private const uint ProcessQueryLimitedInformation = 0x1000;
+    private const uint WmClose = 0x0010;
+
+    private delegate bool EnumWindowsCallback(IntPtr window, IntPtr parameter);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern IntPtr OpenProcess(uint desiredAccess, bool inheritHandle, int processId);
+
+    [DllImport("kernel32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CloseHandle(IntPtr handle);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetPackageFullName(IntPtr process, ref uint packageFullNameLength, StringBuilder? packageFullName);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool EnumWindows(EnumWindowsCallback callback, IntPtr parameter);
+
+    [DllImport("user32.dll")]
+    private static extern uint GetWindowThreadProcessId(IntPtr window, out int processId);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetClassNameW(IntPtr window, StringBuilder className, int maximumCount);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool PostMessageW(IntPtr window, uint message, IntPtr wparam, IntPtr lparam);
 
     private static bool WaitForElementSearch(Session session, By by, int timeoutMS) =>
         session.WaitFor(

--- a/src/modules/NewPlus/NewShellExtensionContextMenu/dll_main.cpp
+++ b/src/modules/NewPlus/NewShellExtensionContextMenu/dll_main.cpp
@@ -5,10 +5,24 @@
 #include "trace.h"
 
 #include <common/Telemetry/EtwTrace/EtwTrace.h>
+#include <common/utils/context_menu_lifecycle.h>
 
 HMODULE module_instance_handle = 0;
 Shared::Trace::ETWTrace trace(L"NewPlusShellExtension");
 std::atomic_uint32_t active_rename_workers = 0;
+
+namespace
+{
+    void ensure_servicing_window()
+    {
+        context_menu_lifecycle::ensure_servicing_window(
+            &module_instance_handle,
+            L"Microsoft.PowerToys.NewPlusContextMenu_",
+            L"PowerToys.NewPlusContextMenu.ServicingWindow",
+            20000,
+            Trace::ServicingWindowInitialization);
+    }
+}
 
 BOOL APIENTRY DllMain(HMODULE module_handle, DWORD ul_reason_for_call, LPVOID reserved)
 {
@@ -29,6 +43,7 @@ BOOL APIENTRY DllMain(HMODULE module_handle, DWORD ul_reason_for_call, LPVOID re
 
 STDAPI DllGetActivationFactory(_In_ HSTRING activatableClassId, _COM_Outptr_ IActivationFactory** factory)
 {
+    ensure_servicing_window();
     return Module<ModuleType::InProc>::GetModule().GetActivationFactory(activatableClassId, factory);
 }
 
@@ -39,6 +54,7 @@ STDAPI DllCanUnloadNow()
 
 STDAPI DllGetClassObject(_In_ REFCLSID rclsid, _In_ REFIID riid, _Outptr_ LPVOID FAR* ppv)
 {
+    ensure_servicing_window();
     return Module<InProc>::GetModule().GetClassObject(rclsid, riid, ppv);
 }
 

--- a/src/modules/NewPlus/NewShellExtensionContextMenu/shell_context_sub_menu_item.cpp
+++ b/src/modules/NewPlus/NewShellExtensionContextMenu/shell_context_sub_menu_item.cpp
@@ -4,6 +4,8 @@
 #include "trace.h"
 #include "Generated Files/resource.h"
 
+#include <common/utils/context_menu_lifecycle.h>
+
 using namespace Microsoft::WRL;
 
 // Sub context menu containing the actual list of templates
@@ -63,6 +65,12 @@ IFACEMETHODIMP shell_context_sub_menu_item::GetState(_In_opt_ IShellItemArray* s
 
 IFACEMETHODIMP shell_context_sub_menu_item::Invoke(_In_opt_ IShellItemArray*, _In_opt_ IBindCtx*) noexcept
 {
+    context_menu_lifecycle::activity_guard activity;
+    if (!activity)
+    {
+        return HRESULT_FROM_WIN32(ERROR_SHUTDOWN_IN_PROGRESS);
+    }
+
     return newplus::utilities::copy_template(template_entry, site_of_folder, mouse_position_at_time_of_invoke);
 }
 
@@ -121,5 +129,11 @@ IFACEMETHODIMP template_folder_context_menu_item::GetIcon(_In_opt_ IShellItemArr
 
 IFACEMETHODIMP template_folder_context_menu_item::Invoke(_In_opt_ IShellItemArray* selection, _In_opt_ IBindCtx*) noexcept
 {
+    context_menu_lifecycle::activity_guard activity;
+    if (!activity)
+    {
+        return HRESULT_FROM_WIN32(ERROR_SHUTDOWN_IN_PROGRESS);
+    }
+
     return newplus::utilities::open_template_folder(shell_template_folder);
 }

--- a/src/modules/NewPlus/NewShellExtensionContextMenu/template_item.cpp
+++ b/src/modules/NewPlus/NewShellExtensionContextMenu/template_item.cpp
@@ -2,6 +2,7 @@
 #include "template_item.h"
 #include "newplus_icon_utilities.h"
 #include "new_utilities.h"
+#include <common/utils/context_menu_lifecycle.h>
 #include <chrono>
 #include <thread>
 #include <shlobj_core.h>
@@ -16,6 +17,7 @@ namespace
         std::filesystem::path target_fullpath;
         POINT mouse_position_at_invoke;
         HMODULE module_reference;
+        context_menu_lifecycle::activity_token lifecycle_activity;
     };
 }
 
@@ -213,16 +215,25 @@ void template_item::enter_rename_mode(const std::filesystem::path target_fullpat
         return;
     }
 
+    const auto lifecycle_activity = context_menu_lifecycle::begin_activity();
+    if (!lifecycle_activity)
+    {
+        FreeLibrary(module_reference);
+        return;
+    }
+
     std::unique_ptr<rename_worker_context> context;
     try
     {
         context = std::make_unique<rename_worker_context>(
             target_fullpath,
             mouse_position_at_invoke,
-            module_reference);
+            module_reference,
+            lifecycle_activity);
     }
     catch (...)
     {
+        context_menu_lifecycle::end_activity(lifecycle_activity);
         FreeLibrary(module_reference);
         return;
     }
@@ -231,6 +242,7 @@ void template_item::enter_rename_mode(const std::filesystem::path target_fullpat
     const HANDLE thread = CreateThread(nullptr, 0, rename_worker_thread_proc, context.get(), 0, nullptr);
     if (thread == nullptr)
     {
+        context_menu_lifecycle::end_activity(lifecycle_activity);
         active_rename_workers.fetch_sub(1);
         FreeLibrary(module_reference);
         return;
@@ -244,9 +256,11 @@ DWORD WINAPI template_item::rename_worker_thread_proc(void* parameter)
 {
     std::unique_ptr<rename_worker_context> context(static_cast<rename_worker_context*>(parameter));
     const HMODULE module_reference = context->module_reference;
+    const auto lifecycle_activity = context->lifecycle_activity;
 
     rename_on_other_thread_workaround(context->target_fullpath, context->mouse_position_at_invoke);
     context.reset();
+    context_menu_lifecycle::end_activity(lifecycle_activity);
     active_rename_workers.fetch_sub(1);
     FreeLibraryAndExitThread(module_reference, 0);
 }

--- a/src/modules/NewPlus/NewShellExtensionContextMenu/trace.cpp
+++ b/src/modules/NewPlus/NewShellExtensionContextMenu/trace.cpp
@@ -59,6 +59,16 @@ void Trace::EventCopyTemplateResult(_In_ const HRESULT hr) noexcept
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
 }
 
+void Trace::ServicingWindowInitialization(_In_ HRESULT hr) noexcept
+{
+    TraceLoggingWriteWrapper(
+        g_hProvider,
+        "NewPlus_ServicingWindowInitialization",
+        ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
+        TraceLoggingHResult(hr),
+        TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
+}
+
 void Trace::EventOpenTemplates() noexcept
 {
     TraceLoggingWriteWrapper(

--- a/src/modules/NewPlus/NewShellExtensionContextMenu/trace.h
+++ b/src/modules/NewPlus/NewShellExtensionContextMenu/trace.h
@@ -12,5 +12,6 @@ public:
     static void EventShowTemplateItems(_In_ const size_t number_of_templates) noexcept;
     static void EventCopyTemplate(_In_ const std::wstring template_file_extension) noexcept;
     static void EventCopyTemplateResult(_In_ const HRESULT hr) noexcept;
+    static void ServicingWindowInitialization(_In_ HRESULT hr) noexcept;
     static void EventOpenTemplates() noexcept;
 };

--- a/src/modules/imageresizer/ImageResizerContextMenu/dllmain.cpp
+++ b/src/modules/imageresizer/ImageResizerContextMenu/dllmain.cpp
@@ -8,6 +8,7 @@
 #include <string>
 
 #include <common/telemetry/EtwTrace/EtwTrace.h>
+#include <common/utils/context_menu_lifecycle.h>
 #include <common/utils/elevation.h>
 #include <common/utils/process_path.h>
 #include <common/utils/resources.h>
@@ -22,6 +23,19 @@ using namespace Microsoft::WRL;
 
 HINSTANCE g_hInst = 0;
 Shared::Trace::ETWTrace trace(L"ImageResizerContextMenu");
+
+namespace
+{
+    void ensure_servicing_window()
+    {
+        context_menu_lifecycle::ensure_servicing_window(
+            &g_hInst,
+            L"Microsoft.PowerToys.ImageResizerContextMenu_",
+            L"PowerToys.ImageResizerContextMenu.ServicingWindow",
+            5000,
+            Trace::ServicingWindowInitialization);
+    }
+}
 
 #define BUFSIZE 4096 * 4
 
@@ -136,6 +150,12 @@ public:
     IFACEMETHODIMP Invoke(_In_opt_ IShellItemArray* selection, _In_opt_ IBindCtx*) noexcept
     try
     {
+        context_menu_lifecycle::activity_guard activity;
+        if (!activity)
+        {
+            return HRESULT_FROM_WIN32(ERROR_SHUTDOWN_IN_PROGRESS);
+        }
+
         trace.UpdateState(true);
 
         Trace::Invoked();
@@ -290,6 +310,7 @@ CoCreatableClassWrlCreatorMapInclude(ImageResizerContextMenuCommand)
 
 STDAPI DllGetActivationFactory(_In_ HSTRING activatableClassId, _COM_Outptr_ IActivationFactory** factory)
 {
+    ensure_servicing_window();
     return Module<ModuleType::InProc>::GetModule().GetActivationFactory(activatableClassId, factory);
 }
 
@@ -300,5 +321,6 @@ STDAPI DllCanUnloadNow()
 
 STDAPI DllGetClassObject(_In_ REFCLSID rclsid, _In_ REFIID riid, _COM_Outptr_ void** instance)
 {
+    ensure_servicing_window();
     return Module<InProc>::GetModule().GetClassObject(rclsid, riid, instance);
 }

--- a/src/modules/imageresizer/ImageResizerLib/trace.cpp
+++ b/src/modules/imageresizer/ImageResizerLib/trace.cpp
@@ -39,6 +39,16 @@ void Trace::InvokedRet(_In_ HRESULT hr) noexcept
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
 }
 
+void Trace::ServicingWindowInitialization(_In_ HRESULT hr) noexcept
+{
+    TraceLoggingWriteWrapper(
+        g_hProvider,
+        "ImageResizer_ServicingWindowInitialization",
+        ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
+        TraceLoggingHResult(hr),
+        TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
+}
+
 void Trace::QueryContextMenuError(_In_ HRESULT hr) noexcept
 {
     TraceLoggingWriteWrapper(

--- a/src/modules/imageresizer/ImageResizerLib/trace.h
+++ b/src/modules/imageresizer/ImageResizerLib/trace.h
@@ -8,5 +8,6 @@ public:
     static void EnableImageResizer(_In_ bool enabled) noexcept;
     static void Invoked() noexcept;
     static void InvokedRet(_In_ HRESULT hr) noexcept;
+    static void ServicingWindowInitialization(_In_ HRESULT hr) noexcept;
     static void QueryContextMenuError(_In_ HRESULT hr) noexcept;
 };

--- a/src/modules/powerrename/PowerRenameContextMenu/dllmain.cpp
+++ b/src/modules/powerrename/PowerRenameContextMenu/dllmain.cpp
@@ -19,6 +19,7 @@
 #include "Generated Files/resource.h"
 
 #include <common/telemetry/EtwTrace/EtwTrace.h>
+#include <common/utils/context_menu_lifecycle.h>
 #include <common/utils/elevation.h>
 #include <common/utils/process_path.h>
 #include <common/utils/resources.h>
@@ -34,6 +35,19 @@ using namespace Microsoft::WRL;
 
 HINSTANCE g_hInst = 0;
 Shared::Trace::ETWTrace trace(L"PowerRenameContextMenu");
+
+namespace
+{
+    void ensure_servicing_window()
+    {
+        context_menu_lifecycle::ensure_servicing_window(
+            &g_hInst,
+            L"Microsoft.PowerToys.PowerRenameContextMenu_",
+            L"PowerToys.PowerRenameContextMenu.ServicingWindow",
+            5000,
+            Trace::ServicingWindowInitialization);
+    }
+}
 
 #define BUFSIZE 4096 * 4
 
@@ -130,6 +144,12 @@ public:
     IFACEMETHODIMP Invoke(_In_opt_ IShellItemArray* selection, _In_opt_ IBindCtx*) noexcept
     try
     {
+        context_menu_lifecycle::activity_guard activity;
+        if (!activity)
+        {
+            return HRESULT_FROM_WIN32(ERROR_SHUTDOWN_IN_PROGRESS);
+        }
+
         if (selection)
         {
             RunPowerRename(selection);
@@ -279,6 +299,7 @@ CoCreatableClassWrlCreatorMapInclude(PowerRenameContextMenuCommand)
 
 STDAPI DllGetActivationFactory(_In_ HSTRING activatableClassId, _COM_Outptr_ IActivationFactory** factory)
 {
+    ensure_servicing_window();
     return Module<ModuleType::InProc>::GetModule().GetActivationFactory(activatableClassId, factory);
 }
 
@@ -289,5 +310,6 @@ STDAPI DllCanUnloadNow()
 
 STDAPI DllGetClassObject(_In_ REFCLSID rclsid, _In_ REFIID riid, _COM_Outptr_ void** instance)
 {
+    ensure_servicing_window();
     return Module<InProc>::GetModule().GetClassObject(rclsid, riid, instance);
 }

--- a/src/modules/powerrename/lib/trace.cpp
+++ b/src/modules/powerrename/lib/trace.cpp
@@ -30,6 +30,16 @@ void Trace::InvokedRet(_In_ HRESULT hr) noexcept
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
 }
 
+void Trace::ServicingWindowInitialization(_In_ HRESULT hr) noexcept
+{
+    TraceLoggingWriteWrapper(
+        g_hProvider,
+        "PowerRename_ServicingWindowInitialization",
+        ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
+        TraceLoggingHResult(hr),
+        TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
+}
+
 void Trace::EnablePowerRename(_In_ bool enabled) noexcept
 {
     TraceLoggingWriteWrapper(

--- a/src/modules/powerrename/lib/trace.h
+++ b/src/modules/powerrename/lib/trace.h
@@ -6,6 +6,7 @@ class Trace : public telemetry::TraceBase {
 public:
   static void Invoked() noexcept;
   static void InvokedRet(_In_ HRESULT hr) noexcept;
+  static void ServicingWindowInitialization(_In_ HRESULT hr) noexcept;
   static void EnablePowerRename(_In_ bool enabled) noexcept;
   static void UIShownRet(_In_ HRESULT hr) noexcept;
   static void RenameOperation(


### PR DESCRIPTION
## Summary of the Pull Request

Fixes packaged context-menu `HANG_QUIESCE` failures during PowerToys update/uninstall for File Locksmith, PowerRename, Image Resizer, and New+.

These commands run in package-dedicated `dllhost.exe` COM surrogates. The surrogates have no top-level window, so packaged Win32 servicing has no `WM_CLOSE` target and waits for its timeout before force-terminating them. The Watson stack consequently shows the normal surrogate wait:

`dllhost!wWinMain -> combase!CoRegisterSurrogateEx -> CSurrogateProcessActivator::WaitForSurrogateTimeout`

This adds a shared lifecycle monitor in `src/common/utils/context_menu_lifecycle.h` and wires it into all four packaged context-menu DLLs.

## PR Checklist

- [x] Closes: AB#51280953
- [x] **Communication:** Discussed with a core contributor during investigation
- [ ] **Tests:** Automated coverage added and targeted builds pass; signed sparse-MSIX servicing A/B remains for CI/nightly validation
- [x] **Localization:** No end-user-facing strings changed

## Detailed Description of the Pull Request / Additional comments

The shared helper:

- Activates only inside the expected package family, so classic/unpackaged hosts are unchanged.
- Holds an ordinary module reference so its window procedure remains valid after COM considers the server unloadable.
- Creates one hidden top-level `WS_POPUP` window on a dedicated message-pump thread, outside `DllMain`.
- Returns `TRUE` for `WM_QUERYENDSESSION`.
- Atomically closes new activity admission on `WM_CLOSE` or confirmed `WM_ENDSESSION`, waits for already-admitted work, then terminates the stateless package-dedicated surrogate before servicing's timeout.
- Cleans up and permits retry when monitor initialization fails.
- Emits one initialization HRESULT telemetry event per module.

Module policy:

- File Locksmith, PowerRename, and Image Resizer receive a 5-second grace period.
- New+ receives 20 seconds because template copying and Explorer rename positioning happen in-process. Its rename worker transfers an activity token until completion.

`DllCanUnloadNow` remains based on the existing COM object/worker counts. No package manifest, registration, IPC contract, or user-facing command behavior changes.

A focused test in `src/modules/FileLocksmith/Tests/FileLocksmith.UITests/FileLocksmithContextMenuTests.cs` activates the real tier-1 command, locates the package-specific `dllhost` and lifecycle window, posts `WM_CLOSE`, requires process exit within five seconds, and verifies Explorer can reactivate the command.

This PR is intentionally separate from #49502. That PR concerns `PowerToys.FileLocksmithUI.exe` native handle enumeration and `0xc0000005`; this PR concerns package servicing of context-menu COM surrogates.

## Validation Steps Performed

- Release x64 builds passed for all four context-menu projects plus File Locksmith, PowerRename, and Image Resizer UITest projects.
- `FileLocksmith.ContextMenu.ServicingShutdown` is discovered by the MSTest executable.
- Local native builds used `/p:SpectreMitigation=false` because this host lacks the optional Spectre-mitigated MSVC libraries, and `/m:1` after a parallel PCH memory-pressure failure.
- Package-generation events were disabled only for local compilation because project-local build logs are held while MakeAppx packs the same directory. No package-generation code changed.

Nightly validation after merge:

1. Activate each modern command and confirm its package-specific `dllhost` owns the expected servicing window.
2. Upgrade from 0.101.x to the nightly and verify the surrogates exit before the timeout with no new `MOAPPLICATION_HANG_*ContextMenu!HANG_QUIESCE` reports.
3. Verify each command reactivates after its previous surrogate exits.
4. Exercise File Locksmith launch, PowerRename multi-file launch, Image Resizer multi-file launch, and New+ template copy/rename before and after update.
5. Compare initialization HRESULT telemetry and Watson buckets by version and integrity level.