### PR TITLE
[GH Actions][UITests] Trigger new UI tests automatically per modified module

### DIFF
--- a/.pipelines/resolveUiTestModules.ps1
+++ b/.pipelines/resolveUiTestModules.ps1
@@ -1,0 +1,48 @@
+# Copyright (c) Microsoft Corporation
+# The Microsoft Corporation licenses this file to you under the MIT license.
+
+param(
+    [Parameter(Mandatory)]
+    [string] $RepoRoot,
+
+    [string[]] $ChangedFile = @()
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -LiteralPath $RepoRoot -PathType Container)) {
+    throw "Repository root does not exist: $RepoRoot"
+}
+
+$touchedModules = @(
+    $ChangedFile |
+        ForEach-Object { $_ -replace '\\', '/' } |
+        ForEach-Object {
+            if ($_ -match '^src/modules/([^/]+)(?:/|$)') {
+                $Matches[1]
+            }
+        } |
+        Sort-Object -Unique
+)
+
+$uiTestModules = foreach ($module in $touchedModules) {
+    $moduleRoot = Join-Path $RepoRoot "src\modules\$module"
+    if (-not (Test-Path -LiteralPath $moduleRoot -PathType Container)) {
+        continue
+    }
+
+    $projects = @(
+        Get-ChildItem -LiteralPath $moduleRoot -Filter '*.csproj' -File -Recurse |
+            Where-Object { $_.BaseName -match '\.UITests(?:\.Next)?$' }
+    )
+    $nextProjects = @($projects | Where-Object { $_.BaseName -match '\.UITests\.Next$' })
+    $selectedProjects = if ($nextProjects.Count -gt 0) { $nextProjects } else { $projects }
+
+    $selectedProjects | ForEach-Object { $_.BaseName }
+}
+
+[PSCustomObject]@{
+    TouchedModules = @($touchedModules)
+    UiTestModules = @($uiTestModules | Sort-Object -Unique)
+}

--- a/.pipelines/resolveUiTestModules.ps1
+++ b/.pipelines/resolveUiTestModules.ps1
@@ -32,14 +32,15 @@ $uiTestModules = foreach ($module in $touchedModules) {
         continue
     }
 
-    $projects = @(
-        Get-ChildItem -LiteralPath $moduleRoot -Filter '*.csproj' -File -Recurse |
-            Where-Object { $_.BaseName -match '\.UITests(?:\.Next)?$' }
-    )
-    $nextProjects = @($projects | Where-Object { $_.BaseName -match '\.UITests\.Next$' })
-    $selectedProjects = if ($nextProjects.Count -gt 0) { $nextProjects } else { $projects }
-
-    $selectedProjects | ForEach-Object { $_.BaseName }
+    Get-ChildItem -LiteralPath $moduleRoot -Filter '*.csproj' -File -Recurse |
+        Where-Object {
+            [xml] $project = Get-Content -LiteralPath $_.FullName -Raw
+            @($project.SelectNodes("//*[local-name()='ProjectReference']")) |
+                Where-Object {
+                    ($_.Include -replace '\\', '/') -match '/UITestAutomation\.Next/UITestAutomation\.Next\.csproj$'
+                }
+        } |
+        ForEach-Object { $_.BaseName }
 }
 
 [PSCustomObject]@{

--- a/.pipelines/tests/resolveUiTestModules.Tests.ps1
+++ b/.pipelines/tests/resolveUiTestModules.Tests.ps1
@@ -4,11 +4,28 @@
 $scriptPath = Join-Path $PSScriptRoot '..\resolveUiTestModules.ps1'
 
 function New-UITestProject {
-    param([Parameter(Mandatory)][string] $RelativePath)
+    param(
+        [Parameter(Mandatory)]
+        [string] $RelativePath,
+
+        [ValidateSet('Next', 'Legacy', 'None')]
+        [string] $Framework = 'Next'
+    )
 
     $path = Join-Path $TestDrive $RelativePath
     New-Item -ItemType Directory -Path (Split-Path $path) -Force | Out-Null
-    '<Project Sdk="Microsoft.NET.Sdk" />' | Set-Content -LiteralPath $path
+    $projectReference = switch ($Framework) {
+        'Next' { '<ProjectReference Include="..\UITestAutomation.Next\UITestAutomation.Next.csproj" />' }
+        'Legacy' { '<ProjectReference Include="..\UITestAutomation\UITestAutomation.csproj" />' }
+        default { '' }
+    }
+    @"
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    $projectReference
+  </ItemGroup>
+</Project>
+"@ | Set-Content -LiteralPath $path
 }
 
 Describe 'resolveUiTestModules' {
@@ -25,10 +42,10 @@ Describe 'resolveUiTestModules' {
         $result.UiTestModules | Should Be @('FileLocksmith.UITests')
     }
 
-    It 'prefers all Next projects over legacy projects in the same module' {
-        New-UITestProject 'src\modules\fancyzones\FancyZones.UITests\FancyZones.UITests.csproj'
+    It 'selects projects using the Next framework and ignores legacy siblings' {
+        New-UITestProject 'src\modules\fancyzones\FancyZones.UITests\FancyZones.UITests.csproj' -Framework Legacy
         New-UITestProject 'src\modules\fancyzones\FancyZones.UITests.Next\FancyZones.UITests.Next.csproj'
-        New-UITestProject 'src\modules\fancyzones\FancyZonesEditor.UITests\FancyZonesEditor.UITests.csproj'
+        New-UITestProject 'src\modules\fancyzones\FancyZonesEditor.UITests\FancyZonesEditor.UITests.csproj' -Framework Legacy
         New-UITestProject 'src\modules\fancyzones\FancyZonesEditor.UITests.Next\FancyZonesEditor.UITests.Next.csproj'
 
         $result = & $scriptPath -RepoRoot $TestDrive -ChangedFile 'src/modules/fancyzones/dll/FancyZones.cpp'
@@ -39,8 +56,9 @@ Describe 'resolveUiTestModules' {
         )
     }
 
-    It 'ignores modules without UI tests and non-module changes' {
-        New-UITestProject 'src\modules\Example\Tests\Example.UnitTests\Example.UnitTests.csproj'
+    It 'ignores modules with only legacy UI tests and non-module changes' {
+        New-UITestProject 'src\modules\Example\Tests\Example.UITests\Example.UITests.csproj' -Framework Legacy
+        New-UITestProject 'src\modules\Example\Tests\Example.UnitTests\Example.UnitTests.csproj' -Framework None
 
         $result = & $scriptPath -RepoRoot $TestDrive -ChangedFile @(
             'doc/devdocs/modules/example.md',

--- a/.pipelines/tests/resolveUiTestModules.Tests.ps1
+++ b/.pipelines/tests/resolveUiTestModules.Tests.ps1
@@ -1,0 +1,53 @@
+# Copyright (c) Microsoft Corporation
+# The Microsoft Corporation licenses this file to you under the MIT license.
+
+$scriptPath = Join-Path $PSScriptRoot '..\resolveUiTestModules.ps1'
+
+function New-UITestProject {
+    param([Parameter(Mandatory)][string] $RelativePath)
+
+    $path = Join-Path $TestDrive $RelativePath
+    New-Item -ItemType Directory -Path (Split-Path $path) -Force | Out-Null
+    '<Project Sdk="Microsoft.NET.Sdk" />' | Set-Content -LiteralPath $path
+}
+
+Describe 'resolveUiTestModules' {
+    It 'selects the UI tests for a touched module' {
+        New-UITestProject 'src\modules\FileLocksmith\Tests\FileLocksmith.UITests\FileLocksmith.UITests.csproj'
+
+        $result = & $scriptPath -RepoRoot $TestDrive -ChangedFile @(
+            'PowerToys.slnx',
+            'src/modules/FileLocksmith/FileLocksmithUI/MainWindow.xaml.cs',
+            'src\modules\FileLocksmith\FileLocksmithLib\FileLocksmith.cpp'
+        )
+
+        $result.TouchedModules | Should Be @('FileLocksmith')
+        $result.UiTestModules | Should Be @('FileLocksmith.UITests')
+    }
+
+    It 'prefers all Next projects over legacy projects in the same module' {
+        New-UITestProject 'src\modules\fancyzones\FancyZones.UITests\FancyZones.UITests.csproj'
+        New-UITestProject 'src\modules\fancyzones\FancyZones.UITests.Next\FancyZones.UITests.Next.csproj'
+        New-UITestProject 'src\modules\fancyzones\FancyZonesEditor.UITests\FancyZonesEditor.UITests.csproj'
+        New-UITestProject 'src\modules\fancyzones\FancyZonesEditor.UITests.Next\FancyZonesEditor.UITests.Next.csproj'
+
+        $result = & $scriptPath -RepoRoot $TestDrive -ChangedFile 'src/modules/fancyzones/dll/FancyZones.cpp'
+
+        $result.UiTestModules | Should Be @(
+            'FancyZones.UITests.Next',
+            'FancyZonesEditor.UITests.Next'
+        )
+    }
+
+    It 'ignores modules without UI tests and non-module changes' {
+        New-UITestProject 'src\modules\Example\Tests\Example.UnitTests\Example.UnitTests.csproj'
+
+        $result = & $scriptPath -RepoRoot $TestDrive -ChangedFile @(
+            'doc/devdocs/modules/example.md',
+            'src/modules/Example/Example.cpp'
+        )
+
+        $result.TouchedModules | Should Be @('Example')
+        @($result.UiTestModules).Count | Should Be 0
+    }
+}

--- a/.pipelines/v2/ci.yml
+++ b/.pipelines/v2/ci.yml
@@ -39,6 +39,10 @@ parameters:
     type: boolean
     displayName: "Run Tests"
     default: true
+  - name: runAffectedUiTests
+    type: boolean
+    displayName: "Run affected UI tests for pull requests"
+    default: true
   - name: useVSPreview
     type: boolean
     displayName: "Build Using Visual Studio Preview"
@@ -51,4 +55,5 @@ extends:
     ${{ if eq(variables['System.PullRequest.IsFork'], 'False') }}:
       enableMsBuildCaching: ${{ parameters.enableMsBuildCaching }}
     runTests: ${{ parameters.runTests }}
+    runAffectedUiTests: ${{ parameters.runAffectedUiTests }}
     useVSPreview: ${{ parameters.useVSPreview }}

--- a/.pipelines/v2/templates/job-resolve-ui-tests.yml
+++ b/.pipelines/v2/templates/job-resolve-ui-tests.yml
@@ -1,0 +1,54 @@
+jobs:
+- job: Resolve
+  displayName: Resolve affected UI test projects
+  condition: eq(variables['Build.Reason'], 'PullRequest')
+  continueOnError: true
+  pool:
+    ${{ if eq(variables['System.CollectionId'], 'cb55739e-4afe-46a3-970f-1b49d8ee7564') }}:
+      name: SHINE-INT-L
+    ${{ else }}:
+      name: SHINE-OSS-L
+    demands: ImageOverride -equals SHINE-VS18-Latest
+  steps:
+    - checkout: self
+      clean: true
+      submodules: false
+      fetchTags: false
+      fetchDepth: 0
+
+    - pwsh: |
+        $ErrorActionPreference = 'Stop'
+        $targetBranch = '$(System.PullRequest.TargetBranch)'
+        if ([string]::IsNullOrWhiteSpace($targetBranch) -or $targetBranch.StartsWith('$(')) {
+          throw 'System.PullRequest.TargetBranch is unavailable for this pull request build.'
+        }
+
+        $targetRef = $targetBranch -replace '^refs/heads/', 'refs/remotes/origin/'
+        & git fetch --no-tags origin "+${targetBranch}:${targetRef}"
+        if ($LASTEXITCODE -ne 0) {
+          throw "Failed to fetch pull request target branch '$targetBranch'."
+        }
+
+        $mergeBase = & git merge-base HEAD $targetRef
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($mergeBase)) {
+          throw "Failed to find the merge base between HEAD and '$targetRef'."
+        }
+
+        $changedFiles = @(& git diff --name-only --diff-filter=ACDMRTUXB "$mergeBase...HEAD")
+        if ($LASTEXITCODE -ne 0) {
+          throw 'Failed to enumerate pull request changes.'
+        }
+
+        $result = & "$(Build.SourcesDirectory)\.pipelines\resolveUiTestModules.ps1" `
+          -RepoRoot "$(Build.SourcesDirectory)" `
+          -ChangedFile $changedFiles
+        $modules = @($result.UiTestModules)
+        $modulesValue = $modules -join ';'
+        $hasUiTests = if ($modules.Count -gt 0) { 'true' } else { 'false' }
+
+        Write-Host "Touched modules: $($result.TouchedModules -join ', ')"
+        Write-Host "Selected UI tests: $($modules -join ', ')"
+        Write-Host "##vso[task.setvariable variable=hasUiTests;isOutput=true]$hasUiTests"
+        Write-Host "##vso[task.setvariable variable=uiTestModules;isOutput=true]$modulesValue"
+      name: resolve
+      displayName: Resolve UI tests from pull request changes

--- a/.pipelines/v2/templates/job-resolve-ui-tests.yml
+++ b/.pipelines/v2/templates/job-resolve-ui-tests.yml
@@ -13,6 +13,7 @@ jobs:
     - checkout: self
       clean: true
       submodules: false
+      persistCredentials: True
       fetchTags: false
       fetchDepth: 0
 

--- a/.pipelines/v2/templates/job-test-project.yml
+++ b/.pipelines/v2/templates/job-test-project.yml
@@ -22,6 +22,15 @@ parameters:
   - name: uiTestModules
     type: object
     default: []
+  - name: autoSelectUiTests
+    type: boolean
+    default: false
+  - name: dependsOn
+    type: object
+    default: []
+  - name: condition
+    type: string
+    default: ''
   - name: installMode
     type: string
     default: 'machine'
@@ -35,6 +44,9 @@ parameters:
 jobs:
 - job: Test${{ parameters.platform }}${{ parameters.configuration }}${{ parameters.jobSuffix }}
   displayName: Test ${{ parameters.platform }} ${{ parameters.configuration }}${{ parameters.jobSuffix }}
+  dependsOn: ${{ parameters.dependsOn }}
+  condition: ${{ parameters.condition }}
+  continueOnError: ${{ parameters.autoSelectUiTests }}
   timeoutInMinutes: 300
   variables:
     ${{ if or(eq(parameters.platform, 'x64Win10'), eq(parameters.platform, 'x64Win11')) }}:
@@ -45,6 +57,8 @@ jobs:
     BuildConfiguration: ${{ parameters.configuration }}
     SrcPath: $(Build.Repository.LocalPath)
     TestArtifactsName: build-${{ variables.BuildPlatform }}-${{ parameters.configuration }}${{ parameters.inputArtifactStem }}
+    ${{ if eq(parameters.autoSelectUiTests, true) }}:
+      AutoUiTestModules: $[ dependencies.Resolve.outputs['resolve.uiTestModules'] ]
   pool:
     ${{ if eq(variables['System.CollectionId'], 'cb55739e-4afe-46a3-970f-1b49d8ee7564') }}:
       ${{ if ne(parameters.platform, 'ARM64') }}:
@@ -197,6 +211,9 @@ jobs:
         "$env:ProgramFiles\PowerToys",
         "$env:LOCALAPPDATA\PowerToys")
       $modulesRaw = '${{ join(';', parameters.uiTestModules) }}'
+      if (-not [string]::IsNullOrWhiteSpace($env:AUTO_UI_TEST_MODULES)) {
+        $modulesRaw = $env:AUTO_UI_TEST_MODULES
+      }
       $selectedModules = @($modulesRaw -split ';' | Where-Object { $_ })
       $allModules = [string]::IsNullOrWhiteSpace($modulesRaw)
       $requiresModernContextMenu = '$(TestPlatform)' -ne 'x64Win10'
@@ -239,6 +256,9 @@ jobs:
         }
       }
     displayName: "Sign sparse MSIX packages (test trust)"
+    ${{ if eq(parameters.autoSelectUiTests, true) }}:
+      env:
+        AUTO_UI_TEST_MODULES: $(AutoUiTestModules)
 
   # Start WinAppDriver once for the whole job — WinAppDriver's documented CI pattern
   # (https://github.com/microsoft/WinAppDriver/blob/master/Docs/CI_AzureDevOps.md). Launching it
@@ -286,6 +306,9 @@ jobs:
 
       # uiTestModules is a template parameter; flatten it to a delimited string for the script.
       $modulesRaw = '${{ join(';', parameters.uiTestModules) }}'
+      if (-not [string]::IsNullOrWhiteSpace($env:AUTO_UI_TEST_MODULES)) {
+        $modulesRaw = $env:AUTO_UI_TEST_MODULES
+      }
       $modules = @()
       if (-not [string]::IsNullOrWhiteSpace($modulesRaw)) {
         $modules = $modulesRaw -split ';' | ForEach-Object { $_.Trim() } | Where-Object { $_ }
@@ -296,7 +319,10 @@ jobs:
       $entries = Get-ChildItem -Path $artifactRoot -Filter '*.runtimeconfig.json' -File -Recurse -ErrorAction SilentlyContinue |
         Where-Object { $_.Name -like '*UITests*' -and $_.FullName -match '\\tests\\' }
       if ($modules.Count -gt 0) {
-        $entries = $entries | Where-Object { $n = $_.Name; ($modules | Where-Object { $n -like "*$_*" }).Count -gt 0 }
+        $entries = $entries | Where-Object {
+          $projectName = $_.Name -replace '\.runtimeconfig\.json$', ''
+          $modules -contains $projectName
+        }
       }
 
       # Run each test assembly once (a project reference can copy a runner into a sibling's output).
@@ -346,6 +372,8 @@ jobs:
     # set `env: { platform: $(TestPlatform) }`; the MTP migration to this pwsh step dropped it.
     env:
       platform: $(TestPlatform)
+      ${{ if eq(parameters.autoSelectUiTests, true) }}:
+        AUTO_UI_TEST_MODULES: $(AutoUiTestModules)
 
   - task: PublishTestResults@2
     displayName: "Publish UI Test Results"

--- a/.pipelines/v2/templates/pipeline-ci-build.yml
+++ b/.pipelines/v2/templates/pipeline-ci-build.yml
@@ -19,6 +19,9 @@ parameters:
   - name: runTests
     type: boolean
     default: true
+  - name: runAffectedUiTests
+    type: boolean
+    default: false
   - name: useVSPreview
     type: boolean
     default: false
@@ -91,6 +94,47 @@ stages:
               artifactName: ${{ parameters.artifactName }}
               metaPackageName: ${{ parameters.metaPackageName }}
             timeoutInMinutes: 90
+
+        - ${{ if eq(parameters.runAffectedUiTests, true) }}:
+          - template: job-resolve-ui-tests.yml
+
+          - ${{ if eq(platform, 'x64') }}:
+            - template: job-test-project.yml
+              parameters:
+                platform: x64Win10
+                configuration: Release
+                buildSource: buildNowSlim
+                useLatestWebView2: ${{ parameters.useLatestWebView2 }}
+                autoSelectUiTests: true
+                dependsOn:
+                  - Build
+                  - Resolve
+                condition: and(succeeded(), eq(dependencies.Resolve.outputs['resolve.hasUiTests'], 'true'))
+
+            - template: job-test-project.yml
+              parameters:
+                platform: x64Win11
+                configuration: Release
+                buildSource: buildNowSlim
+                useLatestWebView2: ${{ parameters.useLatestWebView2 }}
+                autoSelectUiTests: true
+                dependsOn:
+                  - Build
+                  - Resolve
+                condition: and(succeeded(), eq(dependencies.Resolve.outputs['resolve.hasUiTests'], 'true'))
+
+          - ${{ if ne(platform, 'x64') }}:
+            - template: job-test-project.yml
+              parameters:
+                platform: ${{ platform }}
+                configuration: Release
+                buildSource: buildNowSlim
+                useLatestWebView2: ${{ parameters.useLatestWebView2 }}
+                autoSelectUiTests: true
+                dependsOn:
+                  - Build
+                  - Resolve
+                condition: and(succeeded(), eq(dependencies.Resolve.outputs['resolve.hasUiTests'], 'true'))
 
   - stage: Build_SDK
     displayName: Build Command Palette Toolkit SDK

--- a/.pipelines/v2/templates/pipeline-ui-tests-automation.yml
+++ b/.pipelines/v2/templates/pipeline-ui-tests-automation.yml
@@ -1,3 +1,7 @@
+trigger: none
+
+pr: none
+
 variables:
   - name: runCodesignValidationInjectionBG
     value: false
@@ -39,8 +43,8 @@ parameters:
 stages:
   - ${{ each platform in parameters.buildPlatforms }}:
     # Full build path: build PowerToys + UI tests + run tests.
-    # buildNow downloads the whole build and runs in place; buildNowSlim downloads only the installer
-    # from that same full build and installs it. Both require the full build, so they share this path.
+    # buildNow downloads the whole build artifact and runs in place; buildNowSlim downloads only the
+    # installer from that same full build and installs it. Both require the full build, so they share this path.
     - ${{ if or(eq(parameters.buildSource, 'buildNow'), eq(parameters.buildSource, 'buildNowSlim')) }}:
       - template: pipeline-ui-tests-full-build.yml
         parameters:


### PR DESCRIPTION
Automatically runs affected UI tests for pull requests as part of the existing PowerToys CI build. Only test projects that reference `UITestAutomation.Next` are selected; legacy-only UI test projects are skipped.

The UI test jobs reuse artifacts from the successful x64 and ARM64 product builds instead of building PowerToys again. These automatic jobs are non-blocking while the workflow is being evaluated.

## PR Checklist

- [ ] Closes: N/A (no linked issue)
- [x] **Communication:** Discussed with core contributors
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** N/A; no end-user-facing strings
- [x] **Dev docs:** N/A; pipeline-only change
- [x] **New binaries:** N/A
- [x] **Documentation updated:** N/A; no user-facing documentation change

## Detailed Description of the Pull Request / Additional comments

- Detects modules changed by a PR from the merge-base diff against its target branch.
- Parses each touched module's `.csproj` files and selects only projects that reference `UITestAutomation.Next.csproj`. Selection does not depend on the project name, so migrated projects such as `FileLocksmith.UITests` remain eligible without a `.Next` suffix.
- Skips modules that have no UI tests on the new framework, including modules with only legacy UI tests.
- Runs selected test assemblies by exact project name to prevent legacy and `.Next` projects from matching each other.
- Adds the affected UI test jobs to the existing x64 and ARM64 CI stages. They depend on the corresponding successful product build and reuse its published installer and test outputs through `buildNowSlim`.
- Runs x64 UI tests on Windows 10 and Windows 11 and ARM64 UI tests on the ARM64 test agent.
- Keeps automatic resolver and UI test jobs non-blocking with `continueOnError`. Manual UI Test Automation runs remain blocking.
- Disables automatic triggers on the standalone UI Test Automation pipeline to avoid a duplicate product build and duplicate test run.

## Validation Steps Performed

- Ran `Invoke-Pester .\.pipelines\tests\resolveUiTestModules.Tests.ps1 -PassThru`: 3 passed, 0 failed.
- Verified real repository mappings:
  - File Locksmith selects `FileLocksmith.UITests`.
  - FancyZones selects `FancyZones.UITests.Next` and `FancyZonesEditor.UITests.Next` while excluding legacy siblings.
  - Color Picker selects `ColorPicker.UITests` based on its new-framework reference.
  - Legacy-only Hosts selects no automatic UI tests.
- Checked all modified PowerShell and YAML files with VS Code diagnostics: no errors.
- Ran `git diff --check` and `git diff --cached --check`: no whitespace errors.