### PR TITLE
Update MSBuildCache to 0.1.340-preview

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.MSBuildCache.AzurePipelines" version="0.1.318-preview" />
-  <package id="Microsoft.MSBuildCache.Local" version="0.1.318-preview" />
-  <package id="Microsoft.MSBuildCache.SharedCompilation" version="0.1.318-preview" />
+  <package id="Microsoft.MSBuildCache.AzurePipelines" version="0.1.340-preview" />
+  <package id="Microsoft.MSBuildCache.Local" version="0.1.340-preview" />
+  <package id="Microsoft.MSBuildCache.SharedCompilation" version="0.1.340-preview" />
 </packages>


### PR DESCRIPTION
Update MSBuildCache to 0.1.340-preview

Release notes:
* https://github.com/microsoft/MSBuildCache/releases/tag/v0.1.327-preview
* https://github.com/microsoft/MSBuildCache/releases/tag/v0.1.328-preview
* https://github.com/microsoft/MSBuildCache/releases/tag/v0.1.340-preview