### PR TITLE
[UITests][MouseUtilities] Migrate to .Next and add test for Cursor Wrap

### DIFF
--- a/.github/skills/ui-tests-local-vm/SKILL.md
+++ b/.github/skills/ui-tests-local-vm/SKILL.md
@@ -194,10 +194,10 @@ pwsh .github\skills\ui-tests-local-vm\scripts\Invoke-LocalVmUiTest.ps1 `
   -ReuseStagedPayload
 ```
 
-The controller starts the VM if needed, prevents automatic host sleep, verifies the interactive
-standard-user desktop, dispatches the guest runner, and waits synchronously for matching
-`status.json`. It fails early if the guest task never starts or exits without status, summarizes TRX,
-and leaves the persistent VM running by default.
+The controller starts the VM if needed, requests automatic host sleep prevention, verifies the
+interactive standard-user desktop, dispatches the guest runner, and waits synchronously for matching
+`status.json`. It reports whether sleep prevention succeeded, fails early if the guest task never
+starts or exits without status, summarizes TRX, and leaves the persistent VM running by default.
 
 ## Non-negotiable rules
 
@@ -240,7 +240,7 @@ and leaves the persistent VM running by default.
   distinguish assertions, skipped/inconclusive tests, zero tests, timeout, or infrastructure failure.
 - Keep the VM after normal runs for iteration. Stop it explicitly when idle; delete its VHDX only for
   an intentional baseline reset.
-- The controller blocks automatic host sleep while active. It cannot override manual sleep, lid-close
-  policy, reboot, shutdown, or power loss; leave the host powered and configured accordingly.
+- The controller requests automatic host sleep prevention and reports `HostSleepPrevented`; failure
+  is a warning. It cannot override manual sleep, lid-close policy, reboot, shutdown, or power loss.
 - Final clean-profile claims require a restored baseline checkpoint or a recreated guest. Restore with
   `Reset-LocalVm.ps1 -Restore`.

--- a/.github/skills/ui-tests-local-vm/SKILL.md
+++ b/.github/skills/ui-tests-local-vm/SKILL.md
@@ -143,8 +143,9 @@ Create and maintain this task list:
 - [ ] 4. Package a lean exchange and verify archive hashes
 - [ ] 5. Run the controller with -PlanOnly and inspect its request/plan
 - [ ] 6. Probe the non-admin interactive desktop before test execution
-- [ ] 7. Run one focused test; read the controller result's `.Failed` array (non-passed tests + first
-        error line) instead of re-parsing TRX, and use `scripts/Invoke-GuestScript.ps1` for guest-state inspection
+- [ ] 7. Run one focused test synchronously; keep the agent turn attached, read the controller
+  result's `.Failed` array (non-passed tests + first error line) instead of re-parsing TRX, and
+  use `scripts/Invoke-GuestScript.ps1` for guest-state inspection
 - [ ] 8. Diagnose the first controlling failure without weakening assertions
 - [ ] 9. Rebuild and rerun with -ReuseStagedPayload
 - [ ] 10. Widen to the full module suite on Windows 10 and report pass rate/root-cause groups
@@ -193,9 +194,10 @@ pwsh .github\skills\ui-tests-local-vm\scripts\Invoke-LocalVmUiTest.ps1 `
   -ReuseStagedPayload
 ```
 
-The controller starts the VM if needed, verifies the interactive standard-user token and desktop,
-dispatches the shared guest runner through a limited interactive scheduled task, streams progress,
-waits for parseable `status.json`, summarizes TRX, and leaves the persistent VM running by default.
+The controller starts the VM if needed, prevents automatic host sleep, verifies the interactive
+standard-user desktop, dispatches the guest runner, and waits synchronously for matching
+`status.json`. It fails early if the guest task never starts or exits without status, summarizes TRX,
+and leaves the persistent VM running by default.
 
 ## Non-negotiable rules
 
@@ -212,6 +214,9 @@ waits for parseable `status.json`, summarizes TRX, and leaves the persistent VM 
   ReFS: Hyper-V on plain ReFS is supported, so `-AllowReFsVolume` overrides the default refusal. The
   scaffold and the exchange are unaffected and run fine on a Dev Drive.
 - Build on the host; run PowerToys and tests only in the VM when host execution is prohibited.
+- Invoke every focused, full-suite, and constrained controller run synchronously. Keep the active
+  agent turn attached until the controller returns matching status/TRX evidence; never background
+  the controller or end the turn while it runs.
 - Finish on two green full suites: Windows 10 and Windows 11, in separate VMs. Windows 10 runs first
   for speed; Windows 11 runs the same unfiltered suite, never a Win11-only subset. Narrow filters are
   for iteration, not for sign-off. On a Windows on ARM host the ARM64 Windows 11 guest covers the
@@ -235,5 +240,7 @@ waits for parseable `status.json`, summarizes TRX, and leaves the persistent VM 
   distinguish assertions, skipped/inconclusive tests, zero tests, timeout, or infrastructure failure.
 - Keep the VM after normal runs for iteration. Stop it explicitly when idle; delete its VHDX only for
   an intentional baseline reset.
+- The controller blocks automatic host sleep while active. It cannot override manual sleep, lid-close
+  policy, reboot, shutdown, or power loss; leave the host powered and configured accordingly.
 - Final clean-profile claims require a restored baseline checkpoint or a recreated guest. Restore with
   `Reset-LocalVm.ps1 -Restore`.

--- a/.github/skills/ui-tests-local-vm/references/agentic-loop.md
+++ b/.github/skills/ui-tests-local-vm/references/agentic-loop.md
@@ -94,6 +94,10 @@ Use the default VM resource profile (4 vCPUs and 8 GB RAM) while creating and st
 not begin on the constrained profile: first prove the test and product behavior with sufficient CPU
 and RAM.
 
+Run the controller synchronously in the foreground and keep the active agent turn attached. It
+prevents automatic host sleep and returns only after matching status/TRX evidence or a bounded
+controller failure. It cannot override manual sleep, lid-close policy, reboot, or power loss.
+
 ```pwsh
 pwsh .github\skills\ui-tests-local-vm\scripts\Invoke-LocalVmUiTest.ps1 `
   -VmName PowerToysUiTest-Win10 `
@@ -151,6 +155,8 @@ The controller prints scalar TRX counters and per-test outcomes. Read both `stat
   `executed == total` even when the test process exits 0.
 - Zero selected tests/MTP exit code 8 is `BLOCKED`.
 - Missing desktop, control channel, archive, or status is `BLOCKED`.
+- A guest task that never starts or exits without matching status is `BLOCKED` immediately; do not
+  wait out the full suite timeout or accept task exit as completion.
 - Proven display/profile/compositor differences are `ENVIRONMENT`.
 - An N/M pass rate proves the execution loop ran, even when the task did not ask to stabilize tests.
 

--- a/.github/skills/ui-tests-local-vm/references/agentic-loop.md
+++ b/.github/skills/ui-tests-local-vm/references/agentic-loop.md
@@ -95,8 +95,9 @@ not begin on the constrained profile: first prove the test and product behavior 
 and RAM.
 
 Run the controller synchronously in the foreground and keep the active agent turn attached. It
-prevents automatic host sleep and returns only after matching status/TRX evidence or a bounded
-controller failure. It cannot override manual sleep, lid-close policy, reboot, or power loss.
+requests automatic host sleep prevention, reports `HostSleepPrevented`, and returns only after
+matching status/TRX evidence or a bounded controller failure. It cannot override manual sleep,
+lid-close policy, reboot, or power loss.
 
 ```pwsh
 pwsh .github\skills\ui-tests-local-vm\scripts\Invoke-LocalVmUiTest.ps1 `

--- a/.github/skills/ui-tests-local-vm/references/troubleshooting.md
+++ b/.github/skills/ui-tests-local-vm/references/troubleshooting.md
@@ -32,7 +32,8 @@ Classify the first failed boundary before changing test code.
 
 | Symptom | Boundary | Action |
 |---|---|---|
-| No `status.json` but the task ended | Guest runner/finalization | Inspect scheduled-task `LastTaskResult`, the guest-local transcript, and the request path. A completed UI is not a completion signal. |
+| No `status.json` but the task ended | Guest runner/finalization | The controller stops on the bounded task-state check. Inspect `LastTaskResult`, the guest-local transcript, and the request path; task exit is not completion. |
+| Test task remains `Ready` and has no `LastRunTime` | Task dispatch | The controller stops after the 30-second launch deadline. Verify the interactive PTUser session and Task Scheduler rather than waiting for the suite timeout. |
 | Interactive `powershell.exe` task stays `Running`, but a local `cmd.exe` probe writes immediately | PTUser PowerShell task host | Stop and unregister only the failed task. Stage and extract payloads through the administrator session, then run a guest-local `.cmd` as an `Interactive`/`Limited` PTUser task. Write the exit code and TRX locally and export one evidence archive afterwards. |
 | `status.json` exists but is temporarily empty | Create/write race | Wait for parseable JSON with matching `RunId`; never finish on file existence alone. The controller already does this. |
 | One attachment subtree fails export | Transient copy failure | Inspect `ExportErrors`. The shared runner uses bounded `robocopy` retries for directories and writes status even when an artifact cannot be copied. |

--- a/.github/skills/ui-tests-local-vm/scripts/Invoke-LocalVmUiTest.ps1
+++ b/.github/skills/ui-tests-local-vm/scripts/Invoke-LocalVmUiTest.ps1
@@ -83,6 +83,9 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+$executionStateContinuous = [uint32]2147483648
+$executionStateSystemRequired = [uint32]2147483649
+$scheduledTaskRunningResult = 267009
 
 if ($PSVersionTable.PSVersion.Major -lt 7) {
     throw 'Run this controller with PowerShell 7 (pwsh).'
@@ -215,6 +218,44 @@ function Start-InteractiveTask {
     } -ArgumentList $TaskName, $Executable, $Arguments, $UserName, $ExecutionTimeLimitMinutes
 }
 
+function Get-InteractiveTaskInfo {
+    param(
+        [Parameter(Mandatory)][System.Management.Automation.Runspaces.PSSession]$Session,
+        [Parameter(Mandatory)][string]$TaskName,
+        [ValidateRange(1, 10)][int]$Attempts = 3
+    )
+
+    for ($attempt = 1; $attempt -le $Attempts; $attempt++) {
+        try {
+            return Invoke-Command -Session $Session -ScriptBlock {
+                param($Name)
+
+                $task = Get-ScheduledTask -TaskName $Name -ErrorAction SilentlyContinue
+                $info = Get-ScheduledTaskInfo -TaskName $Name -ErrorAction SilentlyContinue
+                $state = if ($null -ne $task) { [string]$task.State } else { 'Missing' }
+                $lastTaskResult = if ($null -ne $info) { [int]$info.LastTaskResult } else { $null }
+                $lastRunTimeUtc = if ($null -ne $info -and $info.LastRunTime.Year -gt 2000) {
+                    $info.LastRunTime.ToUniversalTime().ToString('o')
+                }
+                else {
+                    $null
+                }
+                [pscustomobject]@{
+                    State = $state
+                    LastTaskResult = $lastTaskResult
+                    LastRunTimeUtc = $lastRunTimeUtc
+                }
+            } -ArgumentList $TaskName -ErrorAction Stop
+        }
+        catch {
+            if ($attempt -eq $Attempts) {
+                throw
+            }
+            Start-Sleep -Milliseconds 250
+        }
+    }
+}
+
 $requiredFiles = @($TestsArchive, $ProductArchive, $WinAppCliArchive, $DotNetArchive)
 if (-not [string]::IsNullOrWhiteSpace($ProductOverlayArchive)) {
     $requiredFiles += $ProductOverlayArchive
@@ -342,7 +383,28 @@ $evidenceExported = $false
 $probeTaskName = "PowerToysUiTest-Probe-$runId"
 $testTaskName = "PowerToysUiTest-Run-$runId"
 $controllerResult = $null
+$executionStateSet = $false
 try {
+    if (-not ('PowerToys.UiTests.LocalVm.NativeMethods' -as [type])) {
+        Add-Type -TypeDefinition @'
+using System.Runtime.InteropServices;
+
+namespace PowerToys.UiTests.LocalVm
+{
+    public static class NativeMethods
+    {
+        [DllImport("kernel32.dll")]
+        public static extern uint SetThreadExecutionState(uint executionState);
+    }
+}
+'@
+    }
+    $executionStateSet = [PowerToys.UiTests.LocalVm.NativeMethods]::SetThreadExecutionState($executionStateSystemRequired) -ne 0
+    if (-not $executionStateSet) {
+        throw 'Failed to prevent host system sleep during the local VM UI-test run.'
+    }
+    Write-Host 'Host automatic sleep prevention: active'
+
     if (-not $SkipStart) {
         $startScript = Join-Path $vmRootPath 'Start-LocalVm.ps1'
         if (-not (Test-Path $startScript -PathType Leaf)) {
@@ -516,12 +578,7 @@ Add-Type -AssemblyName System.Windows.Forms
             break
         }
         if ([DateTime]::UtcNow -ge $probeDeadline) {
-            $probeTaskInfo = Invoke-Command -Session $session -ScriptBlock {
-                param($Name)
-                $task = Get-ScheduledTask -TaskName $Name -ErrorAction SilentlyContinue
-                $info = Get-ScheduledTaskInfo -TaskName $Name -ErrorAction SilentlyContinue
-                [pscustomobject]@{ State = [string]$task.State; LastTaskResult = $info.LastTaskResult }
-            } -ArgumentList $probeTaskName
+            $probeTaskInfo = Get-InteractiveTaskInfo -Session $session -TaskName $probeTaskName
             throw "Interactive desktop probe did not complete. Task state: $($probeTaskInfo.State); result: $($probeTaskInfo.LastTaskResult)."
         }
         Start-Sleep -Seconds 1
@@ -546,6 +603,7 @@ Add-Type -AssemblyName System.Windows.Forms
 
     $runnerArguments = '-NoLogo -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File "{0}" -RequestPath "{1}"' -f $guestRunnerPath, $guestRequestPath
     $taskLimitMinutes = [Math]::Min(1440, $TimeoutMinutes + 5)
+    $taskDispatchedUtc = [DateTime]::UtcNow
     $testTask = Start-InteractiveTask `
         -Session $session -TaskName $testTaskName `
         -Executable $guestPowerShell -Arguments $runnerArguments `
@@ -553,6 +611,8 @@ Add-Type -AssemblyName System.Windows.Forms
     Write-Host "UI-test task: $($testTask.TaskName), user $($testTask.UserId)"
 
     $deadline = [DateTime]::UtcNow.AddMinutes($TimeoutMinutes)
+    $taskStartDeadline = $taskDispatchedUtc.AddSeconds(30)
+    $nextTaskCheckUtc = $taskDispatchedUtc.AddSeconds(5)
     $lastProgress = $null
     $status = $null
     do {
@@ -571,6 +631,25 @@ Add-Type -AssemblyName System.Windows.Forms
             $status = $candidate
             break
         }
+        if ([DateTime]::UtcNow -ge $nextTaskCheckUtc) {
+            $taskInfo = Get-InteractiveTaskInfo -Session $session -TaskName $testTaskName
+            $nextTaskCheckUtc = [DateTime]::UtcNow.AddSeconds(5)
+            $taskIsActive = $taskInfo.State -in @('Running', 'Queued') -or $taskInfo.LastTaskResult -eq $scheduledTaskRunningResult
+            if (-not $taskIsActive -and
+                [string]::IsNullOrWhiteSpace($taskInfo.LastRunTimeUtc) -and
+                [DateTime]::UtcNow -ge $taskStartDeadline) {
+                throw "Local VM UI-test task did not start within 30 seconds. Task state: $($taskInfo.State); result: $($taskInfo.LastTaskResult)."
+            }
+            if (-not $taskIsActive -and -not [string]::IsNullOrWhiteSpace($taskInfo.LastRunTimeUtc)) {
+                $candidate = Read-GuestJson `
+                    -Context $guestContext -Session $session -RelativePath $statusRelative -Attempts 20
+                if ($null -ne $candidate -and $candidate.RunId -eq $runId) {
+                    $status = $candidate
+                    break
+                }
+                throw "Local VM UI-test task ended without matching status.json. Task state: $($taskInfo.State); result: $($taskInfo.LastTaskResult); last run UTC: $($taskInfo.LastRunTimeUtc)."
+            }
+        }
         if ([DateTime]::UtcNow -ge $deadline) {
             # Absorb a status file that was still being created when the deadline elapsed.
             $candidate = Read-GuestJson `
@@ -579,12 +658,7 @@ Add-Type -AssemblyName System.Windows.Forms
                 $status = $candidate
                 break
             }
-            $taskInfo = Invoke-Command -Session $session -ScriptBlock {
-                param($Name)
-                $task = Get-ScheduledTask -TaskName $Name -ErrorAction SilentlyContinue
-                $info = Get-ScheduledTaskInfo -TaskName $Name -ErrorAction SilentlyContinue
-                [pscustomobject]@{ State = [string]$task.State; LastTaskResult = $info.LastTaskResult }
-            } -ArgumentList $testTaskName
+            $taskInfo = Get-InteractiveTaskInfo -Session $session -TaskName $testTaskName
             throw "Local VM UI-test run timed out. Task state: $($taskInfo.State); result: $($taskInfo.LastTaskResult)."
         }
         Start-Sleep -Seconds 1
@@ -608,6 +682,7 @@ Add-Type -AssemblyName System.Windows.Forms
     }
     $controllerResult = [pscustomobject]@{
         Controller = $controllerName
+        HostSleepPrevented = $executionStateSet
         RunId = $runId
         BuildLabel = $status.BuildLabel
         Status = $effectiveStatus
@@ -684,6 +759,9 @@ finally {
                 Write-Warning "The requested post-run VM stop failed: $($_.Exception.Message)"
             }
         }
+    }
+    if ($executionStateSet) {
+        $null = [PowerToys.UiTests.LocalVm.NativeMethods]::SetThreadExecutionState($executionStateContinuous)
     }
 }
 

--- a/.github/skills/ui-tests-local-vm/scripts/Invoke-LocalVmUiTest.ps1
+++ b/.github/skills/ui-tests-local-vm/scripts/Invoke-LocalVmUiTest.ps1
@@ -385,8 +385,9 @@ $testTaskName = "PowerToysUiTest-Run-$runId"
 $controllerResult = $null
 $executionStateSet = $false
 try {
-    if (-not ('PowerToys.UiTests.LocalVm.NativeMethods' -as [type])) {
-        Add-Type -TypeDefinition @'
+    try {
+        if (-not ('PowerToys.UiTests.LocalVm.NativeMethods' -as [type])) {
+            Add-Type -TypeDefinition @'
 using System.Runtime.InteropServices;
 
 namespace PowerToys.UiTests.LocalVm
@@ -398,12 +399,19 @@ namespace PowerToys.UiTests.LocalVm
     }
 }
 '@
+        }
+
+        $executionStateSet = [PowerToys.UiTests.LocalVm.NativeMethods]::SetThreadExecutionState($executionStateSystemRequired) -ne 0
+        if ($executionStateSet) {
+            Write-Host 'Host automatic sleep prevention: active'
+        }
+        else {
+            Write-Warning 'Host automatic sleep prevention was rejected; the local VM run will continue.'
+        }
     }
-    $executionStateSet = [PowerToys.UiTests.LocalVm.NativeMethods]::SetThreadExecutionState($executionStateSystemRequired) -ne 0
-    if (-not $executionStateSet) {
-        throw 'Failed to prevent host system sleep during the local VM UI-test run.'
+    catch {
+        Write-Warning "Host automatic sleep prevention is unavailable; the local VM run will continue: $($_.Exception.Message)"
     }
-    Write-Host 'Host automatic sleep prevention: active'
 
     if (-not $SkipStart) {
         $startScript = Join-Path $vmRootPath 'Start-LocalVm.ps1'
@@ -761,7 +769,12 @@ finally {
         }
     }
     if ($executionStateSet) {
-        $null = [PowerToys.UiTests.LocalVm.NativeMethods]::SetThreadExecutionState($executionStateContinuous)
+        try {
+            $null = [PowerToys.UiTests.LocalVm.NativeMethods]::SetThreadExecutionState($executionStateContinuous)
+        }
+        catch {
+            Write-Warning "Host sleep-prevention cleanup failed: $($_.Exception.Message)"
+        }
     }
 }
 

--- a/.github/skills/ui-tests-migration/SKILL.md
+++ b/.github/skills/ui-tests-migration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ui-tests-migration
-description: "Migrate and stabilize PowerToys UI tests from WinAppDriver/Selenium to Microsoft.PowerToys.UITest.Next and winappcli. Use for ports, new UITest projects, flaky CI tests, persistent local-VM validation on Hyper-V, resettable clean-baseline runs, Explorer/Shell selection, preview handlers, thumbnail providers, hotkey activation, stateful process lifecycle, composed WinUI/WebView visual baselines, or cross-window/foreground failures. Covers APIs, scaffolding, test design, diagnostics, agentic execution, and CI hardening. Keywords: UI test, UITests, UITestAutomation.Next, winappcli, WinAppDriver, Selenium, local VM, Hyper-V, checkpoint, migrate, port, flaky, CI stability, Explorer, Shell extension, WebView2."
+description: "Migrate and stabilize PowerToys UI tests from WinAppDriver/Selenium to Microsoft.PowerToys.UITest.Next and winappcli. Use for ports, new UITest projects, flaky CI tests, persistent local-VM validation on Hyper-V, resettable clean-baseline runs, Settings IPC authentication/test signing, Explorer/Shell selection, preview handlers, thumbnail providers, hotkey activation, stateful process lifecycle, composed WinUI/WebView visual baselines, or cross-window/foreground failures. Covers APIs, scaffolding, test design, diagnostics, agentic execution, and CI hardening. Keywords: UI test, UITests, UITestAutomation.Next, winappcli, WinAppDriver, Selenium, Settings IPC, not-microsoft-signed, Authenticode, local VM, Hyper-V, checkpoint, migrate, flaky, CI stability, Explorer, Shell extension, WebView2."
 license: Complete terms in LICENSE.txt
 ---
 
@@ -89,8 +89,10 @@ module, which tests) comes from the calling prompt.
 8. **[references/ci-stability.md](references/ci-stability.md)** — the CI-stability capstone: the
   Win32-window vs UIA-element mental model, state-boundary worksheet, stable-sample waits, retry
   semantics, foreground/integrity constraints, process lifecycle, composed visual capture, and a
-  **pre-flight checklist** to apply BEFORE the first CI push so the first run *validates* instead of
-  *discovers*. Read this to spend one CI iteration instead of six.
+  **pre-flight checklist** to apply BEFORE the first CI push. It also covers Release Runner/Settings
+  IPC authentication, the existing CI companion-signing mechanism, and why a visible Settings toggle
+  must never be rescued with a settings-file/restart fallback. Read this to spend one CI iteration
+  instead of six.
 9. **[ui-tests-local-vm](../ui-tests-local-vm/SKILL.md)** — the live desktop execution loop:
   scaffold or reuse a persistent Hyper-V VM, run as a true standard user, refresh only
   changed payloads, iterate through durable TRX/evidence, and restore or recreate the baseline for
@@ -154,6 +156,11 @@ Create a TODO list and work top-to-bottom. Each step links to the reference that
   (stable authoritative signals, retry classification, foreground/integrity, lifecycle reset
   scope, non-activating helper processes, composed capture, DPI manifest, single-module enable,
   first-run suppression)
+- [ ] 7a. If a test changes a module's enabled state through Settings, keep the real Settings UI +
+  immediate runtime assertion. Verify the selected UITest project is covered by the existing
+  `$requiresAuthenticatedSettingsIpc` companion-signing path in
+  `.pipelines/v2/templates/job-test-project.yml`; never add a test-side settings/restart fallback
+  for Release CI — [references/ci-stability.md](references/ci-stability.md#principle-5a--keep-module-lifecycle-tests-on-real-release-settings-ipc)
 - [ ] 8. Build the new project to exit code 0 — this SKILL.md "Build & validate"
 - [ ] 9. Run one deterministic test in the local VM and diagnose the first failure
       — ../ui-tests-local-vm/SKILL.md
@@ -262,6 +269,10 @@ $exe = "<repo>\x64\Debug\tests\<Module>.UITests.Next\net10.0-windows10.0.26100.0
   resending the chord may close a healthy window. Restart only after a terminal readiness failure.
 - **Do NOT replace or weaken visual baselines before proving capture is correct.** Foreground HWND,
   DWM z-order, composed WebView content, theme, and platform are separate failure sources.
+- **Do NOT work around a Release Runner `not-microsoft-signed` Settings rejection in test code.** Do
+  not seed the global enabled map, restart PowerToys, bypass authentication, or weaken the lifecycle
+  assertion. Reuse the pipeline's existing Runner/Settings companion-signing mechanism; see
+  [references/ci-stability.md](references/ci-stability.md#principle-5a--keep-module-lifecycle-tests-on-real-release-settings-ipc).
 
 ## What is NICE to do
 

--- a/.github/skills/ui-tests-migration/references/ci-stability.md
+++ b/.github/skills/ui-tests-migration/references/ci-stability.md
@@ -222,6 +222,79 @@ restart), when the enabled-module set changes, or to recover from a terminal fai
 
 ---
 
+## Principle 5a — Keep module lifecycle tests on real Release Settings IPC
+
+The Runner is the server for the Settings named pipe and owns module enable/disable lifecycle. Since
+the security hardening in #49527, a **Release** Runner accepts `PowerToys.Settings.exe` only when the
+client is in the Runner-relative `WinUI3Apps` directory, has the allow-listed basename and matching
+file version, and carries an intact Microsoft Authenticode signature chaining to `LocalMachine\Root`.
+Debug builds relax only the signature check; directory, basename, and version checks remain active.
+
+This creates a deceptive CI symptom:
+
+| Environment | Expected behavior |
+|---|---|
+| Local Debug Runner + unsigned Settings | Direct Settings lifecycle works because `_DEBUG` compiles out only the signature requirement. |
+| Installed Microsoft-signed Release build | Direct Settings lifecycle works through the production authentication path. |
+| Unsigned PR Release build without test setup | The switch may visibly change, but the Runner rejects the client before dispatch/persistence; module events/processes remain alive. |
+
+Do not treat an older green Settings-toggle test as proof that unsigned Release IPC is healthy. It
+may predate #49527, run against Debug, install officially signed bits, or assert only `ToggleState`
+without checking a Runner-owned effect. Establish the build configuration, signing path, and runtime
+assertion before comparing suites.
+
+The UIA `ToggleState` is therefore **not** proof that enable/disable reached the Runner. A lifecycle
+test must assert both the switch state and the immediate product effect: process start/exit, named
+event availability, window/shortcut behavior, registration, or another module-owned signal.
+
+### Diagnose before changing tests
+
+When several Settings-driven lifecycle tests fail together in Release CI while feature tests pass:
+
+1. Read the attached `RunnerLogs\runner-log_*.log` before editing code.
+2. Classify the exact rejection:
+
+| Runner reason | Route |
+|---|---|
+| `not-microsoft-signed` for the expected `PowerToys.Settings.exe` path | Missing CI companion-signing opt-in. Fix pipeline setup, not the test. |
+| `bad-directory`, `bad-basename`, or `version-mismatch` | Packaging/layout/version defect. Signing alone is not the fix. |
+| No authentication rejection | Continue ordinary test/product diagnosis; do not assume IPC authentication. |
+
+The authentication source of truth is `src/runner/settings_window.cpp` plus
+`src/common/interop/pipe_caller_auth.cpp`.
+
+### Reuse the existing CI mechanism
+
+Do not create a second signing script or a module-specific test bypass. The UI Test Automation
+pipeline already has the supported mechanism:
+
+- `.pipelines/signSparsePackages.ps1 -RequiredAuthenticodeFile` signs unpackaged companion binaries
+  with a disposable test certificate whose subject matches the Microsoft publisher expected by the
+  Release verifier. It imports the test root into `LocalMachine\Root`/`TrustedPeople`, validates the
+  signatures, records the certificate marker, and removes trust/private keys in pipeline cleanup.
+- `.pipelines/v2/templates/job-test-project.yml` computes `$requiresAuthenticatedSettingsIpc` from
+  the selected `uiTestModules` and passes both `PowerToys.exe` and `PowerToys.Settings.exe` as required
+  Authenticode files. Its package roots cover the run-in-place artifact, machine-level install, and
+  per-user install.
+
+For a new selected suite that drives module enable/disable through Settings:
+
+1. Add the exact project family to the existing `$requiresAuthenticatedSettingsIpc` selection
+  condition. Preserve existing project families and all-module behavior.
+2. Keep both companion filenames in the shared required-file list. Do not copy the signing block.
+3. Preview the pipeline and require the signing branch in every requested platform/install-mode job.
+4. In CI logs, require `Successfully signed` and `Verified required Authenticode file(s)` for both
+  Runner and Settings before accepting the run.
+5. Keep the tests unchanged in shape: drive the real switch, verify `ToggleState`, then assert the
+  runtime effect directly.
+
+**Forbidden workaround:** never make a lifecycle test pass by writing the global `enabled` map and
+restarting PowerToys after `not-microsoft-signed`. That tests startup from seeded state, not the user
+workflow, hides a broken Settings-to-Runner contract, and duplicates infrastructure the pipeline
+already provides. Never weaken or compile out the Release authentication policy for UI tests.
+
+---
+
 ## Principle 6 — Everything on-screen, DPI-correct, from a clean profile
 
 The whole "passes local, fails CI" cluster is environment differences a dev box papers over. Each has
@@ -307,6 +380,9 @@ likely extra CI iteration.
 - [ ] Pipeline helper processes have no visible foreground-capable windows; detached consoles start hidden
 - [ ] Process lifecycle is explicit per scenario: close/preserve/input-idle/process-tree restart
 - [ ] Module settings are seeded and hot-reloaded, not applied by relaunching PowerToys (P5 / Recipe 17)
+- [ ] Settings-driven module lifecycle tests assert both ToggleState and the immediate Runner-owned
+  effect; selected suites are covered by `$requiresAuthenticatedSettingsIpc` and reuse
+  `RequiredAuthenticodeFile` for Runner + Settings (P5a / Recipe 2)
 - [ ] Renderer readiness is separate from window/title readiness; composed visuals use visible DWM capture
 - [ ] Explorer-driven tests verify exact selected paths and focused path via `ExplorerShell` (Recipe 13)
 - [ ] Explorer view mode/icon size is set through `ExplorerShell`, then independently verified by item geometry

--- a/.github/skills/ui-tests-migration/references/patterns-and-pitfalls.md
+++ b/.github/skills/ui-tests-migration/references/patterns-and-pitfalls.md
@@ -72,6 +72,17 @@ private static bool WaitForProcess(string name, bool expected, int timeoutMS)
 > (actually `PowerToys.MeasureToolUI`), `PowerToys.FancyZonesEditor`, etc. — see `ModuleConfigData.cs`
 > in the harness for the authoritative list.
 
+> **Release CI / Settings IPC:** Keep this exact interaction shape. The switch state proves only the
+> UI changed; the process/event/window assertion proves the Runner accepted the command. If every
+> lifecycle assertion fails in Release CI and `RunnerLogs` says
+> `Rejected unauthenticated Settings pipe client ... reason=not-microsoft-signed`, do **not** write
+> `settings.json` and restart the Runner from the test. Opt the selected test project into the
+> existing `$requiresAuthenticatedSettingsIpc` path in
+> `.pipelines/v2/templates/job-test-project.yml`, which reuses
+> `.pipelines/signSparsePackages.ps1 -RequiredAuthenticodeFile` for `PowerToys.exe` and
+> `PowerToys.Settings.exe`. See
+> [ci-stability.md](ci-stability.md#principle-5a--keep-module-lifecycle-tests-on-real-release-settings-ipc).
+
 ## Recipe 3 — Read the activation shortcut from a `ShortcutControl`
 
 PowerToys' `ShortcutControl` renders the current chord on its inner `EditButton`, exposing the readable

--- a/.github/skills/ui-tests-pipeline-ci/SKILL.md
+++ b/.github/skills/ui-tests-pipeline-ci/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ui-tests-pipeline-ci
-description: "Microsoft FTE-only workflow for validating setup, queueing, monitoring, and stabilizing PowerToys UI Test Automation through an existing Azure CLI session and Azure DevOps REST APIs. Use after local VM suites pass, when asked to run UITests CI, perform a setup preflight/readiness check, diagnose repeated az login prompts or 401/403 permission failures, reuse a successful build, inspect recordings/artifacts, or manage the three-run limit. Keywords: FTE, az, Azure CLI, Azure DevOps, pipeline, UI Test Automation, UITests CI, buildNow, specificBuildId, uiTestModules, CI flake."
+description: "Microsoft FTE-only workflow for validating setup, queueing, autonomously waiting for, and stabilizing PowerToys UI Test Automation through an existing Azure CLI session and Azure DevOps REST APIs. Use after local VM suites pass, when asked to run UITests CI, perform a setup preflight/readiness check, diagnose repeated az login prompts or 401/403 permission failures, reuse a successful build, inspect recordings/artifacts, or manage the three-run limit. Includes an agent-owned foreground completion waiter. Keywords: FTE, az, Azure CLI, Azure DevOps, pipeline, UI Test Automation, UITests CI, buildNow, specificBuildId, uiTestModules, CI flake."
 license: MIT
 ---
 
@@ -54,10 +54,11 @@ Do not use this skill for local execution. Complete
    a fix hypothesis. Preserve assertions and classify infrastructure failures separately.
 8. **Tracked runs remain unfinished work.** After queueing, persist the build ID, branch, source SHA,
    attempt number, and parameters in session/task state. Do not mark the task complete or claim a
-   terminal result while that build is nonterminal. If no authenticated completion waiter exists,
-   arm the one-hour scheduled continuation in the agentic loop rather than relying on a passive
-   handoff. On every scheduled wake, resume, notification, or user turn that continues the tracked CI
-   task, query that exact build ID before other Azure work and continue from its current state.
+   terminal result while that build is nonterminal. Immediately run
+   [Wait-AzureDevOpsBuild.ps1](./scripts/Wait-AzureDevOpsBuild.ps1) synchronously in the foreground,
+   bound to the exact build ID, branch, and source SHA. Keep the same agent turn alive until the
+   waiter returns, then verify the terminal result and continue stabilization without user input.
+   Do not end the turn or call `task_complete` while the waiter runs.
 
 ## Internal constants
 
@@ -69,6 +70,7 @@ Do not use this skill for local execution. Complete
 | Current known definition ID | `161438` (discover by name each session; do not blindly hardcode) |
 | Azure DevOps token resource | `499b84ac-1321-427f-aa17-267ca6975798` |
 | Required setup check | `scripts/Test-AzureDevOpsSetup.ps1` |
+| Required completion waiter | `scripts/Wait-AzureDevOpsBuild.ps1` |
 | Platforms | `arm64`, `x64` |
 | Default booleans | `enableMsBuildCaching=false`, `useVSPreview=false`, `useLatestWebView2=false` |
 
@@ -84,7 +86,7 @@ contains:
 - `buildNow` versus `specificBuildId` decision rules.
 - Exact queue parameters and branch targeting.
 - Monitoring, failure evidence, direct Azure Test attachment downloads, and recording links.
-- Tracked-run continuation, one-hour scheduled polling, and completion-notification limits.
+- Agent-owned foreground completion waiting and truthful client capability limits.
 - The three-run stabilization ledger and stop conditions.
 
 ## Completion standard

--- a/.github/skills/ui-tests-pipeline-ci/references/agentic-loop.md
+++ b/.github/skills/ui-tests-pipeline-ci/references/agentic-loop.md
@@ -262,14 +262,17 @@ source SHA.
 
 Run the setup preflight first. Keep the waiter attached to the active agent turn; do not use an
 async/background mode, end the response, or call `task_complete` while it runs. The waiter validates
-identity on every read, polls every 120 seconds, prevents system sleep, and returns on terminal
-status, timeout, or a genuine query failure.
+identity on every read, polls every 120 seconds, requests system sleep prevention, and returns on
+terminal status, timeout, or a genuine query failure.
 
-When it emits `Event=terminal`, immediately query timeline, logs, tests, and artifacts and apply the
-completion standard. If it times out while builds are progressing, invoke another bounded foreground
-wait. For authentication or repeated query errors, rerun the setup preflight and follow its blocker
-rules. After a failed terminal run, diagnose, fix, rerun local gates, queue the next authorized
-attempt, and invoke a new waiter.
+Read the waiter's JSON-lines `Event`: `progress` is a successful nonterminal read, `query-error` is a
+retryable read failure, `terminal` means every build completed, and `timeout` ends the bounded wait.
+Require at least one `progress` or `terminal` record before attributing a nonzero exit to Azure DevOps;
+otherwise diagnose the waiter invocation itself. On `terminal`, immediately query timeline, logs,
+tests, and artifacts and apply the completion standard. If it times out while builds are progressing,
+invoke another bounded foreground wait. For authentication or repeated query errors, rerun the setup
+preflight and follow its blocker rules. After a failed terminal run, diagnose, fix, rerun local gates,
+queue the next authorized attempt, and invoke a new waiter.
 
 This mechanism relies on a client that keeps a synchronous shell tool call attached to the active
 agent turn. Copilot CLI in autopilot mode supports that execution model. If the current client cannot

--- a/.github/skills/ui-tests-pipeline-ci/references/agentic-loop.md
+++ b/.github/skills/ui-tests-pipeline-ci/references/agentic-loop.md
@@ -241,32 +241,39 @@ Modules: [<exact project stems>]
 State: <notStarted|inProgress|...>
 ```
 
-After any interruption, scheduled wake, or user turn, query every exact checkpointed build ID before
-other Azure work. Never rediscover by adopting the newest run.
+After any interruption or user turn, query every exact checkpointed build ID before other Azure
+work. Never rediscover by adopting the newest run.
 
-### One-hour scheduled continuation
+### Agent-owned foreground completion waiter
 
-Do not leave a nonterminal build with a passive handoff. Full builds normally take 60-90 minutes and
-test-only validation about 40 minutes. Arm one one-shot host wake-up at a time; after each wake,
-query exact build IDs and re-arm for one hour only if work remains nonterminal.
+After queueing and checkpointing, invoke the bundled waiter synchronously in the foreground:
 
-Monitoring state is scoped to exact build IDs. If the user reports a tracked build's status and asks
-to stop its now-obsolete watcher, remove only that build's task/marker. Do not treat that as a
-standing opt-out: every later build queued by the agent must immediately receive a fresh one-shot
-continuation and remain monitored until terminal unless the user explicitly opts out for that new
-build.
+```pwsh
+pwsh -NoLogo -NoProfile -File `
+  .github\skills\ui-tests-pipeline-ci\scripts\Wait-AzureDevOpsBuild.ps1 `
+  -BuildId <BUILD_ID> `
+  -ExpectedBranch <EXACT_REFS_HEADS_BRANCH> `
+  -ExpectedSourceVersion <40_CHARACTER_SOURCE_SHA>
+```
 
-The scheduled action only wakes the agent. Do not put `az`, a token, build parameters, or any Azure
-request in it. On Windows without a native agent scheduler:
+For an explicitly authorized supplemental architecture run, pass both checkpointed IDs to one
+invocation, for example `-BuildId 123456789,123456790`. Every ID must share the expected branch and
+source SHA.
 
-1. Persist build IDs, unique task name, marker under `$env:TEMP`, scheduled UTC/local time, and
-   watcher terminal ID in session state.
-2. Register a current-user, limited one-shot task for `(Get-Date).AddHours(1)` whose only action
-   writes the marker. Use an encoded PowerShell command for deterministic quoting.
-3. Start one asynchronous `FileSystemWatcher` terminal for the marker. Do not use `Start-Sleep`, a
-   timer loop, or repeated Azure requests.
-4. On notification, remove marker and task, then query exact IDs through `Invoke-AzDevOpsRest`.
-5. Re-arm only after an authenticated status query confirms a build remains nonterminal.
+Run the setup preflight first. Keep the waiter attached to the active agent turn; do not use an
+async/background mode, end the response, or call `task_complete` while it runs. The waiter validates
+identity on every read, polls every 120 seconds, prevents system sleep, and returns on terminal
+status, timeout, or a genuine query failure.
+
+When it emits `Event=terminal`, immediately query timeline, logs, tests, and artifacts and apply the
+completion standard. If it times out while builds are progressing, invoke another bounded foreground
+wait. For authentication or repeated query errors, rerun the setup preflight and follow its blocker
+rules. After a failed terminal run, diagnose, fix, rerun local gates, queue the next authorized
+attempt, and invoke a new waiter.
+
+This mechanism relies on a client that keeps a synchronous shell tool call attached to the active
+agent turn. Copilot CLI in autopilot mode supports that execution model. If the current client cannot
+do so, state that limitation before queueing.
 
 ## 5. Monitor exact builds
 

--- a/.github/skills/ui-tests-pipeline-ci/scripts/AzureDevOps.ps1
+++ b/.github/skills/ui-tests-pipeline-ci/scripts/AzureDevOps.ps1
@@ -191,3 +191,58 @@ function Get-AzDevOpsPagedValues
         ContinuationToken = $continuationToken
     }
 }
+
+function ConvertTo-AzDevOpsBuildSnapshot
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [object] $Build,
+
+        [Parameter(Mandatory)]
+        [int] $RequestedId,
+
+        [Parameter(Mandatory)]
+        [string] $ExpectedBranch,
+
+        [Parameter(Mandatory)]
+        [string] $ExpectedSourceVersion
+    )
+
+    if ([int]$Build.id -ne $RequestedId)
+    {
+        throw "Requested build $RequestedId but Azure DevOps returned build $($Build.id)."
+    }
+
+    if ([string]$Build.sourceBranch -cne $ExpectedBranch)
+    {
+        throw "Build $RequestedId source branch '$($Build.sourceBranch)' does not match '$ExpectedBranch'."
+    }
+
+    if ([string]$Build.sourceVersion -ine $ExpectedSourceVersion)
+    {
+        throw "Build $RequestedId source version '$($Build.sourceVersion)' does not match '$ExpectedSourceVersion'."
+    }
+
+    $propertyValue = {
+        param([string] $Name)
+
+        $property = $Build.PSObject.Properties[$Name]
+        if ($null -ne $property)
+        {
+            $property.Value
+        }
+    }
+
+    [pscustomobject]@{
+        Id = [int]$Build.id
+        BuildNumber = [string]$Build.buildNumber
+        Status = [string]$Build.status
+        Result = [string](& $propertyValue 'result')
+        QueueTime = & $propertyValue 'queueTime'
+        StartTime = & $propertyValue 'startTime'
+        FinishTime = & $propertyValue 'finishTime'
+        LastChangedDate = & $propertyValue 'lastChangedDate'
+        WebUrl = [string]$Build._links.web.href
+    }
+}

--- a/.github/skills/ui-tests-pipeline-ci/scripts/Wait-AzureDevOpsBuild.ps1
+++ b/.github/skills/ui-tests-pipeline-ci/scripts/Wait-AzureDevOpsBuild.ps1
@@ -78,15 +78,19 @@ $lastOutputUtc = [DateTime]::MinValue
 $lastBuilds = @()
 $consecutiveErrors = 0
 $waitHandle = [Threading.ManualResetEventSlim]::new($false)
+$executionStateContinuous = [uint32]2147483648
+$executionStateSystemRequired = [uint32]2147483649
 $executionStateSet = $false
 
 try
 {
     if ($IsWindows)
     {
-        if (-not ('PowerToys.UiTests.Ci.NativeMethods' -as [type]))
+        try
         {
-            Add-Type -TypeDefinition @'
+            if (-not ('PowerToys.UiTests.Ci.NativeMethods' -as [type]))
+            {
+                Add-Type -TypeDefinition @'
 using System.Runtime.InteropServices;
 
 namespace PowerToys.UiTests.Ci
@@ -98,12 +102,17 @@ namespace PowerToys.UiTests.Ci
     }
 }
 '@
-        }
+            }
 
-        $executionStateSet = [PowerToys.UiTests.Ci.NativeMethods]::SetThreadExecutionState([uint32]2147483649) -ne 0
-        if (-not $executionStateSet)
+            $executionStateSet = [PowerToys.UiTests.Ci.NativeMethods]::SetThreadExecutionState($executionStateSystemRequired) -ne 0
+            if (-not $executionStateSet)
+            {
+                Write-Warning 'System sleep prevention was rejected; the Azure DevOps wait will continue.'
+            }
+        }
+        catch
         {
-            throw 'Failed to prevent system sleep while waiting for Azure DevOps builds.'
+            Write-Warning "System sleep prevention is unavailable; the Azure DevOps wait will continue: $($_.Exception.Message)"
         }
     }
 
@@ -161,34 +170,11 @@ namespace PowerToys.UiTests.Ci
         $builds = @(
             foreach ($response in $responses)
             {
-                $id = $response.RequestedId
-                $build = $response.Build
-                if ([int]$build.id -ne $id)
-                {
-                    throw "Requested build $id but Azure DevOps returned build $($build.id)."
-                }
-
-                if ([string]$build.sourceBranch -cne $ExpectedBranch)
-                {
-                    throw "Build $id source branch '$($build.sourceBranch)' does not match '$ExpectedBranch'."
-                }
-
-                if ([string]$build.sourceVersion -ine $expectedSourceVersionNormalized)
-                {
-                    throw "Build $id source version '$($build.sourceVersion)' does not match '$ExpectedSourceVersion'."
-                }
-
-                [pscustomobject]@{
-                    Id = [int]$build.id
-                    BuildNumber = [string]$build.buildNumber
-                    Status = [string]$build.status
-                    Result = [string]$build.result
-                    QueueTime = $build.queueTime
-                    StartTime = $build.startTime
-                    FinishTime = $build.finishTime
-                    LastChangedDate = $build.lastChangedDate
-                    WebUrl = [string]$build._links.web.href
-                }
+                ConvertTo-AzDevOpsBuildSnapshot `
+                    -Build $response.Build `
+                    -RequestedId $response.RequestedId `
+                    -ExpectedBranch $ExpectedBranch `
+                    -ExpectedSourceVersion $expectedSourceVersionNormalized
             }
         )
         $lastBuilds = $builds
@@ -239,7 +225,16 @@ finally
 {
     if ($executionStateSet)
     {
-        $null = [PowerToys.UiTests.Ci.NativeMethods]::SetThreadExecutionState([uint32]2147483648)
+        # Best effort: the request is per-thread and PowerShell may resume finally on another thread.
+        # Process exit clears any request that remains associated with the original thread.
+        try
+        {
+            $null = [PowerToys.UiTests.Ci.NativeMethods]::SetThreadExecutionState($executionStateContinuous)
+        }
+        catch
+        {
+            Write-Warning "System sleep-prevention cleanup failed: $($_.Exception.Message)"
+        }
     }
 
     $waitHandle.Dispose()

--- a/.github/skills/ui-tests-pipeline-ci/scripts/Wait-AzureDevOpsBuild.ps1
+++ b/.github/skills/ui-tests-pipeline-ci/scripts/Wait-AzureDevOpsBuild.ps1
@@ -1,0 +1,246 @@
+# Copyright (c) Microsoft Corporation
+# The Microsoft Corporation licenses this file to you under the MIT license.
+# See the LICENSE file in the project root for more information.
+
+#requires -Version 7.0
+
+<#
+.SYNOPSIS
+Waits synchronously for exact Azure DevOps builds to become terminal.
+
+.DESCRIPTION
+Polls checkpointed build IDs through the existing Azure CLI-authenticated REST helper. Every response
+must match the expected branch and source commit. The process remains in the foreground so an active
+agent turn resumes when all builds become terminal. On Windows, the process prevents system sleep
+while it waits.
+
+.PARAMETER BuildId
+One or more numeric Azure DevOps build IDs.
+
+.PARAMETER ExpectedBranch
+The exact source branch ref expected for every build.
+
+.PARAMETER ExpectedSourceVersion
+The exact 40-character source commit expected for every build.
+
+.PARAMETER PollIntervalSeconds
+Seconds between authenticated status reads. Defaults to 120.
+
+.PARAMETER TimeoutMinutes
+Maximum total wait. Defaults to 180 minutes.
+
+.PARAMETER MaxConsecutiveErrors
+Number of consecutive REST failures allowed before stopping. Defaults to 3.
+
+.EXAMPLE
+pwsh -NoLogo -NoProfile -File `
+  .github\skills\ui-tests-pipeline-ci\scripts\Wait-AzureDevOpsBuild.ps1 `
+  -BuildId 123456789 `
+  -ExpectedBranch refs/heads/example `
+  -ExpectedSourceVersion 0123456789abcdef0123456789abcdef01234567
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [ValidateRange(1, [int]::MaxValue)]
+    [int[]] $BuildId,
+
+    [Parameter(Mandatory)]
+    [ValidatePattern('^refs/heads/.+')]
+    [string] $ExpectedBranch,
+
+    [Parameter(Mandatory)]
+    [ValidatePattern('^[0-9a-fA-F]{40}$')]
+    [string] $ExpectedSourceVersion,
+
+    [ValidateRange(10, 3600)]
+    [int] $PollIntervalSeconds = 120,
+
+    [ValidateRange(1, 720)]
+    [int] $TimeoutMinutes = 180,
+
+    [ValidateRange(1, 20)]
+    [int] $MaxConsecutiveErrors = 3
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'AzureDevOps.ps1')
+
+$buildIds = @($BuildId | Sort-Object -Unique)
+$expectedSourceVersionNormalized = $ExpectedSourceVersion.ToLowerInvariant()
+$deadlineUtc = [DateTime]::UtcNow.AddMinutes($TimeoutMinutes)
+$lastFingerprint = $null
+$lastOutputUtc = [DateTime]::MinValue
+$lastBuilds = @()
+$consecutiveErrors = 0
+$waitHandle = [Threading.ManualResetEventSlim]::new($false)
+$executionStateSet = $false
+
+try
+{
+    if ($IsWindows)
+    {
+        if (-not ('PowerToys.UiTests.Ci.NativeMethods' -as [type]))
+        {
+            Add-Type -TypeDefinition @'
+using System.Runtime.InteropServices;
+
+namespace PowerToys.UiTests.Ci
+{
+    public static class NativeMethods
+    {
+        [DllImport("kernel32.dll")]
+        public static extern uint SetThreadExecutionState(uint executionState);
+    }
+}
+'@
+        }
+
+        $executionStateSet = [PowerToys.UiTests.Ci.NativeMethods]::SetThreadExecutionState([uint32]2147483649) -ne 0
+        if (-not $executionStateSet)
+        {
+            throw 'Failed to prevent system sleep while waiting for Azure DevOps builds.'
+        }
+    }
+
+    $null = Test-AzDevOpsSession
+
+    while ($true)
+    {
+        $observedUtc = [DateTime]::UtcNow
+        try
+        {
+            $responses = @(
+                foreach ($id in $buildIds)
+                {
+                    [pscustomobject]@{
+                        RequestedId = $id
+                        Build = (Invoke-AzDevOpsRest `
+                                -Uri "_apis/build/builds/${id}?api-version=7.1").Body
+                    }
+                }
+            )
+            $consecutiveErrors = 0
+        }
+        catch
+        {
+            $consecutiveErrors++
+            if ($consecutiveErrors -ge $MaxConsecutiveErrors)
+            {
+                throw "Azure DevOps status query failed $consecutiveErrors consecutive times: $($_.Exception.Message)"
+            }
+
+            [pscustomobject]@{
+                Event = 'query-error'
+                ObservedUtc = $observedUtc.ToString('o')
+                ConsecutiveErrors = $consecutiveErrors
+                Message = $_.Exception.Message
+            } | ConvertTo-Json -Compress
+
+            $remainingSeconds = [Math]::Floor(($deadlineUtc - [DateTime]::UtcNow).TotalSeconds)
+            if ($remainingSeconds -le 0)
+            {
+                [pscustomobject]@{
+                    Event = 'timeout'
+                    ObservedUtc = [DateTime]::UtcNow.ToString('o')
+                    TimeoutMinutes = $TimeoutMinutes
+                    Builds = $lastBuilds
+                } | ConvertTo-Json -Depth 6 -Compress
+                throw "Timed out after $TimeoutMinutes minutes waiting for build(s): $($buildIds -join ', ')."
+            }
+
+            $waitSeconds = [Math]::Min($PollIntervalSeconds, $remainingSeconds)
+            $null = $waitHandle.Wait([TimeSpan]::FromSeconds($waitSeconds))
+            continue
+        }
+
+        $builds = @(
+            foreach ($response in $responses)
+            {
+                $id = $response.RequestedId
+                $build = $response.Build
+                if ([int]$build.id -ne $id)
+                {
+                    throw "Requested build $id but Azure DevOps returned build $($build.id)."
+                }
+
+                if ([string]$build.sourceBranch -cne $ExpectedBranch)
+                {
+                    throw "Build $id source branch '$($build.sourceBranch)' does not match '$ExpectedBranch'."
+                }
+
+                if ([string]$build.sourceVersion -ine $expectedSourceVersionNormalized)
+                {
+                    throw "Build $id source version '$($build.sourceVersion)' does not match '$ExpectedSourceVersion'."
+                }
+
+                [pscustomobject]@{
+                    Id = [int]$build.id
+                    BuildNumber = [string]$build.buildNumber
+                    Status = [string]$build.status
+                    Result = [string]$build.result
+                    QueueTime = $build.queueTime
+                    StartTime = $build.startTime
+                    FinishTime = $build.finishTime
+                    LastChangedDate = $build.lastChangedDate
+                    WebUrl = [string]$build._links.web.href
+                }
+            }
+        )
+        $lastBuilds = $builds
+
+        if (@($builds | Where-Object Status -NE 'completed').Count -eq 0)
+        {
+            [pscustomobject]@{
+                Event = 'terminal'
+                ObservedUtc = $observedUtc.ToString('o')
+                Builds = $builds
+            } | ConvertTo-Json -Depth 6 -Compress
+            return
+        }
+
+        $fingerprint = @($builds | ForEach-Object {
+                "$($_.Id):$($_.Status):$($_.Result):$($_.LastChangedDate)"
+            }) -join '|'
+        if ($fingerprint -ne $lastFingerprint -or ($observedUtc - $lastOutputUtc).TotalMinutes -ge 15)
+        {
+            [pscustomobject]@{
+                Event = 'progress'
+                ObservedUtc = $observedUtc.ToString('o')
+                DeadlineUtc = $deadlineUtc.ToString('o')
+                Builds = $builds
+            } | ConvertTo-Json -Depth 6 -Compress
+            $lastFingerprint = $fingerprint
+            $lastOutputUtc = $observedUtc
+        }
+
+        $remainingSeconds = [Math]::Floor(($deadlineUtc - [DateTime]::UtcNow).TotalSeconds)
+        if ($remainingSeconds -le 0)
+        {
+            [pscustomobject]@{
+                Event = 'timeout'
+                ObservedUtc = [DateTime]::UtcNow.ToString('o')
+                TimeoutMinutes = $TimeoutMinutes
+                Builds = $builds
+            } | ConvertTo-Json -Depth 6 -Compress
+            $states = @($builds | ForEach-Object { "$($_.Id)=$($_.Status)/$($_.Result)" }) -join ', '
+            throw "Timed out after $TimeoutMinutes minutes waiting for build(s): $states."
+        }
+
+        $waitSeconds = [Math]::Min($PollIntervalSeconds, $remainingSeconds)
+        $null = $waitHandle.Wait([TimeSpan]::FromSeconds($waitSeconds))
+    }
+}
+finally
+{
+    if ($executionStateSet)
+    {
+        $null = [PowerToys.UiTests.Ci.NativeMethods]::SetThreadExecutionState([uint32]2147483648)
+    }
+
+    $waitHandle.Dispose()
+}

--- a/.github/skills/ui-tests-pipeline-ci/tests/Wait-AzureDevOpsBuild.Tests.ps1
+++ b/.github/skills/ui-tests-pipeline-ci/tests/Wait-AzureDevOpsBuild.Tests.ps1
@@ -1,0 +1,77 @@
+# Copyright (c) Microsoft Corporation
+# The Microsoft Corporation licenses this file to you under the MIT license.
+# See the LICENSE file in the project root for more information.
+
+Describe 'ConvertTo-AzDevOpsBuildSnapshot' {
+    BeforeAll {
+        Set-StrictMode -Version Latest
+        . (Join-Path $PSScriptRoot '..\scripts\AzureDevOps.ps1')
+
+        $script:branch = 'refs/heads/test-branch'
+        $script:sourceVersion = '0123456789abcdef0123456789abcdef01234567'
+    }
+
+    It 'projects a not-started build without optional result or time properties' {
+        $build = [pscustomobject]@{
+            id = 101
+            buildNumber = '20260829.1'
+            status = 'notStarted'
+            sourceBranch = $script:branch
+            sourceVersion = $script:sourceVersion
+            queueTime = '2026-08-29T18:00:00Z'
+            lastChangedDate = '2026-08-29T18:00:00Z'
+            _links = [pscustomobject]@{ web = [pscustomobject]@{ href = 'https://example.test/101' } }
+        }
+
+        $snapshot = ConvertTo-AzDevOpsBuildSnapshot -Build $build -RequestedId 101 -ExpectedBranch $script:branch -ExpectedSourceVersion $script:sourceVersion
+
+        $snapshot.Status | Should Be 'notStarted'
+        $snapshot.Result | Should BeNullOrEmpty
+        $snapshot.StartTime | Should BeNullOrEmpty
+        $snapshot.FinishTime | Should BeNullOrEmpty
+    }
+
+    It 'projects an in-progress build without result or finish time' {
+        $build = [pscustomobject]@{
+            id = 102
+            buildNumber = '20260829.2'
+            status = 'inProgress'
+            sourceBranch = $script:branch
+            sourceVersion = $script:sourceVersion
+            queueTime = '2026-08-29T18:00:00Z'
+            startTime = '2026-08-29T18:01:00Z'
+            lastChangedDate = '2026-08-29T18:02:00Z'
+            _links = [pscustomobject]@{ web = [pscustomobject]@{ href = 'https://example.test/102' } }
+        }
+
+        $snapshot = ConvertTo-AzDevOpsBuildSnapshot -Build $build -RequestedId 102 -ExpectedBranch $script:branch -ExpectedSourceVersion $script:sourceVersion
+
+        $snapshot.Status | Should Be 'inProgress'
+        $snapshot.Result | Should BeNullOrEmpty
+        $snapshot.StartTime | Should Be '2026-08-29T18:01:00Z'
+        $snapshot.FinishTime | Should BeNullOrEmpty
+    }
+
+    It 'projects a completed build with result and times' {
+        $build = [pscustomobject]@{
+            id = 103
+            buildNumber = '20260829.3'
+            status = 'completed'
+            result = 'succeeded'
+            sourceBranch = $script:branch
+            sourceVersion = $script:sourceVersion
+            queueTime = '2026-08-29T18:00:00Z'
+            startTime = '2026-08-29T18:01:00Z'
+            finishTime = '2026-08-29T18:03:00Z'
+            lastChangedDate = '2026-08-29T18:03:01Z'
+            _links = [pscustomobject]@{ web = [pscustomobject]@{ href = 'https://example.test/103' } }
+        }
+
+        $snapshot = ConvertTo-AzDevOpsBuildSnapshot -Build $build -RequestedId 103 -ExpectedBranch $script:branch -ExpectedSourceVersion $script:sourceVersion
+
+        $snapshot.Status | Should Be 'completed'
+        $snapshot.Result | Should Be 'succeeded'
+        $snapshot.StartTime | Should Be '2026-08-29T18:01:00Z'
+        $snapshot.FinishTime | Should Be '2026-08-29T18:03:00Z'
+    }
+}

--- a/.pipelines/v2/templates/job-test-project.yml
+++ b/.pipelines/v2/templates/job-test-project.yml
@@ -201,6 +201,7 @@ jobs:
       $allModules = [string]::IsNullOrWhiteSpace($modulesRaw)
       $requiresModernContextMenu = '$(TestPlatform)' -ne 'x64Win10'
       $requiresPowerRename = $allModules -or @($selectedModules | Where-Object { $_ -match 'PowerRename' }).Count -gt 0
+      $requiresAuthenticatedSettingsIpc = $allModules -or @($selectedModules | Where-Object { $_ -match 'PowerRename|MouseUtils' }).Count -gt 0
       $requiredPackages = @()
       $requiredAuthenticodeFiles = @()
       $certificateMarkerPath = "$(Agent.WorkFolder)\PowerToysUiTestState\SigningCertificates.txt"
@@ -213,7 +214,7 @@ jobs:
         $requiredPackages += 'PowerRenameContextMenuPackage.msix'
       }
 
-      if ($requiresPowerRename) {
+      if ($requiresAuthenticatedSettingsIpc) {
         $requiredAuthenticodeFiles += 'PowerToys.exe', 'PowerToys.Settings.exe'
       }
 

--- a/PowerToys.slnx
+++ b/PowerToys.slnx
@@ -605,6 +605,10 @@
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />
     </Project>
+    <Project Path="src/modules/MouseUtils/MouseUtils.UITests.Next/MouseUtils.UITests.Next.csproj">
+      <Platform Solution="*|ARM64" Project="ARM64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
   </Folder>
   <Folder Name="/modules/keyboardmanager/Tests/">
     <Project Path="src/modules/keyboardmanager/KeyboardManagerEditorTest/KeyboardManagerEditorTest.vcxproj" Id="62173d9a-6724-4c00-a1c8-fb646480a9ec" />

--- a/src/common/UITestAutomation.Next.UnitTests/KeyboardHelperTests.cs
+++ b/src/common/UITestAutomation.Next.UnitTests/KeyboardHelperTests.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.PowerToys.UITest.Next;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.PowerToys.UITestAutomationNext.UnitTests;
+
+[TestClass]
+public class KeyboardHelperTests
+{
+    [TestMethod]
+    public void CreateChordPlanKeepsLeftControlSideSpecific()
+    {
+        var (chord, heldKeys) = KeyboardHelper.CreateChordPlan(Key.LCtrl, Key.A);
+
+        Assert.AreEqual("a", chord);
+        CollectionAssert.AreEqual(new[] { Key.LCtrl }, heldKeys.ToArray());
+    }
+
+    [TestMethod]
+    public void CreateChordPlanKeepsRightControlSideSpecific()
+    {
+        var (chord, heldKeys) = KeyboardHelper.CreateChordPlan(Key.RCtrl, Key.A);
+
+        Assert.AreEqual("a", chord);
+        CollectionAssert.AreEqual(new[] { Key.RCtrl }, heldKeys.ToArray());
+    }
+
+    [TestMethod]
+    public void SendKeysRejectsLayoutDependentOemKeys()
+    {
+        Assert.ThrowsExactly<NotSupportedException>(() => KeyboardHelper.SendKeys(Key.OemPeriod));
+    }
+}

--- a/src/common/UITestAutomation.Next/KeyboardHelper.cs
+++ b/src/common/UITestAutomation.Next/KeyboardHelper.cs
@@ -105,16 +105,48 @@ public static class KeyboardHelper
 
     private const uint KEYEVENTF_KEYUP = 0x2;
     private const uint KEYEVENTF_EXTENDEDKEY = 0x1;
-    private const byte VK_LWIN = 0x5B;
 
     /// <summary>
-    /// Send a chord of keys. If the chord contains <see cref="Key.LWin"/>, LWIN is held via
-    /// <c>keybd_event</c> while the remaining keys are sent via <see cref="FormsSendKeys.SendWait"/>.
-    /// Otherwise everything goes through SendKeys.SendWait (the modifier-aware Windows path).
+    /// Send a chord of keys. LWIN and side-specific Ctrl keys are held via <c>keybd_event</c> while
+    /// the remaining keys are sent via <see cref="FormsSendKeys.SendWait"/>. Otherwise everything
+    /// goes through SendKeys.SendWait (the modifier-aware Windows path).
     /// </summary>
     public static void SendKeys(params Key[] keys)
     {
-        bool winDown = false;
+        var (chord, heldKeys) = CreateChordPlan(keys);
+        foreach (var key in heldKeys)
+        {
+            PressKey(key);
+        }
+
+        try
+        {
+            if (chord.Length > 0)
+            {
+                FormsSendKeys.SendWait(chord);
+            }
+            else if (heldKeys.Count > 0)
+            {
+                Thread.Sleep(20);
+            }
+        }
+        finally
+        {
+            for (var index = heldKeys.Count - 1; index >= 0; index--)
+            {
+                ReleaseKey(heldKeys[index]);
+            }
+        }
+    }
+
+    internal static (string Chord, IReadOnlyList<Key> HeldKeys) CreateChordPlan(params Key[] keys)
+    {
+        if (keys.Contains(Key.OemPeriod))
+        {
+            throw new NotSupportedException($"Use {nameof(SendKey)} for OEM keys so input follows the active keyboard layout.");
+        }
+
+        var heldKeys = new List<Key>();
         var chord = new System.Text.StringBuilder();
 
         foreach (var k in keys)
@@ -122,12 +154,12 @@ public static class KeyboardHelper
             switch (k)
             {
                 case Key.LWin:
-                    keybd_event(VK_LWIN, 0, 0, UIntPtr.Zero);
-                    winDown = true;
+                case Key.LCtrl:
+                case Key.RCtrl:
+                    heldKeys.Add(k);
                     break;
                 case Key.Ctrl:
-                case Key.LCtrl:
-                case Key.RCtrl: chord.Append('^'); break;
+                    chord.Append('^'); break;
                 case Key.Shift:
                 case Key.LShift: chord.Append('+'); break;
                 case Key.Alt: chord.Append('%'); break;
@@ -158,7 +190,6 @@ public static class KeyboardHelper
                 case Key.F10: chord.Append("{F10}"); break;
                 case Key.F11: chord.Append("{F11}"); break;
                 case Key.F12: chord.Append("{F12}"); break;
-                case Key.OemPeriod: chord.Append('.'); break;
                 default:
                     // Letter / digit keys map to their lowercase character for SendKeys.
                     chord.Append(((char)k).ToString().ToLowerInvariant());
@@ -166,20 +197,7 @@ public static class KeyboardHelper
             }
         }
 
-        try
-        {
-            if (chord.Length > 0)
-            {
-                FormsSendKeys.SendWait(chord.ToString());
-            }
-        }
-        finally
-        {
-            if (winDown)
-            {
-                keybd_event(VK_LWIN, 0, KEYEVENTF_KEYUP, UIntPtr.Zero);
-            }
-        }
+        return (chord.ToString(), heldKeys);
     }
 
     /// <summary>

--- a/src/common/UITestAutomation.Next/KeyboardHelper.cs
+++ b/src/common/UITestAutomation.Next/KeyboardHelper.cs
@@ -11,6 +11,8 @@ namespace Microsoft.PowerToys.UITest.Next;
 public enum Key : byte
 {
     Ctrl = 0x11,
+    LCtrl = 0xA2,
+    RCtrl = 0xA3,
     Shift = 0x10,
     LShift = 0xA0,
     Alt = 0x12,
@@ -81,6 +83,7 @@ public enum Key : byte
     F10 = 0x79,
     F11 = 0x7A,
     F12 = 0x7B,
+    OemPeriod = 0xBE,
 }
 
 /// <summary>
@@ -122,7 +125,9 @@ public static class KeyboardHelper
                     keybd_event(VK_LWIN, 0, 0, UIntPtr.Zero);
                     winDown = true;
                     break;
-                case Key.Ctrl: chord.Append('^'); break;
+                case Key.Ctrl:
+                case Key.LCtrl:
+                case Key.RCtrl: chord.Append('^'); break;
                 case Key.Shift:
                 case Key.LShift: chord.Append('+'); break;
                 case Key.Alt: chord.Append('%'); break;
@@ -153,6 +158,7 @@ public static class KeyboardHelper
                 case Key.F10: chord.Append("{F10}"); break;
                 case Key.F11: chord.Append("{F11}"); break;
                 case Key.F12: chord.Append("{F12}"); break;
+                case Key.OemPeriod: chord.Append('.'); break;
                 default:
                     // Letter / digit keys map to their lowercase character for SendKeys.
                     chord.Append(((char)k).ToString().ToLowerInvariant());
@@ -210,6 +216,7 @@ public static class KeyboardHelper
     }
 
     private static bool IsExtended(Key key) => key is
+        Key.RCtrl or
         Key.Left or Key.Up or Key.Right or Key.Down or
         Key.Home or Key.End or Key.PageUp or Key.PageDown or
         Key.Insert or Key.Delete;

--- a/src/common/UITestAutomation.Next/MouseHelper.cs
+++ b/src/common/UITestAutomation.Next/MouseHelper.cs
@@ -41,6 +41,7 @@ public static class MouseHelper
 
     private const uint INPUT_MOUSE = 0;
 
+    private const uint MouseEventMove = 0x01;
     private const uint MOUSEEVENTF_LEFTDOWN = 0x02;
     private const uint MOUSEEVENTF_LEFTUP = 0x04;
     private const uint MOUSEEVENTF_RIGHTDOWN = 0x08;
@@ -52,10 +53,10 @@ public static class MouseHelper
     private const int ClickDelayMs = 100;
     private const int WheelTick = 120;
 
-    [DllImport("user32.dll")]
+    [DllImport("user32.dll", SetLastError = true)]
     private static extern bool SetCursorPos(int x, int y);
 
-    [DllImport("user32.dll")]
+    [DllImport("user32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool GetCursorPos(out POINT lpPoint);
 
@@ -63,12 +64,48 @@ public static class MouseHelper
     private static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
 
     /// <summary>Move the OS cursor to absolute screen coordinates.</summary>
-    public static void MoveTo(int x, int y) => SetCursorPos(x, y);
+    public static void MoveTo(int x, int y)
+    {
+        if (!SetCursorPos(x, y))
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+    }
+
+    /// <summary>
+    /// Move the cursor by a relative delta using real mouse input. Stepped movement is useful for
+    /// utilities that observe low-level or raw mouse movement rather than only the final position.
+    /// </summary>
+    public static void MoveBy(int deltaX, int deltaY, int steps = 1, int delayMs = 15)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(steps);
+        ArgumentOutOfRangeException.ThrowIfNegative(delayMs);
+
+        var previousX = 0;
+        var previousY = 0;
+        for (var step = 1; step <= steps; step++)
+        {
+            var targetX = (int)Math.Round((double)deltaX * step / steps);
+            var targetY = (int)Math.Round((double)deltaY * step / steps);
+            SendMouseInput(MouseEventMove, dx: targetX - previousX, dy: targetY - previousY);
+            previousX = targetX;
+            previousY = targetY;
+
+            if (delayMs > 0 && step < steps)
+            {
+                Thread.Sleep(delayMs);
+            }
+        }
+    }
 
     /// <summary>Current cursor position in screen pixels.</summary>
     public static (int X, int Y) GetMousePosition()
     {
-        GetCursorPos(out var p);
+        if (!GetCursorPos(out var p))
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
         return (p.X, p.Y);
     }
 
@@ -178,7 +215,7 @@ public static class MouseHelper
     /// Button and wheel events fire at the current cursor position, so <paramref name="data"/>
     /// only carries the wheel delta for <c>MOUSEEVENTF_WHEEL</c>.
     /// </summary>
-    private static void SendMouseInput(uint flags, int data = 0)
+    private static void SendMouseInput(uint flags, int data = 0, int dx = 0, int dy = 0)
     {
         var inputs = new INPUT[]
         {
@@ -187,8 +224,8 @@ public static class MouseHelper
                 Type = INPUT_MOUSE,
                 Mi = new MOUSEINPUT
                 {
-                    Dx = 0,
-                    Dy = 0,
+                    Dx = dx,
+                    Dy = dy,
                     MouseData = (uint)data,
                     DwFlags = flags,
                     Time = 0,

--- a/src/common/UITestAutomation.Next/MouseHelper.cs
+++ b/src/common/UITestAutomation.Next/MouseHelper.cs
@@ -64,6 +64,7 @@ public static class MouseHelper
     private static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
 
     /// <summary>Move the OS cursor to absolute screen coordinates.</summary>
+    /// <exception cref="Win32Exception"><c>SetCursorPos</c> rejected the requested position.</exception>
     public static void MoveTo(int x, int y)
     {
         if (!SetCursorPos(x, y))

--- a/src/common/UITestAutomation.Next/NamedEventHelper.cs
+++ b/src/common/UITestAutomation.Next/NamedEventHelper.cs
@@ -68,7 +68,7 @@ public static class NamedEventHelper
             handle.Dispose();
             return true;
         }
-        catch (Exception)
+        catch (WaitHandleCannotBeOpenedException)
         {
             return false;
         }

--- a/src/common/UITestAutomation.Next/NamedEventHelper.cs
+++ b/src/common/UITestAutomation.Next/NamedEventHelper.cs
@@ -19,6 +19,21 @@ public static class NamedEventHelper
     /// <summary>Toggles the FancyZones layout editor open/closed.</summary>
     public const string FancyZonesEditorToggle = @"Local\FancyZones-ToggleEditorEvent-1e174338-06a3-472b-874d-073b21c62f14";
 
+    /// <summary>Triggers Find My Mouse.</summary>
+    public const string FindMyMouseTrigger = @"Local\FindMyMouseTriggerEvent-5a9dc5f4-1c74-4f2f-a66f-1b9b6a2f9b23";
+
+    /// <summary>Toggles Mouse Highlighter.</summary>
+    public const string MouseHighlighterToggle = @"Local\MouseHighlighterTriggerEvent-1e3c9c3d-3fdf-4f9a-9a52-31c9b3c3a8f4";
+
+    /// <summary>Toggles Mouse Pointer Crosshairs.</summary>
+    public const string MouseCrosshairsToggle = @"Local\MouseCrosshairsTriggerEvent-0d4c7f92-0a5c-4f5c-b64b-8a2a2f7e0b21";
+
+    /// <summary>Shows the Mouse Jump preview.</summary>
+    public const string MouseJumpShowPreview = @"Local\MouseJumpEvent-aa0be051-3396-4976-b7ba-1a9cc7d236a5";
+
+    /// <summary>Toggles Cursor Wrap.</summary>
+    public const string CursorWrapToggle = @"Local\CursorWrapTriggerEvent-1f8452b5-4e6e-45b3-8b09-13f14a5900c9";
+
     /// <summary>Set an existing named event. Returns false when no module currently owns it.</summary>
     public static bool TrySignal(string name)
     {
@@ -40,6 +55,33 @@ public static class NamedEventHelper
         }
     }
 
+    /// <summary>Whether a named event currently exists.</summary>
+    public static bool Exists(string name)
+    {
+        try
+        {
+            if (!EventWaitHandle.TryOpenExisting(name, out var handle))
+            {
+                return false;
+            }
+
+            handle.Dispose();
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>Wait until a module creates a named event without signaling it.</summary>
+    public static bool WaitUntilAvailable(string name, int timeoutMS = 15_000, int pollIntervalMS = 250) =>
+        WaitForAvailability(name, expected: true, timeoutMS, pollIntervalMS);
+
+    /// <summary>Wait until a module closes a named event.</summary>
+    public static bool WaitUntilUnavailable(string name, int timeoutMS = 15_000, int pollIntervalMS = 250) =>
+        WaitForAvailability(name, expected: false, timeoutMS, pollIntervalMS);
+
     /// <summary>Wait until a module has created the named event, then signal it.</summary>
     public static bool WaitAndSignal(string name, int timeoutMS = 15_000, int pollIntervalMS = 250)
     {
@@ -47,6 +89,25 @@ public static class NamedEventHelper
         while (true)
         {
             if (TrySignal(name))
+            {
+                return true;
+            }
+
+            if (DateTime.UtcNow >= deadline)
+            {
+                return false;
+            }
+
+            Thread.Sleep(pollIntervalMS);
+        }
+    }
+
+    private static bool WaitForAvailability(string name, bool expected, int timeoutMS, int pollIntervalMS)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromMilliseconds(timeoutMS);
+        while (true)
+        {
+            if (Exists(name) == expected)
             {
                 return true;
             }

--- a/src/modules/MouseUtils/MouseUtils.UITests.Next/AssemblyInfo.cs
+++ b/src/modules/MouseUtils/MouseUtils.UITests.Next/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[assembly: DoNotParallelize]

--- a/src/modules/MouseUtils/MouseUtils.UITests.Next/CursorWrapTests.cs
+++ b/src/modules/MouseUtils/MouseUtils.UITests.Next/CursorWrapTests.cs
@@ -11,7 +11,12 @@ namespace MouseUtils.UITests;
 public class CursorWrapTests : UITestBase
 {
     private const string ModuleName = "CursorWrap";
+    private const string ToggleId = "MouseUtils_CursorWrapToggleId";
     private static readonly IDisposable ModuleSettings = SettingsConfigHelper.PreserveModuleSettings(ModuleName);
+
+    static CursorWrapTests()
+    {
+    }
 
     public CursorWrapTests()
         : base(PowerToysModule.PowerToysSettings, enableModules: new[] { ModuleName })
@@ -56,9 +61,7 @@ public class CursorWrapTests : UITestBase
     public void ShortcutTogglesWrappingAndModuleDisableStopsIt()
     {
         MouseUtilsTestHelper.NavigateToMouseUtilities(this);
-        var toggle = Session.Find<ToggleSwitch>(By.Name("CursorWrap"), 5_000);
-        toggle.Toggle(true);
-        Assert.IsTrue(toggle.WaitForProperty("ToggleState", "On", 5_000), "CursorWrap toggle did not reach On.");
+        var toggle = MouseUtilsTestHelper.SetModuleEnabled(this, ToggleId, true);
         Assert.IsTrue(
             NamedEventHelper.WaitUntilAvailable(NamedEventHelper.CursorWrapToggle),
             "CursorWrap did not create its trigger event after being enabled.");
@@ -71,8 +74,8 @@ public class CursorWrapTests : UITestBase
         KeyboardHelper.SendKeys(Key.LWin, Key.Alt, Key.U);
         AssertDoesNotWrap(CursorEdge.Left);
 
-        toggle.Toggle(false);
-        Assert.IsTrue(toggle.WaitForProperty("ToggleState", "Off", 5_000), "CursorWrap toggle did not reach Off.");
+        toggle = MouseUtilsTestHelper.SetModuleEnabled(this, ToggleId, false);
+        Assert.IsFalse(toggle.IsOn, "CursorWrap toggle should be off.");
         Assert.IsTrue(
             NamedEventHelper.WaitUntilUnavailable(NamedEventHelper.CursorWrapToggle),
             "CursorWrap trigger event remained available after the module was disabled.");

--- a/src/modules/MouseUtils/MouseUtils.UITests.Next/CursorWrapTests.cs
+++ b/src/modules/MouseUtils/MouseUtils.UITests.Next/CursorWrapTests.cs
@@ -73,11 +73,8 @@ public class CursorWrapTests : UITestBase
 
         toggle.Toggle(false);
         Assert.IsTrue(toggle.WaitForProperty("ToggleState", "Off", 5_000), "CursorWrap toggle did not reach Off.");
-        MouseUtilsTestHelper.EnsureModuleStateApplied(
-            this,
-            ModuleName,
-            enabled: false,
-            () => NamedEventHelper.WaitUntilUnavailable(NamedEventHelper.CursorWrapToggle),
+        Assert.IsTrue(
+            NamedEventHelper.WaitUntilUnavailable(NamedEventHelper.CursorWrapToggle),
             "CursorWrap trigger event remained available after the module was disabled.");
         AssertDoesNotWrap(CursorEdge.Left);
     }

--- a/src/modules/MouseUtils/MouseUtils.UITests.Next/CursorWrapTests.cs
+++ b/src/modules/MouseUtils/MouseUtils.UITests.Next/CursorWrapTests.cs
@@ -1,0 +1,337 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.PowerToys.UITest.Next;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MouseUtils.UITests;
+
+[TestClass]
+public class CursorWrapTests : UITestBase
+{
+    private const string ModuleName = "CursorWrap";
+    private static readonly IDisposable ModuleSettings = SettingsConfigHelper.PreserveModuleSettings(ModuleName);
+
+    public CursorWrapTests()
+        : base(PowerToysModule.PowerToysSettings, enableModules: new[] { ModuleName })
+    {
+    }
+
+    [ClassCleanup]
+    public static void RestoreModuleSettings() => ModuleSettings.Dispose();
+
+    protected override void PrepareTestState()
+    {
+        var configuration = TestContext.TestName switch
+        {
+            nameof(HorizontalOnlyWrapsOnlyHorizontalEdges) => new CursorWrapConfiguration(WrapMode: 2),
+            nameof(VerticalOnlyWrapsOnlyVerticalEdges) => new CursorWrapConfiguration(WrapMode: 1),
+            nameof(CtrlActivationModeRequiresCtrl) => new CursorWrapConfiguration(ActivationMode: 1),
+            nameof(ShiftActivationModeRequiresShift) => new CursorWrapConfiguration(ActivationMode: 2),
+            nameof(SingleMonitorSuppressionBlocksWrapping) => new CursorWrapConfiguration(DisableOnSingleMonitor: true),
+            nameof(AutoActivateStartsWrappingWithoutShortcut) => new CursorWrapConfiguration(AutoActivate: true),
+            nameof(ChangedShortcutTogglesWrapping) => new CursorWrapConfiguration(ShortcutCode: (int)Key.Y),
+            _ => new CursorWrapConfiguration(),
+        };
+
+        MouseUtilsTestHelper.ReplaceModuleSettings(ModuleName, CreateSettings(configuration));
+    }
+
+    [TestCleanup]
+    public async Task CleanupInput()
+    {
+        await CaptureFailureArtifactsBeforeCleanupAsync();
+        MouseHelper.LeftUp();
+        MouseHelper.RightUp();
+        KeyboardHelper.ReleaseKey(Key.Ctrl);
+        KeyboardHelper.ReleaseKey(Key.Shift);
+        KeyboardHelper.ReleaseKey(Key.Alt);
+        KeyboardHelper.ReleaseKey(Key.LWin);
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    [TestCategory("CursorWrap")]
+    public void ShortcutTogglesWrappingAndModuleDisableStopsIt()
+    {
+        MouseUtilsTestHelper.NavigateToMouseUtilities(this);
+        var toggle = Session.Find<ToggleSwitch>(By.Name("CursorWrap"), 5_000);
+        toggle.Toggle(true);
+        Assert.IsTrue(toggle.WaitForProperty("ToggleState", "On", 5_000), "CursorWrap toggle did not reach On.");
+        Assert.IsTrue(
+            NamedEventHelper.WaitUntilAvailable(NamedEventHelper.CursorWrapToggle),
+            "CursorWrap did not create its trigger event after being enabled.");
+
+        MouseUtilsTestHelper.Step(this, "Activating CursorWrap with Win+Alt+U");
+        KeyboardHelper.SendKeys(Key.LWin, Key.Alt, Key.U);
+        AssertWraps(CursorEdge.Left);
+
+        MouseUtilsTestHelper.Step(this, "Deactivating CursorWrap with Win+Alt+U");
+        KeyboardHelper.SendKeys(Key.LWin, Key.Alt, Key.U);
+        AssertDoesNotWrap(CursorEdge.Left);
+
+        toggle.Toggle(false);
+        Assert.IsTrue(toggle.WaitForProperty("ToggleState", "Off", 5_000), "CursorWrap toggle did not reach Off.");
+        Assert.IsTrue(
+            NamedEventHelper.WaitUntilUnavailable(NamedEventHelper.CursorWrapToggle),
+            "CursorWrap trigger event remained available after the module was disabled.");
+        AssertDoesNotWrap(CursorEdge.Left);
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    [TestCategory("CursorWrap")]
+    public void BothModeWrapsAllEdges()
+    {
+        ActivateWithNamedEvent();
+        foreach (var edge in Enum.GetValues<CursorEdge>())
+        {
+            AssertWraps(edge);
+        }
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    [TestCategory("CursorWrap")]
+    public void HorizontalOnlyWrapsOnlyHorizontalEdges()
+    {
+        ActivateWithNamedEvent();
+        AssertWraps(CursorEdge.Left);
+        AssertWraps(CursorEdge.Right);
+        AssertDoesNotWrap(CursorEdge.Top);
+        AssertDoesNotWrap(CursorEdge.Bottom);
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    [TestCategory("CursorWrap")]
+    public void VerticalOnlyWrapsOnlyVerticalEdges()
+    {
+        ActivateWithNamedEvent();
+        AssertWraps(CursorEdge.Top);
+        AssertWraps(CursorEdge.Bottom);
+        AssertDoesNotWrap(CursorEdge.Left);
+        AssertDoesNotWrap(CursorEdge.Right);
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    [TestCategory("CursorWrap")]
+    public void CtrlActivationModeRequiresCtrl()
+    {
+        ActivateWithNamedEvent();
+        AssertDoesNotWrap(CursorEdge.Left);
+        AssertWraps(CursorEdge.Left, Key.Ctrl);
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    [TestCategory("CursorWrap")]
+    public void ShiftActivationModeRequiresShift()
+    {
+        ActivateWithNamedEvent();
+        AssertDoesNotWrap(CursorEdge.Top);
+        AssertWraps(CursorEdge.Top, Key.Shift);
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    [TestCategory("CursorWrap")]
+    public void DragSuppressionBlocksWrappingWhileLeftButtonIsDown()
+    {
+        ActivateWithNamedEvent();
+        AssertDoesNotWrap(CursorEdge.Left, holdLeftButton: true);
+        AssertWraps(CursorEdge.Left);
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    [TestCategory("CursorWrap")]
+    public void SingleMonitorSuppressionBlocksWrapping()
+    {
+        Assert.AreEqual(1, MonitorInfo.Count, "This scenario requires the single-monitor VM profile.");
+        ActivateWithNamedEvent();
+        foreach (var edge in Enum.GetValues<CursorEdge>())
+        {
+            AssertDoesNotWrap(edge);
+        }
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    [TestCategory("CursorWrap")]
+    public void AutoActivateStartsWrappingWithoutShortcut()
+    {
+        Assert.IsTrue(
+            NamedEventHelper.WaitUntilAvailable(NamedEventHelper.CursorWrapToggle),
+            "CursorWrap did not create its trigger event.");
+        AssertWraps(CursorEdge.Right);
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    [TestCategory("CursorWrap")]
+    public void ChangedShortcutTogglesWrapping()
+    {
+        Assert.IsTrue(
+            NamedEventHelper.WaitUntilAvailable(NamedEventHelper.CursorWrapToggle),
+            "CursorWrap did not create its trigger event.");
+
+        KeyboardHelper.SendKeys(Key.LWin, Key.Alt, Key.U);
+        AssertDoesNotWrap(CursorEdge.Left);
+
+        KeyboardHelper.SendKeys(Key.LWin, Key.Alt, Key.Y);
+        AssertWraps(CursorEdge.Left);
+    }
+
+    private static string CreateSettings(CursorWrapConfiguration configuration) => $$"""
+        {
+          "name": "CursorWrap",
+          "version": "1.0",
+          "properties": {
+            "activation_shortcut": { "win": true, "ctrl": false, "alt": true, "shift": false, "code": {{configuration.ShortcutCode}}, "key": "" },
+            "auto_activate": { "value": {{configuration.AutoActivate.ToString().ToLowerInvariant()}} },
+            "disable_wrap_during_drag": { "value": {{configuration.DisableDuringDrag.ToString().ToLowerInvariant()}} },
+            "wrap_mode": { "value": {{configuration.WrapMode}} },
+            "activation_mode": { "value": {{configuration.ActivationMode}} },
+            "disable_cursor_wrap_on_single_monitor": { "value": {{configuration.DisableOnSingleMonitor.ToString().ToLowerInvariant()}} }
+          }
+        }
+        """;
+
+    private void ActivateWithNamedEvent()
+    {
+        MouseUtilsTestHelper.Step(this, "Activating CursorWrap through its named event");
+        Assert.IsTrue(
+            NamedEventHelper.WaitAndSignal(NamedEventHelper.CursorWrapToggle),
+            "CursorWrap did not create or respond to its trigger event.");
+    }
+
+    private void AssertWraps(CursorEdge edge, Key? heldKey = null, bool holdLeftButton = false)
+    {
+        var monitor = MonitorInfo.GetPrimary()!;
+        var attempts = new List<(int X, int Y)>();
+        for (var attempt = 1; attempt <= 3; attempt++)
+        {
+            var after = MoveAcrossEdge(edge, heldKey, holdLeftButton);
+            attempts.Add(after);
+            var wrapped = edge switch
+            {
+                CursorEdge.Left => after.X >= monitor.Right - 10,
+                CursorEdge.Right => after.X <= monitor.Left + 10,
+                CursorEdge.Top => after.Y >= monitor.Bottom - 10,
+                CursorEdge.Bottom => after.Y <= monitor.Top + 10,
+                _ => false,
+            };
+            if (wrapped)
+            {
+                return;
+            }
+
+            Thread.Sleep(100);
+        }
+
+        Assert.Fail($"Cursor did not wrap from {edge} after three complete crossings; final positions: {string.Join(", ", attempts.Select(position => $"({position.X},{position.Y})"))}.");
+    }
+
+    private void AssertDoesNotWrap(CursorEdge edge, Key? heldKey = null, bool holdLeftButton = false)
+    {
+        var after = MoveAcrossEdge(edge, heldKey, holdLeftButton);
+        var monitor = MonitorInfo.GetPrimary()!;
+        var stayed = edge switch
+        {
+            CursorEdge.Left => after.X <= monitor.Left + 10,
+            CursorEdge.Right => after.X >= monitor.Right - 10,
+            CursorEdge.Top => after.Y <= monitor.Top + 10,
+            CursorEdge.Bottom => after.Y >= monitor.Bottom - 10,
+            _ => false,
+        };
+
+        Assert.IsTrue(stayed, $"Cursor unexpectedly wrapped from {edge}; final position was ({after.X},{after.Y}).");
+    }
+
+    private (int X, int Y) MoveAcrossEdge(CursorEdge edge, Key? heldKey, bool holdLeftButton)
+    {
+        var monitor = MonitorInfo.GetPrimary();
+        Assert.IsNotNull(monitor, "No primary monitor was reported.");
+        var centerX = monitor.Left + (monitor.Width / 2);
+        var centerY = monitor.Top + (monitor.Height / 2);
+        MouseHelper.MoveTo(centerX, centerY);
+        MouseHelper.MoveBy(2, 2);
+
+        var start = edge switch
+        {
+            CursorEdge.Left => (monitor.Left + 120, centerY),
+            CursorEdge.Right => (monitor.Right - 121, centerY),
+            CursorEdge.Top => (centerX, monitor.Top + 120),
+            CursorEdge.Bottom => (centerX, monitor.Bottom - 121),
+            _ => throw new ArgumentOutOfRangeException(nameof(edge)),
+        };
+        var inward = edge switch
+        {
+            CursorEdge.Left => (2, 0),
+            CursorEdge.Right => (-2, 0),
+            CursorEdge.Top => (0, 2),
+            CursorEdge.Bottom => (0, -2),
+            _ => throw new ArgumentOutOfRangeException(nameof(edge)),
+        };
+        var outward = edge switch
+        {
+            CursorEdge.Left => (-500, 0),
+            CursorEdge.Right => (500, 0),
+            CursorEdge.Top => (0, -500),
+            CursorEdge.Bottom => (0, 500),
+            _ => throw new ArgumentOutOfRangeException(nameof(edge)),
+        };
+
+        MouseHelper.MoveTo(start.Item1, start.Item2);
+        if (heldKey.HasValue)
+        {
+            KeyboardHelper.PressKey(heldKey.Value);
+        }
+
+        if (holdLeftButton)
+        {
+            MouseHelper.LeftDown();
+        }
+
+        try
+        {
+            MouseHelper.MoveBy(inward.Item1, inward.Item2);
+            MouseHelper.MoveBy(outward.Item1, outward.Item2);
+            Thread.Sleep(150);
+            var after = MouseHelper.GetMousePosition();
+            MouseUtilsTestHelper.Step(this, $"Cursor {edge} crossing ended at ({after.X},{after.Y})");
+            return after;
+        }
+        finally
+        {
+            if (holdLeftButton)
+            {
+                MouseHelper.LeftUp();
+            }
+
+            if (heldKey.HasValue)
+            {
+                KeyboardHelper.ReleaseKey(heldKey.Value);
+            }
+        }
+    }
+
+    private sealed record CursorWrapConfiguration(
+        bool AutoActivate = false,
+        bool DisableDuringDrag = true,
+        int WrapMode = 0,
+        int ActivationMode = 0,
+        bool DisableOnSingleMonitor = false,
+        int ShortcutCode = (int)Key.U);
+
+    private enum CursorEdge
+    {
+        Left,
+        Right,
+        Top,
+        Bottom,
+    }
+}

--- a/src/modules/MouseUtils/MouseUtils.UITests.Next/CursorWrapTests.cs
+++ b/src/modules/MouseUtils/MouseUtils.UITests.Next/CursorWrapTests.cs
@@ -73,8 +73,11 @@ public class CursorWrapTests : UITestBase
 
         toggle.Toggle(false);
         Assert.IsTrue(toggle.WaitForProperty("ToggleState", "Off", 5_000), "CursorWrap toggle did not reach Off.");
-        Assert.IsTrue(
-            NamedEventHelper.WaitUntilUnavailable(NamedEventHelper.CursorWrapToggle),
+        MouseUtilsTestHelper.EnsureModuleStateApplied(
+            this,
+            ModuleName,
+            enabled: false,
+            () => NamedEventHelper.WaitUntilUnavailable(NamedEventHelper.CursorWrapToggle),
             "CursorWrap trigger event remained available after the module was disabled.");
         AssertDoesNotWrap(CursorEdge.Left);
     }

--- a/src/modules/MouseUtils/MouseUtils.UITests.Next/FindMyMouseTests.cs
+++ b/src/modules/MouseUtils/MouseUtils.UITests.Next/FindMyMouseTests.cs
@@ -1,0 +1,418 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using Microsoft.PowerToys.UITest.Next;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MouseUtils.UITests;
+
+[TestClass]
+public class FindMyMouseTests : UITestBase
+{
+    private const string ModuleName = "FindMyMouse";
+    private const string ToggleId = "MouseUtils_FindMyMouseToggleId";
+    private const string WindowClass = "FindMyMouse";
+    private static readonly IDisposable ModuleSettings = SettingsConfigHelper.PreserveModuleSettings(ModuleName);
+    private static IDisposable? clientAreaAnimations;
+
+    public FindMyMouseTests()
+        : base(PowerToysModule.PowerToysSettings, enableModules: new[] { ModuleName })
+    {
+    }
+
+    [ClassInitialize]
+    public static void PrepareClass(TestContext testContext)
+    {
+        _ = testContext;
+        clientAreaAnimations = MouseUtilsTestHelper.PreserveClientAreaAnimationsEnabled();
+    }
+
+    [ClassCleanup]
+    public static void RestoreClassState()
+    {
+        try
+        {
+            clientAreaAnimations?.Dispose();
+        }
+        finally
+        {
+            ModuleSettings.Dispose();
+        }
+    }
+
+    protected override void PrepareTestState()
+    {
+        var configuration = TestContext.TestName switch
+        {
+            nameof(AppearanceColorsRadiusAndAlphaAreApplied) => new FindMyMouseConfiguration(
+                BackgroundColor: "#80FF0000",
+                SpotlightColor: "#8000FF00",
+                Radius: 80,
+                AnimationDurationMs: 1,
+                InitialZoom: 1),
+            nameof(InitialZoomIsApplied) => new FindMyMouseConfiguration(
+                BackgroundColor: "#FFFF0000",
+                SpotlightColor: "#FF00FF00",
+                Radius: 40,
+                AnimationDurationMs: 2_000,
+                InitialZoom: 1),
+            nameof(AnimationDurationIsApplied) => new FindMyMouseConfiguration(
+                BackgroundColor: "#FFFF0000",
+                SpotlightColor: "#FF00FF00",
+                Radius: 40,
+                AnimationDurationMs: 10_000,
+                InitialZoom: 9),
+            nameof(RightControlActivates) => new FindMyMouseConfiguration(ActivationMethod: 1),
+            nameof(CustomShortcutActivates) => new FindMyMouseConfiguration(ActivationMethod: 3),
+            nameof(IncludeWinKeyGatesDoubleControlActivation) => new FindMyMouseConfiguration(IncludeWinKey: true),
+            nameof(ExcludedForegroundAppBlocksActivation) => new FindMyMouseConfiguration(ExcludedApps: "PowerToys.Settings.exe"),
+            _ => new FindMyMouseConfiguration(),
+        };
+
+        MouseUtilsTestHelper.ReplaceModuleSettings(ModuleName, CreateSettings(configuration));
+    }
+
+    [TestCleanup]
+    public async Task CleanupInput()
+    {
+        await CaptureFailureArtifactsBeforeCleanupAsync();
+        MouseHelper.LeftUp();
+        MouseHelper.RightUp();
+        KeyboardHelper.ReleaseKey(Key.LCtrl);
+        KeyboardHelper.ReleaseKey(Key.RCtrl);
+        KeyboardHelper.ReleaseKey(Key.LWin);
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    [TestCategory("Mouse Utils #1")]
+    [TestCategory("Mouse Utils #2")]
+    [TestCategory("Mouse Utils #3")]
+    [TestCategory("Mouse Utils #4")]
+    public void ActivationAndKeyboardMouseDismissal()
+    {
+        MouseUtilsTestHelper.NavigateToMouseUtilities(this);
+        MouseUtilsTestHelper.SetModuleEnabled(this, ToggleId, true);
+        var window = MouseUtilsTestHelper.WaitForWindowClass(WindowClass);
+
+        using (var keyboardDismissal = new WindowShowWatcher(WindowClass, window.Hwnd.ToInt64()))
+        {
+            DoubleTap(Key.LCtrl);
+            Assert.IsTrue(keyboardDismissal.Wait(5_000), "Double left Ctrl did not show Find My Mouse.");
+            KeyboardHelper.SendKey(Key.A);
+            Assert.IsTrue(keyboardDismissal.WaitForHidden(5_000), "A keyboard key did not dismiss Find My Mouse.");
+        }
+
+        using var mouseDismissal = new WindowShowWatcher(WindowClass, window.Hwnd.ToInt64());
+        DoubleTap(Key.LCtrl);
+        Assert.IsTrue(mouseDismissal.Wait(5_000), "Second double left Ctrl did not show Find My Mouse.");
+        MouseHelper.LeftClick();
+        Assert.IsTrue(mouseDismissal.WaitForHidden(5_000), "A mouse button did not dismiss Find My Mouse.");
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    [TestCategory("Mouse Utils #5")]
+    [TestCategory("Mouse Utils #6")]
+    public void DisabledModuleRejectsActivationAndReenableWorks()
+    {
+        MouseUtilsTestHelper.NavigateToMouseUtilities(this);
+        var toggle = MouseUtilsTestHelper.SetModuleEnabled(this, ToggleId, false);
+        Assert.IsTrue(
+            NamedEventHelper.WaitUntilUnavailable(NamedEventHelper.FindMyMouseTrigger),
+            "Find My Mouse trigger event remained available after disabling the module.");
+
+        using (var disabledWatcher = new WindowShowWatcher(WindowClass))
+        {
+            DoubleTap(Key.LCtrl);
+            Assert.IsFalse(disabledWatcher.Wait(1_500), "Find My Mouse appeared while disabled.");
+        }
+
+        _ = toggle;
+        MouseUtilsTestHelper.SetModuleEnabled(this, ToggleId, true);
+        Assert.IsTrue(
+            NamedEventHelper.WaitUntilAvailable(NamedEventHelper.FindMyMouseTrigger),
+            "Find My Mouse trigger event was not recreated after enabling.");
+        var window = MouseUtilsTestHelper.WaitForWindowClass(WindowClass);
+        using var enabledWatcher = new WindowShowWatcher(WindowClass, window.Hwnd.ToInt64());
+        TriggerUntilShown(enabledWatcher, () => DoubleTap(Key.LCtrl), "double left Ctrl after re-enabling");
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    [TestCategory("Mouse Utils #10")]
+    [TestCategory("Mouse Utils #11")]
+    [TestCategory("Mouse Utils #12")]
+    public void AppearanceColorsRadiusAndAlphaAreApplied()
+    {
+        WindowHelper.MinimizeWindow(new IntPtr(Session.WindowHandle));
+        var (centerX, centerY) = WindowHelper.GetScreenCenter();
+        MouseHelper.MoveTo(centerX, centerY);
+        var spotlightPoint = (X: centerX + 40, Y: centerY);
+        var backgroundPoint = (X: centerX + 120, Y: centerY);
+        var spotlightBase = GetStablePixel(spotlightPoint.X, spotlightPoint.Y);
+        var backgroundBase = GetStablePixel(backgroundPoint.X, backgroundPoint.Y);
+        var window = MouseUtilsTestHelper.WaitForWindowClass(WindowClass);
+        using var watcher = new WindowShowWatcher(WindowClass, window.Hwnd.ToInt64());
+
+        Assert.IsTrue(NamedEventHelper.WaitAndSignal(NamedEventHelper.FindMyMouseTrigger), "Find My Mouse trigger event was unavailable.");
+        Assert.IsTrue(watcher.Wait(5_000), "Find My Mouse did not show for appearance validation.");
+
+        var expectedSpotlight = Blend(Color.Lime, spotlightBase, 128);
+        var expectedBackground = Blend(Color.Red, backgroundBase, 128);
+        AssertPixelNear(spotlightPoint.X, spotlightPoint.Y, expectedSpotlight, "spotlight color/alpha inside the configured radius");
+        AssertPixelNear(backgroundPoint.X, backgroundPoint.Y, expectedBackground, "background color/alpha outside the configured radius");
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    public void InitialZoomIsApplied()
+    {
+        MouseUtilsTestHelper.RunWithClientAreaAnimationsEnabled(() =>
+        {
+            WindowHelper.MinimizeWindow(new IntPtr(Session.WindowHandle));
+            var (centerX, centerY) = WindowHelper.GetScreenCenter();
+            MouseHelper.MoveTo(centerX, centerY);
+            var window = MouseUtilsTestHelper.WaitForWindowClass(WindowClass);
+            using var watcher = new WindowShowWatcher(WindowClass, window.Hwnd.ToInt64());
+
+            Assert.IsTrue(NamedEventHelper.WaitAndSignal(NamedEventHelper.FindMyMouseTrigger), "Find My Mouse trigger event was unavailable.");
+            Assert.IsTrue(watcher.Wait(5_000), "Find My Mouse did not show for initial-zoom validation.");
+            var result = WaitHelper.WaitForStable(
+                () => new
+                {
+                    Inside = WindowHelper.GetPixelColor(centerX + 20, centerY),
+                    Outside = WindowHelper.GetPixelColor(centerX + 80, centerY),
+                },
+                sample => sample is not null && sample.Inside.G > sample.Inside.R && sample.Outside.R > sample.Outside.G,
+                5_000,
+                requiredConsecutiveMatches: 2,
+                pollIntervalMS: 25);
+
+            Assert.IsTrue(result.Succeeded, $"The configured 1x initial zoom did not keep the 80px probe outside the 40px spotlight. Last sample: {result.LastObservation}.");
+        });
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    public void AnimationDurationIsApplied()
+    {
+        MouseUtilsTestHelper.RunWithClientAreaAnimationsEnabled(() =>
+        {
+            WindowHelper.MinimizeWindow(new IntPtr(Session.WindowHandle));
+            var (centerX, centerY) = WindowHelper.GetScreenCenter();
+            MouseHelper.MoveTo(centerX, centerY);
+            var probeX = centerX + 80;
+            _ = MouseUtilsTestHelper.WaitForWindowClass(WindowClass);
+
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            Assert.IsTrue(NamedEventHelper.WaitAndSignal(NamedEventHelper.FindMyMouseTrigger), "Find My Mouse trigger event was unavailable.");
+            var initialSpotlight = WaitHelper.WaitForStable(
+                () => new
+                {
+                    Center = WindowHelper.GetPixelColor(centerX + 20, centerY),
+                    Probe = WindowHelper.GetPixelColor(probeX, centerY),
+                },
+                sample => sample is not null && sample.Center.G > sample.Center.R && sample.Probe.G > sample.Probe.R,
+                8_000,
+                pollIntervalMS: 20);
+            Assert.IsTrue(
+                initialSpotlight.Succeeded,
+                $"The 9x initial spotlight never covered the 80px probe; last sample: {initialSpotlight.LastObservation}.");
+            var finalRadius = WaitHelper.WaitForStable(
+                () => new
+                {
+                    Center = WindowHelper.GetPixelColor(centerX + 20, centerY),
+                    Probe = WindowHelper.GetPixelColor(probeX, centerY),
+                },
+                sample => sample is not null && sample.Center.G > sample.Center.R && sample.Probe.R > sample.Probe.G,
+                12_000,
+                requiredConsecutiveMatches: 3,
+                pollIntervalMS: 20);
+            Assert.IsTrue(finalRadius.Succeeded, "The spotlight did not reach its configured 40px radius after the 10-second animation.");
+            var crossingTime = stopwatch.Elapsed;
+            Assert.IsTrue(
+                crossingTime >= TimeSpan.FromSeconds(3) && crossingTime <= TimeSpan.FromSeconds(12),
+                $"Configured 10-second spotlight animation crossed the 80px probe after {crossingTime.TotalSeconds:F1}s; expected 3-12s for the eased transition.");
+        });
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    public void RightControlActivates()
+    {
+        AssertActivation(() => DoubleTap(Key.RCtrl), "double right Ctrl");
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    public void CustomShortcutActivates()
+    {
+        AssertActivation(() => KeyboardHelper.SendKeys(Key.LWin, Key.Shift, Key.F), "Win+Shift+F");
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    public void IncludeWinKeyGatesDoubleControlActivation()
+    {
+        var window = MouseUtilsTestHelper.WaitForWindowClass(WindowClass);
+        using (var withoutWin = new WindowShowWatcher(WindowClass, window.Hwnd.ToInt64()))
+        {
+            DoubleTap(Key.LCtrl);
+            Assert.IsFalse(withoutWin.Wait(1_500), "Double Ctrl activated despite the required Windows key not being held.");
+        }
+
+        using var withWin = new WindowShowWatcher(WindowClass, window.Hwnd.ToInt64());
+        KeyboardHelper.PressKey(Key.LWin);
+        try
+        {
+            DoubleTap(Key.LCtrl);
+        }
+        finally
+        {
+            KeyboardHelper.ReleaseKey(Key.LWin);
+        }
+
+        Assert.IsTrue(withWin.Wait(5_000), "Win plus double Ctrl did not activate Find My Mouse.");
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    public void ExcludedForegroundAppBlocksActivation()
+    {
+        var settingsHwnd = new IntPtr(Session.WindowHandle);
+        Assert.IsTrue(WindowControl.WaitForForeground(settingsHwnd, 5_000, 2), "Settings could not become foreground for the exclusion precondition.");
+        using (var excluded = new WindowShowWatcher(WindowClass))
+        {
+            Assert.IsTrue(NamedEventHelper.WaitAndSignal(NamedEventHelper.FindMyMouseTrigger), "Find My Mouse trigger event was unavailable.");
+            Assert.IsFalse(excluded.Wait(1_500), "Find My Mouse activated while excluded PowerToys.Settings.exe owned foreground.");
+        }
+
+        using var notepad = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("notepad.exe") { UseShellExecute = true });
+        Assert.IsNotNull(notepad, "Could not start the allowed foreground Notepad fixture.");
+        try
+        {
+            var notepadWindow = WindowsFinder.WaitForWindowByProcess("notepad", 10_000);
+            Assert.IsNotNull(notepadWindow, "Notepad did not create a visible window.");
+            Assert.IsTrue(
+                WindowControl.WaitForForeground(new IntPtr(notepadWindow.WindowHandle), 5_000, 2),
+                $"Notepad could not become foreground. Current foreground: {WindowControl.GetForegroundWindowInfo()}.");
+
+            using var allowed = new WindowShowWatcher(WindowClass);
+            Assert.IsTrue(NamedEventHelper.TrySignal(NamedEventHelper.FindMyMouseTrigger), "Find My Mouse trigger event disappeared.");
+            Assert.IsTrue(allowed.Wait(5_000), "Find My Mouse remained blocked after an allowed app gained foreground.");
+        }
+        finally
+        {
+            WindowControl.TryKillProcessTreeByNameAndWait("notepad", 5_000);
+        }
+    }
+
+    private static string CreateSettings(FindMyMouseConfiguration configuration) => $$"""
+        {
+          "name": "FindMyMouse",
+          "version": "1.1",
+          "properties": {
+            "activation_method": { "value": {{configuration.ActivationMethod}} },
+            "include_win_key": { "value": {{configuration.IncludeWinKey.ToString().ToLowerInvariant()}} },
+            "activation_shortcut": { "win": true, "ctrl": false, "alt": false, "shift": true, "code": 70, "key": "" },
+            "do_not_activate_on_game_mode": { "value": false },
+            "background_color": { "value": "{{configuration.BackgroundColor}}" },
+            "spotlight_color": { "value": "{{configuration.SpotlightColor}}" },
+            "spotlight_radius": { "value": {{configuration.Radius}} },
+            "animation_duration_ms": { "value": {{configuration.AnimationDurationMs}} },
+            "spotlight_initial_zoom": { "value": {{configuration.InitialZoom}} },
+            "excluded_apps": { "value": "{{configuration.ExcludedApps}}" },
+            "shaking_minimum_distance": { "value": 100 },
+            "shaking_interval_ms": { "value": 2000 },
+            "shaking_factor": { "value": 150 }
+          }
+        }
+        """;
+
+    private static void DoubleTap(Key controlKey)
+    {
+        KeyboardHelper.SendKey(controlKey);
+        Thread.Sleep(150);
+        KeyboardHelper.SendKey(controlKey);
+    }
+
+    private void AssertActivation(Action trigger, string description)
+    {
+        var window = MouseUtilsTestHelper.WaitForWindowClass(WindowClass);
+        using var watcher = new WindowShowWatcher(WindowClass, window.Hwnd.ToInt64());
+        TriggerUntilShown(watcher, trigger, description);
+    }
+
+    private static void TriggerUntilShown(WindowShowWatcher watcher, Action trigger, string description)
+    {
+        for (var attempt = 1; attempt <= 3; attempt++)
+        {
+            if (watcher.Wait(0))
+            {
+                return;
+            }
+
+            trigger();
+            if (watcher.Wait(5_000))
+            {
+                return;
+            }
+        }
+
+        Assert.Fail($"Find My Mouse did not activate from {description} after three attempts.");
+    }
+
+    private static Color Blend(Color foreground, Color background, int alpha)
+    {
+        var inverse = 255 - alpha;
+        return Color.FromArgb(
+            ((foreground.R * alpha) + (background.R * inverse) + 127) / 255,
+            ((foreground.G * alpha) + (background.G * inverse) + 127) / 255,
+            ((foreground.B * alpha) + (background.B * inverse) + 127) / 255);
+    }
+
+    private static Color GetStablePixel(int x, int y)
+    {
+        Color? previous = null;
+        var result = WaitHelper.WaitForStable(
+            () => WindowHelper.GetPixelColor(x, y),
+            color =>
+            {
+                var matchesPrevious = previous.HasValue && color.ToArgb() == previous.Value.ToArgb();
+                previous = color;
+                return matchesPrevious;
+            },
+            2_000,
+            requiredConsecutiveMatches: 4,
+            pollIntervalMS: 100);
+        return result.LastObservation;
+    }
+
+    private static void AssertPixelNear(int x, int y, Color expected, string description)
+    {
+        const int tolerance = 4;
+        var result = WaitHelper.WaitForStable(
+            () => WindowHelper.GetPixelColor(x, y),
+            actual =>
+                Math.Abs(actual.R - expected.R) <= tolerance &&
+                Math.Abs(actual.G - expected.G) <= tolerance &&
+                Math.Abs(actual.B - expected.B) <= tolerance,
+            5_000,
+            requiredConsecutiveMatches: 2,
+            pollIntervalMS: 100);
+        Assert.IsTrue(result.Succeeded, $"Unexpected {description} at ({x},{y}). Expected {expected}; observed {result.LastObservation}.");
+    }
+
+    private sealed record FindMyMouseConfiguration(
+        int ActivationMethod = 0,
+        bool IncludeWinKey = false,
+        string BackgroundColor = "#FFFF0000",
+        string SpotlightColor = "#FF00FF00",
+        int Radius = 80,
+        int AnimationDurationMs = 1,
+        int InitialZoom = 1,
+        string ExcludedApps = "");
+}

--- a/src/modules/MouseUtils/MouseUtils.UITests.Next/FindMyMouseTests.cs
+++ b/src/modules/MouseUtils/MouseUtils.UITests.Next/FindMyMouseTests.cs
@@ -3,8 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Drawing;
+using System.Text.Json.Nodes;
 using Microsoft.PowerToys.UITest.Next;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static MouseUtils.UITests.MouseUtilsTestHelper;
 
 namespace MouseUtils.UITests;
 
@@ -16,6 +18,11 @@ public class FindMyMouseTests : UITestBase
     private const string WindowClass = "FindMyMouse";
     private static readonly IDisposable ModuleSettings = SettingsConfigHelper.PreserveModuleSettings(ModuleName);
     private static IDisposable? clientAreaAnimations;
+    private NotepadFixture? notepadFixture;
+
+    static FindMyMouseTests()
+    {
+    }
 
     public FindMyMouseTests()
         : base(PowerToysModule.PowerToysSettings, enableModules: new[] { ModuleName })
@@ -32,14 +39,7 @@ public class FindMyMouseTests : UITestBase
     [ClassCleanup]
     public static void RestoreClassState()
     {
-        try
-        {
-            clientAreaAnimations?.Dispose();
-        }
-        finally
-        {
-            ModuleSettings.Dispose();
-        }
+        DisposeAll(clientAreaAnimations, ModuleSettings);
     }
 
     protected override void PrepareTestState()
@@ -83,6 +83,8 @@ public class FindMyMouseTests : UITestBase
         KeyboardHelper.ReleaseKey(Key.LCtrl);
         KeyboardHelper.ReleaseKey(Key.RCtrl);
         KeyboardHelper.ReleaseKey(Key.LWin);
+        notepadFixture?.Dispose();
+        notepadFixture = null;
     }
 
     [TestMethod]
@@ -161,8 +163,8 @@ public class FindMyMouseTests : UITestBase
 
         var expectedSpotlight = Blend(Color.Lime, spotlightBase, 128);
         var expectedBackground = Blend(Color.Red, backgroundBase, 128);
-        AssertPixelNear(spotlightPoint.X, spotlightPoint.Y, expectedSpotlight, "spotlight color/alpha inside the configured radius");
-        AssertPixelNear(backgroundPoint.X, backgroundPoint.Y, expectedBackground, "background color/alpha outside the configured radius");
+        AssertPixelNear(spotlightPoint.X, spotlightPoint.Y, expectedSpotlight, 4, "spotlight color/alpha inside the configured radius");
+        AssertPixelNear(backgroundPoint.X, backgroundPoint.Y, expectedBackground, 4, "background color/alpha outside the configured radius");
     }
 
     [TestMethod]
@@ -289,12 +291,10 @@ public class FindMyMouseTests : UITestBase
             Assert.IsFalse(excluded.Wait(1_500), "Find My Mouse activated while excluded PowerToys.Settings.exe owned foreground.");
         }
 
-        using var notepad = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("notepad.exe") { UseShellExecute = true });
-        Assert.IsNotNull(notepad, "Could not start the allowed foreground Notepad fixture.");
+        notepadFixture = NotepadFixture.Start();
         try
         {
-            var notepadWindow = WindowsFinder.WaitForWindowByProcess("notepad", 10_000);
-            Assert.IsNotNull(notepadWindow, "Notepad did not create a visible window.");
+            var notepadWindow = notepadFixture.Window;
             Assert.IsTrue(
                 WindowControl.WaitForForeground(new IntPtr(notepadWindow.WindowHandle), 5_000, 2),
                 $"Notepad could not become foreground. Current foreground: {WindowControl.GetForegroundWindowInfo()}.");
@@ -305,31 +305,40 @@ public class FindMyMouseTests : UITestBase
         }
         finally
         {
-            WindowControl.TryKillProcessTreeByNameAndWait("notepad", 5_000);
+            notepadFixture.Dispose();
+            notepadFixture = null;
         }
     }
 
-    private static string CreateSettings(FindMyMouseConfiguration configuration) => $$"""
+        private static string CreateSettings(FindMyMouseConfiguration configuration) => new JsonObject
         {
-          "name": "FindMyMouse",
-          "version": "1.1",
-          "properties": {
-            "activation_method": { "value": {{configuration.ActivationMethod}} },
-            "include_win_key": { "value": {{configuration.IncludeWinKey.ToString().ToLowerInvariant()}} },
-            "activation_shortcut": { "win": true, "ctrl": false, "alt": false, "shift": true, "code": 70, "key": "" },
-            "do_not_activate_on_game_mode": { "value": false },
-            "background_color": { "value": "{{configuration.BackgroundColor}}" },
-            "spotlight_color": { "value": "{{configuration.SpotlightColor}}" },
-            "spotlight_radius": { "value": {{configuration.Radius}} },
-            "animation_duration_ms": { "value": {{configuration.AnimationDurationMs}} },
-            "spotlight_initial_zoom": { "value": {{configuration.InitialZoom}} },
-            "excluded_apps": { "value": "{{configuration.ExcludedApps}}" },
-            "shaking_minimum_distance": { "value": 100 },
-            "shaking_interval_ms": { "value": 2000 },
-            "shaking_factor": { "value": 150 }
-          }
-        }
-        """;
+                ["name"] = "FindMyMouse",
+                ["version"] = "1.1",
+                ["properties"] = new JsonObject
+                {
+                        ["activation_method"] = new JsonObject { ["value"] = configuration.ActivationMethod },
+                        ["include_win_key"] = new JsonObject { ["value"] = configuration.IncludeWinKey },
+                        ["activation_shortcut"] = new JsonObject
+                        {
+                                ["win"] = true,
+                                ["ctrl"] = false,
+                                ["alt"] = false,
+                                ["shift"] = true,
+                                ["code"] = 70,
+                                ["key"] = string.Empty,
+                        },
+                        ["do_not_activate_on_game_mode"] = new JsonObject { ["value"] = false },
+                        ["background_color"] = new JsonObject { ["value"] = configuration.BackgroundColor },
+                        ["spotlight_color"] = new JsonObject { ["value"] = configuration.SpotlightColor },
+                        ["spotlight_radius"] = new JsonObject { ["value"] = configuration.Radius },
+                        ["animation_duration_ms"] = new JsonObject { ["value"] = configuration.AnimationDurationMs },
+                        ["spotlight_initial_zoom"] = new JsonObject { ["value"] = configuration.InitialZoom },
+                        ["excluded_apps"] = new JsonObject { ["value"] = configuration.ExcludedApps },
+                        ["shaking_minimum_distance"] = new JsonObject { ["value"] = 100 },
+                        ["shaking_interval_ms"] = new JsonObject { ["value"] = 2000 },
+                        ["shaking_factor"] = new JsonObject { ["value"] = 150 },
+                },
+        }.ToJsonString();
 
     private static void DoubleTap(Key controlKey)
     {
@@ -362,47 +371,6 @@ public class FindMyMouseTests : UITestBase
         }
 
         Assert.Fail($"Find My Mouse did not activate from {description} after three attempts.");
-    }
-
-    private static Color Blend(Color foreground, Color background, int alpha)
-    {
-        var inverse = 255 - alpha;
-        return Color.FromArgb(
-            ((foreground.R * alpha) + (background.R * inverse) + 127) / 255,
-            ((foreground.G * alpha) + (background.G * inverse) + 127) / 255,
-            ((foreground.B * alpha) + (background.B * inverse) + 127) / 255);
-    }
-
-    private static Color GetStablePixel(int x, int y)
-    {
-        Color? previous = null;
-        var result = WaitHelper.WaitForStable(
-            () => WindowHelper.GetPixelColor(x, y),
-            color =>
-            {
-                var matchesPrevious = previous.HasValue && color.ToArgb() == previous.Value.ToArgb();
-                previous = color;
-                return matchesPrevious;
-            },
-            2_000,
-            requiredConsecutiveMatches: 4,
-            pollIntervalMS: 100);
-        return result.LastObservation;
-    }
-
-    private static void AssertPixelNear(int x, int y, Color expected, string description)
-    {
-        const int tolerance = 4;
-        var result = WaitHelper.WaitForStable(
-            () => WindowHelper.GetPixelColor(x, y),
-            actual =>
-                Math.Abs(actual.R - expected.R) <= tolerance &&
-                Math.Abs(actual.G - expected.G) <= tolerance &&
-                Math.Abs(actual.B - expected.B) <= tolerance,
-            5_000,
-            requiredConsecutiveMatches: 2,
-            pollIntervalMS: 100);
-        Assert.IsTrue(result.Succeeded, $"Unexpected {description} at ({x},{y}). Expected {expected}; observed {result.LastObservation}.");
     }
 
     private sealed record FindMyMouseConfiguration(

--- a/src/modules/MouseUtils/MouseUtils.UITests.Next/FindMyMouseTests.cs
+++ b/src/modules/MouseUtils/MouseUtils.UITests.Next/FindMyMouseTests.cs
@@ -120,8 +120,11 @@ public class FindMyMouseTests : UITestBase
     {
         MouseUtilsTestHelper.NavigateToMouseUtilities(this);
         var toggle = MouseUtilsTestHelper.SetModuleEnabled(this, ToggleId, false);
-        Assert.IsTrue(
-            NamedEventHelper.WaitUntilUnavailable(NamedEventHelper.FindMyMouseTrigger),
+        MouseUtilsTestHelper.EnsureModuleStateApplied(
+            this,
+            ModuleName,
+            enabled: false,
+            () => NamedEventHelper.WaitUntilUnavailable(NamedEventHelper.FindMyMouseTrigger),
             "Find My Mouse trigger event remained available after disabling the module.");
 
         using (var disabledWatcher = new WindowShowWatcher(WindowClass))
@@ -132,8 +135,11 @@ public class FindMyMouseTests : UITestBase
 
         _ = toggle;
         MouseUtilsTestHelper.SetModuleEnabled(this, ToggleId, true);
-        Assert.IsTrue(
-            NamedEventHelper.WaitUntilAvailable(NamedEventHelper.FindMyMouseTrigger),
+        MouseUtilsTestHelper.EnsureModuleStateApplied(
+            this,
+            ModuleName,
+            enabled: true,
+            () => NamedEventHelper.WaitUntilAvailable(NamedEventHelper.FindMyMouseTrigger),
             "Find My Mouse trigger event was not recreated after enabling.");
         var window = MouseUtilsTestHelper.WaitForWindowClass(WindowClass);
         using var enabledWatcher = new WindowShowWatcher(WindowClass, window.Hwnd.ToInt64());

--- a/src/modules/MouseUtils/MouseUtils.UITests.Next/FindMyMouseTests.cs
+++ b/src/modules/MouseUtils/MouseUtils.UITests.Next/FindMyMouseTests.cs
@@ -119,12 +119,9 @@ public class FindMyMouseTests : UITestBase
     public void DisabledModuleRejectsActivationAndReenableWorks()
     {
         MouseUtilsTestHelper.NavigateToMouseUtilities(this);
-        var toggle = MouseUtilsTestHelper.SetModuleEnabled(this, ToggleId, false);
-        MouseUtilsTestHelper.EnsureModuleStateApplied(
-            this,
-            ModuleName,
-            enabled: false,
-            () => NamedEventHelper.WaitUntilUnavailable(NamedEventHelper.FindMyMouseTrigger),
+        MouseUtilsTestHelper.SetModuleEnabled(this, ToggleId, false);
+        Assert.IsTrue(
+            NamedEventHelper.WaitUntilUnavailable(NamedEventHelper.FindMyMouseTrigger),
             "Find My Mouse trigger event remained available after disabling the module.");
 
         using (var disabledWatcher = new WindowShowWatcher(WindowClass))
@@ -133,13 +130,9 @@ public class FindMyMouseTests : UITestBase
             Assert.IsFalse(disabledWatcher.Wait(1_500), "Find My Mouse appeared while disabled.");
         }
 
-        _ = toggle;
         MouseUtilsTestHelper.SetModuleEnabled(this, ToggleId, true);
-        MouseUtilsTestHelper.EnsureModuleStateApplied(
-            this,
-            ModuleName,
-            enabled: true,
-            () => NamedEventHelper.WaitUntilAvailable(NamedEventHelper.FindMyMouseTrigger),
+        Assert.IsTrue(
+            NamedEventHelper.WaitUntilAvailable(NamedEventHelper.FindMyMouseTrigger),
             "Find My Mouse trigger event was not recreated after enabling.");
         var window = MouseUtilsTestHelper.WaitForWindowClass(WindowClass);
         using var enabledWatcher = new WindowShowWatcher(WindowClass, window.Hwnd.ToInt64());

--- a/src/modules/MouseUtils/MouseUtils.UITests.Next/MouseHighlighterTests.cs
+++ b/src/modules/MouseUtils/MouseUtils.UITests.Next/MouseHighlighterTests.cs
@@ -133,8 +133,11 @@ public class MouseHighlighterTests : UITestBase
 
         MouseUtilsTestHelper.NavigateToMouseUtilities(this);
         MouseUtilsTestHelper.SetModuleEnabled(this, ToggleId, false);
-        Assert.IsTrue(
-            NamedEventHelper.WaitUntilUnavailable(NamedEventHelper.MouseHighlighterToggle),
+        MouseUtilsTestHelper.EnsureModuleStateApplied(
+            this,
+            ModuleName,
+            enabled: false,
+            () => NamedEventHelper.WaitUntilUnavailable(NamedEventHelper.MouseHighlighterToggle),
             "Mouse Highlighter trigger event remained available after disabling the module.");
         using var disabledWatcher = new WindowShowWatcher(WindowClass);
         KeyboardHelper.SendKeys(Key.LWin, Key.Shift, Key.O);
@@ -249,43 +252,70 @@ public class MouseHighlighterTests : UITestBase
         MouseHelper.MoveTo(centerX, centerY);
         Activate();
 
-        MouseHelper.LeftClick();
-        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
-        MouseHelper.MoveTo(centerX + 250, centerY + 200);
         var expectedHighIntensityGlow = Blend(Color.Magenta, nearBase, 95);
-        Assert.IsTrue(
-            WaitHelper.WaitForStable(
+        var observedNearGlow = false;
+        var observedOuterRipple = false;
+        var maximumChangedOuterSamples = 0;
+        for (var attempt = 1; attempt <= 3 && !observedOuterRipple; attempt++)
+        {
+            MouseHelper.MoveTo(centerX, centerY);
+            MouseHelper.LeftClick();
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            MouseHelper.MoveTo(centerX + 250, centerY + 200);
+            var attemptObservedNearGlow = WaitHelper.WaitForStable(
                 () => WindowHelper.GetPixelColor(nearPoint.X, nearPoint.Y),
                 color => IsNear(color, expectedHighIntensityGlow, 20),
-                350,
+                750,
                 requiredConsecutiveMatches: 1,
-                pollIntervalMS: 10).Succeeded,
-            "The configured high-intensity Ripple glow did not render near the click point.");
-        if (stopwatch.ElapsedMilliseconds < 900)
-        {
-            Thread.Sleep(900 - (int)stopwatch.ElapsedMilliseconds);
+                pollIntervalMS: 10).Succeeded;
+            observedNearGlow |= attemptObservedNearGlow;
+
+            if (attemptObservedNearGlow)
+            {
+                if (stopwatch.ElapsedMilliseconds < 900)
+                {
+                    Thread.Sleep(900 - (int)stopwatch.ElapsedMilliseconds);
+                }
+
+                var outerRipple = WaitHelper.WaitForStable(
+                    () =>
+                    {
+                        using var current = CaptureSquare(centerX, centerY, captureRadius);
+                        return CountRipplePixels(
+                            outerBaseline,
+                            current,
+                            minimumRadius: defaultMaximumRadius + 4,
+                            maximumRadius: configuredMaximumRadius + 4);
+                    },
+                    changedPixels =>
+                    {
+                        maximumChangedOuterSamples = Math.Max(maximumChangedOuterSamples, changedPixels);
+                        return changedPixels >= 12;
+                    },
+                    900,
+                    requiredConsecutiveMatches: 1,
+                    pollIntervalMS: 20);
+                observedOuterRipple = outerRipple.Succeeded;
+            }
+
+            if (!observedOuterRipple && attempt < 3)
+            {
+                MouseUtilsTestHelper.Step(
+                    this,
+                    $"Ripple click attempt {attempt}/3 did not expose the complete configured effect; retrying after it clears");
+                Assert.IsTrue(
+                    WaitForRippleToClear(nearPoint, farPoint, nearBase, farBase, 3_000),
+                    "Ripple did not clear before retrying the complete click effect.");
+            }
         }
 
-        using var rippleFrame = CaptureSquare(centerX, centerY, captureRadius);
-        var changedOuterSamples = CountRipplePixels(
-            outerBaseline,
-            rippleFrame,
-            minimumRadius: defaultMaximumRadius + 4,
-            maximumRadius: configuredMaximumRadius + 4);
-        var missingRippleMessage = $"The configured 120px, 1.8-second Ripple was absent outside the default maximum radius after 900ms; " +
-            $"annulus={defaultMaximumRadius + 4}-{configuredMaximumRadius + 4}px, changed pixels={changedOuterSamples}.";
-        Assert.IsTrue(changedOuterSamples >= 12, missingRippleMessage);
+        Assert.IsTrue(observedNearGlow, "The configured high-intensity Ripple glow did not render near the click point.");
         Assert.IsTrue(
-            WaitHelper.WaitForStable(
-                () => new
-                {
-                    Near = WindowHelper.GetPixelColor(nearPoint.X, nearPoint.Y),
-                    Far = WindowHelper.GetPixelColor(farPoint.X, farPoint.Y),
-                },
-                sample => sample is not null && IsNear(sample.Near, nearBase, 5) && IsNear(sample.Far, farBase, 5),
-                2_000,
-                requiredConsecutiveMatches: 5,
-                pollIntervalMS: 50).Succeeded,
+            observedOuterRipple,
+            $"The configured 120px, 1.8-second Ripple was absent outside the default maximum radius after 900ms on three complete attempts; " +
+            $"annulus={defaultMaximumRadius + 4}-{configuredMaximumRadius + 4}px, maximum changed pixels={maximumChangedOuterSamples}.");
+        Assert.IsTrue(
+            WaitForRippleToClear(nearPoint, farPoint, nearBase, farBase, 2_000),
             "Ripple remained after its configured 1.8-second duration.");
     }
 
@@ -473,6 +503,23 @@ public class MouseHighlighterTests : UITestBase
             pollIntervalMS: 100);
         return result.LastObservation;
     }
+
+    private static bool WaitForRippleToClear(
+        (int X, int Y) nearPoint,
+        (int X, int Y) farPoint,
+        Color nearBase,
+        Color farBase,
+        int timeoutMs) =>
+        WaitHelper.WaitForStable(
+            () => new
+            {
+                Near = WindowHelper.GetPixelColor(nearPoint.X, nearPoint.Y),
+                Far = WindowHelper.GetPixelColor(farPoint.X, farPoint.Y),
+            },
+            sample => IsNear(sample.Near, nearBase, 5) && IsNear(sample.Far, farBase, 5),
+            timeoutMs,
+            requiredConsecutiveMatches: 5,
+            pollIntervalMS: 50).Succeeded;
 
     private static double Distance(int x1, int y1, int x2, int y2)
     {

--- a/src/modules/MouseUtils/MouseUtils.UITests.Next/MouseHighlighterTests.cs
+++ b/src/modules/MouseUtils/MouseUtils.UITests.Next/MouseHighlighterTests.cs
@@ -133,11 +133,8 @@ public class MouseHighlighterTests : UITestBase
 
         MouseUtilsTestHelper.NavigateToMouseUtilities(this);
         MouseUtilsTestHelper.SetModuleEnabled(this, ToggleId, false);
-        MouseUtilsTestHelper.EnsureModuleStateApplied(
-            this,
-            ModuleName,
-            enabled: false,
-            () => NamedEventHelper.WaitUntilUnavailable(NamedEventHelper.MouseHighlighterToggle),
+        Assert.IsTrue(
+            NamedEventHelper.WaitUntilUnavailable(NamedEventHelper.MouseHighlighterToggle),
             "Mouse Highlighter trigger event remained available after disabling the module.");
         using var disabledWatcher = new WindowShowWatcher(WindowClass);
         KeyboardHelper.SendKeys(Key.LWin, Key.Shift, Key.O);

--- a/src/modules/MouseUtils/MouseUtils.UITests.Next/MouseHighlighterTests.cs
+++ b/src/modules/MouseUtils/MouseUtils.UITests.Next/MouseHighlighterTests.cs
@@ -1,0 +1,613 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using Microsoft.PowerToys.UITest.Next;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MouseUtils.UITests;
+
+[TestClass]
+public class MouseHighlighterTests : UITestBase
+{
+    private const string ModuleName = "MouseHighlighter";
+    private const string ToggleId = "MouseUtils_MouseHighlighterToggleId";
+    private const string WindowClass = "MouseHighlighter";
+    private static readonly IDisposable ModuleSettings = SettingsConfigHelper.PreserveModuleSettings(ModuleName);
+    private static IDisposable? clientAreaAnimations;
+
+    public MouseHighlighterTests()
+        : base(PowerToysModule.PowerToysSettings, enableModules: new[] { ModuleName })
+    {
+    }
+
+    [ClassInitialize]
+    public static void PrepareClass(TestContext testContext)
+    {
+        _ = testContext;
+        clientAreaAnimations = MouseUtilsTestHelper.PreserveClientAreaAnimationsEnabled();
+    }
+
+    [ClassCleanup]
+    public static void RestoreClassState()
+    {
+        try
+        {
+            clientAreaAnimations?.Dispose();
+        }
+        finally
+        {
+            ModuleSettings.Dispose();
+        }
+    }
+
+    protected override void PrepareTestState()
+    {
+        var configuration = TestContext.TestName switch
+        {
+            nameof(ChangedShortcutTogglesAndDisabledModuleRejectsActivation) => new HighlighterConfiguration(ShortcutCode: (int)Key.O),
+            nameof(CircleAlphaRadiusAndFadeTimingAreApplied) => new HighlighterConfiguration(
+                LeftColor: "#80FF0000",
+                RightColor: "#8000FF00",
+                Radius: 100,
+                FadeDelayMs: 2_000,
+                FadeDurationMs: 4_000),
+            nameof(SpotlightModeUsesAlwaysColorAndRadius) => new HighlighterConfiguration(
+                AlwaysColor: "#80FF0000",
+                Radius: 80,
+                SpotlightMode: true),
+            nameof(RippleQuickClickUsesSizeIntensityAndDuration) => RippleConfiguration(),
+            nameof(RippleHeldIndicatorFollowsDragWhenEnabled) => RippleConfiguration(showDragTrail: true),
+            nameof(RippleHeldIndicatorStaysAtPressWhenDisabled) => RippleConfiguration(showDragTrail: false),
+            nameof(RippleRightReleasePulseIsDrawn) => RippleConfiguration(showReleasePulse: true),
+            nameof(AutoActivateStartsVisible) => new HighlighterConfiguration(AutoActivate: true),
+            _ => new HighlighterConfiguration(),
+        };
+
+        MouseUtilsTestHelper.ReplaceModuleSettings(ModuleName, CreateSettings(configuration));
+    }
+
+    [TestCleanup]
+    public async Task CleanupInput()
+    {
+        await CaptureFailureArtifactsBeforeCleanupAsync();
+        MouseHelper.LeftUp();
+        MouseHelper.RightUp();
+        KeyboardHelper.ReleaseKey(Key.LWin);
+        KeyboardHelper.ReleaseKey(Key.Shift);
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    [TestCategory("Mouse Utils #17")]
+    [TestCategory("Mouse Utils #18")]
+    [TestCategory("Mouse Utils #19")]
+    [TestCategory("Mouse Utils #20")]
+    public void CircleClicksAndDragsFollowCursor()
+    {
+        var window = MouseUtilsTestHelper.WaitForWindowClass(WindowClass);
+        WindowHelper.MinimizeWindow(new IntPtr(Session.WindowHandle));
+        using var activationWatcher = new WindowShowWatcher(WindowClass, window.Hwnd.ToInt64());
+        KeyboardHelper.SendKeys(Key.LWin, Key.Shift, Key.H);
+        Assert.IsTrue(activationWatcher.Wait(5_000), "The default Win+Shift+H shortcut did not show Mouse Highlighter.");
+        var (centerX, centerY) = WindowHelper.GetScreenCenter();
+        MouseHelper.MoveTo(centerX, centerY);
+
+        MouseHelper.LeftDown();
+        AssertPixelNear(centerX + 25, centerY, Color.Red, "left-button circle");
+        MouseHelper.MoveBy(180, 100, steps: 20, delayMs: 20);
+        var moved = MouseHelper.GetMousePosition();
+        AssertColorNearPoint(moved.X, moved.Y, Color.Red, 45, "left-button circle did not follow the drag");
+        MouseHelper.LeftUp();
+
+        MouseHelper.MoveTo(centerX, centerY);
+        MouseHelper.RightDown();
+        AssertPixelNear(centerX + 25, centerY, Color.Lime, "right-button circle");
+        MouseHelper.MoveBy(-180, 100, steps: 20, delayMs: 20);
+        moved = MouseHelper.GetMousePosition();
+        AssertColorNearPoint(moved.X, moved.Y, Color.Lime, 45, "right-button circle did not follow the drag");
+        MouseHelper.RightUp();
+
+        KeyboardHelper.SendKeys(Key.LWin, Key.Shift, Key.H);
+        Assert.IsTrue(activationWatcher.WaitForHidden(5_000), "The default shortcut did not hide Mouse Highlighter.");
+        using var deactivatedClick = new WindowShowWatcher(WindowClass, window.Hwnd.ToInt64());
+        MouseHelper.LeftClickAt(centerX, centerY);
+        Assert.IsFalse(deactivatedClick.Wait(1_000), "A click showed Mouse Highlighter after the shortcut toggled it off.");
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    [TestCategory("Mouse Utils #21")]
+    [TestCategory("Mouse Utils #22")]
+    public void ChangedShortcutTogglesAndDisabledModuleRejectsActivation()
+    {
+        var window = MouseUtilsTestHelper.WaitForWindowClass(WindowClass);
+        using (var enabledWatcher = new WindowShowWatcher(WindowClass, window.Hwnd.ToInt64()))
+        {
+            KeyboardHelper.SendKeys(Key.LWin, Key.Shift, Key.O);
+            Assert.IsTrue(enabledWatcher.Wait(5_000), "Changed Win+Shift+O shortcut did not show Mouse Highlighter.");
+            KeyboardHelper.SendKeys(Key.LWin, Key.Shift, Key.O);
+            Assert.IsTrue(enabledWatcher.WaitForHidden(5_000), "Changed shortcut did not hide Mouse Highlighter.");
+        }
+
+        MouseUtilsTestHelper.NavigateToMouseUtilities(this);
+        MouseUtilsTestHelper.SetModuleEnabled(this, ToggleId, false);
+        Assert.IsTrue(
+            NamedEventHelper.WaitUntilUnavailable(NamedEventHelper.MouseHighlighterToggle),
+            "Mouse Highlighter trigger event remained available after disabling the module.");
+        using var disabledWatcher = new WindowShowWatcher(WindowClass);
+        KeyboardHelper.SendKeys(Key.LWin, Key.Shift, Key.O);
+        Assert.IsFalse(disabledWatcher.Wait(1_500), "Mouse Highlighter appeared from its shortcut while disabled.");
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    [TestCategory("Mouse Utils #23")]
+    [TestCategory("Mouse Utils #24")]
+    public void CircleAlphaRadiusAndFadeTimingAreApplied()
+    {
+        MouseUtilsTestHelper.RunWithClientAreaAnimationsEnabled(() =>
+        {
+            WindowHelper.MinimizeWindow(new IntPtr(Session.WindowHandle));
+            var (centerX, centerY) = WindowHelper.GetScreenCenter();
+            MouseHelper.MoveTo(centerX, centerY);
+            var inner = (X: centerX + 60, Y: centerY);
+            var fadePoint = (X: centerX + 35, Y: centerY);
+            var outer = (X: centerX + 130, Y: centerY);
+            var innerBase = GetStablePixel(inner.X, inner.Y);
+            var fadeBase = GetStablePixel(fadePoint.X, fadePoint.Y);
+            var outerBase = GetStablePixel(outer.X, outer.Y);
+            Activate();
+
+            MouseHelper.LeftDown();
+            var expectedInner = Blend(Color.Red, innerBase, 128);
+            var expectedFadePoint = Blend(Color.Red, fadeBase, 128);
+            AssertPixelNear(inner.X, inner.Y, expectedInner, "semi-transparent left circle inside its 100px radius and 70px pressed radius");
+            AssertPixelNear(fadePoint.X, fadePoint.Y, expectedFadePoint, "semi-transparent left circle inside its pressed radius");
+            AssertPixelNear(outer.X, outer.Y, outerBase, "desktop outside the configured 100px radius");
+            var fullContrast = ColorDistance(expectedFadePoint, fadeBase);
+            var fadeStopwatch = System.Diagnostics.Stopwatch.StartNew();
+            MouseHelper.LeftUp();
+
+            var fadeStarted = WaitHelper.WaitForStable(
+                () => WindowHelper.GetPixelColor(fadePoint.X, fadePoint.Y),
+                color => ColorDistance(color, fadeBase) <= fullContrast * 0.9,
+                4_000,
+                pollIntervalMS: 20);
+            Assert.IsTrue(fadeStarted.Succeeded, "The circle did not begin fading after the button was released.");
+            var fadeStartedAt = fadeStopwatch.Elapsed;
+            Assert.IsTrue(
+                fadeStartedAt >= TimeSpan.FromSeconds(1.4) && fadeStartedAt <= TimeSpan.FromSeconds(3.5),
+                $"Configured 2-second fade delay began after {fadeStartedAt.TotalSeconds:F1}s; expected 1.4-3.5s.");
+            var fadeCompleted = WaitHelper.WaitForStable(
+                () => WindowHelper.GetPixelColor(fadePoint.X, fadePoint.Y),
+                color => IsNear(color, fadeBase, 5),
+                7_000,
+                requiredConsecutiveMatches: 3,
+                pollIntervalMS: 50);
+            Assert.IsTrue(fadeCompleted.Succeeded, "Circle did not return to the desktop color after its configured fade duration.");
+            var observedFadeDuration = fadeStopwatch.Elapsed - fadeStartedAt;
+            Assert.IsTrue(
+                observedFadeDuration >= TimeSpan.FromSeconds(1.5) && observedFadeDuration <= TimeSpan.FromSeconds(6.5),
+                $"Configured 4-second fade completed {observedFadeDuration.TotalSeconds:F1}s after its first visible transition; expected 1.5-6.5s.");
+
+            MouseHelper.RightDown();
+            var expectedRight = Blend(Color.Lime, fadeBase, 128);
+            AssertPixelNear(fadePoint.X, fadePoint.Y, expectedRight, "semi-transparent right circle inside its 70px radius");
+            MouseHelper.RightUp();
+        });
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    public void SpotlightModeUsesAlwaysColorAndRadius()
+    {
+        WindowHelper.MinimizeWindow(new IntPtr(Session.WindowHandle));
+        var (centerX, centerY) = WindowHelper.GetScreenCenter();
+        MouseHelper.MoveTo(centerX, centerY);
+        var inside = (X: centerX + 40, Y: centerY);
+        var outside = (X: centerX + 120, Y: centerY);
+        var insideBase = GetStablePixel(inside.X, inside.Y);
+        var outsideBase = GetStablePixel(outside.X, outside.Y);
+        MouseHelper.MoveBy(160, 80, steps: 20, delayMs: 20);
+        var calibratedTarget = MouseHelper.GetMousePosition();
+        var movedInside = (X: calibratedTarget.X + 30, Y: calibratedTarget.Y);
+        var movedOutside = (X: calibratedTarget.X + 120, Y: calibratedTarget.Y);
+        var movedInsideBase = GetStablePixel(movedInside.X, movedInside.Y);
+        var movedOutsideBase = GetStablePixel(movedOutside.X, movedOutside.Y);
+        MouseHelper.MoveTo(centerX, centerY);
+        Activate();
+
+        AssertPixelNear(inside.X, inside.Y, insideBase, "transparent Spotlight hole inside the configured radius");
+        AssertPixelNear(outside.X, outside.Y, Blend(Color.Red, outsideBase, 128), "Spotlight tint outside the configured radius");
+
+        MouseHelper.MoveBy(160, 80, steps: 20, delayMs: 20);
+        var moved = MouseHelper.GetMousePosition();
+        Assert.IsTrue(
+            Distance(moved.X, moved.Y, calibratedTarget.X, calibratedTarget.Y) <= 10,
+            $"Calibrated relative movement ended at ({calibratedTarget.X},{calibratedTarget.Y}), but overlay movement ended at ({moved.X},{moved.Y}).");
+        AssertPixelNear(movedInside.X, movedInside.Y, movedInsideBase, "transparent Spotlight hole after cursor movement");
+        AssertPixelNear(movedOutside.X, movedOutside.Y, Blend(Color.Red, movedOutsideBase, 128), "Spotlight tint after cursor movement");
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    public void RippleQuickClickUsesSizeIntensityAndDuration()
+    {
+        WindowHelper.MinimizeWindow(new IntPtr(Session.WindowHandle));
+        var (centerX, centerY) = WindowHelper.GetScreenCenter();
+        var nearPoint = (X: centerX + 10, Y: centerY);
+        var farPoint = (X: centerX + 100, Y: centerY);
+        var defaultMaximumRadius = (int)Math.Ceiling(60 * 1.4);
+        var configuredMaximumRadius = (int)Math.Ceiling(120 * 1.4);
+        var captureRadius = configuredMaximumRadius + 10;
+        MouseHelper.MoveTo(centerX - 250, centerY - 200);
+        var nearBase = GetStablePixel(nearPoint.X, nearPoint.Y);
+        var farBase = GetStablePixel(farPoint.X, farPoint.Y);
+        using var outerBaseline = CaptureSquare(centerX, centerY, captureRadius);
+        MouseHelper.MoveTo(centerX, centerY);
+        Activate();
+
+        MouseHelper.LeftClick();
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        MouseHelper.MoveTo(centerX + 250, centerY + 200);
+        var expectedHighIntensityGlow = Blend(Color.Magenta, nearBase, 95);
+        Assert.IsTrue(
+            WaitHelper.WaitForStable(
+                () => WindowHelper.GetPixelColor(nearPoint.X, nearPoint.Y),
+                color => IsNear(color, expectedHighIntensityGlow, 20),
+                350,
+                requiredConsecutiveMatches: 1,
+                pollIntervalMS: 10).Succeeded,
+            "The configured high-intensity Ripple glow did not render near the click point.");
+        if (stopwatch.ElapsedMilliseconds < 900)
+        {
+            Thread.Sleep(900 - (int)stopwatch.ElapsedMilliseconds);
+        }
+
+        using var rippleFrame = CaptureSquare(centerX, centerY, captureRadius);
+        var changedOuterSamples = CountRipplePixels(
+            outerBaseline,
+            rippleFrame,
+            minimumRadius: defaultMaximumRadius + 4,
+            maximumRadius: configuredMaximumRadius + 4);
+        var missingRippleMessage = $"The configured 120px, 1.8-second Ripple was absent outside the default maximum radius after 900ms; " +
+            $"annulus={defaultMaximumRadius + 4}-{configuredMaximumRadius + 4}px, changed pixels={changedOuterSamples}.";
+        Assert.IsTrue(changedOuterSamples >= 12, missingRippleMessage);
+        Assert.IsTrue(
+            WaitHelper.WaitForStable(
+                () => new
+                {
+                    Near = WindowHelper.GetPixelColor(nearPoint.X, nearPoint.Y),
+                    Far = WindowHelper.GetPixelColor(farPoint.X, farPoint.Y),
+                },
+                sample => sample is not null && IsNear(sample.Near, nearBase, 5) && IsNear(sample.Far, farBase, 5),
+                2_000,
+                requiredConsecutiveMatches: 5,
+                pollIntervalMS: 50).Succeeded,
+            "Ripple remained after its configured 1.8-second duration.");
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    public void RippleHeldIndicatorFollowsDragWhenEnabled()
+    {
+        AssertRippleDragTrail(expectedToFollow: true);
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    public void RippleHeldIndicatorStaysAtPressWhenDisabled()
+    {
+        AssertRippleDragTrail(expectedToFollow: false);
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    public void RippleRightReleasePulseIsDrawn()
+    {
+        WindowHelper.MinimizeWindow(new IntPtr(Session.WindowHandle));
+        var (centerX, centerY) = WindowHelper.GetScreenCenter();
+        MouseHelper.MoveTo(centerX, centerY);
+        Activate();
+
+        MouseHelper.RightDown();
+        Thread.Sleep(350);
+        const int captureRadius = 55;
+        using var heldFrame = CaptureSquare(centerX, centerY, captureRadius);
+        MouseHelper.RightUp();
+        MouseHelper.MoveTo(centerX + 250, centerY + 200);
+        var releasePulse = WaitHelper.WaitForStable(
+            () =>
+            {
+                using var current = CaptureSquare(centerX, centerY, captureRadius);
+                return CountAxisPixelsTowardColor(heldFrame, current, Color.Yellow, minimumRadius: 18, maximumRadius: 50);
+            },
+            changedPixels => changedPixels >= 20,
+            1_500,
+            pollIntervalMS: 20);
+        Assert.IsTrue(
+            releasePulse.Succeeded,
+            $"Right-button release did not draw the configured yellow crosshair lines; maximum qualifying axis pixels={releasePulse.LastObservation}.");
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    public void AutoActivateStartsVisible()
+    {
+        Assert.IsTrue(
+            WaitHelper.WaitForStable(
+                () => WindowControl.IsAnyWindowOfClassVisible(WindowClass),
+                visible => visible,
+                10_000,
+                requiredConsecutiveMatches: 3).Succeeded,
+            "Mouse Highlighter did not start visible when auto-activate was enabled.");
+    }
+
+    private static HighlighterConfiguration RippleConfiguration(bool showDragTrail = true, bool showReleasePulse = true) => new(
+        LeftColor: "#FFFF00FF",
+        RightColor: "#FFFFFF00",
+        AlwaysColor: "#00000000",
+        RippleMode: true,
+        RippleSize: 120,
+        RippleIntensity: 1.35,
+        RippleDurationMs: 1_800,
+        RippleShowDragTrail: showDragTrail,
+        RippleShowReleasePulse: showReleasePulse);
+
+    private static string CreateSettings(HighlighterConfiguration configuration) => $$"""
+        {
+          "name": "MouseHighlighter",
+          "version": "1.2",
+          "properties": {
+            "activation_shortcut": { "win": true, "ctrl": false, "alt": false, "shift": true, "code": {{configuration.ShortcutCode}}, "key": "" },
+            "left_button_click_color": { "value": "{{configuration.LeftColor}}" },
+            "right_button_click_color": { "value": "{{configuration.RightColor}}" },
+            "always_color": { "value": "{{configuration.AlwaysColor}}" },
+            "highlight_radius": { "value": {{configuration.Radius}} },
+            "highlight_fade_delay_ms": { "value": {{configuration.FadeDelayMs}} },
+            "highlight_fade_duration_ms": { "value": {{configuration.FadeDurationMs}} },
+            "auto_activate": { "value": {{configuration.AutoActivate.ToString().ToLowerInvariant()}} },
+            "spotlight_mode": { "value": {{configuration.SpotlightMode.ToString().ToLowerInvariant()}} },
+            "ripple_mode": { "value": {{configuration.RippleMode.ToString().ToLowerInvariant()}} },
+            "ripple_size": { "value": {{configuration.RippleSize}} },
+            "ripple_intensity": { "value": {{configuration.RippleIntensity.ToString(System.Globalization.CultureInfo.InvariantCulture)}} },
+            "ripple_duration_ms": { "value": {{configuration.RippleDurationMs}} },
+            "ripple_show_drag_trail": { "value": {{configuration.RippleShowDragTrail.ToString().ToLowerInvariant()}} },
+            "ripple_show_release_pulse": { "value": {{configuration.RippleShowReleasePulse.ToString().ToLowerInvariant()}} }
+          }
+        }
+        """;
+
+    private static void Activate()
+    {
+        Assert.IsTrue(
+            NamedEventHelper.WaitAndSignal(NamedEventHelper.MouseHighlighterToggle),
+            "Mouse Highlighter did not create or respond to its trigger event.");
+        Assert.IsTrue(
+            WaitHelper.WaitForStable(
+                () => WindowControl.IsAnyWindowOfClassVisible(WindowClass),
+                visible => visible,
+                5_000,
+                requiredConsecutiveMatches: 2).Succeeded,
+            "Mouse Highlighter window did not become visible.");
+    }
+
+    private void AssertRippleDragTrail(bool expectedToFollow)
+    {
+        WindowHelper.MinimizeWindow(new IntPtr(Session.WindowHandle));
+        var (centerX, centerY) = WindowHelper.GetScreenCenter();
+        MouseHelper.MoveTo(centerX, centerY);
+        Activate();
+
+        MouseHelper.LeftDown();
+        Thread.Sleep(350);
+        AssertRippleRingNear(centerX, centerY, "held Ripple indicator did not appear at the press point");
+        MouseHelper.MoveBy(180, 80, steps: 20, delayMs: 20);
+        var moved = MouseHelper.GetMousePosition();
+        if (expectedToFollow)
+        {
+            AssertRippleRingNear(moved.X, moved.Y, "held Ripple indicator did not follow the drag");
+        }
+        else
+        {
+            AssertRippleRingNear(centerX, centerY, "held Ripple indicator moved despite drag trail being disabled");
+        }
+
+        MouseHelper.LeftUp();
+    }
+
+    private static void AssertRippleRingNear(int centerX, int centerY, string message)
+    {
+        Assert.IsTrue(
+            WaitHelper.WaitForStable(
+                () => Enumerable.Range(42, 28)
+                    .SelectMany(radius => new[]
+                    {
+                        WindowHelper.GetPixelColor(centerX + radius, centerY),
+                        WindowHelper.GetPixelColor(centerX - radius, centerY),
+                        WindowHelper.GetPixelColor(centerX, centerY + radius),
+                        WindowHelper.GetPixelColor(centerX, centerY - radius),
+                    })
+                    .Count(color => color.R > color.G + 30 && color.B > color.G + 30),
+                count => count >= 2,
+                1_500,
+                requiredConsecutiveMatches: 1,
+                pollIntervalMS: 30).Succeeded,
+            message);
+    }
+
+    private static void AssertColorNearPoint(int centerX, int centerY, Color expected, int searchRadius, string message)
+    {
+        Assert.IsTrue(
+            WaitHelper.WaitForStable(
+                () => Enumerable.Range(-searchRadius, (searchRadius * 2) + 1)
+                    .Where(offset => offset % 5 == 0)
+                    .SelectMany(offset => new[]
+                    {
+                        WindowHelper.GetPixelColor(centerX + offset, centerY),
+                        WindowHelper.GetPixelColor(centerX, centerY + offset),
+                    })
+                    .Any(color => IsNear(color, expected, 5)),
+                found => found,
+                2_000,
+                requiredConsecutiveMatches: 1,
+                pollIntervalMS: 50).Succeeded,
+            message);
+    }
+
+    private static Color GetStablePixel(int x, int y)
+    {
+        Color? previous = null;
+        var result = WaitHelper.WaitForStable(
+            () => WindowHelper.GetPixelColor(x, y),
+            color =>
+            {
+                var matchesPrevious = previous.HasValue && color.ToArgb() == previous.Value.ToArgb();
+                previous = color;
+                return matchesPrevious;
+            },
+            2_000,
+            requiredConsecutiveMatches: 4,
+            pollIntervalMS: 100);
+        return result.LastObservation;
+    }
+
+    private static double Distance(int x1, int y1, int x2, int y2)
+    {
+        var deltaX = x2 - x1;
+        var deltaY = y2 - y1;
+        return Math.Sqrt((deltaX * deltaX) + (deltaY * deltaY));
+    }
+
+    private static Bitmap CaptureSquare(int centerX, int centerY, int radius)
+    {
+        var bitmap = new Bitmap((radius * 2) + 1, (radius * 2) + 1);
+        try
+        {
+            using var graphics = Graphics.FromImage(bitmap);
+            graphics.CopyFromScreen(centerX - radius, centerY - radius, 0, 0, bitmap.Size);
+            return bitmap;
+        }
+        catch
+        {
+            bitmap.Dispose();
+            throw;
+        }
+    }
+
+    private static int CountRipplePixels(Bitmap baseline, Bitmap current, int minimumRadius, int maximumRadius)
+    {
+        var center = baseline.Width / 2;
+        var minimumSquared = minimumRadius * minimumRadius;
+        var maximumSquared = maximumRadius * maximumRadius;
+        var count = 0;
+        for (var y = 0; y < baseline.Height; y++)
+        {
+            var deltaY = y - center;
+            for (var x = 0; x < baseline.Width; x++)
+            {
+                var deltaX = x - center;
+                var distanceSquared = (deltaX * deltaX) + (deltaY * deltaY);
+                if (distanceSquared < minimumSquared || distanceSquared > maximumSquared)
+                {
+                    continue;
+                }
+
+                var before = baseline.GetPixel(x, y);
+                var after = current.GetPixel(x, y);
+                if (ColorDistance(after, Color.Magenta) <= ColorDistance(before, Color.Magenta) - 6)
+                {
+                    count++;
+                }
+            }
+        }
+
+        return count;
+    }
+
+    private static int CountAxisPixelsTowardColor(Bitmap baseline, Bitmap current, Color target, int minimumRadius, int maximumRadius)
+    {
+        var center = baseline.Width / 2;
+        var count = 0;
+        for (var radius = minimumRadius; radius <= maximumRadius; radius++)
+        {
+            for (var bandOffset = -2; bandOffset <= 2; bandOffset++)
+            {
+                var points = new[]
+                {
+                    (X: center + radius, Y: center + bandOffset),
+                    (X: center - radius, Y: center + bandOffset),
+                    (X: center + bandOffset, Y: center + radius),
+                    (X: center + bandOffset, Y: center - radius),
+                };
+                foreach (var point in points)
+                {
+                    var beforeDistance = ColorDistance(baseline.GetPixel(point.X, point.Y), target);
+                    var afterDistance = ColorDistance(current.GetPixel(point.X, point.Y), target);
+                    if (afterDistance <= 60 && afterDistance <= beforeDistance - 20)
+                    {
+                        count++;
+                    }
+                }
+            }
+        }
+
+        return count;
+    }
+
+    private static double ColorDistance(Color first, Color second)
+    {
+        var red = first.R - second.R;
+        var green = first.G - second.G;
+        var blue = first.B - second.B;
+        return Math.Sqrt((red * red) + (green * green) + (blue * blue));
+    }
+
+    private static Color Blend(Color foreground, Color background, int alpha)
+    {
+        var inverse = 255 - alpha;
+        return Color.FromArgb(
+            ((foreground.R * alpha) + (background.R * inverse) + 127) / 255,
+            ((foreground.G * alpha) + (background.G * inverse) + 127) / 255,
+            ((foreground.B * alpha) + (background.B * inverse) + 127) / 255);
+    }
+
+    private static void AssertPixelNear(int x, int y, Color expected, string description)
+    {
+        Assert.IsTrue(
+            WaitHelper.WaitForStable(
+                () => WindowHelper.GetPixelColor(x, y),
+                color => IsNear(color, expected, 5),
+                5_000,
+                requiredConsecutiveMatches: 2,
+                pollIntervalMS: 50).Succeeded,
+            $"Unexpected {description} at ({x},{y}); expected {expected}, observed {WindowHelper.GetPixelColor(x, y)}.");
+    }
+
+    private static void AssertColorNear(Color actual, Color expected, int tolerance, string message) =>
+        Assert.IsTrue(IsNear(actual, expected, tolerance), $"{message}. Expected {expected}; observed {actual}.");
+
+    private static bool IsNear(Color actual, Color expected, int tolerance) =>
+        Math.Abs(actual.R - expected.R) <= tolerance &&
+        Math.Abs(actual.G - expected.G) <= tolerance &&
+        Math.Abs(actual.B - expected.B) <= tolerance;
+
+    private sealed record HighlighterConfiguration(
+        int ShortcutCode = (int)Key.H,
+        string LeftColor = "#FFFF0000",
+        string RightColor = "#FF00FF00",
+        string AlwaysColor = "#00000000",
+        int Radius = 50,
+        int FadeDelayMs = 100,
+        int FadeDurationMs = 300,
+        bool AutoActivate = false,
+        bool SpotlightMode = false,
+        bool RippleMode = false,
+        int RippleSize = 60,
+        double RippleIntensity = 0.7,
+        int RippleDurationMs = 480,
+        bool RippleShowDragTrail = true,
+        bool RippleShowReleasePulse = true);
+}

--- a/src/modules/MouseUtils/MouseUtils.UITests.Next/MouseHighlighterTests.cs
+++ b/src/modules/MouseUtils/MouseUtils.UITests.Next/MouseHighlighterTests.cs
@@ -5,6 +5,7 @@
 using System.Drawing;
 using Microsoft.PowerToys.UITest.Next;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static MouseUtils.UITests.MouseUtilsTestHelper;
 
 namespace MouseUtils.UITests;
 
@@ -16,6 +17,10 @@ public class MouseHighlighterTests : UITestBase
     private const string WindowClass = "MouseHighlighter";
     private static readonly IDisposable ModuleSettings = SettingsConfigHelper.PreserveModuleSettings(ModuleName);
     private static IDisposable? clientAreaAnimations;
+
+    static MouseHighlighterTests()
+    {
+    }
 
     public MouseHighlighterTests()
         : base(PowerToysModule.PowerToysSettings, enableModules: new[] { ModuleName })
@@ -32,14 +37,7 @@ public class MouseHighlighterTests : UITestBase
     [ClassCleanup]
     public static void RestoreClassState()
     {
-        try
-        {
-            clientAreaAnimations?.Dispose();
-        }
-        finally
-        {
-            ModuleSettings.Dispose();
-        }
+        DisposeAll(clientAreaAnimations, ModuleSettings);
     }
 
     protected override void PrepareTestState()
@@ -95,7 +93,7 @@ public class MouseHighlighterTests : UITestBase
         MouseHelper.MoveTo(centerX, centerY);
 
         MouseHelper.LeftDown();
-        AssertPixelNear(centerX + 25, centerY, Color.Red, "left-button circle");
+        AssertPixelNear(centerX + 25, centerY, Color.Red, 5, "left-button circle");
         MouseHelper.MoveBy(180, 100, steps: 20, delayMs: 20);
         var moved = MouseHelper.GetMousePosition();
         AssertColorNearPoint(moved.X, moved.Y, Color.Red, 45, "left-button circle did not follow the drag");
@@ -103,7 +101,7 @@ public class MouseHighlighterTests : UITestBase
 
         MouseHelper.MoveTo(centerX, centerY);
         MouseHelper.RightDown();
-        AssertPixelNear(centerX + 25, centerY, Color.Lime, "right-button circle");
+        AssertPixelNear(centerX + 25, centerY, Color.Lime, 5, "right-button circle");
         MouseHelper.MoveBy(-180, 100, steps: 20, delayMs: 20);
         moved = MouseHelper.GetMousePosition();
         AssertColorNearPoint(moved.X, moved.Y, Color.Lime, 45, "right-button circle did not follow the drag");
@@ -163,9 +161,9 @@ public class MouseHighlighterTests : UITestBase
             MouseHelper.LeftDown();
             var expectedInner = Blend(Color.Red, innerBase, 128);
             var expectedFadePoint = Blend(Color.Red, fadeBase, 128);
-            AssertPixelNear(inner.X, inner.Y, expectedInner, "semi-transparent left circle inside its 100px radius and 70px pressed radius");
-            AssertPixelNear(fadePoint.X, fadePoint.Y, expectedFadePoint, "semi-transparent left circle inside its pressed radius");
-            AssertPixelNear(outer.X, outer.Y, outerBase, "desktop outside the configured 100px radius");
+            AssertPixelNear(inner.X, inner.Y, expectedInner, 5, "semi-transparent left circle inside its 100px radius and 70px pressed radius");
+            AssertPixelNear(fadePoint.X, fadePoint.Y, expectedFadePoint, 5, "semi-transparent left circle inside its pressed radius");
+            AssertPixelNear(outer.X, outer.Y, outerBase, 5, "desktop outside the configured 100px radius");
             var fullContrast = ColorDistance(expectedFadePoint, fadeBase);
             var fadeStopwatch = System.Diagnostics.Stopwatch.StartNew();
             MouseHelper.LeftUp();
@@ -194,7 +192,7 @@ public class MouseHighlighterTests : UITestBase
 
             MouseHelper.RightDown();
             var expectedRight = Blend(Color.Lime, fadeBase, 128);
-            AssertPixelNear(fadePoint.X, fadePoint.Y, expectedRight, "semi-transparent right circle inside its 70px radius");
+            AssertPixelNear(fadePoint.X, fadePoint.Y, expectedRight, 5, "semi-transparent right circle inside its 70px radius");
             MouseHelper.RightUp();
         });
     }
@@ -219,16 +217,16 @@ public class MouseHighlighterTests : UITestBase
         MouseHelper.MoveTo(centerX, centerY);
         Activate();
 
-        AssertPixelNear(inside.X, inside.Y, insideBase, "transparent Spotlight hole inside the configured radius");
-        AssertPixelNear(outside.X, outside.Y, Blend(Color.Red, outsideBase, 128), "Spotlight tint outside the configured radius");
+        AssertPixelNear(inside.X, inside.Y, insideBase, 5, "transparent Spotlight hole inside the configured radius");
+        AssertPixelNear(outside.X, outside.Y, Blend(Color.Red, outsideBase, 128), 5, "Spotlight tint outside the configured radius");
 
         MouseHelper.MoveBy(160, 80, steps: 20, delayMs: 20);
         var moved = MouseHelper.GetMousePosition();
         Assert.IsTrue(
             Distance(moved.X, moved.Y, calibratedTarget.X, calibratedTarget.Y) <= 10,
             $"Calibrated relative movement ended at ({calibratedTarget.X},{calibratedTarget.Y}), but overlay movement ended at ({moved.X},{moved.Y}).");
-        AssertPixelNear(movedInside.X, movedInside.Y, movedInsideBase, "transparent Spotlight hole after cursor movement");
-        AssertPixelNear(movedOutside.X, movedOutside.Y, Blend(Color.Red, movedOutsideBase, 128), "Spotlight tint after cursor movement");
+        AssertPixelNear(movedInside.X, movedInside.Y, movedInsideBase, 5, "transparent Spotlight hole after cursor movement");
+        AssertPixelNear(movedOutside.X, movedOutside.Y, Blend(Color.Red, movedOutsideBase, 128), 5, "Spotlight tint after cursor movement");
     }
 
     [TestMethod]
@@ -239,8 +237,10 @@ public class MouseHighlighterTests : UITestBase
         var (centerX, centerY) = WindowHelper.GetScreenCenter();
         var nearPoint = (X: centerX + 10, Y: centerY);
         var farPoint = (X: centerX + 100, Y: centerY);
-        var defaultMaximumRadius = (int)Math.Ceiling(60 * 1.4);
-        var configuredMaximumRadius = (int)Math.Ceiling(120 * 1.4);
+        const double rendererRadiusScale = 1.4;
+        const int minimumChangedAnnulusPixels = 12;
+        var defaultMaximumRadius = (int)Math.Ceiling(60 * rendererRadiusScale);
+        var configuredMaximumRadius = (int)Math.Ceiling(120 * rendererRadiusScale);
         var captureRadius = configuredMaximumRadius + 10;
         MouseHelper.MoveTo(centerX - 250, centerY - 200);
         var nearBase = GetStablePixel(nearPoint.X, nearPoint.Y);
@@ -287,7 +287,7 @@ public class MouseHighlighterTests : UITestBase
                     changedPixels =>
                     {
                         maximumChangedOuterSamples = Math.Max(maximumChangedOuterSamples, changedPixels);
-                        return changedPixels >= 12;
+                        return changedPixels >= minimumChangedAnnulusPixels;
                     },
                     900,
                     requiredConsecutiveMatches: 1,
@@ -447,9 +447,14 @@ public class MouseHighlighterTests : UITestBase
 
     private static void AssertRippleRingNear(int centerX, int centerY, string message)
     {
+        // The configured 120px ripple renders its held magenta ring across radii 42-69; requiring
+        // magenta to dominate green by 30 rejects neutral desktop pixels without demanding exact alpha.
+        const int heldRingMinimumRadius = 42;
+        const int heldRingRadiusCount = 28;
+        const int magentaChannelDominance = 30;
         Assert.IsTrue(
             WaitHelper.WaitForStable(
-                () => Enumerable.Range(42, 28)
+                () => Enumerable.Range(heldRingMinimumRadius, heldRingRadiusCount)
                     .SelectMany(radius => new[]
                     {
                         WindowHelper.GetPixelColor(centerX + radius, centerY),
@@ -457,7 +462,7 @@ public class MouseHighlighterTests : UITestBase
                         WindowHelper.GetPixelColor(centerX, centerY + radius),
                         WindowHelper.GetPixelColor(centerX, centerY - radius),
                     })
-                    .Count(color => color.R > color.G + 30 && color.B > color.G + 30),
+                    .Count(color => color.R > color.G + magentaChannelDominance && color.B > color.G + magentaChannelDominance),
                 count => count >= 2,
                 1_500,
                 requiredConsecutiveMatches: 1,
@@ -484,23 +489,6 @@ public class MouseHighlighterTests : UITestBase
             message);
     }
 
-    private static Color GetStablePixel(int x, int y)
-    {
-        Color? previous = null;
-        var result = WaitHelper.WaitForStable(
-            () => WindowHelper.GetPixelColor(x, y),
-            color =>
-            {
-                var matchesPrevious = previous.HasValue && color.ToArgb() == previous.Value.ToArgb();
-                previous = color;
-                return matchesPrevious;
-            },
-            2_000,
-            requiredConsecutiveMatches: 4,
-            pollIntervalMS: 100);
-        return result.LastObservation;
-    }
-
     private static bool WaitForRippleToClear(
         (int X, int Y) nearPoint,
         (int X, int Y) farPoint,
@@ -517,13 +505,6 @@ public class MouseHighlighterTests : UITestBase
             timeoutMs,
             requiredConsecutiveMatches: 5,
             pollIntervalMS: 50).Succeeded;
-
-    private static double Distance(int x1, int y1, int x2, int y2)
-    {
-        var deltaX = x2 - x1;
-        var deltaY = y2 - y1;
-        return Math.Sqrt((deltaX * deltaX) + (deltaY * deltaY));
-    }
 
     private static Bitmap CaptureSquare(int centerX, int centerY, int radius)
     {
@@ -543,6 +524,7 @@ public class MouseHighlighterTests : UITestBase
 
     private static int CountRipplePixels(Bitmap baseline, Bitmap current, int minimumRadius, int maximumRadius)
     {
+        const int minimumColorDistanceImprovement = 6;
         var center = baseline.Width / 2;
         var minimumSquared = minimumRadius * minimumRadius;
         var maximumSquared = maximumRadius * maximumRadius;
@@ -561,7 +543,7 @@ public class MouseHighlighterTests : UITestBase
 
                 var before = baseline.GetPixel(x, y);
                 var after = current.GetPixel(x, y);
-                if (ColorDistance(after, Color.Magenta) <= ColorDistance(before, Color.Magenta) - 6)
+                if (ColorDistance(after, Color.Magenta) <= ColorDistance(before, Color.Magenta) - minimumColorDistanceImprovement)
                 {
                     count++;
                 }
@@ -608,35 +590,6 @@ public class MouseHighlighterTests : UITestBase
         var blue = first.B - second.B;
         return Math.Sqrt((red * red) + (green * green) + (blue * blue));
     }
-
-    private static Color Blend(Color foreground, Color background, int alpha)
-    {
-        var inverse = 255 - alpha;
-        return Color.FromArgb(
-            ((foreground.R * alpha) + (background.R * inverse) + 127) / 255,
-            ((foreground.G * alpha) + (background.G * inverse) + 127) / 255,
-            ((foreground.B * alpha) + (background.B * inverse) + 127) / 255);
-    }
-
-    private static void AssertPixelNear(int x, int y, Color expected, string description)
-    {
-        Assert.IsTrue(
-            WaitHelper.WaitForStable(
-                () => WindowHelper.GetPixelColor(x, y),
-                color => IsNear(color, expected, 5),
-                5_000,
-                requiredConsecutiveMatches: 2,
-                pollIntervalMS: 50).Succeeded,
-            $"Unexpected {description} at ({x},{y}); expected {expected}, observed {WindowHelper.GetPixelColor(x, y)}.");
-    }
-
-    private static void AssertColorNear(Color actual, Color expected, int tolerance, string message) =>
-        Assert.IsTrue(IsNear(actual, expected, tolerance), $"{message}. Expected {expected}; observed {actual}.");
-
-    private static bool IsNear(Color actual, Color expected, int tolerance) =>
-        Math.Abs(actual.R - expected.R) <= tolerance &&
-        Math.Abs(actual.G - expected.G) <= tolerance &&
-        Math.Abs(actual.B - expected.B) <= tolerance;
 
     private sealed record HighlighterConfiguration(
         int ShortcutCode = (int)Key.H,

--- a/src/modules/MouseUtils/MouseUtils.UITests.Next/MouseJumpTests.cs
+++ b/src/modules/MouseUtils/MouseUtils.UITests.Next/MouseJumpTests.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Drawing;
 using Microsoft.PowerToys.UITest.Next;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static MouseUtils.UITests.MouseUtilsTestHelper;
 
 namespace MouseUtils.UITests;
 
@@ -16,7 +17,13 @@ public class MouseJumpTests : UITestBase
     private const string ProcessName = "PowerToys.MouseJump.WinUI3";
     private const string WindowTitle = "MouseJump.WinUI3";
     private const string ToggleId = "MouseUtils_MouseJumpToggleId";
+    private const int DefaultBorderThickness = 6;
     private static readonly IDisposable ModuleSettings = SettingsConfigHelper.PreserveModuleSettings(ModuleName);
+    private NotepadFixture? notepadFixture;
+
+    static MouseJumpTests()
+    {
+    }
 
     public MouseJumpTests()
         : base(PowerToysModule.PowerToysSettings, enableModules: new[] { ModuleName })
@@ -66,7 +73,8 @@ public class MouseJumpTests : UITestBase
     {
         await CaptureFailureArtifactsBeforeCleanupAsync();
         KeyboardHelper.SendKeys(Key.Esc);
-        WindowControl.TryKillProcessTreeByNameAndWait("notepad", 5_000);
+        notepadFixture?.Dispose();
+        notepadFixture = null;
         WindowControl.TryKillProcessTreeByNameAndWait(ProcessName, 10_000);
     }
 
@@ -82,10 +90,9 @@ public class MouseJumpTests : UITestBase
         Assert.IsTrue(
             NamedEventHelper.WaitUntilAvailable(NamedEventHelper.MouseJumpShowPreview),
             "Mouse Jump did not create its show-preview event.");
-        var hwnd = WaitForPreviewHwnd();
-        Assert.AreNotEqual(IntPtr.Zero, hwnd, "Mouse Jump did not create its hidden preview HWND.");
+        var previewWindow = WaitForPreviewWindow();
 
-        using var shortcutWatcher = new WindowShowWatcher(GetPreviewWindow().ClassName, hwnd.ToInt64());
+        using var shortcutWatcher = new WindowShowWatcher(previewWindow.ClassName, previewWindow.Hwnd.ToInt64());
         KeyboardHelper.SendKeys(Key.LWin, Key.Shift, Key.D);
         Assert.IsTrue(shortcutWatcher.Wait(10_000), "The default Win+Shift+D shortcut did not show Mouse Jump.");
     }
@@ -98,11 +105,11 @@ public class MouseJumpTests : UITestBase
     public void PreviewClickMovesCursorAndDisableStopsActivation()
     {
         var preview = ShowPreview();
-        var previewClassName = GetPreviewWindow().ClassName;
+        var previewClassName = WaitForPreviewWindow().ClassName;
         var bounds = WindowHelper.GetWindowBounds(new IntPtr(preview.WindowHandle));
         var clickX = bounds.Left + ((bounds.Right - bounds.Left) / 2);
         var clickY = bounds.Top + ((bounds.Bottom - bounds.Top) / 2);
-        using (var watcher = new WindowShowWatcher(GetPreviewWindow().ClassName, preview.WindowHandle))
+        using (var watcher = new WindowShowWatcher(previewClassName, preview.WindowHandle))
         {
             var previewHwnd = new IntPtr(preview.WindowHandle);
             WindowControl.WaitForForeground(previewHwnd, 2_000);
@@ -136,15 +143,14 @@ public class MouseJumpTests : UITestBase
     [TestCategory("Mouse Utils #40")]
     public void ChangedShortcutActivatesPreview()
     {
-        var hwnd = WaitForPreviewHwnd();
-        var className = GetPreviewWindow().ClassName;
-        using (var defaultShortcut = new WindowShowWatcher(className, hwnd.ToInt64()))
+        var previewWindow = WaitForPreviewReady();
+        using (var defaultShortcut = new WindowShowWatcher(previewWindow.ClassName, previewWindow.Hwnd.ToInt64()))
         {
             KeyboardHelper.SendKeys(Key.LWin, Key.Shift, Key.D);
             Assert.IsFalse(defaultShortcut.Wait(1_500), "The old Mouse Jump shortcut still showed the preview.");
         }
 
-        using var changedShortcut = new WindowShowWatcher(className, hwnd.ToInt64());
+        using var changedShortcut = new WindowShowWatcher(previewWindow.ClassName, previewWindow.Hwnd.ToInt64());
         KeyboardHelper.SendKeys(Key.LWin, Key.Shift, Key.Z);
         Assert.IsTrue(changedShortcut.Wait(10_000), "Changed Win+Shift+Z shortcut did not show Mouse Jump.");
     }
@@ -157,11 +163,9 @@ public class MouseJumpTests : UITestBase
         Assert.IsTrue(
             WindowControl.WaitForForeground(new IntPtr(preview.WindowHandle), 5_000, 2),
             $"Mouse Jump was not foreground before the focus-loss transition. Current foreground: {WindowControl.GetForegroundWindowInfo()}.");
-        using var focusWatcher = new WindowShowWatcher(GetPreviewWindow().ClassName, preview.WindowHandle);
-        using var notepad = Process.Start(new ProcessStartInfo("notepad.exe") { UseShellExecute = true });
-        Assert.IsNotNull(notepad, "Could not start the focus-loss Notepad fixture.");
-        var notepadWindow = WindowsFinder.WaitForWindowByProcess("notepad", 10_000);
-        Assert.IsNotNull(notepadWindow, "Notepad did not create a visible window.");
+        using var focusWatcher = new WindowShowWatcher(WaitForPreviewWindow().ClassName, preview.WindowHandle);
+        notepadFixture = NotepadFixture.Start();
+        var notepadWindow = notepadFixture.Window;
         Assert.IsTrue(
             WindowControl.WaitForForeground(new IntPtr(notepadWindow.WindowHandle), 5_000, 2),
             "Notepad could not gain foreground to exercise Mouse Jump focus-loss dismissal.");
@@ -181,7 +185,8 @@ public class MouseJumpTests : UITestBase
 
         var primary = MonitorInfo.GetPrimary();
         Assert.IsNotNull(primary, "No primary monitor was reported.");
-        var renderedContentAspectRatio = (width - 12d) / (height - 12d);
+        var borderContribution = 2d * DefaultBorderThickness;
+        var renderedContentAspectRatio = (width - borderContribution) / (height - borderContribution);
         var displayAspectRatio = primary.Width / (double)primary.Height;
         Assert.IsTrue(
             Math.Abs(renderedContentAspectRatio - displayAspectRatio) <= 0.02,
@@ -257,16 +262,7 @@ public class MouseJumpTests : UITestBase
 
     private static Session ShowPreview()
     {
-        Assert.IsTrue(
-            NamedEventHelper.WaitUntilAvailable(NamedEventHelper.MouseJumpShowPreview),
-            "Mouse Jump module did not create its show-preview event.");
-        if (!WaitForProcess(expected: true, timeoutMs: 1_000))
-        {
-            KeyboardHelper.SendKeys(Key.LWin, Key.Shift, Key.D);
-            Assert.IsTrue(WaitForProcess(expected: true), "Mouse Jump WinUI3 process did not start after activation.");
-        }
-
-        Assert.AreNotEqual(IntPtr.Zero, WaitForPreviewHwnd(), "Mouse Jump hidden preview HWND was not created.");
+        _ = WaitForPreviewReady();
 
         for (var attempt = 1; attempt <= 3; attempt++)
         {
@@ -290,43 +286,66 @@ public class MouseJumpTests : UITestBase
 
     private static WindowControl.ProcessWindow GetPreviewWindow()
     {
-        var processIds = Process.GetProcessesByName(ProcessName).Select(process => process.Id).ToArray();
-        return WindowControl.EnumerateProcessWindows(processIds)
-            .FirstOrDefault(window => window.Title.Equals(WindowTitle, StringComparison.OrdinalIgnoreCase));
+        var processes = Process.GetProcessesByName(ProcessName);
+        try
+        {
+            var processIds = processes.Select(process => process.Id).ToArray();
+            return WindowControl.EnumerateProcessWindows(processIds)
+                .FirstOrDefault(window => window.Title.Equals(WindowTitle, StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            foreach (var process in processes)
+            {
+                process.Dispose();
+            }
+        }
     }
 
-    private static IntPtr WaitForPreviewHwnd()
+    private static WindowControl.ProcessWindow WaitForPreviewReady()
+    {
+        Assert.IsTrue(
+            NamedEventHelper.WaitUntilAvailable(NamedEventHelper.MouseJumpShowPreview),
+            "Mouse Jump module did not create its show-preview event.");
+        Assert.IsTrue(WaitForProcess(expected: true), "Mouse Jump WinUI3 process did not start.");
+        return WaitForPreviewWindow();
+    }
+
+    private static WindowControl.ProcessWindow WaitForPreviewWindow()
     {
         var result = WaitHelper.WaitForStable(
             GetPreviewWindow,
-            window => window.Hwnd != IntPtr.Zero,
+            window => window.Hwnd != IntPtr.Zero && !string.IsNullOrWhiteSpace(window.ClassName),
             15_000,
             requiredConsecutiveMatches: 2,
             pollIntervalMS: 100);
-        return result.LastObservation.Hwnd;
+        Assert.IsTrue(result.Succeeded, "Mouse Jump did not create a preview window with a usable HWND and class name.");
+        return result.LastObservation;
     }
 
     private static bool WaitForProcess(bool expected, int timeoutMs = 15_000)
     {
         return WaitHelper.WaitForStable(
-            () => Process.GetProcessesByName(ProcessName).Length > 0,
+            () =>
+            {
+                var processes = Process.GetProcessesByName(ProcessName);
+                try
+                {
+                    return processes.Length > 0;
+                }
+                finally
+                {
+                    foreach (var process in processes)
+                    {
+                        process.Dispose();
+                    }
+                }
+            },
             running => running == expected,
             timeoutMs,
             requiredConsecutiveMatches: 2,
             pollIntervalMS: 100).Succeeded;
     }
-
-    private static double Distance(int x1, int y1, int x2, int y2)
-    {
-        var deltaX = x2 - x1;
-        var deltaY = y2 - y1;
-        return Math.Sqrt((deltaX * deltaX) + (deltaY * deltaY));
-    }
-
-    private static bool IsNear(Color actual, Color expected, int tolerance) =>
-        Math.Abs(actual.R - expected.R) <= tolerance &&
-        Math.Abs(actual.G - expected.G) <= tolerance &&
-        Math.Abs(actual.B - expected.B) <= tolerance;
 
     private sealed record MouseJumpConfiguration(
         int ShortcutCode = (int)Key.D,
@@ -335,7 +354,7 @@ public class MouseJumpTests : UITestBase
         string PreviewType = "Bezelled",
         string BackgroundColor1 = "#0D57D2",
         string BackgroundColor2 = "#0344C0",
-        int BorderThickness = 6,
+        int BorderThickness = DefaultBorderThickness,
         string BorderColor = "#0078D4",
         int BorderPadding = 4,
         int BezelThickness = 12,
@@ -343,4 +362,4 @@ public class MouseJumpTests : UITestBase
         int ScreenMargin = 4,
         string ScreenColor1 = "#191970",
         string ScreenColor2 = "#191970");
-    }
+}

--- a/src/modules/MouseUtils/MouseUtils.UITests.Next/MouseJumpTests.cs
+++ b/src/modules/MouseUtils/MouseUtils.UITests.Next/MouseJumpTests.cs
@@ -124,7 +124,12 @@ public class MouseJumpTests : UITestBase
 
         MouseUtilsTestHelper.NavigateToMouseUtilities(this);
         MouseUtilsTestHelper.SetModuleEnabled(this, ToggleId, false);
-        Assert.IsTrue(WaitForProcess(expected: false), "Mouse Jump process did not exit after disabling the module.");
+        MouseUtilsTestHelper.EnsureModuleStateApplied(
+            this,
+            ModuleName,
+            enabled: false,
+            () => WaitForProcess(expected: false),
+            "Mouse Jump process did not exit after disabling the module.");
         using var disabledActivation = new WindowShowWatcher(previewClassName);
         KeyboardHelper.SendKeys(Key.LWin, Key.Shift, Key.D);
         Assert.IsFalse(disabledActivation.Wait(2_000), "Mouse Jump preview appeared while the module was disabled.");

--- a/src/modules/MouseUtils/MouseUtils.UITests.Next/MouseJumpTests.cs
+++ b/src/modules/MouseUtils/MouseUtils.UITests.Next/MouseJumpTests.cs
@@ -124,12 +124,7 @@ public class MouseJumpTests : UITestBase
 
         MouseUtilsTestHelper.NavigateToMouseUtilities(this);
         MouseUtilsTestHelper.SetModuleEnabled(this, ToggleId, false);
-        MouseUtilsTestHelper.EnsureModuleStateApplied(
-            this,
-            ModuleName,
-            enabled: false,
-            () => WaitForProcess(expected: false),
-            "Mouse Jump process did not exit after disabling the module.");
+        Assert.IsTrue(WaitForProcess(expected: false), "Mouse Jump process did not exit after disabling the module.");
         using var disabledActivation = new WindowShowWatcher(previewClassName);
         KeyboardHelper.SendKeys(Key.LWin, Key.Shift, Key.D);
         Assert.IsFalse(disabledActivation.Wait(2_000), "Mouse Jump preview appeared while the module was disabled.");

--- a/src/modules/MouseUtils/MouseUtils.UITests.Next/MouseJumpTests.cs
+++ b/src/modules/MouseUtils/MouseUtils.UITests.Next/MouseJumpTests.cs
@@ -1,0 +1,346 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Drawing;
+using Microsoft.PowerToys.UITest.Next;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MouseUtils.UITests;
+
+[TestClass]
+public class MouseJumpTests : UITestBase
+{
+    private const string ModuleName = "MouseJump";
+    private const string ProcessName = "PowerToys.MouseJump.WinUI3";
+    private const string WindowTitle = "MouseJump.WinUI3";
+    private const string ToggleId = "MouseUtils_MouseJumpToggleId";
+    private static readonly IDisposable ModuleSettings = SettingsConfigHelper.PreserveModuleSettings(ModuleName);
+
+    public MouseJumpTests()
+        : base(PowerToysModule.PowerToysSettings, enableModules: new[] { ModuleName })
+    {
+    }
+
+    protected override IReadOnlyList<string> StaleProcessNames { get; } = new[]
+    {
+        "PowerToys",
+        "PowerToys.Settings",
+        "PowerToys.FancyZonesEditor",
+        ProcessName,
+        "PowerToys.MouseJumpUI",
+    };
+
+    [ClassCleanup]
+    public static void RestoreModuleSettings() => ModuleSettings.Dispose();
+
+    protected override void PrepareTestState()
+    {
+        var configuration = TestContext.TestName switch
+        {
+            nameof(ChangedShortcutActivatesPreview) => new MouseJumpConfiguration(ShortcutCode: (int)Key.Z),
+            nameof(ThumbnailSizeSetsPreviewBounds) => new MouseJumpConfiguration(Width: 640, Height: 480, PreviewType: "Compact"),
+            nameof(CustomPreviewStyleRendersConfiguredColors) => new MouseJumpConfiguration(
+                Width: 640,
+                Height: 480,
+                PreviewType: "Custom",
+                BackgroundColor1: "#FF00FF",
+                BackgroundColor2: "#FF00FF",
+                BorderThickness: 12,
+                BorderColor: "#00FF00",
+                BorderPadding: 12,
+                BezelThickness: 12,
+                BezelColor: "#FFFF00",
+                ScreenMargin: 10,
+                ScreenColor1: "#00FFFF",
+                ScreenColor2: "#00FFFF"),
+            _ => new MouseJumpConfiguration(),
+        };
+
+        MouseUtilsTestHelper.ReplaceModuleSettings(ModuleName, CreateSettings(configuration));
+    }
+
+    [TestCleanup]
+    public async Task CleanupWindows()
+    {
+        await CaptureFailureArtifactsBeforeCleanupAsync();
+        KeyboardHelper.SendKeys(Key.Esc);
+        WindowControl.TryKillProcessTreeByNameAndWait("notepad", 5_000);
+        WindowControl.TryKillProcessTreeByNameAndWait(ProcessName, 10_000);
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    [TestCategory("Mouse Utils #39")]
+    public void SettingsPageLoadsAndProcessRuns()
+    {
+        MouseUtilsTestHelper.NavigateToMouseUtilities(this);
+        var toggle = MouseUtilsTestHelper.SetModuleEnabled(this, ToggleId, true);
+        Assert.IsTrue(toggle.IsOn, "Mouse Jump toggle should be on.");
+        Assert.IsTrue(WaitForProcess(expected: true), "Mouse Jump WinUI3 process did not start.");
+        Assert.IsTrue(
+            NamedEventHelper.WaitUntilAvailable(NamedEventHelper.MouseJumpShowPreview),
+            "Mouse Jump did not create its show-preview event.");
+        var hwnd = WaitForPreviewHwnd();
+        Assert.AreNotEqual(IntPtr.Zero, hwnd, "Mouse Jump did not create its hidden preview HWND.");
+
+        using var shortcutWatcher = new WindowShowWatcher(GetPreviewWindow().ClassName, hwnd.ToInt64());
+        KeyboardHelper.SendKeys(Key.LWin, Key.Shift, Key.D);
+        Assert.IsTrue(shortcutWatcher.Wait(10_000), "The default Win+Shift+D shortcut did not show Mouse Jump.");
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    [TestCategory("Mouse Utils #39")]
+    [TestCategory("Mouse Utils #41")]
+    [TestCategory("Mouse Utils #45")]
+    public void PreviewClickMovesCursorAndDisableStopsActivation()
+    {
+        var preview = ShowPreview();
+        var previewClassName = GetPreviewWindow().ClassName;
+        var bounds = WindowHelper.GetWindowBounds(new IntPtr(preview.WindowHandle));
+        var clickX = bounds.Left + ((bounds.Right - bounds.Left) / 2);
+        var clickY = bounds.Top + ((bounds.Bottom - bounds.Top) / 2);
+        using (var watcher = new WindowShowWatcher(GetPreviewWindow().ClassName, preview.WindowHandle))
+        {
+            var previewHwnd = new IntPtr(preview.WindowHandle);
+            WindowControl.WaitForForeground(previewHwnd, 2_000);
+            Assert.IsTrue(
+                WindowControl.IsPointOwnedByWindow(previewHwnd, clickX, clickY),
+                $"Mouse Jump did not own its preview midpoint ({clickX},{clickY}) before the click.");
+            MouseHelper.LeftClickAt(clickX, clickY);
+            Assert.IsTrue(watcher.WaitForHidden(5_000), "Clicking the Mouse Jump preview did not hide it.");
+        }
+
+        var primary = MonitorInfo.GetPrimary();
+        Assert.IsNotNull(primary, "No primary monitor was reported.");
+        var expectedX = primary.Left + (primary.Width / 2);
+        var expectedY = primary.Top + (primary.Height / 2);
+        var cursor = MouseHelper.GetMousePosition();
+        Assert.IsTrue(
+            Distance(cursor.X, cursor.Y, expectedX, expectedY) <= 20,
+            $"Preview-center click mapped to ({cursor.X},{cursor.Y}), expected primary midpoint ({expectedX},{expectedY}).");
+
+        MouseUtilsTestHelper.NavigateToMouseUtilities(this);
+        MouseUtilsTestHelper.SetModuleEnabled(this, ToggleId, false);
+        Assert.IsTrue(WaitForProcess(expected: false), "Mouse Jump process did not exit after disabling the module.");
+        using var disabledActivation = new WindowShowWatcher(previewClassName);
+        KeyboardHelper.SendKeys(Key.LWin, Key.Shift, Key.D);
+        Assert.IsFalse(disabledActivation.Wait(2_000), "Mouse Jump preview appeared while the module was disabled.");
+        Assert.IsFalse(WaitForProcess(expected: true, timeoutMs: 1_000), "Mouse Jump process restarted while the module was disabled.");
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    [TestCategory("Mouse Utils #40")]
+    public void ChangedShortcutActivatesPreview()
+    {
+        var hwnd = WaitForPreviewHwnd();
+        var className = GetPreviewWindow().ClassName;
+        using (var defaultShortcut = new WindowShowWatcher(className, hwnd.ToInt64()))
+        {
+            KeyboardHelper.SendKeys(Key.LWin, Key.Shift, Key.D);
+            Assert.IsFalse(defaultShortcut.Wait(1_500), "The old Mouse Jump shortcut still showed the preview.");
+        }
+
+        using var changedShortcut = new WindowShowWatcher(className, hwnd.ToInt64());
+        KeyboardHelper.SendKeys(Key.LWin, Key.Shift, Key.Z);
+        Assert.IsTrue(changedShortcut.Wait(10_000), "Changed Win+Shift+Z shortcut did not show Mouse Jump.");
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    public void FocusLossDismissesPreview()
+    {
+        var preview = ShowPreview();
+        Assert.IsTrue(
+            WindowControl.WaitForForeground(new IntPtr(preview.WindowHandle), 5_000, 2),
+            $"Mouse Jump was not foreground before the focus-loss transition. Current foreground: {WindowControl.GetForegroundWindowInfo()}.");
+        using var focusWatcher = new WindowShowWatcher(GetPreviewWindow().ClassName, preview.WindowHandle);
+        using var notepad = Process.Start(new ProcessStartInfo("notepad.exe") { UseShellExecute = true });
+        Assert.IsNotNull(notepad, "Could not start the focus-loss Notepad fixture.");
+        var notepadWindow = WindowsFinder.WaitForWindowByProcess("notepad", 10_000);
+        Assert.IsNotNull(notepadWindow, "Notepad did not create a visible window.");
+        Assert.IsTrue(
+            WindowControl.WaitForForeground(new IntPtr(notepadWindow.WindowHandle), 5_000, 2),
+            "Notepad could not gain foreground to exercise Mouse Jump focus-loss dismissal.");
+        Assert.IsTrue(focusWatcher.WaitForHidden(5_000), "Mouse Jump did not dismiss after losing focus.");
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    public void ThumbnailSizeSetsPreviewBounds()
+    {
+        var preview = ShowPreview();
+        var bounds = WindowHelper.GetWindowBounds(new IntPtr(preview.WindowHandle));
+        var width = bounds.Right - bounds.Left;
+        var height = bounds.Bottom - bounds.Top;
+        Assert.IsTrue(width is >= 620 and <= 650, $"Configured 640px preview width rendered as {width}px.");
+        Assert.IsTrue(height <= 480, $"Configured 480px maximum preview height rendered as {height}px.");
+
+        var primary = MonitorInfo.GetPrimary();
+        Assert.IsNotNull(primary, "No primary monitor was reported.");
+        var renderedContentAspectRatio = (width - 12d) / (height - 12d);
+        var displayAspectRatio = primary.Width / (double)primary.Height;
+        Assert.IsTrue(
+            Math.Abs(renderedContentAspectRatio - displayAspectRatio) <= 0.02,
+            $"Preview content aspect ratio {renderedContentAspectRatio:F3} did not preserve display ratio {displayAspectRatio:F3}.");
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    public void CustomPreviewStyleRendersConfiguredColors()
+    {
+        var preview = ShowPreview();
+        var path = Path.Combine(TestContext.TestResultsDirectory ?? Path.GetTempPath(), $"mouse-jump-custom-{Guid.NewGuid():N}.png");
+        WindowHelper.CaptureVisibleWindow(new IntPtr(preview.WindowHandle), path);
+        try
+        {
+            using var image = new Bitmap(path);
+            var colors = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["#FF00FF"] = 0,
+                ["#00FF00"] = 0,
+                ["#FFFF00"] = 0,
+            };
+
+            for (var y = 0; y < image.Height; y += 2)
+            {
+                for (var x = 0; x < image.Width; x += 2)
+                {
+                    var pixel = image.GetPixel(x, y);
+                    foreach (var key in colors.Keys.ToArray())
+                    {
+                        var expected = ColorTranslator.FromHtml(key);
+                        if (IsNear(pixel, expected, 4))
+                        {
+                            colors[key]++;
+                        }
+                    }
+                }
+            }
+
+            Assert.IsTrue(colors["#FF00FF"] > 100, $"Custom canvas background was not rendered; magenta sample count={colors["#FF00FF"]}.");
+            Assert.IsTrue(colors["#00FF00"] > 100, $"Custom canvas border was not rendered; green sample count={colors["#00FF00"]}.");
+            Assert.IsTrue(colors["#FFFF00"] > 100, $"Custom screen bezel was not rendered; yellow sample count={colors["#FFFF00"]}.");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    private static string CreateSettings(MouseJumpConfiguration configuration) => $$"""
+        {
+          "name": "MouseJump",
+          "version": "1.1",
+          "properties": {
+            "activation_shortcut": { "win": true, "ctrl": false, "alt": false, "shift": true, "code": {{configuration.ShortcutCode}}, "key": "" },
+            "thumbnail_size": { "width": {{configuration.Width}}, "height": {{configuration.Height}} },
+            "preview_type": "{{configuration.PreviewType}}",
+            "background_color_1": "{{configuration.BackgroundColor1}}",
+            "background_color_2": "{{configuration.BackgroundColor2}}",
+            "border_thickness": {{configuration.BorderThickness}},
+            "border_color": "{{configuration.BorderColor}}",
+            "border_3d_depth": 0,
+            "border_padding": {{configuration.BorderPadding}},
+            "bezel_thickness": {{configuration.BezelThickness}},
+            "bezel_color": "{{configuration.BezelColor}}",
+            "bezel_3d_depth": 0,
+            "screen_margin": {{configuration.ScreenMargin}},
+            "screen_color_1": "{{configuration.ScreenColor1}}",
+            "screen_color_2": "{{configuration.ScreenColor2}}"
+          }
+        }
+        """;
+
+    private static Session ShowPreview()
+    {
+        Assert.IsTrue(
+            NamedEventHelper.WaitUntilAvailable(NamedEventHelper.MouseJumpShowPreview),
+            "Mouse Jump module did not create its show-preview event.");
+        if (!WaitForProcess(expected: true, timeoutMs: 1_000))
+        {
+            KeyboardHelper.SendKeys(Key.LWin, Key.Shift, Key.D);
+            Assert.IsTrue(WaitForProcess(expected: true), "Mouse Jump WinUI3 process did not start after activation.");
+        }
+
+        Assert.AreNotEqual(IntPtr.Zero, WaitForPreviewHwnd(), "Mouse Jump hidden preview HWND was not created.");
+
+        for (var attempt = 1; attempt <= 3; attempt++)
+        {
+            Assert.IsTrue(
+                NamedEventHelper.WaitAndSignal(NamedEventHelper.MouseJumpShowPreview, 10_000),
+                "Mouse Jump show-preview event was unavailable.");
+            var preview = WindowsFinder.WaitForWindowByApp(
+                ProcessName,
+                window => window.Title.Equals(WindowTitle, StringComparison.OrdinalIgnoreCase),
+                timeoutMS: 5_000);
+            if (preview is not null)
+            {
+                WindowControl.WaitForForeground(new IntPtr(preview.WindowHandle), 2_000);
+                return preview;
+            }
+        }
+
+        Assert.Fail("Mouse Jump preview did not become visible after three show-event attempts.");
+        return null!;
+    }
+
+    private static WindowControl.ProcessWindow GetPreviewWindow()
+    {
+        var processIds = Process.GetProcessesByName(ProcessName).Select(process => process.Id).ToArray();
+        return WindowControl.EnumerateProcessWindows(processIds)
+            .FirstOrDefault(window => window.Title.Equals(WindowTitle, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static IntPtr WaitForPreviewHwnd()
+    {
+        var result = WaitHelper.WaitForStable(
+            GetPreviewWindow,
+            window => window.Hwnd != IntPtr.Zero,
+            15_000,
+            requiredConsecutiveMatches: 2,
+            pollIntervalMS: 100);
+        return result.LastObservation.Hwnd;
+    }
+
+    private static bool WaitForProcess(bool expected, int timeoutMs = 15_000)
+    {
+        return WaitHelper.WaitForStable(
+            () => Process.GetProcessesByName(ProcessName).Length > 0,
+            running => running == expected,
+            timeoutMs,
+            requiredConsecutiveMatches: 2,
+            pollIntervalMS: 100).Succeeded;
+    }
+
+    private static double Distance(int x1, int y1, int x2, int y2)
+    {
+        var deltaX = x2 - x1;
+        var deltaY = y2 - y1;
+        return Math.Sqrt((deltaX * deltaX) + (deltaY * deltaY));
+    }
+
+    private static bool IsNear(Color actual, Color expected, int tolerance) =>
+        Math.Abs(actual.R - expected.R) <= tolerance &&
+        Math.Abs(actual.G - expected.G) <= tolerance &&
+        Math.Abs(actual.B - expected.B) <= tolerance;
+
+    private sealed record MouseJumpConfiguration(
+        int ShortcutCode = (int)Key.D,
+        int Width = 800,
+        int Height = 600,
+        string PreviewType = "Bezelled",
+        string BackgroundColor1 = "#0D57D2",
+        string BackgroundColor2 = "#0344C0",
+        int BorderThickness = 6,
+        string BorderColor = "#0078D4",
+        int BorderPadding = 4,
+        int BezelThickness = 12,
+        string BezelColor = "#222222",
+        int ScreenMargin = 4,
+        string ScreenColor1 = "#191970",
+        string ScreenColor2 = "#191970");
+    }

--- a/src/modules/MouseUtils/MouseUtils.UITests.Next/MousePointerCrosshairsTests.cs
+++ b/src/modules/MouseUtils/MouseUtils.UITests.Next/MousePointerCrosshairsTests.cs
@@ -132,11 +132,8 @@ public class MousePointerCrosshairsTests : UITestBase
     {
         MouseUtilsTestHelper.NavigateToMouseUtilities(this);
         MouseUtilsTestHelper.SetModuleEnabled(this, ToggleId, false);
-        MouseUtilsTestHelper.EnsureModuleStateApplied(
-            this,
-            ModuleName,
-            enabled: false,
-            () => NamedEventHelper.WaitUntilUnavailable(NamedEventHelper.MouseCrosshairsToggle),
+        Assert.IsTrue(
+            NamedEventHelper.WaitUntilUnavailable(NamedEventHelper.MouseCrosshairsToggle),
             "Crosshairs trigger event remained available after disabling the module.");
 
         using (var disabledWatcher = new WindowShowWatcher(WindowClass))
@@ -146,11 +143,8 @@ public class MousePointerCrosshairsTests : UITestBase
         }
 
         MouseUtilsTestHelper.SetModuleEnabled(this, ToggleId, true);
-        MouseUtilsTestHelper.EnsureModuleStateApplied(
-            this,
-            ModuleName,
-            enabled: true,
-            () => NamedEventHelper.WaitUntilAvailable(NamedEventHelper.MouseCrosshairsToggle),
+        Assert.IsTrue(
+            NamedEventHelper.WaitUntilAvailable(NamedEventHelper.MouseCrosshairsToggle),
             "Crosshairs trigger event was not recreated after enabling the module.");
         var window = MouseUtilsTestHelper.WaitForWindowClass(WindowClass);
         using var enabledWatcher = new WindowShowWatcher(WindowClass, window.Hwnd.ToInt64());

--- a/src/modules/MouseUtils/MouseUtils.UITests.Next/MousePointerCrosshairsTests.cs
+++ b/src/modules/MouseUtils/MouseUtils.UITests.Next/MousePointerCrosshairsTests.cs
@@ -5,6 +5,7 @@
 using System.Drawing;
 using Microsoft.PowerToys.UITest.Next;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static MouseUtils.UITests.MouseUtilsTestHelper;
 
 namespace MouseUtils.UITests;
 
@@ -18,6 +19,10 @@ public class MousePointerCrosshairsTests : UITestBase
 
     private static readonly IDisposable ModuleSettings = SettingsConfigHelper.PreserveModuleSettings(ModuleName);
 
+    static MousePointerCrosshairsTests()
+    {
+    }
+
     public MousePointerCrosshairsTests()
         : base(PowerToysModule.PowerToysSettings, enableModules: new[] { ModuleName })
     {
@@ -27,8 +32,8 @@ public class MousePointerCrosshairsTests : UITestBase
     {
         var configuration = TestContext.TestName switch
         {
-            "DisabledModuleRejectsActivationAndChangedShortcutWorks" => new CrosshairsConfiguration(ShortcutCode: (int)Key.O),
-            "HorizontalOrientationFixedLengthAndBorderAreApplied" => new CrosshairsConfiguration(
+            nameof(DisabledModuleRejectsActivationAndChangedShortcutWorks) => new CrosshairsConfiguration(ShortcutCode: (int)Key.O),
+            nameof(HorizontalOrientationFixedLengthAndBorderAreApplied) => new CrosshairsConfiguration(
                 Color: "#00FF00",
                 Radius: 35,
                 Thickness: 12,
@@ -38,7 +43,7 @@ public class MousePointerCrosshairsTests : UITestBase
                 FixedLengthEnabled: true,
                 FixedLength: 120),
             nameof(OpacityBlendsWithDesktop) => new CrosshairsConfiguration(Opacity: 50),
-            "AutoActivateStartsVisible" => new CrosshairsConfiguration(AutoActivate: true),
+            nameof(AutoActivateStartsVisible) => new CrosshairsConfiguration(AutoActivate: true),
             _ => new CrosshairsConfiguration(),
         };
 
@@ -162,6 +167,8 @@ public class MousePointerCrosshairsTests : UITestBase
         MouseHelper.MoveTo(centerX, centerY);
         Assert.IsTrue(NamedEventHelper.WaitAndSignal(NamedEventHelper.MouseCrosshairsToggle), "Crosshairs trigger event was unavailable.");
 
+        // Radius 35 leaves the center gap; 12px core plus 6px border determines the Y probes, and
+        // fixed length 120 from the gap determines the arm-end probes around X=150.
         var result = WaitHelper.WaitForStable(
             () => new
             {
@@ -356,20 +363,6 @@ public class MousePointerCrosshairsTests : UITestBase
             ? new CrosshairsOrigin((int)verticalPixels.Average(), (int)horizontalPixels.Average())
             : null;
     }
-
-    private static Color Blend(Color foreground, Color background, int alpha)
-    {
-        var inverse = 255 - alpha;
-        return Color.FromArgb(
-            ((foreground.R * alpha) + (background.R * inverse) + 127) / 255,
-            ((foreground.G * alpha) + (background.G * inverse) + 127) / 255,
-            ((foreground.B * alpha) + (background.B * inverse) + 127) / 255);
-    }
-
-    private static bool IsNear(Color actual, Color expected, int tolerance) =>
-        Math.Abs(actual.R - expected.R) <= tolerance &&
-        Math.Abs(actual.G - expected.G) <= tolerance &&
-        Math.Abs(actual.B - expected.B) <= tolerance;
 
     private static string CreateSettings(CrosshairsConfiguration configuration) => $$"""
                 {

--- a/src/modules/MouseUtils/MouseUtils.UITests.Next/MousePointerCrosshairsTests.cs
+++ b/src/modules/MouseUtils/MouseUtils.UITests.Next/MousePointerCrosshairsTests.cs
@@ -131,9 +131,12 @@ public class MousePointerCrosshairsTests : UITestBase
     public void DisabledModuleRejectsActivationAndChangedShortcutWorks()
     {
         MouseUtilsTestHelper.NavigateToMouseUtilities(this);
-        var toggle = MouseUtilsTestHelper.SetModuleEnabled(this, ToggleId, false);
-        Assert.IsTrue(
-            NamedEventHelper.WaitUntilUnavailable(NamedEventHelper.MouseCrosshairsToggle),
+        MouseUtilsTestHelper.SetModuleEnabled(this, ToggleId, false);
+        MouseUtilsTestHelper.EnsureModuleStateApplied(
+            this,
+            ModuleName,
+            enabled: false,
+            () => NamedEventHelper.WaitUntilUnavailable(NamedEventHelper.MouseCrosshairsToggle),
             "Crosshairs trigger event remained available after disabling the module.");
 
         using (var disabledWatcher = new WindowShowWatcher(WindowClass))
@@ -142,10 +145,12 @@ public class MousePointerCrosshairsTests : UITestBase
             Assert.IsFalse(disabledWatcher.Wait(1_500), "The changed shortcut showed Crosshairs while the module was disabled.");
         }
 
-        toggle.Toggle(true);
-        Assert.IsTrue(toggle.WaitForProperty("ToggleState", "On", 5_000), "Crosshairs toggle did not return to On.");
-        Assert.IsTrue(
-            NamedEventHelper.WaitUntilAvailable(NamedEventHelper.MouseCrosshairsToggle),
+        MouseUtilsTestHelper.SetModuleEnabled(this, ToggleId, true);
+        MouseUtilsTestHelper.EnsureModuleStateApplied(
+            this,
+            ModuleName,
+            enabled: true,
+            () => NamedEventHelper.WaitUntilAvailable(NamedEventHelper.MouseCrosshairsToggle),
             "Crosshairs trigger event was not recreated after enabling the module.");
         var window = MouseUtilsTestHelper.WaitForWindowClass(WindowClass);
         using var enabledWatcher = new WindowShowWatcher(WindowClass, window.Hwnd.ToInt64());

--- a/src/modules/MouseUtils/MouseUtils.UITests.Next/MousePointerCrosshairsTests.cs
+++ b/src/modules/MouseUtils/MouseUtils.UITests.Next/MousePointerCrosshairsTests.cs
@@ -1,0 +1,414 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using Microsoft.PowerToys.UITest.Next;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MouseUtils.UITests;
+
+[TestClass]
+public class MousePointerCrosshairsTests : UITestBase
+{
+    private const string ModuleName = "MousePointerCrosshairs";
+    private const string ToggleId = "MouseUtils_MousePointerCrosshairsToggleId";
+    private const string WindowClass = "MousePointerCrosshairs";
+    private const string CrosshairsColor = "#FF0000";
+
+    private static readonly IDisposable ModuleSettings = SettingsConfigHelper.PreserveModuleSettings(ModuleName);
+
+    public MousePointerCrosshairsTests()
+        : base(PowerToysModule.PowerToysSettings, enableModules: new[] { ModuleName })
+    {
+    }
+
+    protected override void PrepareTestState()
+    {
+        var configuration = TestContext.TestName switch
+        {
+            "DisabledModuleRejectsActivationAndChangedShortcutWorks" => new CrosshairsConfiguration(ShortcutCode: (int)Key.O),
+            "HorizontalOrientationFixedLengthAndBorderAreApplied" => new CrosshairsConfiguration(
+                Color: "#00FF00",
+                Radius: 35,
+                Thickness: 12,
+                BorderColor: "#0000FF",
+                BorderSize: 6,
+                Orientation: 2,
+                FixedLengthEnabled: true,
+                FixedLength: 120),
+            nameof(OpacityBlendsWithDesktop) => new CrosshairsConfiguration(Opacity: 50),
+            "AutoActivateStartsVisible" => new CrosshairsConfiguration(AutoActivate: true),
+            _ => new CrosshairsConfiguration(),
+        };
+
+        MouseUtilsTestHelper.ReplaceModuleSettings(ModuleName, CreateSettings(configuration));
+    }
+
+    [ClassCleanup]
+    public static void RestoreModuleSettings() => ModuleSettings.Dispose();
+
+    [TestCleanup]
+    public async Task CleanupInput()
+    {
+        await CaptureFailureArtifactsBeforeCleanupAsync();
+        MouseHelper.LeftUp();
+        MouseHelper.RightUp();
+        KeyboardHelper.ReleaseKey(Key.Ctrl);
+        KeyboardHelper.ReleaseKey(Key.Shift);
+        KeyboardHelper.ReleaseKey(Key.Alt);
+        KeyboardHelper.ReleaseKey(Key.LWin);
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    [TestCategory("Mouse Utils #29")]
+    [TestCategory("Mouse Utils #30")]
+    public void ActivationTracksCursorAndHides()
+    {
+        MouseUtilsTestHelper.NavigateToMouseUtilities(this);
+        MouseUtilsTestHelper.SetModuleEnabled(this, ToggleId, true);
+        Key[] activationKeys = [Key.LWin, Key.Alt, Key.P];
+
+        var crosshairsWindow = MouseUtilsTestHelper.WaitForWindowClass(WindowClass);
+        Assert.IsFalse(crosshairsWindow.IsVisible, "Crosshairs should start hidden before activation.");
+
+        WindowHelper.MinimizeWindow(new IntPtr(Session.WindowHandle));
+        var (centerX, centerY) = WindowHelper.GetScreenCenter();
+        MouseHelper.MoveTo(centerX, centerY);
+
+        MouseUtilsTestHelper.Step(this, "Signaling the Crosshairs named event as a positive detector control");
+        using (var detectorControl = new WindowShowWatcher(WindowClass, crosshairsWindow.Hwnd.ToInt64()))
+        {
+            Assert.IsTrue(
+                NamedEventHelper.WaitAndSignal(NamedEventHelper.MouseCrosshairsToggle, 10_000),
+                "The Crosshairs named event was not created by the enabled module.");
+            Assert.IsTrue(
+                detectorControl.Wait(5_000),
+                "The known-good named event did not produce a Crosshairs SHOW event.");
+            AssertCrosshairsAt(centerX, centerY);
+
+            Assert.IsTrue(
+                NamedEventHelper.TrySignal(NamedEventHelper.MouseCrosshairsToggle),
+                "The Crosshairs named event disappeared before the positive control could hide the overlay.");
+            Assert.IsTrue(
+                detectorControl.WaitForHidden(5_000),
+                $"The positive-control Crosshairs HWND did not hide. Events: {string.Join(", ", detectorControl.Events)}");
+        }
+
+        using var watcher = new WindowShowWatcher(WindowClass, crosshairsWindow.Hwnd.ToInt64());
+        MouseUtilsTestHelper.Step(this, "Sending the Crosshairs shortcut after the module-ready positive control");
+        KeyboardHelper.SendKeys(activationKeys);
+        var shown = watcher.Wait(10_000);
+
+        MouseUtilsTestHelper.Step(this, $"Crosshairs window events: {string.Join(", ", watcher.Events)}");
+        Assert.IsTrue(shown, "Crosshairs did not emit a SHOW event after the activation shortcut.");
+        AssertCrosshairsAt(centerX, centerY);
+
+        MouseUtilsTestHelper.Step(this, "Moving the cursor with relative input and checking the new crosshair origin");
+        MouseHelper.MoveBy(160, 100, steps: 10);
+        var moved = MouseHelper.GetMousePosition();
+        Assert.IsTrue(
+            Math.Abs(moved.X - centerX) > 50 || Math.Abs(moved.Y - centerY) > 50,
+            $"Relative input did not move the cursor far enough: ({centerX},{centerY}) -> ({moved.X},{moved.Y}).");
+        var movedOrigin = AssertCrosshairsNear(moved.X, moved.Y);
+        Assert.IsTrue(
+            Math.Abs(movedOrigin.X - centerX) > 50 || Math.Abs(movedOrigin.Y - centerY) > 50,
+            $"Crosshairs did not follow the cursor away from ({centerX},{centerY}); observed origin ({movedOrigin.X},{movedOrigin.Y}).");
+
+        MouseUtilsTestHelper.Step(this, "Sending the shortcut again and waiting for the exact Crosshairs HWND to hide");
+        KeyboardHelper.SendKeys(activationKeys);
+        Assert.IsTrue(
+            watcher.WaitForHidden(5_000),
+            $"Crosshairs HWND 0x{crosshairsWindow.Hwnd:X} did not hide. Events: {string.Join(", ", watcher.Events)}");
+        Assert.IsFalse(WindowControl.IsAnyWindowOfClassVisible(WindowClass), "Crosshairs remained visible after the second shortcut.");
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    [TestCategory("Mouse Utils #31")]
+    [TestCategory("Mouse Utils #32")]
+    public void DisabledModuleRejectsActivationAndChangedShortcutWorks()
+    {
+        MouseUtilsTestHelper.NavigateToMouseUtilities(this);
+        var toggle = MouseUtilsTestHelper.SetModuleEnabled(this, ToggleId, false);
+        Assert.IsTrue(
+            NamedEventHelper.WaitUntilUnavailable(NamedEventHelper.MouseCrosshairsToggle),
+            "Crosshairs trigger event remained available after disabling the module.");
+
+        using (var disabledWatcher = new WindowShowWatcher(WindowClass))
+        {
+            KeyboardHelper.SendKeys(Key.LWin, Key.Alt, Key.O);
+            Assert.IsFalse(disabledWatcher.Wait(1_500), "The changed shortcut showed Crosshairs while the module was disabled.");
+        }
+
+        toggle.Toggle(true);
+        Assert.IsTrue(toggle.WaitForProperty("ToggleState", "On", 5_000), "Crosshairs toggle did not return to On.");
+        Assert.IsTrue(
+            NamedEventHelper.WaitUntilAvailable(NamedEventHelper.MouseCrosshairsToggle),
+            "Crosshairs trigger event was not recreated after enabling the module.");
+        var window = MouseUtilsTestHelper.WaitForWindowClass(WindowClass);
+        using var enabledWatcher = new WindowShowWatcher(WindowClass, window.Hwnd.ToInt64());
+        KeyboardHelper.SendKeys(Key.LWin, Key.Alt, Key.O);
+        Assert.IsTrue(enabledWatcher.Wait(5_000), "The changed Win+Alt+O shortcut did not show Crosshairs.");
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    [TestCategory("Mouse Utils #33")]
+    public void HorizontalOrientationFixedLengthAndBorderAreApplied()
+    {
+        WindowHelper.MinimizeWindow(new IntPtr(Session.WindowHandle));
+        var (centerX, centerY) = WindowHelper.GetScreenCenter();
+        MouseHelper.MoveTo(centerX, centerY);
+        Assert.IsTrue(NamedEventHelper.WaitAndSignal(NamedEventHelper.MouseCrosshairsToggle), "Crosshairs trigger event was unavailable.");
+
+        var result = WaitHelper.WaitForStable(
+            () => new
+            {
+                Gap = WindowHelper.GetPixelColorHex(centerX + 25, centerY),
+                BorderStart = WindowHelper.GetPixelColorHex(centerX + 31, centerY),
+                Core = WindowHelper.GetPixelColorHex(centerX + 45, centerY),
+                CoreThickness = WindowHelper.GetPixelColorHex(centerX + 60, centerY + 5),
+                BorderThickness = WindowHelper.GetPixelColorHex(centerX + 60, centerY + 9),
+                OutsideThickness = WindowHelper.GetPixelColorHex(centerX + 60, centerY + 13),
+                CoreEnd = WindowHelper.GetPixelColorHex(centerX + 150, centerY),
+                BorderEnd = WindowHelper.GetPixelColorHex(centerX + 158, centerY),
+                Vertical = WindowHelper.GetPixelColorHex(centerX, centerY - 60),
+                Beyond = WindowHelper.GetPixelColorHex(centerX + 165, centerY),
+            },
+            sample => sample is not null &&
+                !sample.Gap.Equals("#00FF00", StringComparison.OrdinalIgnoreCase) &&
+                sample.BorderStart.Equals("#0000FF", StringComparison.OrdinalIgnoreCase) &&
+                sample.Core.Equals("#00FF00", StringComparison.OrdinalIgnoreCase) &&
+                sample.CoreThickness.Equals("#00FF00", StringComparison.OrdinalIgnoreCase) &&
+                sample.BorderThickness.Equals("#0000FF", StringComparison.OrdinalIgnoreCase) &&
+                !sample.OutsideThickness.Equals("#00FF00", StringComparison.OrdinalIgnoreCase) &&
+                !sample.OutsideThickness.Equals("#0000FF", StringComparison.OrdinalIgnoreCase) &&
+                sample.CoreEnd.Equals("#00FF00", StringComparison.OrdinalIgnoreCase) &&
+                sample.BorderEnd.Equals("#0000FF", StringComparison.OrdinalIgnoreCase) &&
+                !sample.Vertical.Equals("#00FF00", StringComparison.OrdinalIgnoreCase) &&
+                !sample.Vertical.Equals("#0000FF", StringComparison.OrdinalIgnoreCase) &&
+                !sample.Beyond.Equals("#00FF00", StringComparison.OrdinalIgnoreCase) &&
+                !sample.Beyond.Equals("#0000FF", StringComparison.OrdinalIgnoreCase),
+            timeoutMS: 5_000,
+            pollIntervalMS: 100);
+
+        Assert.IsTrue(result.Succeeded, $"Horizontal fixed-length Crosshairs geometry did not match. Last sample: {result.LastObservation}.");
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    public void OpacityBlendsWithDesktop()
+    {
+        WindowHelper.MinimizeWindow(new IntPtr(Session.WindowHandle));
+        var (centerX, centerY) = WindowHelper.GetScreenCenter();
+        MouseHelper.MoveTo(centerX, centerY);
+        var probeX = centerX + 60;
+        Color? previous = null;
+        var baseline = WaitHelper.WaitForStable(
+            () => WindowHelper.GetPixelColor(probeX, centerY),
+            color =>
+            {
+                var matchesPrevious = previous.HasValue && color.ToArgb() == previous.Value.ToArgb();
+                previous = color;
+                return matchesPrevious;
+            },
+            2_000,
+            requiredConsecutiveMatches: 4,
+            pollIntervalMS: 100).LastObservation;
+
+        Assert.IsTrue(NamedEventHelper.WaitAndSignal(NamedEventHelper.MouseCrosshairsToggle), "Crosshairs trigger event was unavailable.");
+        var expected = Blend(Color.Red, baseline, 128);
+        var result = WaitHelper.WaitForStable(
+            () => WindowHelper.GetPixelColor(probeX, centerY),
+            color => IsNear(color, expected, 5),
+            5_000,
+            requiredConsecutiveMatches: 3,
+            pollIntervalMS: 100);
+
+        Assert.IsTrue(result.Succeeded, $"50% Crosshairs opacity did not blend as expected. Expected {expected}; observed {result.LastObservation}.");
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    public void AutoActivateStartsVisible()
+    {
+        var result = WaitHelper.WaitForStable(
+            () => WindowControl.IsAnyWindowOfClassVisible(WindowClass),
+            visible => visible,
+            timeoutMS: 10_000,
+            requiredConsecutiveMatches: 3,
+            pollIntervalMS: 100);
+        Assert.IsTrue(result.Succeeded, "Crosshairs did not start visible when auto-activate was enabled.");
+    }
+
+    [TestMethod]
+    [TestCategory("MouseUtils")]
+    public void GlidingCursorMovesAndEscapeCancels()
+    {
+        WindowHelper.MinimizeWindow(new IntPtr(Session.WindowHandle));
+        var (centerX, centerY) = WindowHelper.GetScreenCenter();
+        MouseHelper.MoveTo(centerX, centerY);
+        var window = MouseUtilsTestHelper.WaitForWindowClass(WindowClass);
+        using var watcher = new WindowShowWatcher(WindowClass, window.Hwnd.ToInt64());
+
+        KeyboardHelper.PressKey(Key.LWin);
+        KeyboardHelper.PressKey(Key.Alt);
+        try
+        {
+            KeyboardHelper.SendKey(Key.OemPeriod);
+        }
+        finally
+        {
+            KeyboardHelper.ReleaseKey(Key.Alt);
+            KeyboardHelper.ReleaseKey(Key.LWin);
+        }
+
+        Assert.IsTrue(watcher.Wait(5_000), "The gliding-cursor shortcut did not show Crosshairs.");
+        var reset = WaitHelper.WaitForStable(
+            MouseHelper.GetMousePosition,
+            position => position.X < centerX - 100,
+            5_000,
+            requiredConsecutiveMatches: 1,
+            pollIntervalMS: 20);
+        Assert.IsTrue(reset.Succeeded, $"Gliding cursor did not reset to the left side. Last position: {reset.LastObservation}.");
+        var resetPosition = reset.LastObservation;
+        var moved = WaitHelper.WaitForStable(
+            MouseHelper.GetMousePosition,
+            position => position.X >= resetPosition.X + 100,
+            5_000,
+            requiredConsecutiveMatches: 2,
+            pollIntervalMS: 20);
+        Assert.IsTrue(moved.Succeeded, $"Gliding cursor did not travel at least 100px after reset. Reset: {resetPosition}; last: {moved.LastObservation}.");
+
+        KeyboardHelper.SendKeys(Key.Esc);
+        Assert.IsTrue(watcher.WaitForHidden(5_000), "Escape did not hide the gliding-cursor Crosshairs.");
+        var stoppedAt = MouseHelper.GetMousePosition();
+        var stopped = WaitHelper.WaitForStable(
+            MouseHelper.GetMousePosition,
+            position => Math.Abs(position.X - stoppedAt.X) <= 2 && Math.Abs(position.Y - stoppedAt.Y) <= 2,
+            2_000,
+            requiredConsecutiveMatches: 5,
+            pollIntervalMS: 100);
+        Assert.IsTrue(stopped.Succeeded, "The cursor continued gliding after Escape.");
+    }
+
+    private static void AssertCrosshairsAt(int cursorX, int cursorY)
+    {
+        var result = WaitHelper.WaitForStable(
+            () => new[]
+            {
+                WindowHelper.GetPixelColorHex(cursorX - 60, cursorY),
+                WindowHelper.GetPixelColorHex(cursorX + 60, cursorY),
+                WindowHelper.GetPixelColorHex(cursorX, cursorY - 60),
+                WindowHelper.GetPixelColorHex(cursorX, cursorY + 60),
+            },
+            colors => colors is not null && colors.All(color => color.Equals(CrosshairsColor, StringComparison.OrdinalIgnoreCase)),
+            timeoutMS: 5_000,
+            requiredConsecutiveMatches: 3,
+            pollIntervalMS: 100);
+
+        Assert.IsTrue(
+            result.Succeeded,
+            $"Expected red Crosshairs arms around ({cursorX},{cursorY}); last samples: {string.Join(", ", result.LastObservation ?? Array.Empty<string>())}");
+    }
+
+    private static CrosshairsOrigin AssertCrosshairsNear(int cursorX, int cursorY)
+    {
+        const int searchRadius = 80;
+        const int maximumLag = 64;
+        var result = WaitHelper.WaitForStable(
+            () => FindCrosshairsOriginNear(cursorX, cursorY, searchRadius),
+            origin => origin is not null &&
+                Math.Abs(origin.X - cursorX) <= maximumLag &&
+                Math.Abs(origin.Y - cursorY) <= maximumLag,
+            timeoutMS: 5_000,
+            requiredConsecutiveMatches: 1,
+            pollIntervalMS: 100);
+
+        Assert.IsTrue(
+            result.Succeeded,
+            $"Expected Crosshairs within {maximumLag}px of ({cursorX},{cursorY}); last observed origin: {result.LastObservation}.");
+        return result.LastObservation!;
+    }
+
+    private static CrosshairsOrigin? FindCrosshairsOriginNear(int cursorX, int cursorY, int searchRadius)
+    {
+        var verticalProbeY = cursorY - searchRadius;
+        var horizontalProbeX = cursorX - searchRadius;
+        var verticalPixels = new List<int>();
+        var horizontalPixels = new List<int>();
+
+        for (var offset = -searchRadius; offset <= searchRadius; offset += 2)
+        {
+            if (WindowHelper.GetPixelColorHex(cursorX + offset, verticalProbeY).Equals(CrosshairsColor, StringComparison.OrdinalIgnoreCase))
+            {
+                verticalPixels.Add(cursorX + offset);
+            }
+
+            if (WindowHelper.GetPixelColorHex(horizontalProbeX, cursorY + offset).Equals(CrosshairsColor, StringComparison.OrdinalIgnoreCase))
+            {
+                horizontalPixels.Add(cursorY + offset);
+            }
+        }
+
+        return verticalPixels.Count > 0 && horizontalPixels.Count > 0
+            ? new CrosshairsOrigin((int)verticalPixels.Average(), (int)horizontalPixels.Average())
+            : null;
+    }
+
+    private static Color Blend(Color foreground, Color background, int alpha)
+    {
+        var inverse = 255 - alpha;
+        return Color.FromArgb(
+            ((foreground.R * alpha) + (background.R * inverse) + 127) / 255,
+            ((foreground.G * alpha) + (background.G * inverse) + 127) / 255,
+            ((foreground.B * alpha) + (background.B * inverse) + 127) / 255);
+    }
+
+    private static bool IsNear(Color actual, Color expected, int tolerance) =>
+        Math.Abs(actual.R - expected.R) <= tolerance &&
+        Math.Abs(actual.G - expected.G) <= tolerance &&
+        Math.Abs(actual.B - expected.B) <= tolerance;
+
+    private static string CreateSettings(CrosshairsConfiguration configuration) => $$"""
+                {
+                    "name": "MousePointerCrosshairs",
+                    "version": "1.0",
+                    "properties": {
+                        "activation_shortcut": { "win": true, "ctrl": false, "alt": true, "shift": false, "code": {{configuration.ShortcutCode}}, "key": "" },
+                        "gliding_cursor_activation_shortcut": { "win": true, "ctrl": false, "alt": true, "shift": false, "code": 190, "key": "" },
+                        "crosshairs_color": { "value": "{{configuration.Color}}" },
+                        "crosshairs_opacity": { "value": {{configuration.Opacity}} },
+                        "crosshairs_radius": { "value": {{configuration.Radius}} },
+                        "crosshairs_thickness": { "value": {{configuration.Thickness}} },
+                        "crosshairs_border_color": { "value": "{{configuration.BorderColor}}" },
+                        "crosshairs_border_size": { "value": {{configuration.BorderSize}} },
+                        "crosshairs_orientation": { "value": {{configuration.Orientation}} },
+                        "crosshairs_auto_hide": { "value": {{configuration.AutoHide.ToString().ToLowerInvariant()}} },
+                        "crosshairs_is_fixed_length_enabled": { "value": {{configuration.FixedLengthEnabled.ToString().ToLowerInvariant()}} },
+                        "crosshairs_fixed_length": { "value": {{configuration.FixedLength}} },
+                        "auto_activate": { "value": {{configuration.AutoActivate.ToString().ToLowerInvariant()}} },
+                        "gliding_travel_speed": { "value": 25 },
+                        "gliding_delay_speed": { "value": 5 }
+                    }
+                }
+                """;
+
+    private sealed record CrosshairsOrigin(int X, int Y);
+
+    private sealed record CrosshairsConfiguration(
+        int ShortcutCode = (int)Key.P,
+        string Color = "#FF0000",
+        int Opacity = 100,
+        int Radius = 20,
+        int Thickness = 9,
+        string BorderColor = "#00FF00",
+        int BorderSize = 0,
+        int Orientation = 0,
+        bool AutoHide = false,
+        bool FixedLengthEnabled = false,
+        int FixedLength = 100,
+        bool AutoActivate = false);
+}

--- a/src/modules/MouseUtils/MouseUtils.UITests.Next/MouseUtils.UITests.Next.csproj
+++ b/src/modules/MouseUtils/MouseUtils.UITests.Next/MouseUtils.UITests.Next.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- Look at Directory.Build.props in root for common stuff as well -->
+  <Import Project="$(RepoRoot)src\Common.Dotnet.CsWinRT.props" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <RootNamespace>MouseUtils.UITests</RootNamespace>
+    <AssemblyName>MouseUtils.UITests.Next</AssemblyName>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+
+    <IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+
+    <!-- UI tests need a live desktop; never run them as part of MSBuild. -->
+    <RunVSTest>false</RunVSTest>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputPath>$(RepoRoot)$(Platform)\$(Configuration)\tests\MouseUtils.UITests.Next\</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\common\UITestAutomation.Next\UITestAutomation.Next.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/modules/MouseUtils/MouseUtils.UITests.Next/MouseUtilsTestHelper.cs
+++ b/src/modules/MouseUtils/MouseUtils.UITests.Next/MouseUtilsTestHelper.cs
@@ -2,6 +2,8 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Text.Json.Nodes;
@@ -65,6 +67,58 @@ internal static class MouseUtilsTestHelper
 
         Assert.Fail($"{toggleId} did not reach {expectedState} after three coordinate-free attempts.");
         return toggle!;
+    }
+
+    internal static void EnsureModuleStateApplied(
+        UITestBase testBase,
+        string moduleName,
+        bool enabled,
+        Func<bool> waitForRuntimeState,
+        string failureMessage)
+    {
+        var runnerProcesses = GetProcessStartTimes(PowerToysModule.Runner);
+        var settingsProcesses = GetProcessStartTimes(PowerToysModule.PowerToysSettings);
+        var settingsPipeRejected = HasUnsignedSettingsPipeRejection(runnerProcesses, settingsProcesses);
+
+        if (!settingsPipeRejected)
+        {
+            if (waitForRuntimeState())
+            {
+                return;
+            }
+
+            runnerProcesses = GetProcessStartTimes(PowerToysModule.Runner);
+            settingsProcesses = GetProcessStartTimes(PowerToysModule.PowerToysSettings);
+            settingsPipeRejected = HasUnsignedSettingsPipeRejection(runnerProcesses, settingsProcesses);
+        }
+
+        if (!settingsPipeRejected)
+        {
+            Assert.Fail(failureMessage);
+            return;
+        }
+
+        if (WaitForModuleEnabledSetting(moduleName, enabled))
+        {
+            Assert.IsTrue(waitForRuntimeState(), failureMessage);
+            return;
+        }
+
+        var persistedState = WaitForReadableModuleEnabledSetting(moduleName);
+        Assert.IsTrue(
+            persistedState.HasValue,
+            $"Could not read enabled.{moduleName} after the Settings pipe client was rejected.");
+        Assert.AreEqual(
+            !enabled,
+            persistedState.Value,
+            $"enabled.{moduleName} reached an unexpected state after the Settings pipe client was rejected.");
+
+        Step(testBase, $"The Release runner rejected the test-signed Settings pipe client; seeding and restarting it to apply enabled.{moduleName}={enabled.ToString().ToLowerInvariant()}");
+        testBase.RestartScope(enabled ? [moduleName] : []);
+        Assert.IsTrue(
+            waitForRuntimeState(),
+            $"{failureMessage} The persisted state was not applied after restarting the runner.");
+        NavigateToMouseUtilities(testBase);
     }
 
     internal static WindowControl.ProcessWindow WaitForWindowClass(string className, int timeoutMs = 10_000)
@@ -239,6 +293,117 @@ internal static class MouseUtilsTestHelper
 
     internal static void Step(UITestBase testBase, string message) =>
         testBase.TestContext.WriteLine($"[{DateTime.UtcNow:HH:mm:ss.fff}] {message}");
+
+    private static Dictionary<int, DateTime> GetProcessStartTimes(PowerToysModule module)
+    {
+        var processes = new Dictionary<int, DateTime>();
+        foreach (var process in Process.GetProcessesByName(SessionHelper.GetProcessName(module)))
+        {
+            using (process)
+            {
+                try
+                {
+                    processes[process.Id] = process.StartTime;
+                }
+                catch (Exception ex) when (ex is InvalidOperationException or System.ComponentModel.Win32Exception)
+                {
+                }
+            }
+        }
+
+        return processes;
+    }
+
+    private static bool HasUnsignedSettingsPipeRejection(
+        IReadOnlyDictionary<int, DateTime> runnerProcesses,
+        IReadOnlyDictionary<int, DateTime> settingsProcesses)
+    {
+        if (runnerProcesses.Count == 0 || settingsProcesses.Count == 0)
+        {
+            return false;
+        }
+
+        var runnerLogs = Path.Combine(SettingsConfigHelper.PowerToysSettingsRoot, "RunnerLogs");
+        if (!Directory.Exists(runnerLogs))
+        {
+            return false;
+        }
+
+        foreach (var path in Directory.EnumerateFiles(runnerLogs, "runner-log*.log"))
+        {
+            try
+            {
+                using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+                using var reader = new StreamReader(stream);
+                while (reader.ReadLine() is { } line)
+                {
+                    if (line.Contains("Rejected unauthenticated Settings pipe client", StringComparison.Ordinal) &&
+                        line.Contains("reason=not-microsoft-signed", StringComparison.Ordinal) &&
+                        TryReadLogTimestamp(line, out var timestamp) &&
+                        runnerProcesses.Any(process =>
+                            timestamp >= process.Value.AddSeconds(-1) &&
+                            line.Contains($"[p-{process.Key}]", StringComparison.Ordinal)) &&
+                        settingsProcesses.Any(process =>
+                            timestamp >= process.Value.AddSeconds(-1) &&
+                            line.Contains($"pid={process.Key} ", StringComparison.Ordinal)))
+                    {
+                        return true;
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryReadLogTimestamp(string line, out DateTime timestamp)
+    {
+        const int timestampLength = 26;
+        timestamp = default;
+        return line.Length > timestampLength + 1 &&
+               DateTime.TryParseExact(
+                   line.AsSpan(1, timestampLength),
+                   "yyyy-MM-dd HH:mm:ss.ffffff",
+                   CultureInfo.InvariantCulture,
+                   DateTimeStyles.AssumeLocal,
+                   out timestamp);
+    }
+
+    private static bool WaitForModuleEnabledSetting(string moduleName, bool enabled) =>
+        WaitHelper.WaitForStable(
+            () => ReadModuleEnabledSetting(moduleName),
+            value => value == enabled,
+            5_000,
+            requiredConsecutiveMatches: 2,
+            pollIntervalMS: 100).Succeeded;
+
+    private static bool? WaitForReadableModuleEnabledSetting(string moduleName)
+    {
+        var result = WaitHelper.WaitForStable(
+            () => ReadModuleEnabledSetting(moduleName),
+            value => value.HasValue,
+            2_000,
+            requiredConsecutiveMatches: 2,
+            pollIntervalMS: 100);
+        return result.Succeeded ? result.LastObservation : null;
+    }
+
+    private static bool? ReadModuleEnabledSetting(string moduleName)
+    {
+        try
+        {
+            var path = Path.Combine(SettingsConfigHelper.PowerToysSettingsRoot, "settings.json");
+            var root = JsonNode.Parse(File.ReadAllText(path));
+            return root?["enabled"]?[moduleName]?.GetValue<bool>();
+        }
+        catch
+        {
+            return null;
+        }
+    }
 
     [DllImport("user32.dll", EntryPoint = "SystemParametersInfoW", SetLastError = true)]
     private static extern bool SystemParametersInfo(int uiAction, int uiParam, ref int pvParam, int fWinIni);

--- a/src/modules/MouseUtils/MouseUtils.UITests.Next/MouseUtilsTestHelper.cs
+++ b/src/modules/MouseUtils/MouseUtils.UITests.Next/MouseUtilsTestHelper.cs
@@ -1,0 +1,268 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
+using System.Text.Json.Nodes;
+using Microsoft.PowerToys.UITest.Next;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MouseUtils.UITests;
+
+internal static class MouseUtilsTestHelper
+{
+    private static readonly string[] ShortcutSeparators = [" + ", "+", " "];
+
+    internal const string InputOutputNavItemId = "InputOutputNavItem";
+    internal const string MouseUtilitiesNavItemId = "MouseUtilitiesNavItem";
+
+    internal static void NavigateToMouseUtilities(UITestBase testBase)
+    {
+        Step(testBase, "Navigating to Mouse Utilities settings");
+        if (!testBase.Session.Has(By.AccessibilityId(MouseUtilitiesNavItemId), 500))
+        {
+            testBase.Session.Find<NavigationViewItem>(By.AccessibilityId(InputOutputNavItemId), 5_000).Click(msPostAction: 500);
+        }
+
+        testBase.Session.Find<NavigationViewItem>(By.AccessibilityId(MouseUtilitiesNavItemId), 5_000).Click(msPostAction: 800);
+    }
+
+    internal static ToggleSwitch SetModuleEnabled(UITestBase testBase, string toggleId, bool enabled)
+    {
+        Step(testBase, $"Setting {toggleId} to {(enabled ? "On" : "Off")}");
+        var expectedState = enabled ? "On" : "Off";
+        ToggleSwitch? toggle = null;
+        for (var attempt = 1; attempt <= 3; attempt++)
+        {
+            toggle = testBase.Session.Find<ToggleSwitch>(By.AccessibilityId(toggleId), 10_000);
+            var actualState = toggle.GetProperty("ToggleState");
+            if (actualState.Equals(expectedState, StringComparison.OrdinalIgnoreCase))
+            {
+                return toggle;
+            }
+
+            var oppositeState = enabled ? "Off" : "On";
+            if (!actualState.Equals(oppositeState, StringComparison.OrdinalIgnoreCase))
+            {
+                Step(testBase, $"{toggleId} returned unreadable ToggleState '{actualState}' on attempt {attempt}/3; reacquiring it");
+                if (toggle.WaitForProperty("ToggleState", expectedState, 3_000))
+                {
+                    return toggle;
+                }
+
+                continue;
+            }
+
+            toggle.Invoke(msPostAction: 500);
+            if (toggle.WaitForProperty("ToggleState", expectedState, 15_000))
+            {
+                return toggle;
+            }
+
+            Step(testBase, $"{toggleId} did not reach {expectedState} on attempt {attempt}/3; reacquiring it");
+        }
+
+        Assert.Fail($"{toggleId} did not reach {expectedState} after three coordinate-free attempts.");
+        return toggle!;
+    }
+
+    internal static WindowControl.ProcessWindow WaitForWindowClass(string className, int timeoutMs = 10_000)
+    {
+        var result = WaitHelper.WaitForStable(
+            () => WindowControl.EnumerateAllWindows().FirstOrDefault(window =>
+                window.ClassName.Equals(className, StringComparison.OrdinalIgnoreCase)),
+            window => window.Hwnd != IntPtr.Zero,
+            timeoutMs,
+            requiredConsecutiveMatches: 2,
+            pollIntervalMS: 100);
+
+        Assert.IsTrue(result.Succeeded, $"Top-level window class '{className}' did not appear within {timeoutMs} ms.");
+        return result.LastObservation;
+    }
+
+    internal static Key[] ReadShortcut(UITestBase testBase, string groupId, int ordinal = 0)
+    {
+        Element? group = null;
+        for (var attempt = 0; attempt < 12 && group is null; attempt++)
+        {
+            group = testBase.Session.FindAll<Element>(By.AccessibilityId(groupId), 0).FirstOrDefault();
+            if (group is null)
+            {
+                MouseHelper.ScrollDown();
+                Thread.Sleep(150);
+            }
+        }
+
+        Assert.IsNotNull(group, $"Settings group '{groupId}' was not found after scrolling the Mouse Utilities page.");
+        group.ScrollIntoView();
+        var buttons = testBase.Session.FindAll<Button>(By.AccessibilityId("EditButton"), 5_000)
+            .Where(button =>
+                button.X >= group!.X &&
+                button.X < group.X + group.Width &&
+                button.Y >= group.Y &&
+                button.Y < group.Y + group.Height)
+            .OrderBy(button => button.Y)
+            .ToList();
+
+        Assert.IsTrue(
+            buttons.Count > ordinal,
+            $"Expected shortcut button {ordinal} inside '{groupId}', but found {buttons.Count}.");
+
+        var shortcutText = buttons[ordinal].HelpText;
+        var keys = ParseShortcutText(shortcutText);
+        Assert.IsTrue(
+            keys.Any(key => key is not (Key.LWin or Key.Ctrl or Key.Shift or Key.Alt)),
+            $"Shortcut text '{shortcutText}' from '{groupId}' did not contain a main key.");
+        Step(testBase, $"Shortcut from {groupId}: '{shortcutText}' => [{string.Join(", ", keys)}]");
+        return keys;
+    }
+
+    internal static Key[] ParseShortcutText(string shortcutText)
+    {
+        var keys = new List<Key>();
+        foreach (var raw in shortcutText.Split(ShortcutSeparators, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var token = raw.Trim();
+            Key? key = token.ToLowerInvariant() switch
+            {
+                "win" or "windows" => Key.LWin,
+                "ctrl" or "control" => Key.Ctrl,
+                "shift" => Key.Shift,
+                "alt" => Key.Alt,
+                _ when token.Length == 1 && token[0] is >= '0' and <= '9' =>
+                    Enum.TryParse<Key>("Num" + token, out var number) ? number : null,
+                _ when token.Length > 0 && char.IsLetter(token[0]) && Enum.TryParse<Key>(token, true, out var parsed) => parsed,
+                _ => null,
+            };
+
+            if (key.HasValue)
+            {
+                keys.Add(key.Value);
+            }
+        }
+
+        return keys.ToArray();
+    }
+
+    internal static void ReplaceModuleSettings(string moduleName, string settingsJson)
+    {
+        SettingsConfigHelper.UpdateModuleSettings(
+            moduleName,
+            settingsJson,
+            current =>
+            {
+                var desired = JsonNode.Parse(settingsJson)?.AsObject()
+                    ?? throw new InvalidOperationException($"Settings seed for '{moduleName}' is not a JSON object.");
+                current.Clear();
+                foreach (var property in desired)
+                {
+                    current[property.Key] = property.Value?.DeepClone();
+                }
+            });
+    }
+
+    internal static void RunWithClientAreaAnimationsEnabled(Action action)
+    {
+        const int spiGetClientAreaAnimation = 0x1042;
+        const int spiSetClientAreaAnimation = 0x1043;
+        var originalValue = 0;
+        Assert.IsTrue(
+            SystemParametersInfo(spiGetClientAreaAnimation, 0, ref originalValue, 0),
+            "Could not read the Windows client-area animation setting.");
+
+        Exception? actionFailure = null;
+        try
+        {
+            if (originalValue == 0)
+            {
+                var enabled = 1;
+                Assert.IsTrue(
+                    SystemParametersInfo(spiSetClientAreaAnimation, 0, ref enabled, 0),
+                    "Could not enable Windows client-area animations for the timing fixture.");
+            }
+
+            action();
+        }
+        catch (Exception ex)
+        {
+            actionFailure = ex;
+        }
+
+        var restored = true;
+        var restoreError = 0;
+        if (originalValue == 0)
+        {
+            var disabled = 0;
+            restored = SystemParametersInfo(spiSetClientAreaAnimation, 0, ref disabled, 0);
+            if (!restored)
+            {
+                restoreError = Marshal.GetLastWin32Error();
+            }
+        }
+
+        if (actionFailure is not null)
+        {
+            if (!restored)
+            {
+                throw new AggregateException(
+                    "The test action failed and the Windows client-area animation setting could not be restored.",
+                    actionFailure,
+                    new InvalidOperationException($"SystemParametersInfoW failed with Win32 error {restoreError}."));
+            }
+
+            ExceptionDispatchInfo.Capture(actionFailure).Throw();
+        }
+
+        Assert.IsTrue(restored, $"Could not restore the Windows client-area animation setting. Win32 error: {restoreError}.");
+    }
+
+    internal static IDisposable PreserveClientAreaAnimationsEnabled()
+    {
+        const int spiGetClientAreaAnimation = 0x1042;
+        const int spiSetClientAreaAnimation = 0x1043;
+        var originalValue = 0;
+        Assert.IsTrue(
+            SystemParametersInfo(spiGetClientAreaAnimation, 0, ref originalValue, 0),
+            "Could not read the Windows client-area animation setting before module launch.");
+
+        if (originalValue == 0)
+        {
+            var enabled = 1;
+            Assert.IsTrue(
+                SystemParametersInfo(spiSetClientAreaAnimation, 0, ref enabled, 0),
+                "Could not enable Windows client-area animations before module launch.");
+        }
+
+        return new ClientAreaAnimationsSnapshot(originalValue);
+    }
+
+    internal static void Step(UITestBase testBase, string message) =>
+        testBase.TestContext.WriteLine($"[{DateTime.UtcNow:HH:mm:ss.fff}] {message}");
+
+    [DllImport("user32.dll", EntryPoint = "SystemParametersInfoW", SetLastError = true)]
+    private static extern bool SystemParametersInfo(int uiAction, int uiParam, ref int pvParam, int fWinIni);
+
+    private sealed class ClientAreaAnimationsSnapshot(int originalValue) : IDisposable
+    {
+        private bool disposed;
+
+        public void Dispose()
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            disposed = true;
+            if (originalValue == 0)
+            {
+                const int spiSetClientAreaAnimation = 0x1043;
+                var disabled = 0;
+                var restored = SystemParametersInfo(spiSetClientAreaAnimation, 0, ref disabled, 0);
+                var error = restored ? 0 : Marshal.GetLastWin32Error();
+                Assert.IsTrue(restored, $"Could not restore the Windows client-area animation setting after the test class. Win32 error: {error}.");
+            }
+        }
+    }
+}

--- a/src/modules/MouseUtils/MouseUtils.UITests.Next/MouseUtilsTestHelper.cs
+++ b/src/modules/MouseUtils/MouseUtils.UITests.Next/MouseUtilsTestHelper.cs
@@ -2,6 +2,8 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+using System.Drawing;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Text.Json.Nodes;
@@ -12,7 +14,8 @@ namespace MouseUtils.UITests;
 
 internal static class MouseUtilsTestHelper
 {
-    private static readonly string[] ShortcutSeparators = [" + ", "+", " "];
+    private const int SpiGetClientAreaAnimation = 0x1042;
+    private const int SpiSetClientAreaAnimation = 0x1043;
 
     internal const string InputOutputNavItemId = "InputOutputNavItem";
     internal const string MouseUtilitiesNavItemId = "MouseUtilitiesNavItem";
@@ -81,70 +84,6 @@ internal static class MouseUtilsTestHelper
         return result.LastObservation;
     }
 
-    internal static Key[] ReadShortcut(UITestBase testBase, string groupId, int ordinal = 0)
-    {
-        Element? group = null;
-        for (var attempt = 0; attempt < 12 && group is null; attempt++)
-        {
-            group = testBase.Session.FindAll<Element>(By.AccessibilityId(groupId), 0).FirstOrDefault();
-            if (group is null)
-            {
-                MouseHelper.ScrollDown();
-                Thread.Sleep(150);
-            }
-        }
-
-        Assert.IsNotNull(group, $"Settings group '{groupId}' was not found after scrolling the Mouse Utilities page.");
-        group.ScrollIntoView();
-        var buttons = testBase.Session.FindAll<Button>(By.AccessibilityId("EditButton"), 5_000)
-            .Where(button =>
-                button.X >= group!.X &&
-                button.X < group.X + group.Width &&
-                button.Y >= group.Y &&
-                button.Y < group.Y + group.Height)
-            .OrderBy(button => button.Y)
-            .ToList();
-
-        Assert.IsTrue(
-            buttons.Count > ordinal,
-            $"Expected shortcut button {ordinal} inside '{groupId}', but found {buttons.Count}.");
-
-        var shortcutText = buttons[ordinal].HelpText;
-        var keys = ParseShortcutText(shortcutText);
-        Assert.IsTrue(
-            keys.Any(key => key is not (Key.LWin or Key.Ctrl or Key.Shift or Key.Alt)),
-            $"Shortcut text '{shortcutText}' from '{groupId}' did not contain a main key.");
-        Step(testBase, $"Shortcut from {groupId}: '{shortcutText}' => [{string.Join(", ", keys)}]");
-        return keys;
-    }
-
-    internal static Key[] ParseShortcutText(string shortcutText)
-    {
-        var keys = new List<Key>();
-        foreach (var raw in shortcutText.Split(ShortcutSeparators, StringSplitOptions.RemoveEmptyEntries))
-        {
-            var token = raw.Trim();
-            Key? key = token.ToLowerInvariant() switch
-            {
-                "win" or "windows" => Key.LWin,
-                "ctrl" or "control" => Key.Ctrl,
-                "shift" => Key.Shift,
-                "alt" => Key.Alt,
-                _ when token.Length == 1 && token[0] is >= '0' and <= '9' =>
-                    Enum.TryParse<Key>("Num" + token, out var number) ? number : null,
-                _ when token.Length > 0 && char.IsLetter(token[0]) && Enum.TryParse<Key>(token, true, out var parsed) => parsed,
-                _ => null,
-            };
-
-            if (key.HasValue)
-            {
-                keys.Add(key.Value);
-            }
-        }
-
-        return keys.ToArray();
-    }
-
     internal static void ReplaceModuleSettings(string moduleName, string settingsJson)
     {
         SettingsConfigHelper.UpdateModuleSettings(
@@ -163,25 +102,13 @@ internal static class MouseUtilsTestHelper
     }
 
     internal static void RunWithClientAreaAnimationsEnabled(Action action)
-    {
-        const int spiGetClientAreaAnimation = 0x1042;
-        const int spiSetClientAreaAnimation = 0x1043;
-        var originalValue = 0;
-        Assert.IsTrue(
-            SystemParametersInfo(spiGetClientAreaAnimation, 0, ref originalValue, 0),
-            "Could not read the Windows client-area animation setting.");
+        => RunWithCleanup(action, PreserveClientAreaAnimationsEnabled());
 
+    private static void RunWithCleanup(Action action, IDisposable cleanup)
+    {
         Exception? actionFailure = null;
         try
         {
-            if (originalValue == 0)
-            {
-                var enabled = 1;
-                Assert.IsTrue(
-                    SystemParametersInfo(spiSetClientAreaAnimation, 0, ref enabled, 0),
-                    "Could not enable Windows client-area animations for the timing fixture.");
-            }
-
             action();
         }
         catch (Exception ex)
@@ -189,48 +116,271 @@ internal static class MouseUtilsTestHelper
             actionFailure = ex;
         }
 
-        var restored = true;
-        var restoreError = 0;
-        if (originalValue == 0)
+        Exception? restoreFailure = null;
+        try
         {
-            var disabled = 0;
-            restored = SystemParametersInfo(spiSetClientAreaAnimation, 0, ref disabled, 0);
-            if (!restored)
-            {
-                restoreError = Marshal.GetLastWin32Error();
-            }
+            cleanup.Dispose();
+        }
+        catch (Exception ex)
+        {
+            restoreFailure = ex;
         }
 
         if (actionFailure is not null)
         {
-            if (!restored)
+            if (restoreFailure is not null)
             {
                 throw new AggregateException(
                     "The test action failed and the Windows client-area animation setting could not be restored.",
                     actionFailure,
-                    new InvalidOperationException($"SystemParametersInfoW failed with Win32 error {restoreError}."));
+                    restoreFailure);
             }
 
             ExceptionDispatchInfo.Capture(actionFailure).Throw();
         }
 
-        Assert.IsTrue(restored, $"Could not restore the Windows client-area animation setting. Win32 error: {restoreError}.");
+        if (restoreFailure is not null)
+        {
+            ExceptionDispatchInfo.Capture(restoreFailure).Throw();
+        }
+    }
+
+    internal static void DisposeAll(params IDisposable?[] snapshots)
+    {
+        var failures = new List<Exception>();
+        foreach (var snapshot in snapshots)
+        {
+            try
+            {
+                snapshot?.Dispose();
+            }
+            catch (Exception ex)
+            {
+                failures.Add(ex);
+            }
+        }
+
+        if (failures.Count == 1)
+        {
+            ExceptionDispatchInfo.Capture(failures[0]).Throw();
+        }
+
+        if (failures.Count > 1)
+        {
+            throw new AggregateException("Multiple Mouse Utils test-state restorations failed.", failures);
+        }
+    }
+
+    internal static Color Blend(Color foreground, Color background, int alpha)
+    {
+        var inverse = 255 - alpha;
+        return Color.FromArgb(
+            ((foreground.R * alpha) + (background.R * inverse) + 127) / 255,
+            ((foreground.G * alpha) + (background.G * inverse) + 127) / 255,
+            ((foreground.B * alpha) + (background.B * inverse) + 127) / 255);
+    }
+
+    internal static Color GetStablePixel(int x, int y)
+    {
+        Color? previous = null;
+        var result = WaitHelper.WaitForStable(
+            () => WindowHelper.GetPixelColor(x, y),
+            color =>
+            {
+                var matchesPrevious = previous.HasValue && color.ToArgb() == previous.Value.ToArgb();
+                previous = color;
+                return matchesPrevious;
+            },
+            2_000,
+            requiredConsecutiveMatches: 4,
+            pollIntervalMS: 100);
+        return result.LastObservation;
+    }
+
+    internal static void AssertPixelNear(int x, int y, Color expected, int tolerance, string description)
+    {
+        var result = WaitHelper.WaitForStable(
+            () => WindowHelper.GetPixelColor(x, y),
+            actual => IsNear(actual, expected, tolerance),
+            5_000,
+            requiredConsecutiveMatches: 2,
+            pollIntervalMS: 100);
+        Assert.IsTrue(
+            result.Succeeded,
+            $"Unexpected {description} at ({x},{y}). Expected {expected}; observed {result.LastObservation}.");
+    }
+
+    internal static bool IsNear(Color actual, Color expected, int tolerance) =>
+        Math.Abs(actual.R - expected.R) <= tolerance &&
+        Math.Abs(actual.G - expected.G) <= tolerance &&
+        Math.Abs(actual.B - expected.B) <= tolerance;
+
+    internal static double Distance(int x1, int y1, int x2, int y2)
+    {
+        var deltaX = x2 - x1;
+        var deltaY = y2 - y1;
+        return Math.Sqrt((deltaX * deltaX) + (deltaY * deltaY));
+    }
+
+    internal sealed class NotepadFixture : IDisposable
+    {
+        private const string ProcessName = "notepad";
+        private readonly string filePath;
+        private readonly bool ownsProcess;
+        private bool disposed;
+
+        private NotepadFixture(string filePath, Session window, bool ownsProcess)
+        {
+            this.filePath = filePath;
+            Window = window;
+            this.ownsProcess = ownsProcess;
+        }
+
+        internal Session Window { get; }
+
+        internal static NotepadFixture Start()
+        {
+            var existingProcessIds = GetProcessIds();
+            var filePath = Path.Combine(Path.GetTempPath(), $"PowerToys-MouseUtils-{Guid.NewGuid():N}.txt");
+            File.WriteAllText(filePath, string.Empty);
+            var fileName = Path.GetFileName(filePath);
+            var baseFileName = Path.GetFileNameWithoutExtension(filePath);
+
+            try
+            {
+                Session? window = null;
+                for (var attempt = 1; attempt <= 2 && window is null; attempt++)
+                {
+                    using var launcher = Process.Start(new ProcessStartInfo
+                    {
+                        FileName = "notepad.exe",
+                        Arguments = $"\"{filePath}\"",
+                        UseShellExecute = true,
+                    });
+                    Assert.IsNotNull(launcher, "Could not start the Notepad fixture.");
+                    window = WindowsFinder.WaitForWindowByApp(
+                        ProcessName,
+                        candidate =>
+                            candidate.Title.Contains(fileName, StringComparison.OrdinalIgnoreCase) ||
+                            candidate.Title.Contains($"{baseFileName} - Notepad", StringComparison.OrdinalIgnoreCase),
+                        timeoutMS: 15_000);
+                }
+
+                Assert.IsNotNull(window, $"Notepad did not open the unique fixture document '{fileName}'.");
+                return new NotepadFixture(filePath, window, !existingProcessIds.Contains(window.ProcessId));
+            }
+            catch
+            {
+                File.Delete(filePath);
+                throw;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            disposed = true;
+            var closed = CloseDocumentTab();
+            if (!closed && ownsProcess)
+            {
+                try
+                {
+                    using var process = Process.GetProcessById(Window.ProcessId);
+                    process.Kill(entireProcessTree: true);
+                    process.WaitForExit(5_000);
+                    closed = true;
+                }
+                catch
+                {
+                }
+            }
+
+            if (closed)
+            {
+                try
+                {
+                    File.Delete(filePath);
+                }
+                catch (IOException)
+                {
+                }
+                catch (UnauthorizedAccessException)
+                {
+                }
+            }
+        }
+
+        private bool CloseDocumentTab()
+        {
+            var windowHandle = new IntPtr(Window.WindowHandle);
+            if (!WindowControl.WaitForForeground(windowHandle, 3_000, requiredConsecutiveMatches: 2))
+            {
+                return false;
+            }
+
+            try
+            {
+                KeyboardHelper.PressKey(Key.Ctrl);
+                Thread.Sleep(50);
+                KeyboardHelper.SendKey(Key.W);
+            }
+            finally
+            {
+                KeyboardHelper.ReleaseKey(Key.Ctrl);
+            }
+
+            var deadline = DateTime.UtcNow.AddSeconds(3);
+            while (DateTime.UtcNow < deadline)
+            {
+                if (!IsOpen())
+                {
+                    return true;
+                }
+
+                Thread.Sleep(100);
+            }
+
+            return !IsOpen();
+        }
+
+        private bool IsOpen() => WindowsFinder.ListByApp(ProcessName).Any(candidate =>
+            candidate.Hwnd == Window.WindowHandle &&
+            (candidate.Title.Contains(Path.GetFileName(filePath), StringComparison.OrdinalIgnoreCase) ||
+             candidate.Title.Contains(Path.GetFileNameWithoutExtension(filePath), StringComparison.OrdinalIgnoreCase)));
+
+        private static HashSet<int> GetProcessIds()
+        {
+            var processes = Process.GetProcessesByName(ProcessName);
+            try
+            {
+                return processes.Select(process => process.Id).ToHashSet();
+            }
+            finally
+            {
+                foreach (var process in processes)
+                {
+                    process.Dispose();
+                }
+            }
+        }
     }
 
     internal static IDisposable PreserveClientAreaAnimationsEnabled()
     {
-        const int spiGetClientAreaAnimation = 0x1042;
-        const int spiSetClientAreaAnimation = 0x1043;
         var originalValue = 0;
         Assert.IsTrue(
-            SystemParametersInfo(spiGetClientAreaAnimation, 0, ref originalValue, 0),
+            SystemParametersInfo(SpiGetClientAreaAnimation, 0, ref originalValue, 0),
             "Could not read the Windows client-area animation setting before module launch.");
 
         if (originalValue == 0)
         {
             var enabled = 1;
             Assert.IsTrue(
-                SystemParametersInfo(spiSetClientAreaAnimation, 0, ref enabled, 0),
+                SystemParametersInfo(SpiSetClientAreaAnimation, 0, ref enabled, 0),
                 "Could not enable Windows client-area animations before module launch.");
         }
 
@@ -257,11 +407,13 @@ internal static class MouseUtilsTestHelper
             disposed = true;
             if (originalValue == 0)
             {
-                const int spiSetClientAreaAnimation = 0x1043;
                 var disabled = 0;
-                var restored = SystemParametersInfo(spiSetClientAreaAnimation, 0, ref disabled, 0);
-                var error = restored ? 0 : Marshal.GetLastWin32Error();
-                Assert.IsTrue(restored, $"Could not restore the Windows client-area animation setting after the test class. Win32 error: {error}.");
+                var restored = SystemParametersInfo(SpiSetClientAreaAnimation, 0, ref disabled, 0);
+                if (!restored)
+                {
+                    throw new InvalidOperationException(
+                        $"Could not restore the Windows client-area animation setting. Win32 error: {Marshal.GetLastWin32Error()}.");
+                }
             }
         }
     }

--- a/src/modules/MouseUtils/MouseUtils.UITests.Next/MouseUtilsTestHelper.cs
+++ b/src/modules/MouseUtils/MouseUtils.UITests.Next/MouseUtilsTestHelper.cs
@@ -2,8 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
-using System.Globalization;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Text.Json.Nodes;
@@ -67,58 +65,6 @@ internal static class MouseUtilsTestHelper
 
         Assert.Fail($"{toggleId} did not reach {expectedState} after three coordinate-free attempts.");
         return toggle!;
-    }
-
-    internal static void EnsureModuleStateApplied(
-        UITestBase testBase,
-        string moduleName,
-        bool enabled,
-        Func<bool> waitForRuntimeState,
-        string failureMessage)
-    {
-        var runnerProcesses = GetProcessStartTimes(PowerToysModule.Runner);
-        var settingsProcesses = GetProcessStartTimes(PowerToysModule.PowerToysSettings);
-        var settingsPipeRejected = HasUnsignedSettingsPipeRejection(runnerProcesses, settingsProcesses);
-
-        if (!settingsPipeRejected)
-        {
-            if (waitForRuntimeState())
-            {
-                return;
-            }
-
-            runnerProcesses = GetProcessStartTimes(PowerToysModule.Runner);
-            settingsProcesses = GetProcessStartTimes(PowerToysModule.PowerToysSettings);
-            settingsPipeRejected = HasUnsignedSettingsPipeRejection(runnerProcesses, settingsProcesses);
-        }
-
-        if (!settingsPipeRejected)
-        {
-            Assert.Fail(failureMessage);
-            return;
-        }
-
-        if (WaitForModuleEnabledSetting(moduleName, enabled))
-        {
-            Assert.IsTrue(waitForRuntimeState(), failureMessage);
-            return;
-        }
-
-        var persistedState = WaitForReadableModuleEnabledSetting(moduleName);
-        Assert.IsTrue(
-            persistedState.HasValue,
-            $"Could not read enabled.{moduleName} after the Settings pipe client was rejected.");
-        Assert.AreEqual(
-            !enabled,
-            persistedState.Value,
-            $"enabled.{moduleName} reached an unexpected state after the Settings pipe client was rejected.");
-
-        Step(testBase, $"The Release runner rejected the test-signed Settings pipe client; seeding and restarting it to apply enabled.{moduleName}={enabled.ToString().ToLowerInvariant()}");
-        testBase.RestartScope(enabled ? [moduleName] : []);
-        Assert.IsTrue(
-            waitForRuntimeState(),
-            $"{failureMessage} The persisted state was not applied after restarting the runner.");
-        NavigateToMouseUtilities(testBase);
     }
 
     internal static WindowControl.ProcessWindow WaitForWindowClass(string className, int timeoutMs = 10_000)
@@ -293,117 +239,6 @@ internal static class MouseUtilsTestHelper
 
     internal static void Step(UITestBase testBase, string message) =>
         testBase.TestContext.WriteLine($"[{DateTime.UtcNow:HH:mm:ss.fff}] {message}");
-
-    private static Dictionary<int, DateTime> GetProcessStartTimes(PowerToysModule module)
-    {
-        var processes = new Dictionary<int, DateTime>();
-        foreach (var process in Process.GetProcessesByName(SessionHelper.GetProcessName(module)))
-        {
-            using (process)
-            {
-                try
-                {
-                    processes[process.Id] = process.StartTime;
-                }
-                catch (Exception ex) when (ex is InvalidOperationException or System.ComponentModel.Win32Exception)
-                {
-                }
-            }
-        }
-
-        return processes;
-    }
-
-    private static bool HasUnsignedSettingsPipeRejection(
-        IReadOnlyDictionary<int, DateTime> runnerProcesses,
-        IReadOnlyDictionary<int, DateTime> settingsProcesses)
-    {
-        if (runnerProcesses.Count == 0 || settingsProcesses.Count == 0)
-        {
-            return false;
-        }
-
-        var runnerLogs = Path.Combine(SettingsConfigHelper.PowerToysSettingsRoot, "RunnerLogs");
-        if (!Directory.Exists(runnerLogs))
-        {
-            return false;
-        }
-
-        foreach (var path in Directory.EnumerateFiles(runnerLogs, "runner-log*.log"))
-        {
-            try
-            {
-                using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
-                using var reader = new StreamReader(stream);
-                while (reader.ReadLine() is { } line)
-                {
-                    if (line.Contains("Rejected unauthenticated Settings pipe client", StringComparison.Ordinal) &&
-                        line.Contains("reason=not-microsoft-signed", StringComparison.Ordinal) &&
-                        TryReadLogTimestamp(line, out var timestamp) &&
-                        runnerProcesses.Any(process =>
-                            timestamp >= process.Value.AddSeconds(-1) &&
-                            line.Contains($"[p-{process.Key}]", StringComparison.Ordinal)) &&
-                        settingsProcesses.Any(process =>
-                            timestamp >= process.Value.AddSeconds(-1) &&
-                            line.Contains($"pid={process.Key} ", StringComparison.Ordinal)))
-                    {
-                        return true;
-                    }
-                }
-            }
-            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-            {
-            }
-        }
-
-        return false;
-    }
-
-    private static bool TryReadLogTimestamp(string line, out DateTime timestamp)
-    {
-        const int timestampLength = 26;
-        timestamp = default;
-        return line.Length > timestampLength + 1 &&
-               DateTime.TryParseExact(
-                   line.AsSpan(1, timestampLength),
-                   "yyyy-MM-dd HH:mm:ss.ffffff",
-                   CultureInfo.InvariantCulture,
-                   DateTimeStyles.AssumeLocal,
-                   out timestamp);
-    }
-
-    private static bool WaitForModuleEnabledSetting(string moduleName, bool enabled) =>
-        WaitHelper.WaitForStable(
-            () => ReadModuleEnabledSetting(moduleName),
-            value => value == enabled,
-            5_000,
-            requiredConsecutiveMatches: 2,
-            pollIntervalMS: 100).Succeeded;
-
-    private static bool? WaitForReadableModuleEnabledSetting(string moduleName)
-    {
-        var result = WaitHelper.WaitForStable(
-            () => ReadModuleEnabledSetting(moduleName),
-            value => value.HasValue,
-            2_000,
-            requiredConsecutiveMatches: 2,
-            pollIntervalMS: 100);
-        return result.Succeeded ? result.LastObservation : null;
-    }
-
-    private static bool? ReadModuleEnabledSetting(string moduleName)
-    {
-        try
-        {
-            var path = Path.Combine(SettingsConfigHelper.PowerToysSettingsRoot, "settings.json");
-            var root = JsonNode.Parse(File.ReadAllText(path));
-            return root?["enabled"]?[moduleName]?.GetValue<bool>();
-        }
-        catch
-        {
-            return null;
-        }
-    }
 
     [DllImport("user32.dll", EntryPoint = "SystemParametersInfoW", SetLastError = true)]
     private static extern bool SystemParametersInfo(int uiAction, int uiParam, ref int pvParam, int fWinIni);

--- a/src/modules/MouseUtils/MouseUtils.UITests.Next/app.manifest
+++ b/src/modules/MouseUtils/MouseUtils.UITests.Next/app.manifest
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MouseUtils.UITests.Next.app"/>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/src/modules/MouseUtils/MouseUtils.UITests/Release-Test-Checklist-Migration-Progress.md
+++ b/src/modules/MouseUtils/MouseUtils.UITests/Release-Test-Checklist-Migration-Progress.md
@@ -1,64 +1,94 @@
-## [Mouse Utils](tests-checklist-template-mouse-utils-section.md)
+## Mouse Utils
 
-Find My Mouse:
-  * Enable FindMyMouse. Then, without moving your mouse:
-    - [x] Press Left Ctrl twice and verify the overlay appears.
-    - [x] Press any other key and verify the overlay disappears.
-    - [x] Press Left Ctrl twice and verify the overlay appears.
-    - [x] Press a mouse button and verify the overlay disappears.
-  * Disable FindMyMouse. Verify the overlay no longer appears when you press Left Ctrl twice.
-  * Enable FindMyMouse. Then, without moving your mouse:
-    - [x] Press Left Ctrl twice and verify the overlay appears.
-  * Enable the "Do not activate on game mode" option. Start playing a game that uses CG native full screen.
-    - [ ] Verify the overlay no longer appears when you press Left Ctrl twice.
-  * Disable the "Do not activate on game mode" option. Start playing the same game.
-    - [ ] Verify the overlay appears when you press Left Ctrl twice. (though it'll likely minimize the game)
-  * Test the different settings and verify they apply:
-    - [ ] Overlay opacity
-    - [x] Background color
-    - [x] Spotlight color
-    - [x] Spotlight radius
-    - [ ] Spotlight initial zoom (1x vs 9x will show the difference)
-    - [ ] Animation duration
-    - [ ] Change activation method to shake and activate by shaking your mouse pointer
-    - [ ] Excluded apps
+The migrated suite is [MouseUtils.UITests.Next](../MouseUtils.UITests.Next/) and currently contains 40 tests. Checked items have an automated effect-based assertion. Unchecked items require physical hardware or desktop state that the single-monitor Hyper-V profile cannot establish faithfully.
 
-Mouse Highlighter:
-  * Enable Mouse Highlighter. Then:
-    - [x] Press the activation shortcut and press left and right click somewhere, verifying the highlights are applied.
-    - [x] With left mouse button pressed, drag the mouse and verify the highlight is dragged with the pointer.
-    - [x] With right mouse button pressed, drag the mouse and verify the highlight is dragged with the pointer.
-    - [x] Press the activation shortcut again and verify no highlights appear when the mouse buttons are clicked.
-    - [x] Disable Mouse Highlighter and verify that the module is not activated when you press the activation shortcut.
-  * Test the different settings and verify they apply:
-    - [x] Change activation shortcut and test it
-    - [x] Left button highlight color
-    - [x] Right button highlight color
-    - [ ] Opacity
-    - [ ] Radius
-    - [ ] Fade delay
-    - [ ] Fade duration
+### Find My Mouse
 
-Mouse Pointer Crosshairs:
-  * Enable Mouse Pointer Crosshairs. Then:
-    - [x] Press the activation shortcut and verify the crosshairs appear, and that they follow the mouse around.
-    - [x] Press the activation shortcut again and verify the crosshairs disappear.
-    - [x] Disable Mouse Pointer Crosshairs and verify that the module is not activated when you press the activation shortcut.
-  * Test the different settings and verify they apply:
-    - [x] Change activation shortcut and test it
-    - [x] Crosshairs color
-    - [ ] Crosshairs opacity
-    - [ ] Crosshairs center radius
-    - [ ] Crosshairs thickness
-    - [ ] Crosshairs border color
-    - [ ] Crosshairs border size
+- [x] Double-tap Left Ctrl and verify the overlay appears.
+- [x] Press another key and verify the overlay disappears.
+- [x] Activate again, press a mouse button, and verify the overlay disappears.
+- [x] Disable the module and verify Left Ctrl no longer activates it.
+- [x] Re-enable the module and verify activation works again.
+- [ ] With "Do not activate on game mode" enabled, verify activation is blocked by an exclusive/native fullscreen game. Manual: requires a real D3D fullscreen foreground fixture.
+- [ ] With "Do not activate on game mode" disabled, verify activation works over the same game. Manual: same fixture requirement.
+- [x] Background and spotlight colors, including their current ARGB alpha values. This replaces the stale standalone "Overlay opacity" row.
+- [x] Spotlight radius.
+- [x] Spotlight initial zoom.
+- [x] Animation duration.
+- [ ] Shake activation. Manual: synthetic cursor movement is not equivalent to physical raw mouse input for the shake detector.
+- [x] Excluded apps block activation only while an excluded process owns foreground.
+- [x] Right Ctrl activation.
+- [x] Custom shortcut activation.
+- [x] Requiring the Windows key gates double-Ctrl activation.
 
-Mouse Jump:
-  * Enable Mouse Jump. Then:
-    - [x] Press the activation shortcut and verify the screens preview appears.
-    - [x] Change activation shortcut and verify that new shortcut triggers Mouse Jump.
-    - [x] Click around the screen preview and ensure that mouse cursor jumped to clicked location.
-    - [ ] Reorder screens in Display settings and confirm that Mouse Jump reflects the change and still works correctly.
-    - [ ] Change scaling of screens and confirm that Mouse Jump still works correctly.
-    - [ ] Unplug additional monitors and confirm that Mouse Jump still works correctly.
-    - [x] Disable Mouse Jump and verify that the module is not activated when you press the activation shortcut.
+Automated by [FindMyMouseTests.cs](../MouseUtils.UITests.Next/FindMyMouseTests.cs).
+
+### Mouse Highlighter
+
+- [x] Toggle the module with its activation shortcut and verify left/right click highlights.
+- [x] Verify left-button and right-button highlights follow their respective drags.
+- [x] Toggle the overlay off and verify click highlights disappear.
+- [x] Disable the module and verify its shortcut cannot activate it.
+- [x] Changed activation shortcut.
+- [x] Left and right highlight colors, including their current ARGB alpha values. This replaces the stale standalone "Opacity" row.
+- [x] Highlight radius.
+- [x] Fade delay.
+- [x] Fade duration.
+- [x] Spotlight mode color, radius, and cursor tracking.
+- [x] Ripple size, intensity, and duration.
+- [x] Ripple drag-trail enabled and disabled behavior.
+- [x] Ripple right-button release pulse.
+- [x] Auto-activate.
+
+Automated by [MouseHighlighterTests.cs](../MouseUtils.UITests.Next/MouseHighlighterTests.cs).
+
+### Mouse Pointer Crosshairs
+
+- [x] Activate Crosshairs and verify the overlay appears and tracks the cursor.
+- [x] Activate again and verify the overlay disappears.
+- [x] Disable the module and verify its shortcut cannot activate it.
+- [x] Changed activation shortcut.
+- [x] Crosshairs color.
+- [x] Crosshairs opacity, validated against the blended desktop pixel color.
+- [x] Center radius.
+- [x] Thickness.
+- [x] Border color.
+- [x] Border size.
+- [x] Horizontal orientation and fixed length.
+- [x] Auto-activate.
+- [x] Gliding Cursor activation, movement, and Escape cancellation.
+- [ ] Auto-hide while the cursor is hidden. Manual: `ShowCursor` is thread-local and cannot create a valid cross-thread hidden-cursor fixture in the test host.
+
+Automated by [MousePointerCrosshairsTests.cs](../MouseUtils.UITests.Next/MousePointerCrosshairsTests.cs).
+
+### Mouse Jump
+
+- [x] Load the settings page and verify the WinUI3 process, named event, and hidden preview HWND are ready.
+- [x] Press the default activation shortcut and verify the preview appears.
+- [x] Change the activation shortcut and verify only the new shortcut shows the preview.
+- [x] Click the preview midpoint and verify the cursor maps to the primary display midpoint.
+- [x] Disable the module and verify the shortcut neither shows the preview nor restarts the process.
+- [x] Verify the preview dismisses when it loses focus.
+- [x] Verify configured thumbnail bounds preserve the display aspect ratio.
+- [x] Verify custom background, border, and bezel colors render.
+- [ ] Reorder displays and verify the preview topology and click mapping. Manual: requires a multi-monitor VM/hardware profile.
+- [ ] Change per-display scaling and verify preview topology and click mapping. Manual: requires mixed-DPI displays.
+- [ ] Unplug and reconnect a display and verify live topology updates. Manual: requires hot-pluggable display hardware.
+
+Automated by [MouseJumpTests.cs](../MouseUtils.UITests.Next/MouseJumpTests.cs).
+
+### Cursor Wrap
+
+- [x] Enable, activate, deactivate, and disable Cursor Wrap; verify wrapping follows module state.
+- [x] Both mode wraps left, right, top, and bottom edges.
+- [x] Horizontal-only mode wraps only left and right edges.
+- [x] Vertical-only mode wraps only top and bottom edges.
+- [x] Ctrl activation mode wraps only while Ctrl is held.
+- [x] Shift activation mode wraps only while Shift is held.
+- [x] "Disable during drag" blocks wrapping while the left button is held.
+- [x] "Disable on single monitor" blocks all edges in the one-monitor profile.
+- [x] Auto-activate starts wrapping without the toggle shortcut.
+- [x] A changed activation shortcut replaces the default shortcut.
+- [ ] Validate outer-edge polygons, adjacent inner edges, gaps, negative coordinates, and mixed DPI on multiple displays. Manual: requires representative multi-monitor layouts; use `CursorWrap/CursorWrapTests` for captured-layout simulation alongside hardware validation.
+
+Automated by [CursorWrapTests.cs](../MouseUtils.UITests.Next/CursorWrapTests.cs).

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/MouseUtilsPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/MouseUtilsPage.xaml
@@ -31,7 +31,10 @@
                             x:Uid="MouseUtils_Enable_CursorWrap"
                             HeaderIcon="{ui:BitmapIcon Source=/Assets/Settings/Icons/CursorWrap.png}"
                             IsEnabled="{x:Bind ViewModel.IsCursorWrapEnabledGpoConfigured, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}">
-                            <ToggleSwitch x:Uid="ToggleSwitch" IsOn="{x:Bind ViewModel.IsCursorWrapEnabled, Mode=TwoWay}" />
+                            <ToggleSwitch
+                                x:Uid="ToggleSwitch"
+                                AutomationProperties.AutomationId="MouseUtils_CursorWrapToggleId"
+                                IsOn="{x:Bind ViewModel.IsCursorWrapEnabled, Mode=TwoWay}" />
                         </tkcontrols:SettingsCard>
                     </controls:GPOInfoControl>
 


### PR DESCRIPTION
<!-- Suggested title: [UITests][Mouse Utilities] Migrate and expand UI tests to UITest.Next -->

## Summary of the Pull Request

Adds a side-by-side `Microsoft.PowerToys.UITest.Next` end-to-end suite for Mouse Utilities. The new Microsoft Testing Platform executable uses winappcli and contains 40 tests across Find My Mouse, Mouse Highlighter, Mouse Pointer Crosshairs, Mouse Jump, and Cursor Wrap.

The suite replaces legacy driver assumptions with effect-based assertions against module windows, named events, processes, cursor movement, and rendered pixels. It also opts Mouse Utils into the pipeline's existing test-signing setup for authenticated Runner/Settings IPC, hardens the shared `.Next` input/event helpers, and adds agent-owned Azure/local-VM completion safeguards used to validate the suite autonomously.

No Mouse Utilities runtime behavior or third-party dependencies are added. The only product-UI change is a stable AutomationId for the existing Cursor Wrap toggle.

## PR Checklist

- [x] Closes: #40667 
- [x] **Communication:** Confirm with core contributors before marking the PR ready for review
- [x] **Tests:** Added and validated locally and in Azure DevOps
- [x] **Localization:** No end-user-facing strings were added
- [x] **Dev docs:** Updated the release-checklist migration map and documented hardware-only gaps
- [x] **New binaries:** No shipped binary was added; the new executable is a test project registered in `PowerToys.slnx`
  - [x] JSON for signing: N/A - no shipped binary
  - [x] WXS for installer: N/A - no installed component
  - [x] YML for CI pipeline: Updated test setup to sign the Runner and Settings IPC companions when Mouse Utils is selected
  - [x] YML for signed pipeline: N/A - no release artifact
- [ ] **Documentation updated:** N/A - no public MicrosoftDocs change is required

## Detailed Description of the Pull Request / Additional comments

### Mouse Utilities UI-test project

Adds `src/modules/MouseUtils/MouseUtils.UITests.Next` as a Microsoft Testing Platform executable using `UITestAutomation.Next` and winappcli. The project is registered for x64 and ARM64 in `PowerToys.slnx`.

The 40 tests are distributed as follows:

| Module | Tests | Coverage highlights |
|---|---:|---|
| Cursor Wrap | 10 | Module lifecycle, all edge directions, horizontal/vertical modes, Ctrl/Shift activation, drag suppression, single-monitor suppression, auto-activate, and changed shortcut |
| Find My Mouse | 9 | Keyboard/mouse dismissal, disable/re-enable, colors and alpha, radius, initial zoom, duration, right Ctrl, custom shortcut, Win-key gating, and excluded apps |
| Mouse Highlighter | 9 | Click/drag tracking, changed shortcut, disable behavior, colors and alpha, radius, fade timing, Spotlight mode, Ripple size/intensity/duration, drag trail, release pulse, and auto-activate |
| Mouse Jump | 6 | Process/event/HWND readiness, default and changed shortcuts, preview click mapping, disable behavior, focus loss, aspect-preserving bounds, and custom colors |
| Mouse Pointer Crosshairs | 6 | Activation/tracking/hide, disable/re-enable, changed shortcut, dimensions and border, opacity, orientation/fixed length, auto-activate, and Gliding Cursor |

Each class enables exactly one module and replaces that module's settings with a deterministic snapshot before launch. Structured JSON is used for Find My Mouse settings, and module readiness is established through authoritative events, processes, and windows rather than proxy UI state.

### Effect-based test support

The selected `UITestAutomation.Next` additions provide:

- Named-event constants and availability/signal waits for all five Mouse Utilities modules.
- Correct event-absence semantics: only a missing event is treated as unavailable; access and other failures remain visible.
- Side-specific Ctrl input and a keyboard-layout guard for OEM-period scenarios.
- Stepped relative mouse movement for modules that consume low-level movement.
- Checked `SetCursorPos` and `GetCursorPos` calls so Win32 failures cannot become false `(0,0)` observations.
- A title-bound Notepad fixture that follows the real editor window across inbox and modern launcher behavior.

Transient overlays are observed with `WindowShowWatcher` rather than UI polling. Visual assertions use shared calibrated desktop-pixel and bitmap helpers, including full-annulus Ripple detection and exact Crosshairs/Spotlight geometry checks. Positive transient effects may retry the complete input-and-observation sequence under constrained scheduling; negative assertions are not retried.

### Authenticated Settings IPC in Release CI

Runner IPC authentication added by #49527 requires the Release Runner to validate the Settings binary before accepting module lifecycle commands. Unsigned PR artifacts cannot satisfy that gate without test setup.

The UI Test Automation pipeline already solves this for PowerRename by signing `PowerToys.exe` and `PowerToys.Settings.exe` with a disposable, machine-trusted test identity whose publisher matches the Release IPC policy. This PR opts `MouseUtils.UITests.Next` into that same existing mechanism.

The test certificate and private key are removed by the pipeline cleanup. Production authentication code and policy are unchanged.

All Mouse Utilities lifecycle tests use the real Settings UI directly. After changing a module switch, they assert the immediate runtime effect through the module's named event, process, window, shortcut, or cursor behavior. There is no settings-file or restart fallback in the tests.

### Autonomous validation hardening

The same branch hardens the execution path used to prove the new tests:

- Adds a synchronous `Wait-AzureDevOpsBuild.ps1` waiter bound to the exact build ID, branch, and source SHA, with typed progress/terminal events and best-effort host sleep prevention.
- Makes Azure build snapshots safe under PowerShell StrictMode when optional REST fields are omitted, covered by canned `notStarted`, `inProgress`, and `completed` Pester cases.
- Hardens local-VM execution with bounded task-start/task-exit checks, retrying task-state reads, and best-effort host sleep prevention so a missing result cannot silently wait until the suite timeout.
- Documents the foreground agent-owned wait requirement and the evidence needed before declaring a CI run complete.

### Checklist migration and manual boundaries

Updates `Release-Test-Checklist-Migration-Progress.md` to map every automated assertion to its test class. The unchecked rows are fixtures the single-monitor Hyper-V environment cannot represent faithfully:

- Exclusive/native fullscreen game-mode behavior.
- Physical raw-mouse shake activation.
- Cross-process hidden-cursor state.
- Multi-monitor topology, mixed DPI, hot-plug, negative coordinates, display gaps, and complex Cursor Wrap edge geometry.

## Validation Steps Performed

### Build and focused validation

- `MouseUtils.UITests.Next` x64 and ARM64 Debug builds: **passed**, empty errors logs.
- Settings UI, Screen Ruler `.Next`, and FancyZones `.Next` x64 builds: **passed**.
- Azure waiter Pester tests: **3/3 passed**.
- Shared `UITestAutomation.Next` unit tests: **19/19 passed**.
- Mouse Utils inventory: **40** test methods, with zero ignored, inconclusive, or not-executed declarations.
- Editor diagnostics and `git diff --check`: **passed**.

### Local VM validation

The complete Mouse Utilities suite passed on both supported x64 operating systems and resource profiles:

| Environment | Allocation | Result | Run ID |
|---|---:|---:|---|
| Windows 10 default | 4 vCPU / 8 GB | **40/40 passed** | `localvm-20260829-004323-60f44915` |
| Windows 11 default | 4 vCPU / 8 GB | **40/40 passed** | `localvm-20260829-004920-412fbecb` |
| Windows 10 constrained | 1 vCPU / 4 GB | **40/40 passed** | `localvm-20260829-002136-d40f5345` |
| Windows 11 constrained | 1 vCPU / 4 GB | **40/40 passed** | `localvm-20260829-003130-d8057027` |

Every listed run executed all 40 tests with zero skipped/not-executed tests and zero evidence-export errors. CPU and memory allocations were verified from Hyper-V while each run was active.

Additional checks passed on both Windows 10 and Windows 11:

- The five direct Settings lifecycle scenarios.
- Screen Ruler's direct `MouseHelper.MoveTo` scenario.
- FancyZones' direct `MouseHelper.MoveTo` scenario.

### Azure DevOps UI Test Automation

Final combined verification build: [156199762 / 20260829.1](https://dev.azure.com/microsoft/c93e867a-8815-43c1-92c4-e7dd5404f1e1/_build/results?buildId=156199762)

Source SHA: `3163ff7db66c92944dabcf1533c2c4f6de14db9a`

Modules: `MouseUtils.UITests.Next`, `ScreenRuler.UITests.Next`, and `FancyZones.UITests.Next`.

The run built fresh ARM64 and x64 product artifacts. Every platform job signed and Authenticode-verified `PowerToys.exe` and `PowerToys.Settings.exe` before testing; stale-certificate removal and final certificate cleanup also succeeded.

| Platform | Azure Test run | FancyZones | Mouse Utils | Screen Ruler | Total |
|---|---:|---:|---:|---:|---:|
| ARM64 | [1654312169](https://microsoft.visualstudio.com/Dart/_TestManagement/Runs?runId=1654312169&_a=runCharts) | **21/21** | **40/40** | **5/5** | **66/66** |
| Windows 10 x64 | [1654313603](https://microsoft.visualstudio.com/Dart/_TestManagement/Runs?runId=1654313603&_a=runCharts) | **21/21** | **40/40** | **5/5** | **66/66** |
| Windows 11 x64 | [1654315321](https://microsoft.visualstudio.com/Dart/_TestManagement/Runs?runId=1654315321&_a=runCharts) | **21/21** | **40/40** | **5/5** | **66/66** |

Final CI result: **198/198 passed**. All five stages succeeded, the timeline contains zero failed records, and there were no failed, skipped, inconclusive, aborted, timed-out, or not-executed results. Normal `build-arm64-Release` and `build-x64-Release` artifacts were published.

Each publish step warned that five optional Screen Ruler `TestExecutionLog_*` attachments were no longer present in the temporary deployment directory. Those tests passed on every platform, and the same diagnostics remain inline in the test results; this is non-blocking evidence loss in the pre-existing best-effort logger.

<img width="1153" height="458" alt="image" src="https://github.com/user-attachments/assets/9d109fc6-8343-4110-9169-67e7bcbcb1ef" />
<img width="990" height="842" alt="image" src="https://github.com/user-attachments/assets/44f17a82-c3ac-477f-ab39-c742c6eca275" />


## Reviewer guide

Suggested review order:

1. `src/modules/MouseUtils/MouseUtils.UITests.Next/MouseUtilsTestHelper.cs` - deterministic setup, Settings navigation, and module-toggle handling.
2. The five test classes in `src/modules/MouseUtils/MouseUtils.UITests.Next` - behavioral coverage and effect assertions.
3. `src/common/UITestAutomation.Next/NamedEventHelper.cs`, `KeyboardHelper.cs`, and `MouseHelper.cs` - shared input/event behavior.
4. `.pipelines/v2/templates/job-test-project.yml` - reuse of the existing companion-signing path.
5. `.github/skills/ui-tests-pipeline-ci` and `.github/skills/ui-tests-local-vm` - foreground waiting and execution hardening.
6. `src/modules/MouseUtils/MouseUtils.UITests/Release-Test-Checklist-Migration-Progress.md` - automated coverage and remaining hardware-only checks.
7. `PowerToys.slnx` and `MouseUtils.UITests.Next.csproj` - x64/ARM64 project registration.