### PR TITLE
CmdPal: Fix separator section notifications

### DIFF
--- a/src/modules/cmdpal/Tests/Microsoft.CommandPalette.Extensions.Toolkit.UnitTests/SeparatorTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CommandPalette.Extensions.Toolkit.UnitTests/SeparatorTests.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit.UnitTests;
+
+[TestClass]
+public class SeparatorTests
+{
+    [TestMethod]
+    [DataRow("Renamed")]
+    [DataRow("")]
+    [DataRow(null)]
+    public void Title_RaisesTitleAndSectionNotifications(string? title)
+    {
+        var separator = new Separator("Original");
+        List<string> notifications = [];
+        separator.PropChanged += (_, args) => notifications.Add(args.PropertyName);
+
+        separator.Title = title;
+        separator.Title = title;
+
+        Assert.AreEqual(title, separator.Section);
+        CollectionAssert.AreEqual(new[] { nameof(Separator.Title), nameof(Separator.Section) }, notifications);
+    }
+}

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Separator.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Separator.cs
@@ -31,7 +31,7 @@ public partial class Separator : BaseObservable, IListItem, ISeparatorContextIte
             {
                 Section = value;
                 OnPropertyChanged();
-                OnPropertyChanged(Section);
+                OnPropertyChanged(nameof(Section));
             }
         }
     }


### PR DESCRIPTION
## Summary of the Pull Request

This PR fixes raising property change notification from Separator for Section property. Code was missing `nameof()`, so it raised actual Section value as a property name.

- Raises the correct `Section` notification when `Separator.Title` changes.
- Adds a unit test to prevent future regression.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #50226
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

