### PR TITLE
[UITests][AlwaysOnTop] Add UI test

### DIFF
--- a/PowerToys.slnx
+++ b/PowerToys.slnx
@@ -169,6 +169,10 @@
   <Folder Name="/modules/AlwaysOnTop/">
     <Project Path="src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.vcxproj" Id="1dc3be92-ce89-43fb-8110-9c043a2fe7a2" />
     <Project Path="src/modules/alwaysontop/AlwaysOnTopModuleInterface/AlwaysOnTopModuleInterface.vcxproj" Id="48a0a19e-a0be-4256-acf8-cc3b80291af9" />
+    <Project Path="src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/AlwaysOnTop.UITests.csproj">
+      <Platform Solution="*|ARM64" Project="ARM64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
   </Folder>
   <Folder Name="/modules/awake/">
     <Project Path="src/modules/awake/Awake.ModuleServices/Awake.ModuleServices.csproj">
@@ -1288,4 +1292,3 @@
   <Project Path="tools/CliShim/CliShim.vcxproj" Id="8a7fb7fa-65ea-4004-ba73-1b237435a57b" />
   <Project Path="tools/CliShim.UnitTests/CliShim.UnitTests.vcxproj" Id="d4b0ed68-867d-46b4-a03f-ec52b9fbebe5" />
 </Solution>
-

--- a/PowerToys.slnx
+++ b/PowerToys.slnx
@@ -1292,3 +1292,4 @@
   <Project Path="tools/CliShim/CliShim.vcxproj" Id="8a7fb7fa-65ea-4004-ba73-1b237435a57b" />
   <Project Path="tools/CliShim.UnitTests/CliShim.UnitTests.vcxproj" Id="d4b0ed68-867d-46b4-a03f-ec52b9fbebe5" />
 </Solution>
+

--- a/doc/devdocs/modules/alwaysontop.md
+++ b/doc/devdocs/modules/alwaysontop.md
@@ -90,6 +90,13 @@ The module provides a user interface for configuring settings in the PowerToys S
 3. Select the Release configuration and build the solution
 4. Run PowerToys.exe from the output directory to test the module
 
+#### Automated UI tests
+
+The winappcli-based suite is in `src/modules/alwaysontop/Tests/AlwaysOnTop.UITests`. It requires an
+interactive desktop and `winapp.exe` on `PATH` (or `WINAPP_CLI_PATH`). The virtual-desktop scenario
+creates a temporary desktop and closes it during cleanup. The sound scenario observes access to the
+Windows media file through an NTFS oplock, so it does not require an audio endpoint.
+
 ### Debug
 1. build the entire project
 2. launch the built Powertoys

--- a/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/AlwaysOnTop.UITests.csproj
+++ b/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/AlwaysOnTop.UITests.csproj
@@ -7,6 +7,7 @@
     <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <UseWindowsForms>true</UseWindowsForms>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <RootNamespace>Microsoft.AlwaysOnTop.UITests</RootNamespace>

--- a/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/AlwaysOnTop.UITests.csproj
+++ b/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/AlwaysOnTop.UITests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- Look at Directory.Build.props in root for common stuff as well -->
+  <Import Project="$(RepoRoot)src\Common.Dotnet.CsWinRT.props" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <RootNamespace>Microsoft.AlwaysOnTop.UITests</RootNamespace>
+    <AssemblyName>AlwaysOnTop.UITests</AssemblyName>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+
+    <IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <RunVSTest>false</RunVSTest>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputPath>$(RepoRoot)$(Platform)\$(Configuration)\tests\AlwaysOnTop.UITests\</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\common\UITestAutomation.Next\UITestAutomation.Next.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/AlwaysOnTopSettingsSeed.cs
+++ b/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/AlwaysOnTopSettingsSeed.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json.Nodes;
+using Microsoft.PowerToys.UITest.Next;
+
+namespace Microsoft.AlwaysOnTop.UITests;
+
+internal static class AlwaysOnTopSettingsSeed
+{
+    internal const string ModuleName = "AlwaysOnTop";
+
+    private const string DefaultSettings = """
+        {
+          "name": "AlwaysOnTop",
+          "properties": {},
+          "version": "0.0.1"
+        }
+        """;
+
+    internal static void ApplyBaseline()
+    {
+        SettingsConfigHelper.UpdateModuleSettings(
+            ModuleName,
+            DefaultSettings,
+            root =>
+            {
+                var properties = root["properties"]?.AsObject()
+                    ?? throw new InvalidOperationException("Always On Top settings have no properties object.");
+                SetValue(properties, "frame-enabled", true);
+                SetValue(properties, "frame-thickness", 4);
+                SetValue(properties, "frame-color", "#0099CC");
+                SetValue(properties, "frame-opacity", 100);
+                SetValue(properties, "frame-accent-color", false);
+                SetValue(properties, "sound-enabled", false);
+                SetValue(properties, "show-in-system-menu", false);
+                SetValue(properties, "do-not-activate-on-game-mode", false);
+                SetValue(properties, "excluded-apps", string.Empty);
+                SetValue(properties, "round-corners-enabled", false);
+                properties["hotkey"] = new JsonObject
+                {
+                    ["value"] = new JsonObject
+                    {
+                        ["win"] = true,
+                        ["ctrl"] = true,
+                        ["alt"] = false,
+                        ["shift"] = false,
+                        ["code"] = (int)'T',
+                        ["key"] = string.Empty,
+                    },
+                };
+            });
+    }
+
+    internal static void Apply(params (string Name, object Value)[] settings)
+    {
+        SettingsConfigHelper.UpdateModuleSettings(
+            ModuleName,
+            DefaultSettings,
+            root =>
+            {
+                if (root["properties"] is not JsonObject properties)
+                {
+                    properties = new JsonObject();
+                    root["properties"] = properties;
+                }
+
+                foreach (var (name, value) in settings)
+                {
+                    SetValue(properties, name, value);
+                }
+            });
+    }
+
+    private static void SetValue(JsonObject properties, string name, object value)
+    {
+        properties[name] = new JsonObject
+        {
+            ["value"] = value switch
+            {
+                bool booleanValue => JsonValue.Create(booleanValue),
+                int integerValue => JsonValue.Create(integerValue),
+                string stringValue => JsonValue.Create(stringValue),
+                _ => throw new ArgumentException($"Unsupported Always On Top setting type: {value.GetType().Name}."),
+            },
+        };
+    }
+}

--- a/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/AlwaysOnTopSettingsSeed.cs
+++ b/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/AlwaysOnTopSettingsSeed.cs
@@ -53,7 +53,7 @@ internal static class AlwaysOnTopSettingsSeed
             });
     }
 
-    internal static void Apply(params (string Name, object Value)[] settings)
+    internal static void Apply(params (string Name, JsonNode? Value)[] settings)
     {
         SettingsConfigHelper.UpdateModuleSettings(
             ModuleName,
@@ -73,17 +73,11 @@ internal static class AlwaysOnTopSettingsSeed
             });
     }
 
-    private static void SetValue(JsonObject properties, string name, object value)
+    private static void SetValue(JsonObject properties, string name, JsonNode? value)
     {
         properties[name] = new JsonObject
         {
-            ["value"] = value switch
-            {
-                bool booleanValue => JsonValue.Create(booleanValue),
-                int integerValue => JsonValue.Create(integerValue),
-                string stringValue => JsonValue.Create(stringValue),
-                _ => throw new ArgumentException($"Unsupported Always On Top setting type: {value.GetType().Name}."),
-            },
+            ["value"] = value?.DeepClone(),
         };
     }
 }

--- a/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/AlwaysOnTopTests.cs
+++ b/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/AlwaysOnTopTests.cs
@@ -95,6 +95,23 @@ public sealed class AlwaysOnTopTests : UITestBase
             }
         }
 
+        if (fixture is not null)
+        {
+            try
+            {
+                if (fixture.IsPinned)
+                {
+                    Step("Cleanup: unpinning the fixture before destroying its window");
+                    TogglePin(expected: false);
+                    _ = WaitForBorder(expected: false, timeoutMs: 5_000);
+                }
+            }
+            catch (Exception ex)
+            {
+                TestContext.WriteLine($"Pinned fixture cleanup failed: {ex.Message}");
+            }
+        }
+
         fixture?.Dispose();
         fixture = null;
 

--- a/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/AlwaysOnTopTests.cs
+++ b/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/AlwaysOnTopTests.cs
@@ -4,6 +4,9 @@
 
 using System.Diagnostics;
 using System.Drawing;
+using System.Drawing.Imaging;
+using System.Globalization;
+using System.Runtime.InteropServices;
 using Microsoft.PowerToys.UITest.Next;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -14,6 +17,9 @@ public sealed class AlwaysOnTopTests : UITestBase
 {
     private const string AlwaysOnTopProcessName = "PowerToys.AlwaysOnTop";
     private const string BorderWindowClass = "AlwaysOnTop_Border";
+
+    // The module's file watcher has no acknowledgement signal. Use this only before negative
+    // assertions where no product state can prove that the new setting has loaded.
     private const int SettingsReloadDelayMs = 3_000;
     private static readonly Key[] ActivationShortcut = [Key.LWin, Key.Ctrl, Key.T];
     private static IDisposable? originalModuleSettings;
@@ -71,7 +77,7 @@ public sealed class AlwaysOnTopTests : UITestBase
 
         Step("Applying the default Always On Top test settings");
         AlwaysOnTopSettingsSeed.ApplyBaseline();
-        Thread.Sleep(SettingsReloadDelayMs);
+        WaitForSettingsReloadWithoutObservableSignal();
     }
 
     [TestCleanup]
@@ -81,6 +87,7 @@ public sealed class AlwaysOnTopTests : UITestBase
 
         CleanupExtraVirtualDesktop();
 
+        // Exclusive D3D device release can fail transiently while Windows leaves full-screen mode.
         for (var attempt = 1; attempt <= 2 && fullScreen is not null; attempt++)
         {
             try
@@ -101,6 +108,7 @@ public sealed class AlwaysOnTopTests : UITestBase
             {
                 if (fixture.IsPinned)
                 {
+                    // Destroying a pinned target can race the product's border timer with a stale HWND.
                     Step("Cleanup: unpinning the fixture before destroying its window");
                     TogglePin(expected: false);
                     _ = WaitForBorder(expected: false, timeoutMs: 5_000);
@@ -118,7 +126,6 @@ public sealed class AlwaysOnTopTests : UITestBase
         try
         {
             AlwaysOnTopSettingsSeed.ApplyBaseline();
-            Thread.Sleep(SettingsReloadDelayMs);
         }
         catch (Exception ex)
         {
@@ -156,6 +163,7 @@ public sealed class AlwaysOnTopTests : UITestBase
 
         Step("Creating and switching to a new virtual desktop");
         KeyboardHelper.SendKeys(Key.LWin, Key.Ctrl, Key.D);
+        extraVirtualDesktopCreated = true;
         var switchedAway = WaitHelper.WaitForStable(
             () => VirtualDesktopHelper.IsWindowOnCurrentDesktop(fixture.Handle),
             isCurrent => isCurrent == false,
@@ -163,7 +171,6 @@ public sealed class AlwaysOnTopTests : UITestBase
             requiredConsecutiveMatches: 2,
             pollIntervalMS: 100);
         Assert.IsTrue(switchedAway.Succeeded, "Windows did not switch away from the fixture's original virtual desktop.");
-        extraVirtualDesktopCreated = true;
         AssertBorderState(expected: false, timeoutMs: 15_000);
         AssertPinState(expected: true);
 
@@ -251,7 +258,6 @@ public sealed class AlwaysOnTopTests : UITestBase
             ("frame-accent-color", false),
             ("round-corners-enabled", false),
             ("sound-enabled", false));
-        Thread.Sleep(SettingsReloadDelayMs);
 
         fixture = TestWindow.Create("Always On Top border settings fixture");
         TogglePin(expected: true);
@@ -282,7 +288,8 @@ public sealed class AlwaysOnTopTests : UITestBase
             requiredConsecutiveMatches: 2,
             pollIntervalMS: 250);
 
-        var updateDiagnostics = $"Last border={update.LastObservation.Border.Width}x{update.LastObservation.Border.Height}, magenta={update.LastObservation.HasUpdatedColor}.";
+        var updateDiagnostics = FormattableString.Invariant(
+            $"Last border={update.LastObservation.Border.Width}x{update.LastObservation.Border.Height}, magenta={update.LastObservation.HasUpdatedColor}.");
         Assert.IsTrue(update.Succeeded, $"The live border update did not settle. {updateDiagnostics}");
     }
 
@@ -292,11 +299,17 @@ public sealed class AlwaysOnTopTests : UITestBase
     public void SoundSettingControlsPlaybackAttempt()
     {
         fixture = TestWindow.Create("Always On Top sound fixture");
+        using var soundFile = SoundFileFixture.Create(TestContext.WriteLine);
         AlwaysOnTopSettingsSeed.Apply(("sound-enabled", true), ("frame-enabled", false));
-        Thread.Sleep(SettingsReloadDelayMs);
+        WaitForSettingsReloadWithoutObservableSignal();
 
-        using (var enabledWatcher = SoundPlaybackWatcher.Create())
+        // The oplock proves that the product opened the sound file; speaker output is intentionally
+        // not asserted because Hyper-V and CI agents do not expose a stable audio endpoint.
+        using (var enabledWatcher = SoundPlaybackWatcher.Create(soundFile.FilePath, TestContext.WriteLine))
         {
+            Assert.IsFalse(
+                enabledWatcher.WaitForAccess(timeoutMs: 250),
+                "Another process opened the pin sound file before Always On Top was triggered.");
             Step($"Watching access to '{enabledWatcher.FilePath}' with sound enabled");
             TogglePin(expected: true);
             Assert.IsTrue(
@@ -306,20 +319,23 @@ public sealed class AlwaysOnTopTests : UITestBase
 
         Step("Disabling sound and returning the fixture to an unpinned state");
         AlwaysOnTopSettingsSeed.Apply(("sound-enabled", false));
-        Thread.Sleep(SettingsReloadDelayMs);
+        WaitForSettingsReloadWithoutObservableSignal();
         TogglePin(expected: false);
 
-        using (var disabledWatcher = SoundPlaybackWatcher.Create())
+        using (var disabledWatcher = SoundPlaybackWatcher.Create(soundFile.FilePath, TestContext.WriteLine))
         {
+            Assert.IsFalse(
+                disabledWatcher.WaitForAccess(timeoutMs: 250),
+                "Another process opened the pin sound file before the disabled-sound check.");
             Step($"Watching access to '{disabledWatcher.FilePath}' with sound disabled");
             TogglePin(expected: true);
             Assert.IsFalse(
-                disabledWatcher.WaitForAccess(timeoutMs: 2_000),
+                disabledWatcher.WaitForAccess(timeoutMs: 3_000),
                 "Always On Top opened its pin sound file even though sound was disabled.");
         }
 
         TestContext.WriteLine(
-            "Playback gating is validated by forcing the product's existing PlaySound call to fail only when invoked; " +
+            "Playback gating is validated by observing the relative sound file opened by PlaySound; " +
             "the Hyper-V guest has no stable audio-capture endpoint for asserting speaker output.");
     }
 
@@ -333,16 +349,15 @@ public sealed class AlwaysOnTopTests : UITestBase
 
         Step($"Excluding the fixture process '{fixture.ProcessFileName}'");
         AlwaysOnTopSettingsSeed.Apply(("excluded-apps", fixture.ProcessFileName));
-        Thread.Sleep(SettingsReloadDelayMs);
+        WaitForSettingsReloadWithoutObservableSignal();
         fixture.Focus();
         KeyboardHelper.SendKeys(ActivationShortcut);
         Thread.Sleep(2_000);
-        Assert.IsFalse(fixture.IsPinned, "Always On Top marked the Direct3D fixture as pinned while Game Mode blocking was enabled.");
+        AssertPinState(expected: false);
         AssertBorderState(expected: false);
 
         Step("Removing the exclusion and pinning the fixture");
         AlwaysOnTopSettingsSeed.Apply(("excluded-apps", string.Empty));
-        Thread.Sleep(SettingsReloadDelayMs);
         TogglePin(expected: true);
         AssertBorderState(expected: true);
 
@@ -373,7 +388,7 @@ public sealed class AlwaysOnTopTests : UITestBase
 
         Step("Enabling the Always On Top Game Mode block");
         AlwaysOnTopSettingsSeed.Apply(("do-not-activate-on-game-mode", true));
-        Thread.Sleep(SettingsReloadDelayMs);
+        WaitForSettingsReloadWithoutObservableSignal();
         fixture.Focus();
         KeyboardHelper.SendKeys(ActivationShortcut);
         Thread.Sleep(2_000);
@@ -393,7 +408,6 @@ public sealed class AlwaysOnTopTests : UITestBase
 
         Step("Disabling the Game Mode block and verifying the same shortcut outside Game Mode");
         AlwaysOnTopSettingsSeed.Apply(("do-not-activate-on-game-mode", false));
-        Thread.Sleep(SettingsReloadDelayMs);
 
         TogglePin(expected: true);
         AssertPinState(expected: true);
@@ -463,7 +477,8 @@ public sealed class AlwaysOnTopTests : UITestBase
             requiredConsecutiveMatches: 2,
             pollIntervalMS: 100);
 
-        var diagnostics = $"Last HWND={result.LastObservation.Hwnd}, size={result.LastObservation.Width}x{result.LastObservation.Height}.";
+        var diagnostics = FormattableString.Invariant(
+            $"Last HWND={result.LastObservation.Hwnd}, size={result.LastObservation.Width}x{result.LastObservation.Height}.");
         Assert.IsTrue(result.Succeeded, $"The Always On Top border did not reach expected visibility within {timeoutMs} ms. {diagnostics}");
         return result.LastObservation;
     }
@@ -496,6 +511,8 @@ public sealed class AlwaysOnTopTests : UITestBase
 
         var candidateCenter = WindowHelper.GetWindowCenter(candidate.Hwnd);
         var centerDistance = Math.Abs(candidateCenter.CenterX - targetCenter.CenterX) + Math.Abs(candidateCenter.CenterY - targetCenter.CenterY);
+
+        // Border and target centers should coincide; tolerate DWM shadow and DPI rounding only.
         return centerDistance <= 32 ? candidate : default;
     }
 
@@ -517,12 +534,15 @@ public sealed class AlwaysOnTopTests : UITestBase
         var rightMargin = borderBounds.Right - frame.Right;
         var bottomMargin = borderBounds.Bottom - frame.Bottom;
 
-        Assert.IsTrue(
-            leftMargin is > 0 and <= 64
+        var marginDiagnostics = FormattableString.Invariant(
+            $"Margins: L={leftMargin}, T={topMargin}, R={rightMargin}, B={bottomMargin}.");
+
+        // Bound the maximized DWM inset while requiring near-symmetric opposite edges.
+        var surroundsFrame = leftMargin is > 0 and <= 64
             && topMargin is > 0 and <= 64
             && rightMargin is > 0 and <= 64
-            && bottomMargin is > 0 and <= 64,
-            $"The border did not surround the maximized DWM frame. Margins: L={leftMargin}, T={topMargin}, R={rightMargin}, B={bottomMargin}.");
+            && bottomMargin is > 0 and <= 64;
+        Assert.IsTrue(surroundsFrame, $"The border did not surround the maximized DWM frame. {marginDiagnostics}");
         Assert.IsTrue(Math.Abs(leftMargin - rightMargin) <= 4, "The maximized border was not horizontally symmetric.");
         Assert.IsTrue(Math.Abs(topMargin - bottomMargin) <= 4, "The maximized border was not vertically symmetric.");
     }
@@ -552,10 +572,28 @@ public sealed class AlwaysOnTopTests : UITestBase
             return false;
         }
 
-        using var image = new Bitmap(width, height);
+        using var image = new Bitmap(width, height, PixelFormat.Format32bppArgb);
         using (var graphics = Graphics.FromImage(image))
         {
             graphics.CopyFromScreen(bounds.Left, bounds.Top, 0, 0, image.Size);
+        }
+
+        var bitmapData = image.LockBits(
+            new Rectangle(0, 0, width, height),
+            ImageLockMode.ReadOnly,
+            PixelFormat.Format32bppArgb);
+        var stride = Math.Abs(bitmapData.Stride);
+        var pixels = new byte[stride * height];
+        try
+        {
+            for (var y = 0; y < height; y++)
+            {
+                Marshal.Copy(IntPtr.Add(bitmapData.Scan0, y * bitmapData.Stride), pixels, y * stride, stride);
+            }
+        }
+        finally
+        {
+            image.UnlockBits(bitmapData);
         }
 
         var band = Math.Min(Math.Max(thickness + 2, 4), Math.Min(width, height) / 3);
@@ -566,12 +604,12 @@ public sealed class AlwaysOnTopTests : UITestBase
             for (var y = 1; y < band; y += 2)
             {
                 samples += 2;
-                if (ColorsMatch(image.GetPixel(x, y), expectedColor))
+                if (PixelMatches(pixels, stride, x, y, expectedColor))
                 {
                     matches++;
                 }
 
-                if (ColorsMatch(image.GetPixel(x, height - 1 - y), expectedColor))
+                if (PixelMatches(pixels, stride, x, height - 1 - y, expectedColor))
                 {
                     matches++;
                 }
@@ -583,27 +621,32 @@ public sealed class AlwaysOnTopTests : UITestBase
             for (var x = 1; x < band; x += 2)
             {
                 samples += 2;
-                if (ColorsMatch(image.GetPixel(x, y), expectedColor))
+                if (PixelMatches(pixels, stride, x, y, expectedColor))
                 {
                     matches++;
                 }
 
-                if (ColorsMatch(image.GetPixel(width - 1 - x, y), expectedColor))
+                if (PixelMatches(pixels, stride, width - 1 - x, y, expectedColor))
                 {
                     matches++;
                 }
             }
         }
 
+        // Require a meaningful share of the sampled edge band while allowing DWM-composited pixels.
         return matches >= Math.Max(8, samples / 12);
     }
 
-    private static bool ColorsMatch(Color actual, Color expected)
+    private static bool PixelMatches(byte[] pixels, int stride, int x, int y, Color expected)
     {
+        var rowOffset = y * stride;
+        var pixelOffset = rowOffset + (x * 4);
         const int tolerance = 24;
-        return Math.Abs(actual.R - expected.R) <= tolerance
-            && Math.Abs(actual.G - expected.G) <= tolerance
-            && Math.Abs(actual.B - expected.B) <= tolerance;
+
+        // Absorb small DWM blending and color-management differences at the rendered edge.
+        return Math.Abs(pixels[pixelOffset + 2] - expected.R) <= tolerance
+            && Math.Abs(pixels[pixelOffset + 1] - expected.G) <= tolerance
+            && Math.Abs(pixels[pixelOffset] - expected.B) <= tolerance;
     }
 
     private static bool WaitForProcess(bool expected, int timeoutMs)
@@ -638,15 +681,21 @@ public sealed class AlwaysOnTopTests : UITestBase
             return;
         }
 
+        var fixtureHandle = fixture?.Handle;
+        if (fixtureHandle is null)
+        {
+            TestContext.WriteLine("Virtual desktop cleanup has no fixture handle; it will not close any desktop.");
+            return;
+        }
+
         try
         {
-            var fixtureOnCurrentDesktop = fixture is not null
-                && VirtualDesktopHelper.IsWindowOnCurrentDesktop(fixture.Handle);
+            var fixtureOnCurrentDesktop = VirtualDesktopHelper.IsWindowOnCurrentDesktop(fixtureHandle.Value);
             if (fixtureOnCurrentDesktop)
             {
                 KeyboardHelper.SendKeys(Key.LWin, Key.Ctrl, Key.Right);
                 var switchedToCreatedDesktop = WaitHelper.WaitForStable(
-                    () => VirtualDesktopHelper.IsWindowOnCurrentDesktop(fixture!.Handle),
+                    () => VirtualDesktopHelper.IsWindowOnCurrentDesktop(fixtureHandle.Value),
                     isCurrent => isCurrent == false,
                     timeoutMS: 10_000,
                     requiredConsecutiveMatches: 2,
@@ -660,7 +709,7 @@ public sealed class AlwaysOnTopTests : UITestBase
 
             KeyboardHelper.SendKeys(Key.LWin, Key.Ctrl, Key.F4);
             var returnedToOriginalDesktop = WaitHelper.WaitForStable(
-                () => VirtualDesktopHelper.IsWindowOnCurrentDesktop(fixture!.Handle),
+                () => VirtualDesktopHelper.IsWindowOnCurrentDesktop(fixtureHandle.Value),
                 isCurrent => isCurrent == true,
                 timeoutMS: 10_000,
                 requiredConsecutiveMatches: 2,
@@ -682,6 +731,12 @@ public sealed class AlwaysOnTopTests : UITestBase
 
     private void Step(string message)
     {
-        TestContext.WriteLine($"[{DateTime.UtcNow:HH:mm:ss.fff}] {message}");
+        var timestamp = DateTime.UtcNow.ToString("HH:mm:ss.fff", CultureInfo.InvariantCulture);
+        TestContext.WriteLine($"[{timestamp}] {message}");
+    }
+
+    private static void WaitForSettingsReloadWithoutObservableSignal()
+    {
+        Thread.Sleep(SettingsReloadDelayMs);
     }
 }

--- a/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/AlwaysOnTopTests.cs
+++ b/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/AlwaysOnTopTests.cs
@@ -1,0 +1,670 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Drawing;
+using Microsoft.PowerToys.UITest.Next;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.AlwaysOnTop.UITests;
+
+[TestClass]
+public sealed class AlwaysOnTopTests : UITestBase
+{
+    private const string AlwaysOnTopProcessName = "PowerToys.AlwaysOnTop";
+    private const string BorderWindowClass = "AlwaysOnTop_Border";
+    private const int SettingsReloadDelayMs = 3_000;
+    private static readonly Key[] ActivationShortcut = [Key.LWin, Key.Ctrl, Key.T];
+    private static IDisposable? originalModuleSettings;
+
+    private TestWindow? fixture;
+    private Direct3DFullScreenScope? fullScreen;
+    private bool extraVirtualDesktopCreated;
+
+    public AlwaysOnTopTests()
+        : base(PowerToysModule.PowerToysSettings, enableModules: [AlwaysOnTopSettingsSeed.ModuleName])
+    {
+    }
+
+    protected override IReadOnlyList<string> StaleProcessNames { get; } =
+    [
+        "PowerToys",
+        "PowerToys.Settings",
+        "PowerToys.AlwaysOnTop",
+        "PowerToys.FancyZonesEditor",
+    ];
+
+    protected override bool ReuseScopeAcrossTests => true;
+
+    [ClassInitialize]
+    public static void InitializeClass(TestContext testContext)
+    {
+        _ = testContext;
+        originalModuleSettings = SettingsConfigHelper.PreserveModuleSettings(AlwaysOnTopSettingsSeed.ModuleName);
+        try
+        {
+            AlwaysOnTopSettingsSeed.ApplyBaseline();
+        }
+        catch
+        {
+            originalModuleSettings.Dispose();
+            originalModuleSettings = null;
+            throw;
+        }
+    }
+
+    [ClassCleanup]
+    public static void CleanupClass()
+    {
+        originalModuleSettings?.Dispose();
+        originalModuleSettings = null;
+    }
+
+    [TestInitialize]
+    public void PrepareTest()
+    {
+        Step("Waiting for the Always On Top process");
+        Assert.IsTrue(
+            WaitForProcess(expected: true, timeoutMs: 15_000),
+            $"{AlwaysOnTopProcessName} did not start from the deterministic enabled-module baseline.");
+
+        Step("Applying the default Always On Top test settings");
+        AlwaysOnTopSettingsSeed.ApplyBaseline();
+        Thread.Sleep(SettingsReloadDelayMs);
+    }
+
+    [TestCleanup]
+    public async Task CleanupTest()
+    {
+        await CaptureFailureArtifactsBeforeCleanupAsync(TimeSpan.FromSeconds(2));
+
+        CleanupExtraVirtualDesktop();
+
+        for (var attempt = 1; attempt <= 2 && fullScreen is not null; attempt++)
+        {
+            try
+            {
+                fullScreen.Dispose();
+                fullScreen = null;
+            }
+            catch (Exception ex)
+            {
+                TestContext.WriteLine($"Full-screen fixture cleanup attempt {attempt}/2 failed: {ex.Message}");
+                Thread.Sleep(250);
+            }
+        }
+
+        fixture?.Dispose();
+        fixture = null;
+
+        try
+        {
+            AlwaysOnTopSettingsSeed.ApplyBaseline();
+            Thread.Sleep(SettingsReloadDelayMs);
+        }
+        catch (Exception ex)
+        {
+            TestContext.WriteLine($"Always On Top settings cleanup failed: {ex.Message}");
+        }
+    }
+
+    [TestMethod]
+    [TestCategory("AlwaysOnTop")]
+    [TestCategory("Always On Top #1")]
+    [TestCategory("Always On Top #2")]
+    public void PinAndUnpinChangesTopmostStateAndBorder()
+    {
+        fixture = TestWindow.Create("Always On Top pin and border fixture");
+        AssertPinState(expected: false);
+        AssertBorderState(expected: false);
+
+        TogglePin(expected: true);
+        AssertPinState(expected: true);
+        AssertBorderState(expected: true);
+
+        TogglePin(expected: false);
+        AssertPinState(expected: false);
+        AssertBorderState(expected: false);
+    }
+
+    [TestMethod]
+    [TestCategory("AlwaysOnTop")]
+    [TestCategory("Always On Top #3")]
+    public void BorderTracksVirtualDesktop()
+    {
+        fixture = TestWindow.Create("Always On Top virtual desktop fixture");
+        TogglePin(expected: true);
+        var originalBorder = WaitForBorder(expected: true);
+
+        Step("Creating and switching to a new virtual desktop");
+        KeyboardHelper.SendKeys(Key.LWin, Key.Ctrl, Key.D);
+        var switchedAway = WaitHelper.WaitForStable(
+            () => VirtualDesktopHelper.IsWindowOnCurrentDesktop(fixture.Handle),
+            isCurrent => isCurrent == false,
+            timeoutMS: 10_000,
+            requiredConsecutiveMatches: 2,
+            pollIntervalMS: 100);
+        Assert.IsTrue(switchedAway.Succeeded, "Windows did not switch away from the fixture's original virtual desktop.");
+        extraVirtualDesktopCreated = true;
+        AssertBorderState(expected: false, timeoutMs: 15_000);
+        AssertPinState(expected: true);
+
+        Step("Returning to the fixture's original virtual desktop");
+        KeyboardHelper.SendKeys(Key.LWin, Key.Ctrl, Key.Left);
+        var switchedBack = WaitHelper.WaitForStable(
+            () => VirtualDesktopHelper.IsWindowOnCurrentDesktop(fixture.Handle),
+            isCurrent => isCurrent == true,
+            timeoutMS: 10_000,
+            requiredConsecutiveMatches: 2,
+            pollIntervalMS: 100);
+        Assert.IsTrue(switchedBack.Succeeded, "Windows did not return to the fixture's original virtual desktop.");
+        var returnedBorder = WaitForBorder(expected: true, timeoutMs: 15_000);
+        Assert.AreEqual(originalBorder.Width, returnedBorder.Width, "The border width changed after returning to the original desktop.");
+        Assert.AreEqual(originalBorder.Height, returnedBorder.Height, "The border height changed after returning to the original desktop.");
+    }
+
+    [TestMethod]
+    [TestCategory("AlwaysOnTop")]
+    [TestCategory("Always On Top #4")]
+    public void BorderTracksMinimizeAndMaximize()
+    {
+        fixture = TestWindow.Create("Always On Top window state fixture");
+        TogglePin(expected: true);
+        _ = WaitForBorder(expected: true);
+
+        Step("Minimizing the pinned fixture window");
+        WindowHelper.MinimizeWindow(fixture.Handle);
+        Assert.IsTrue(
+            WaitHelper.WaitForStable(
+                () => fixture.IsMinimized,
+                minimized => minimized,
+                timeoutMS: 5_000,
+                requiredConsecutiveMatches: 2,
+                pollIntervalMS: 100).Succeeded,
+            "The fixture did not reach the minimized state.");
+        AssertBorderState(expected: false, timeoutMs: 10_000);
+        AssertPinState(expected: true);
+
+        Step("Restoring the pinned fixture window");
+        WindowHelper.RestoreWindow(fixture.Handle);
+        Assert.IsTrue(
+            WaitHelper.WaitForStable(
+                () => fixture.IsMinimized,
+                minimized => !minimized,
+                timeoutMS: 5_000,
+                requiredConsecutiveMatches: 2,
+                pollIntervalMS: 100).Succeeded,
+            "The fixture did not restore from its minimized state.");
+        fixture.Focus();
+        _ = WaitForBorder(expected: true, timeoutMs: 10_000);
+        AssertPinState(expected: true);
+
+        Step("Maximizing the pinned fixture window");
+        WindowHelper.MaximizeWindow(fixture.Handle);
+        Assert.IsTrue(
+            WaitHelper.WaitForStable(
+                () => fixture.IsMaximized,
+                maximized => maximized,
+                timeoutMS: 5_000,
+                requiredConsecutiveMatches: 2,
+                pollIntervalMS: 100).Succeeded,
+            "The fixture did not reach the maximized state.");
+        var maximizedBorder = WaitForBorder(expected: true, timeoutMs: 10_000);
+        AssertPinState(expected: true);
+        AssertBorderSurroundsVisibleFrame(maximizedBorder);
+    }
+
+    [TestMethod]
+    [TestCategory("AlwaysOnTop")]
+    [TestCategory("Always On Top #5")]
+    public void BorderColorAndThicknessUpdateWhilePinned()
+    {
+        const int initialThickness = 4;
+        const int updatedThickness = 18;
+        var initialColor = Color.FromArgb(0x00, 0xCC, 0x66);
+        var updatedColor = Color.FromArgb(0xFF, 0x00, 0xFF);
+
+        Step("Applying the initial custom border color and thickness");
+        AlwaysOnTopSettingsSeed.Apply(
+            ("frame-enabled", true),
+            ("frame-thickness", initialThickness),
+            ("frame-color", "#00CC66"),
+            ("frame-opacity", 100),
+            ("frame-accent-color", false),
+            ("round-corners-enabled", false),
+            ("sound-enabled", false));
+        Thread.Sleep(SettingsReloadDelayMs);
+
+        fixture = TestWindow.Create("Always On Top border settings fixture");
+        TogglePin(expected: true);
+        var initialBorder = WaitForBorder(expected: true);
+        Assert.IsTrue(
+            WaitForBorderColor(initialColor, initialThickness, timeoutMs: 10_000),
+            "The initial custom green border color was not visible.");
+
+        Step("Changing the pinned window border to magenta and increasing its thickness");
+        AlwaysOnTopSettingsSeed.Apply(
+            ("frame-thickness", updatedThickness),
+            ("frame-color", "#FF00FF"));
+
+        var update = WaitHelper.WaitForStable(
+            observe: () =>
+            {
+                var border = FindNearestVisibleBorder();
+                return (
+                    Border: border,
+                    HasUpdatedColor: border.Hwnd != IntPtr.Zero && BorderContainsColor(border, updatedColor, updatedThickness));
+            },
+            isMatch: state =>
+                state.Border.Hwnd != IntPtr.Zero
+                && state.Border.Width >= initialBorder.Width + ((updatedThickness - initialThickness) * 2) - 4
+                && state.Border.Height >= initialBorder.Height + ((updatedThickness - initialThickness) * 2) - 4
+                && state.HasUpdatedColor,
+            timeoutMS: 15_000,
+            requiredConsecutiveMatches: 2,
+            pollIntervalMS: 250);
+
+        var updateDiagnostics = $"Last border={update.LastObservation.Border.Width}x{update.LastObservation.Border.Height}, magenta={update.LastObservation.HasUpdatedColor}.";
+        Assert.IsTrue(update.Succeeded, $"The live border update did not settle. {updateDiagnostics}");
+    }
+
+    [TestMethod]
+    [TestCategory("AlwaysOnTop")]
+    [TestCategory("Always On Top #6")]
+    public void SoundSettingControlsPlaybackAttempt()
+    {
+        fixture = TestWindow.Create("Always On Top sound fixture");
+        AlwaysOnTopSettingsSeed.Apply(("sound-enabled", true), ("frame-enabled", false));
+        Thread.Sleep(SettingsReloadDelayMs);
+
+        using (var enabledWatcher = SoundPlaybackWatcher.Create())
+        {
+            Step($"Watching access to '{enabledWatcher.FilePath}' with sound enabled");
+            TogglePin(expected: true);
+            Assert.IsTrue(
+                enabledWatcher.WaitForAccess(timeoutMs: 5_000),
+                "Enabling sound did not cause Always On Top to open its pin sound file.");
+        }
+
+        Step("Disabling sound and returning the fixture to an unpinned state");
+        AlwaysOnTopSettingsSeed.Apply(("sound-enabled", false));
+        Thread.Sleep(SettingsReloadDelayMs);
+        TogglePin(expected: false);
+
+        using (var disabledWatcher = SoundPlaybackWatcher.Create())
+        {
+            Step($"Watching access to '{disabledWatcher.FilePath}' with sound disabled");
+            TogglePin(expected: true);
+            Assert.IsFalse(
+                disabledWatcher.WaitForAccess(timeoutMs: 2_000),
+                "Always On Top opened its pin sound file even though sound was disabled.");
+        }
+
+        TestContext.WriteLine(
+            "Playback gating is validated by forcing the product's existing PlaySound call to fail only when invoked; " +
+            "the Hyper-V guest has no stable audio-capture endpoint for asserting speaker output.");
+    }
+
+    [TestMethod]
+    [TestCategory("AlwaysOnTop")]
+    [TestCategory("Always On Top #7")]
+    [TestCategory("Always On Top #8")]
+    public void ExcludedApplicationCannotBePinnedAndIsUnpinnedWhenAdded()
+    {
+        fixture = TestWindow.Create("Always On Top exclusion fixture");
+
+        Step($"Excluding the fixture process '{fixture.ProcessFileName}'");
+        AlwaysOnTopSettingsSeed.Apply(("excluded-apps", fixture.ProcessFileName));
+        Thread.Sleep(SettingsReloadDelayMs);
+        fixture.Focus();
+        KeyboardHelper.SendKeys(ActivationShortcut);
+        Thread.Sleep(2_000);
+        Assert.IsFalse(fixture.IsPinned, "Always On Top marked the Direct3D fixture as pinned while Game Mode blocking was enabled.");
+        AssertBorderState(expected: false);
+
+        Step("Removing the exclusion and pinning the fixture");
+        AlwaysOnTopSettingsSeed.Apply(("excluded-apps", string.Empty));
+        Thread.Sleep(SettingsReloadDelayMs);
+        TogglePin(expected: true);
+        AssertBorderState(expected: true);
+
+        Step("Excluding the already pinned fixture");
+        AlwaysOnTopSettingsSeed.Apply(("excluded-apps", fixture.ProcessFileName));
+        AssertPinState(expected: false, timeoutMs: 10_000);
+        AssertBorderState(expected: false, timeoutMs: 10_000);
+    }
+
+    [TestMethod]
+    [TestCategory("AlwaysOnTop")]
+    [TestCategory("Always On Top #9")]
+    public void GameModeSettingBlocksPinning()
+    {
+        fixture = TestWindow.Create("Always On Top Direct3D game fixture");
+
+        Step("Entering Direct3D full-screen exclusive mode");
+        fullScreen = Direct3DFullScreenScope.Enter(fixture);
+        var gameMode = WaitHelper.WaitForStable(
+            Direct3DFullScreenScope.QueryUserNotificationState,
+            state => state == Direct3DFullScreenScope.UserNotificationState.RunningDirect3DFullScreen,
+            timeoutMS: 10_000,
+            requiredConsecutiveMatches: 2,
+            pollIntervalMS: 250);
+        Assert.IsTrue(
+            gameMode.Succeeded,
+            $"Windows did not report Direct3D full-screen Game Mode. Last state: {gameMode.LastObservation}.");
+
+        Step("Enabling the Always On Top Game Mode block");
+        AlwaysOnTopSettingsSeed.Apply(("do-not-activate-on-game-mode", true));
+        Thread.Sleep(SettingsReloadDelayMs);
+        fixture.Focus();
+        KeyboardHelper.SendKeys(ActivationShortcut);
+        Thread.Sleep(2_000);
+        Assert.IsFalse(fixture.IsPinned, "Always On Top marked the Direct3D fixture as pinned while Game Mode blocking was enabled.");
+
+        Step("Leaving Direct3D full-screen mode");
+        fullScreen.Dispose();
+        fullScreen = null;
+        var normalMode = WaitHelper.WaitForStable(
+            Direct3DFullScreenScope.QueryUserNotificationState,
+            state => state != Direct3DFullScreenScope.UserNotificationState.RunningDirect3DFullScreen,
+            timeoutMS: 10_000,
+            requiredConsecutiveMatches: 2,
+            pollIntervalMS: 250);
+        Assert.IsTrue(normalMode.Succeeded, "Windows continued reporting Direct3D full-screen mode after the fixture exited it.");
+        Assert.IsFalse(fixture.IsTopmost, "The Direct3D fixture remained topmost after leaving full-screen mode.");
+
+        Step("Disabling the Game Mode block and verifying the same shortcut outside Game Mode");
+        AlwaysOnTopSettingsSeed.Apply(("do-not-activate-on-game-mode", false));
+        Thread.Sleep(SettingsReloadDelayMs);
+
+        TogglePin(expected: true);
+        AssertPinState(expected: true);
+    }
+
+    private void TogglePin(bool expected)
+    {
+        var targetState = expected ? "pinned" : "unpinned";
+        for (var attempt = 1; attempt <= 3; attempt++)
+        {
+            if (PinStateMatches(expected))
+            {
+                return;
+            }
+
+            Step($"Sending {string.Join(" + ", ActivationShortcut)} to make the fixture {targetState} (attempt {attempt}/3)");
+            fixture!.Focus();
+            KeyboardHelper.SendKeys(ActivationShortcut);
+
+            if (WaitForPinState(expected, timeoutMs: 3_000))
+            {
+                return;
+            }
+        }
+
+        AssertPinState(expected);
+    }
+
+    private void AssertPinState(bool expected, int timeoutMs = 7_000)
+    {
+        var succeeded = WaitForPinState(expected, timeoutMs);
+        var diagnostics = $"PinnedProperty={fixture!.IsPinned}, TopmostStyle={fixture.IsTopmost}.";
+        Assert.IsTrue(succeeded, $"The fixture did not reach the expected pin state. {diagnostics}");
+    }
+
+    private bool WaitForPinState(bool expected, int timeoutMs)
+    {
+        var result = WaitHelper.WaitForStable(
+            observe: () => (fixture!.IsPinned, fixture.IsTopmost),
+            isMatch: state => state.IsPinned == expected && state.IsTopmost == expected,
+            timeoutMS: timeoutMs,
+            requiredConsecutiveMatches: 2,
+            pollIntervalMS: 100);
+        return result.Succeeded;
+    }
+
+    private bool PinStateMatches(bool expected)
+    {
+        return fixture!.IsPinned == expected && fixture.IsTopmost == expected;
+    }
+
+    private void AssertBorderState(bool expected, int timeoutMs = 7_000)
+    {
+        var border = WaitForBorder(expected, timeoutMs);
+        if (expected)
+        {
+            Assert.AreNotEqual(IntPtr.Zero, border.Hwnd, "The Always On Top border window was not visible.");
+        }
+    }
+
+    private WindowControl.ProcessWindow WaitForBorder(bool expected, int timeoutMs = 7_000)
+    {
+        var result = WaitHelper.WaitForStable(
+            FindNearestVisibleBorder,
+            border => (border.Hwnd != IntPtr.Zero) == expected,
+            timeoutMS: timeoutMs,
+            requiredConsecutiveMatches: 2,
+            pollIntervalMS: 100);
+
+        var diagnostics = $"Last HWND={result.LastObservation.Hwnd}, size={result.LastObservation.Width}x{result.LastObservation.Height}.";
+        Assert.IsTrue(result.Succeeded, $"The Always On Top border did not reach expected visibility within {timeoutMs} ms. {diagnostics}");
+        return result.LastObservation;
+    }
+
+    private WindowControl.ProcessWindow FindNearestVisibleBorder()
+    {
+        if (fixture is null)
+        {
+            return default;
+        }
+
+        var targetCenter = WindowHelper.GetWindowCenter(fixture.Handle);
+        var display = WindowHelper.GetDisplaySize();
+        var candidate = WindowControl.EnumerateAllWindows()
+            .Where(window =>
+                window.IsVisible
+                && window.ClassName.Equals(BorderWindowClass, StringComparison.OrdinalIgnoreCase)
+                && IsOnScreen(window.Hwnd, display))
+            .OrderBy(
+                window =>
+                {
+                    var center = WindowHelper.GetWindowCenter(window.Hwnd);
+                    return Math.Abs(center.CenterX - targetCenter.CenterX) + Math.Abs(center.CenterY - targetCenter.CenterY);
+                })
+            .FirstOrDefault();
+        if (candidate.Hwnd == IntPtr.Zero)
+        {
+            return default;
+        }
+
+        var candidateCenter = WindowHelper.GetWindowCenter(candidate.Hwnd);
+        var centerDistance = Math.Abs(candidateCenter.CenterX - targetCenter.CenterX) + Math.Abs(candidateCenter.CenterY - targetCenter.CenterY);
+        return centerDistance <= 32 ? candidate : default;
+    }
+
+    private static bool IsOnScreen(IntPtr window, (int Width, int Height) display)
+    {
+        var bounds = WindowHelper.GetWindowBounds(window);
+        return bounds.Right > 0
+            && bounds.Bottom > 0
+            && bounds.Left < display.Width
+            && bounds.Top < display.Height;
+    }
+
+    private void AssertBorderSurroundsVisibleFrame(WindowControl.ProcessWindow border)
+    {
+        var frame = fixture!.VisibleFrameBounds;
+        var borderBounds = WindowHelper.GetWindowBounds(border.Hwnd);
+        var leftMargin = frame.Left - borderBounds.Left;
+        var topMargin = frame.Top - borderBounds.Top;
+        var rightMargin = borderBounds.Right - frame.Right;
+        var bottomMargin = borderBounds.Bottom - frame.Bottom;
+
+        Assert.IsTrue(
+            leftMargin is > 0 and <= 64
+            && topMargin is > 0 and <= 64
+            && rightMargin is > 0 and <= 64
+            && bottomMargin is > 0 and <= 64,
+            $"The border did not surround the maximized DWM frame. Margins: L={leftMargin}, T={topMargin}, R={rightMargin}, B={bottomMargin}.");
+        Assert.IsTrue(Math.Abs(leftMargin - rightMargin) <= 4, "The maximized border was not horizontally symmetric.");
+        Assert.IsTrue(Math.Abs(topMargin - bottomMargin) <= 4, "The maximized border was not vertically symmetric.");
+    }
+
+    private bool WaitForBorderColor(Color expectedColor, int thickness, int timeoutMs)
+    {
+        var result = WaitHelper.WaitForStable(
+            observe: () =>
+            {
+                var border = FindNearestVisibleBorder();
+                return border.Hwnd != IntPtr.Zero && BorderContainsColor(border, expectedColor, thickness);
+            },
+            isMatch: matches => matches,
+            timeoutMS: timeoutMs,
+            requiredConsecutiveMatches: 2,
+            pollIntervalMS: 250);
+        return result.Succeeded;
+    }
+
+    private static bool BorderContainsColor(WindowControl.ProcessWindow border, Color expectedColor, int thickness)
+    {
+        var bounds = WindowHelper.GetWindowBounds(border.Hwnd);
+        var width = bounds.Right - bounds.Left;
+        var height = bounds.Bottom - bounds.Top;
+        if (width <= 0 || height <= 0)
+        {
+            return false;
+        }
+
+        using var image = new Bitmap(width, height);
+        using (var graphics = Graphics.FromImage(image))
+        {
+            graphics.CopyFromScreen(bounds.Left, bounds.Top, 0, 0, image.Size);
+        }
+
+        var band = Math.Min(Math.Max(thickness + 2, 4), Math.Min(width, height) / 3);
+        var matches = 0;
+        var samples = 0;
+        for (var x = 2; x < width - 2; x += 4)
+        {
+            for (var y = 1; y < band; y += 2)
+            {
+                samples += 2;
+                if (ColorsMatch(image.GetPixel(x, y), expectedColor))
+                {
+                    matches++;
+                }
+
+                if (ColorsMatch(image.GetPixel(x, height - 1 - y), expectedColor))
+                {
+                    matches++;
+                }
+            }
+        }
+
+        for (var y = band; y < height - band; y += 4)
+        {
+            for (var x = 1; x < band; x += 2)
+            {
+                samples += 2;
+                if (ColorsMatch(image.GetPixel(x, y), expectedColor))
+                {
+                    matches++;
+                }
+
+                if (ColorsMatch(image.GetPixel(width - 1 - x, y), expectedColor))
+                {
+                    matches++;
+                }
+            }
+        }
+
+        return matches >= Math.Max(8, samples / 12);
+    }
+
+    private static bool ColorsMatch(Color actual, Color expected)
+    {
+        const int tolerance = 24;
+        return Math.Abs(actual.R - expected.R) <= tolerance
+            && Math.Abs(actual.G - expected.G) <= tolerance
+            && Math.Abs(actual.B - expected.B) <= tolerance;
+    }
+
+    private static bool WaitForProcess(bool expected, int timeoutMs)
+    {
+        var result = WaitHelper.WaitForStable(
+            observe: () =>
+            {
+                var processes = Process.GetProcessesByName(AlwaysOnTopProcessName);
+                try
+                {
+                    return processes.Length > 0;
+                }
+                finally
+                {
+                    foreach (var process in processes)
+                    {
+                        process.Dispose();
+                    }
+                }
+            },
+            isMatch: present => present == expected,
+            timeoutMS: timeoutMs,
+            requiredConsecutiveMatches: 2,
+            pollIntervalMS: 100);
+        return result.Succeeded;
+    }
+
+    private void CleanupExtraVirtualDesktop()
+    {
+        if (!extraVirtualDesktopCreated)
+        {
+            return;
+        }
+
+        try
+        {
+            var fixtureOnCurrentDesktop = fixture is not null
+                && VirtualDesktopHelper.IsWindowOnCurrentDesktop(fixture.Handle);
+            if (fixtureOnCurrentDesktop)
+            {
+                KeyboardHelper.SendKeys(Key.LWin, Key.Ctrl, Key.Right);
+                var switchedToCreatedDesktop = WaitHelper.WaitForStable(
+                    () => VirtualDesktopHelper.IsWindowOnCurrentDesktop(fixture!.Handle),
+                    isCurrent => isCurrent == false,
+                    timeoutMS: 10_000,
+                    requiredConsecutiveMatches: 2,
+                    pollIntervalMS: 100);
+                if (!switchedToCreatedDesktop.Succeeded)
+                {
+                    TestContext.WriteLine("Virtual desktop cleanup did not reach the created desktop; it will not close any desktop.");
+                    return;
+                }
+            }
+
+            KeyboardHelper.SendKeys(Key.LWin, Key.Ctrl, Key.F4);
+            var returnedToOriginalDesktop = WaitHelper.WaitForStable(
+                () => VirtualDesktopHelper.IsWindowOnCurrentDesktop(fixture!.Handle),
+                isCurrent => isCurrent == true,
+                timeoutMS: 10_000,
+                requiredConsecutiveMatches: 2,
+                pollIntervalMS: 100);
+            if (!returnedToOriginalDesktop.Succeeded)
+            {
+                TestContext.WriteLine("Virtual desktop cleanup could not confirm a return to the original desktop.");
+            }
+        }
+        catch (Exception ex)
+        {
+            TestContext.WriteLine($"Virtual desktop cleanup failed: {ex.Message}");
+        }
+        finally
+        {
+            extraVirtualDesktopCreated = false;
+        }
+    }
+
+    private void Step(string message)
+    {
+        TestContext.WriteLine($"[{DateTime.UtcNow:HH:mm:ss.fff}] {message}");
+    }
+}

--- a/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/DesktopHygiene.cs
+++ b/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/DesktopHygiene.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using Microsoft.PowerToys.UITest.Next;
+
+namespace Microsoft.AlwaysOnTop.UITests;
+
+internal static class DesktopHygiene
+{
+    private const uint WmClose = 0x0010;
+
+    internal static void DismissForegroundShellSurface(WindowControl.ForegroundWindowInfo foreground)
+    {
+        if (!foreground.ProcessName.Equals("ShellExperienceHost", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        _ = PostMessageW(foreground.Hwnd, WmClose, IntPtr.Zero, IntPtr.Zero);
+        Thread.Sleep(250);
+        if (!IsConfirmedForeground(foreground.Hwnd))
+        {
+            return;
+        }
+
+        var display = WindowHelper.GetDisplaySize();
+
+        // Windows notifications anchor their rightmost action above the taskbar at this inset.
+        MouseHelper.LeftClickAt(display.Width - 100, display.Height - 84);
+        Thread.Sleep(500);
+        if (!IsConfirmedForeground(foreground.Hwnd))
+        {
+            return;
+        }
+
+        KeyboardHelper.SendKeys(Key.Alt, Key.F4);
+        Thread.Sleep(500);
+    }
+
+    [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool PostMessageW(IntPtr hWnd, uint message, IntPtr wParam, IntPtr lParam);
+
+    private static bool IsConfirmedForeground(IntPtr hwnd)
+    {
+        return WindowControl.GetForegroundWindowInfo().Hwnd == hwnd;
+    }
+}

--- a/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/Direct3DFullScreenScope.cs
+++ b/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/Direct3DFullScreenScope.cs
@@ -8,10 +8,10 @@ namespace Microsoft.AlwaysOnTop.UITests;
 
 internal sealed class Direct3DFullScreenScope : IDisposable
 {
-    private const uint D3dSdkVersion = 32;
+    private const uint D3dSdkVersion = 32; // D3D_SDK_VERSION from d3d9.h.
     private const uint D3dCreateFpuPreserve = 0x00000002;
     private const uint D3dCreateSoftwareVertexProcessing = 0x00000020;
-    private const uint D3dPresentIntervalImmediate = 0x80000000;
+    private const uint D3dPresentIntervalImmediate = 0x80000000; // D3DPRESENT_INTERVAL_IMMEDIATE.
     private const int D3dSwapEffectDiscard = 1;
     private const int D3dDevTypeHardware = 1;
     private const int D3dDevTypeReference = 2;
@@ -103,6 +103,7 @@ internal sealed class Direct3DFullScreenScope : IDisposable
             throw new InvalidOperationException("Direct3DCreate9 returned a null interface.");
         }
 
+        // IDirect3D9 slot 8: GetAdapterDisplayMode (after the three IUnknown slots).
         var getDisplayMode = GetComMethod<GetAdapterDisplayModeDelegate>(direct3D, 8);
         var modeResult = getDisplayMode(direct3D, 0, out var mode);
         if (modeResult < 0)
@@ -131,9 +132,10 @@ internal sealed class Direct3DFullScreenScope : IDisposable
             PresentationInterval = D3dPresentIntervalImmediate,
         };
 
+        // IDirect3D9 slot 16: CreateDevice.
         var createDevice = GetComMethod<CreateDeviceDelegate>(direct3D, 16);
         var behaviorFlags = D3dCreateFpuPreserve | D3dCreateSoftwareVertexProcessing;
-        var createResult = createDevice(
+        var hardwareCreateResult = createDevice(
             direct3D,
             0,
             D3dDevTypeHardware,
@@ -142,9 +144,10 @@ internal sealed class Direct3DFullScreenScope : IDisposable
             ref parameters,
             out device);
 
-        if (createResult < 0)
+        int? referenceCreateResult = null;
+        if (hardwareCreateResult < 0)
         {
-            createResult = createDevice(
+            referenceCreateResult = createDevice(
                 direct3D,
                 0,
                 D3dDevTypeReference,
@@ -154,11 +157,14 @@ internal sealed class Direct3DFullScreenScope : IDisposable
                 out device);
         }
 
-        if (createResult < 0 || device == IntPtr.Zero)
+        if ((referenceCreateResult ?? hardwareCreateResult) < 0 || device == IntPtr.Zero)
         {
-            throw new InvalidOperationException($"IDirect3D9::CreateDevice failed with HRESULT 0x{createResult:X8}.");
+            var referenceResult = referenceCreateResult.HasValue ? $"0x{referenceCreateResult.Value:X8}" : "not attempted";
+            throw new InvalidOperationException(
+                $"IDirect3D9::CreateDevice failed. HAL=0x{hardwareCreateResult:X8}; REF={referenceResult}.");
         }
 
+        // IDirect3DDevice9 slot 17: Present.
         var present = GetComMethod<PresentDelegate>(device, 17);
         _ = present(device, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
     }

--- a/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/Direct3DFullScreenScope.cs
+++ b/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/Direct3DFullScreenScope.cs
@@ -1,0 +1,258 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace Microsoft.AlwaysOnTop.UITests;
+
+internal sealed class Direct3DFullScreenScope : IDisposable
+{
+    private const uint D3dSdkVersion = 32;
+    private const uint D3dCreateFpuPreserve = 0x00000002;
+    private const uint D3dCreateSoftwareVertexProcessing = 0x00000020;
+    private const uint D3dPresentIntervalImmediate = 0x80000000;
+    private const int D3dSwapEffectDiscard = 1;
+    private const int D3dDevTypeHardware = 1;
+    private const int D3dDevTypeReference = 2;
+
+    private readonly TestWindow window;
+    private readonly System.Drawing.Rectangle originalBounds;
+    private readonly System.Windows.Forms.FormBorderStyle originalBorderStyle;
+    private readonly System.Windows.Forms.FormWindowState originalWindowState;
+    private IntPtr direct3D;
+    private IntPtr device;
+    private bool disposed;
+
+    private Direct3DFullScreenScope(TestWindow window)
+    {
+        this.window = window;
+        var originalState = window.Invoke(
+            () =>
+            {
+                var form = window.GetForm();
+                return (form.Bounds, form.FormBorderStyle, form.WindowState);
+            });
+        originalBounds = originalState.Bounds;
+        originalBorderStyle = originalState.FormBorderStyle;
+        originalWindowState = originalState.WindowState;
+
+        try
+        {
+            window.Invoke(CreateDevice);
+        }
+        catch
+        {
+            window.Invoke(
+                () =>
+                {
+                    ReleaseDevice();
+                    RestoreWindow();
+                });
+            throw;
+        }
+    }
+
+    internal static Direct3DFullScreenScope Enter(TestWindow window)
+    {
+        return new Direct3DFullScreenScope(window);
+    }
+
+    internal static UserNotificationState QueryUserNotificationState()
+    {
+        var result = SHQueryUserNotificationState(out var state);
+        if (result < 0)
+        {
+            Marshal.ThrowExceptionForHR(result);
+        }
+
+        return state;
+    }
+
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        window.Invoke(
+            () =>
+            {
+                ReleaseDevice();
+                RestoreWindow();
+            });
+        disposed = true;
+    }
+
+    [DllImport("d3d9.dll", ExactSpelling = true)]
+    private static extern IntPtr Direct3DCreate9(uint sdkVersion);
+
+    [DllImport("shell32.dll")]
+    private static extern int SHQueryUserNotificationState(out UserNotificationState state);
+
+    private void CreateDevice()
+    {
+        var form = window.GetForm();
+        form.WindowState = System.Windows.Forms.FormWindowState.Normal;
+        form.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
+
+        direct3D = Direct3DCreate9(D3dSdkVersion);
+        if (direct3D == IntPtr.Zero)
+        {
+            throw new InvalidOperationException("Direct3DCreate9 returned a null interface.");
+        }
+
+        var getDisplayMode = GetComMethod<GetAdapterDisplayModeDelegate>(direct3D, 8);
+        var modeResult = getDisplayMode(direct3D, 0, out var mode);
+        if (modeResult < 0)
+        {
+            throw new InvalidOperationException($"IDirect3D9::GetAdapterDisplayMode failed with HRESULT 0x{modeResult:X8}.");
+        }
+
+        form.Bounds = new System.Drawing.Rectangle(0, 0, (int)mode.Width, (int)mode.Height);
+        form.Activate();
+
+        var parameters = new D3dPresentParameters
+        {
+            BackBufferWidth = mode.Width,
+            BackBufferHeight = mode.Height,
+            BackBufferFormat = mode.Format,
+            BackBufferCount = 1,
+            MultiSampleType = 0,
+            MultiSampleQuality = 0,
+            SwapEffect = D3dSwapEffectDiscard,
+            DeviceWindow = form.Handle,
+            Windowed = 0,
+            EnableAutoDepthStencil = 0,
+            AutoDepthStencilFormat = 0,
+            Flags = 0,
+            FullScreenRefreshRateInHz = mode.RefreshRate,
+            PresentationInterval = D3dPresentIntervalImmediate,
+        };
+
+        var createDevice = GetComMethod<CreateDeviceDelegate>(direct3D, 16);
+        var behaviorFlags = D3dCreateFpuPreserve | D3dCreateSoftwareVertexProcessing;
+        var createResult = createDevice(
+            direct3D,
+            0,
+            D3dDevTypeHardware,
+            form.Handle,
+            behaviorFlags,
+            ref parameters,
+            out device);
+
+        if (createResult < 0)
+        {
+            createResult = createDevice(
+                direct3D,
+                0,
+                D3dDevTypeReference,
+                form.Handle,
+                behaviorFlags,
+                ref parameters,
+                out device);
+        }
+
+        if (createResult < 0 || device == IntPtr.Zero)
+        {
+            throw new InvalidOperationException($"IDirect3D9::CreateDevice failed with HRESULT 0x{createResult:X8}.");
+        }
+
+        var present = GetComMethod<PresentDelegate>(device, 17);
+        _ = present(device, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+    }
+
+    private void ReleaseDevice()
+    {
+        if (device != IntPtr.Zero)
+        {
+            Marshal.Release(device);
+            device = IntPtr.Zero;
+        }
+
+        if (direct3D != IntPtr.Zero)
+        {
+            Marshal.Release(direct3D);
+            direct3D = IntPtr.Zero;
+        }
+    }
+
+    private void RestoreWindow()
+    {
+        var form = window.GetForm();
+        form.WindowState = System.Windows.Forms.FormWindowState.Normal;
+        form.TopMost = false;
+        form.FormBorderStyle = originalBorderStyle;
+        form.Bounds = originalBounds;
+        form.WindowState = originalWindowState;
+    }
+
+    private static T GetComMethod<T>(IntPtr instance, int index)
+        where T : Delegate
+    {
+        var vtable = Marshal.ReadIntPtr(instance);
+        var method = Marshal.ReadIntPtr(vtable, index * IntPtr.Size);
+        return Marshal.GetDelegateForFunctionPointer<T>(method);
+    }
+
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    private delegate int GetAdapterDisplayModeDelegate(IntPtr instance, uint adapter, out D3dDisplayMode mode);
+
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    private delegate int CreateDeviceDelegate(
+        IntPtr instance,
+        uint adapter,
+        int deviceType,
+        IntPtr focusWindow,
+        uint behaviorFlags,
+        ref D3dPresentParameters presentationParameters,
+        out IntPtr returnedDeviceInterface);
+
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    private delegate int PresentDelegate(
+        IntPtr instance,
+        IntPtr sourceRectangle,
+        IntPtr destinationRectangle,
+        IntPtr destinationWindowOverride,
+        IntPtr dirtyRegion);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct D3dDisplayMode
+    {
+        internal uint Width;
+        internal uint Height;
+        internal uint RefreshRate;
+        internal int Format;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct D3dPresentParameters
+    {
+        internal uint BackBufferWidth;
+        internal uint BackBufferHeight;
+        internal int BackBufferFormat;
+        internal uint BackBufferCount;
+        internal int MultiSampleType;
+        internal uint MultiSampleQuality;
+        internal int SwapEffect;
+        internal IntPtr DeviceWindow;
+        internal int Windowed;
+        internal int EnableAutoDepthStencil;
+        internal int AutoDepthStencilFormat;
+        internal uint Flags;
+        internal uint FullScreenRefreshRateInHz;
+        internal uint PresentationInterval;
+    }
+
+    internal enum UserNotificationState
+    {
+        NotPresent = 1,
+        Busy = 2,
+        RunningDirect3DFullScreen = 3,
+        PresentationMode = 4,
+        AcceptsNotifications = 5,
+        QuietTime = 6,
+        App = 7,
+    }
+}

--- a/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/SoundFileFixture.cs
+++ b/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/SoundFileFixture.cs
@@ -1,0 +1,175 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Win32.SafeHandles;
+
+namespace Microsoft.AlwaysOnTop.UITests;
+
+/// <summary>
+/// Provides the relative <c>Media\Speech On.wav</c> path used by Always On Top. The UI-test harness
+/// launches PowerToys with its executable directory as the working directory, which child modules
+/// inherit. The playback test's positive oplock assertion guards that launch contract.
+/// </summary>
+internal sealed class SoundFileFixture : IDisposable
+{
+    private const uint ProcessQueryLimitedInformation = 0x1000;
+
+    private readonly string mediaDirectory;
+    private readonly bool createdDirectory;
+    private readonly bool createdFile;
+    private readonly Action<string> log;
+    private bool disposed;
+
+    private SoundFileFixture(string executablePath, Action<string> log)
+    {
+        this.log = log;
+        mediaDirectory = Path.Combine(Path.GetDirectoryName(executablePath)!, "Media");
+        FilePath = Path.Combine(mediaDirectory, "Speech On.wav");
+        createdDirectory = !Directory.Exists(mediaDirectory);
+
+        try
+        {
+            Directory.CreateDirectory(mediaDirectory);
+            createdFile = !File.Exists(FilePath);
+            if (createdFile)
+            {
+                var sourcePath = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.Windows),
+                    "Media",
+                    "Speech On.wav");
+                if (!File.Exists(sourcePath))
+                {
+                    throw new FileNotFoundException("The Windows Speech On sound used by the test fixture is unavailable.", sourcePath);
+                }
+
+                File.Copy(sourcePath, FilePath);
+            }
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Dispose();
+            throw new InvalidOperationException(
+                $"The playback test requires write access to the module working directory '{mediaDirectory}'.",
+                ex);
+        }
+        catch
+        {
+            Dispose();
+            throw;
+        }
+    }
+
+    internal string FilePath { get; }
+
+    internal static SoundFileFixture Create(Action<string> log)
+    {
+        ArgumentNullException.ThrowIfNull(log);
+        var processes = Process.GetProcessesByName("PowerToys.AlwaysOnTop");
+        var failures = new List<string>();
+        try
+        {
+            foreach (var process in processes)
+            {
+                try
+                {
+                    return new SoundFileFixture(QueryExecutablePath(process.Id), log);
+                }
+                catch (Win32Exception ex)
+                {
+                    failures.Add($"PID {process.Id}: {ex.Message}");
+                }
+            }
+        }
+        finally
+        {
+            foreach (var process in processes)
+            {
+                process.Dispose();
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"The PowerToys.AlwaysOnTop executable path is unavailable. {string.Join("; ", failures)}");
+    }
+
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+        if (createdFile)
+        {
+            DeleteFileWithRetry(FilePath);
+        }
+
+        if (createdDirectory && Directory.Exists(mediaDirectory) && !Directory.EnumerateFileSystemEntries(mediaDirectory).Any())
+        {
+            try
+            {
+                Directory.Delete(mediaDirectory);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                log($"Could not remove playback fixture directory '{mediaDirectory}': {ex.Message}");
+            }
+        }
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern SafeProcessHandle OpenProcess(uint desiredAccess, [MarshalAs(UnmanagedType.Bool)] bool inheritHandle, int processId);
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool QueryFullProcessImageNameW(
+        SafeProcessHandle process,
+        uint flags,
+        StringBuilder executablePath,
+        ref uint size);
+
+    private static string QueryExecutablePath(int processId)
+    {
+        using var process = OpenProcess(ProcessQueryLimitedInformation, inheritHandle: false, processId);
+        if (process.IsInvalid)
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error(), $"Opening process {processId} failed.");
+        }
+
+        var capacity = 32_768;
+        var path = new StringBuilder(capacity);
+        var size = (uint)capacity;
+        if (!QueryFullProcessImageNameW(process, 0, path, ref size))
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error(), $"Reading process {processId}'s executable path failed.");
+        }
+
+        return path.ToString();
+    }
+
+    private void DeleteFileWithRetry(string path)
+    {
+        Exception? lastError = null;
+        for (var attempt = 1; attempt <= 50; attempt++)
+        {
+            try
+            {
+                File.Delete(path);
+                return;
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                lastError = ex;
+                Thread.Sleep(100);
+            }
+        }
+
+        log($"Could not remove playback fixture file '{path}': {lastError?.Message ?? "unknown error"}");
+    }
+}

--- a/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/SoundPlaybackWatcher.cs
+++ b/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/SoundPlaybackWatcher.cs
@@ -1,0 +1,237 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace Microsoft.AlwaysOnTop.UITests;
+
+internal sealed class SoundPlaybackWatcher : IDisposable
+{
+    private const uint FsctlRequestOplockLevel1 = 0x00090000;
+    private const int ErrorIoPending = 997;
+    private const uint GenericRead = 0x80000000;
+    private const uint FileShareRead = 0x00000001;
+    private const uint FileShareWrite = 0x00000002;
+    private const uint FileShareDelete = 0x00000004;
+    private const uint OpenExisting = 3;
+    private const uint FileFlagOverlapped = 0x40000000;
+
+    private readonly string targetPath;
+    private readonly string mediaDirectory;
+    private readonly bool createdTarget;
+    private readonly bool createdDirectory;
+    private readonly SafeFileHandle fileHandle;
+    private readonly EventWaitHandle oplockBroken = new(false, EventResetMode.ManualReset);
+    private readonly IntPtr overlapped;
+    private bool disposed;
+
+    private SoundPlaybackWatcher(string productRoot)
+    {
+        mediaDirectory = Path.Combine(productRoot, "Media");
+        targetPath = Path.Combine(mediaDirectory, "Speech On.wav");
+        createdDirectory = !Directory.Exists(mediaDirectory);
+        Directory.CreateDirectory(mediaDirectory);
+
+        createdTarget = !File.Exists(targetPath);
+        if (createdTarget)
+        {
+            var sourcePath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.Windows),
+                "Media",
+                "Speech On.wav");
+            if (!File.Exists(sourcePath))
+            {
+                throw new FileNotFoundException("The Windows Speech On sound used by the test fixture is unavailable.", sourcePath);
+            }
+
+            File.Copy(sourcePath, targetPath);
+        }
+
+        fileHandle = CreateFileW(
+            targetPath,
+            GenericRead,
+            FileShareRead | FileShareWrite | FileShareDelete,
+            IntPtr.Zero,
+            OpenExisting,
+            FileFlagOverlapped,
+            IntPtr.Zero);
+        if (fileHandle.IsInvalid)
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error(), $"Opening '{targetPath}' for oplock monitoring failed.");
+        }
+
+        overlapped = Marshal.AllocHGlobal(Marshal.SizeOf<NativeOverlappedData>());
+        var data = new NativeOverlappedData
+        {
+            EventHandle = oplockBroken.SafeWaitHandle.DangerousGetHandle(),
+        };
+        Marshal.StructureToPtr(data, overlapped, fDeleteOld: false);
+        try
+        {
+            RequestOplock();
+        }
+        catch
+        {
+            fileHandle.Dispose();
+            Marshal.FreeHGlobal(overlapped);
+            oplockBroken.Dispose();
+            DeleteFixtureFiles();
+            throw;
+        }
+    }
+
+    internal string FilePath => targetPath;
+
+    internal static SoundPlaybackWatcher Create()
+    {
+        var processes = Process.GetProcessesByName("PowerToys.AlwaysOnTop");
+        try
+        {
+            var executable = processes
+                .Select(process => process.MainModule?.FileName)
+                .FirstOrDefault(path => !string.IsNullOrWhiteSpace(path))
+                ?? throw new InvalidOperationException("The PowerToys.AlwaysOnTop executable path is unavailable.");
+            return new SoundPlaybackWatcher(Path.GetDirectoryName(executable)!);
+        }
+        finally
+        {
+            foreach (var process in processes)
+            {
+                process.Dispose();
+            }
+        }
+    }
+
+    internal bool WaitForAccess(int timeoutMs)
+    {
+        return oplockBroken.WaitOne(timeoutMs);
+    }
+
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        _ = CancelIoEx(fileHandle, overlapped);
+        if (!GetOverlappedResult(fileHandle, overlapped, out _, wait: true))
+        {
+            const int errorOperationAborted = 995;
+            var error = Marshal.GetLastWin32Error();
+            if (error != errorOperationAborted)
+            {
+                throw new Win32Exception(error, $"Completing the oplock request for '{targetPath}' failed.");
+            }
+        }
+
+        fileHandle.Dispose();
+        Marshal.FreeHGlobal(overlapped);
+        oplockBroken.Dispose();
+        disposed = true;
+        DeleteFixtureFiles();
+    }
+
+    private void DeleteFixtureFiles()
+    {
+        if (createdTarget)
+        {
+            DeleteFileWithRetry(targetPath);
+        }
+
+        if (createdDirectory && Directory.Exists(mediaDirectory) && !Directory.EnumerateFileSystemEntries(mediaDirectory).Any())
+        {
+            Directory.Delete(mediaDirectory);
+        }
+    }
+
+    private static void DeleteFileWithRetry(string path)
+    {
+        for (var attempt = 1; attempt <= 50; attempt++)
+        {
+            try
+            {
+                File.Delete(path);
+                return;
+            }
+            catch (IOException) when (attempt < 50)
+            {
+                Thread.Sleep(100);
+            }
+            catch (UnauthorizedAccessException) when (attempt < 50)
+            {
+                Thread.Sleep(100);
+            }
+        }
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern SafeFileHandle CreateFileW(
+        [MarshalAs(UnmanagedType.LPWStr)] string fileName,
+        uint desiredAccess,
+        uint shareMode,
+        IntPtr securityAttributes,
+        uint creationDisposition,
+        uint flagsAndAttributes,
+        IntPtr templateFile);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool DeviceIoControl(
+        SafeFileHandle device,
+        uint ioControlCode,
+        IntPtr inputBuffer,
+        uint inputBufferSize,
+        IntPtr outputBuffer,
+        uint outputBufferSize,
+        out uint bytesReturned,
+        IntPtr overlapped);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CancelIoEx(SafeFileHandle file, IntPtr overlapped);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetOverlappedResult(
+        SafeFileHandle file,
+        IntPtr overlapped,
+        out uint bytesTransferred,
+        [MarshalAs(UnmanagedType.Bool)] bool wait);
+
+    private void RequestOplock()
+    {
+        if (DeviceIoControl(
+            fileHandle,
+            FsctlRequestOplockLevel1,
+            IntPtr.Zero,
+            0,
+            IntPtr.Zero,
+            0,
+            out _,
+            overlapped))
+        {
+            throw new InvalidOperationException($"The sound-file oplock on '{targetPath}' completed before playback was triggered.");
+        }
+
+        var error = Marshal.GetLastWin32Error();
+        if (error != ErrorIoPending)
+        {
+            throw new Win32Exception(error, $"Requesting an oplock on '{targetPath}' failed.");
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NativeOverlappedData
+    {
+        internal IntPtr Internal;
+        internal IntPtr InternalHigh;
+        internal uint Offset;
+        internal uint OffsetHigh;
+        internal IntPtr EventHandle;
+    }
+}

--- a/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/SoundPlaybackWatcher.cs
+++ b/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/SoundPlaybackWatcher.cs
@@ -3,12 +3,16 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
 
 namespace Microsoft.AlwaysOnTop.UITests;
 
+/// <summary>
+/// Uses a level-1 NTFS oplock to observe the product opening its sound file without requiring an
+/// audio endpoint. The signal is machine-wide, so callers verify it has not fired before triggering
+/// the product action.
+/// </summary>
 internal sealed class SoundPlaybackWatcher : IDisposable
 {
     private const uint FsctlRequestOplockLevel1 = 0x00090000;
@@ -21,35 +25,16 @@ internal sealed class SoundPlaybackWatcher : IDisposable
     private const uint FileFlagOverlapped = 0x40000000;
 
     private readonly string targetPath;
-    private readonly string mediaDirectory;
-    private readonly bool createdTarget;
-    private readonly bool createdDirectory;
+    private readonly Action<string>? log;
     private readonly SafeFileHandle fileHandle;
     private readonly EventWaitHandle oplockBroken = new(false, EventResetMode.ManualReset);
     private readonly IntPtr overlapped;
     private bool disposed;
 
-    private SoundPlaybackWatcher(string productRoot)
+    private SoundPlaybackWatcher(string targetPath, Action<string>? log)
     {
-        mediaDirectory = Path.Combine(productRoot, "Media");
-        targetPath = Path.Combine(mediaDirectory, "Speech On.wav");
-        createdDirectory = !Directory.Exists(mediaDirectory);
-        Directory.CreateDirectory(mediaDirectory);
-
-        createdTarget = !File.Exists(targetPath);
-        if (createdTarget)
-        {
-            var sourcePath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.Windows),
-                "Media",
-                "Speech On.wav");
-            if (!File.Exists(sourcePath))
-            {
-                throw new FileNotFoundException("The Windows Speech On sound used by the test fixture is unavailable.", sourcePath);
-            }
-
-            File.Copy(sourcePath, targetPath);
-        }
+        this.targetPath = targetPath;
+        this.log = log;
 
         fileHandle = CreateFileW(
             targetPath,
@@ -79,31 +64,21 @@ internal sealed class SoundPlaybackWatcher : IDisposable
             fileHandle.Dispose();
             Marshal.FreeHGlobal(overlapped);
             oplockBroken.Dispose();
-            DeleteFixtureFiles();
             throw;
         }
     }
 
     internal string FilePath => targetPath;
 
-    internal static SoundPlaybackWatcher Create()
+    internal static SoundPlaybackWatcher Create(string targetPath, Action<string>? log = null)
     {
-        var processes = Process.GetProcessesByName("PowerToys.AlwaysOnTop");
-        try
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetPath);
+        if (!File.Exists(targetPath))
         {
-            var executable = processes
-                .Select(process => process.MainModule?.FileName)
-                .FirstOrDefault(path => !string.IsNullOrWhiteSpace(path))
-                ?? throw new InvalidOperationException("The PowerToys.AlwaysOnTop executable path is unavailable.");
-            return new SoundPlaybackWatcher(Path.GetDirectoryName(executable)!);
+            throw new FileNotFoundException("The Always On Top sound file used by the playback watcher is unavailable.", targetPath);
         }
-        finally
-        {
-            foreach (var process in processes)
-            {
-                process.Dispose();
-            }
-        }
+
+        return new SoundPlaybackWatcher(targetPath, log);
     }
 
     internal bool WaitForAccess(int timeoutMs)
@@ -118,54 +93,29 @@ internal sealed class SoundPlaybackWatcher : IDisposable
             return;
         }
 
-        _ = CancelIoEx(fileHandle, overlapped);
-        if (!GetOverlappedResult(fileHandle, overlapped, out _, wait: true))
-        {
-            const int errorOperationAborted = 995;
-            var error = Marshal.GetLastWin32Error();
-            if (error != errorOperationAborted)
-            {
-                throw new Win32Exception(error, $"Completing the oplock request for '{targetPath}' failed.");
-            }
-        }
-
-        fileHandle.Dispose();
-        Marshal.FreeHGlobal(overlapped);
-        oplockBroken.Dispose();
         disposed = true;
-        DeleteFixtureFiles();
-    }
-
-    private void DeleteFixtureFiles()
-    {
-        if (createdTarget)
+        try
         {
-            DeleteFileWithRetry(targetPath);
+            _ = CancelIoEx(fileHandle, overlapped);
+            if (!GetOverlappedResult(fileHandle, overlapped, out _, wait: true))
+            {
+                const int errorOperationAborted = 995;
+                var error = Marshal.GetLastWin32Error();
+                if (error != errorOperationAborted)
+                {
+                    log?.Invoke($"Completing the sound-file oplock for '{targetPath}' failed: {new Win32Exception(error).Message}");
+                }
+            }
         }
-
-        if (createdDirectory && Directory.Exists(mediaDirectory) && !Directory.EnumerateFileSystemEntries(mediaDirectory).Any())
+        catch (Exception ex)
         {
-            Directory.Delete(mediaDirectory);
+            log?.Invoke($"Disposing the sound-file oplock for '{targetPath}' failed: {ex.Message}");
         }
-    }
-
-    private static void DeleteFileWithRetry(string path)
-    {
-        for (var attempt = 1; attempt <= 50; attempt++)
+        finally
         {
-            try
-            {
-                File.Delete(path);
-                return;
-            }
-            catch (IOException) when (attempt < 50)
-            {
-                Thread.Sleep(100);
-            }
-            catch (UnauthorizedAccessException) when (attempt < 50)
-            {
-                Thread.Sleep(100);
-            }
+            fileHandle.Dispose();
+            Marshal.FreeHGlobal(overlapped);
+            oplockBroken.Dispose();
         }
     }
 

--- a/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/TestWindow.cs
+++ b/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/TestWindow.cs
@@ -1,0 +1,365 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using Microsoft.PowerToys.UITest.Next;
+
+namespace Microsoft.AlwaysOnTop.UITests;
+
+internal sealed class TestWindow : IDisposable
+{
+    private const int GwlExStyle = -20;
+    private const long WsExTopmost = 0x00000008L;
+    private const uint WmClose = 0x0010;
+    private const string PinnedProperty = "AlwaysOnTop_Pinned";
+
+    private readonly ManualResetEventSlim ready = new();
+    private readonly Thread windowThread;
+    private System.Windows.Forms.Form? form;
+    private Exception? startupFailure;
+    private long windowHandle;
+    private int stopRequested;
+    private bool disposed;
+
+    private TestWindow(string title)
+    {
+        windowThread = new Thread(() => RunWindow(title))
+        {
+            IsBackground = true,
+            Name = $"AlwaysOnTop UI test fixture: {title}",
+        };
+        windowThread.SetApartmentState(ApartmentState.STA);
+        windowThread.Start();
+
+        if (!ready.Wait(TimeSpan.FromSeconds(10)))
+        {
+            Dispose();
+            throw new TimeoutException($"The test window '{title}' did not become ready.");
+        }
+
+        if (startupFailure is not null)
+        {
+            Dispose();
+            throw new InvalidOperationException($"The test window '{title}' failed to start.", startupFailure);
+        }
+    }
+
+    internal IntPtr Handle => new(Interlocked.Read(ref windowHandle));
+
+    internal string ProcessFileName => Path.GetFileName(Environment.ProcessPath)
+        ?? throw new InvalidOperationException("The UI test process file name is unavailable.");
+
+    internal static TestWindow Create(string title)
+    {
+        var window = new TestWindow(title);
+        try
+        {
+            window.Focus();
+            return window;
+        }
+        catch
+        {
+            window.Dispose();
+            throw;
+        }
+    }
+
+    internal bool IsPinned =>
+        GetPropW(RequireLiveHandle(), PinnedProperty) != IntPtr.Zero;
+
+    internal bool IsTopmost =>
+        (GetWindowLongPtrW(RequireLiveHandle(), GwlExStyle).ToInt64() & WsExTopmost) != 0;
+
+    internal bool IsMinimized => IsIconic(RequireLiveHandle());
+
+    internal bool IsMaximized => IsZoomed(RequireLiveHandle());
+
+    internal (int Left, int Top, int Right, int Bottom) VisibleFrameBounds
+    {
+        get
+        {
+            var handle = RequireLiveHandle();
+            var result = DwmGetWindowAttribute(
+                handle,
+                DwmExtendedFrameBoundsAttribute,
+                out var bounds,
+                Marshal.SizeOf<Rect>());
+            if (result < 0)
+            {
+                Marshal.ThrowExceptionForHR(result);
+            }
+
+            return (bounds.Left, bounds.Top, bounds.Right, bounds.Bottom);
+        }
+    }
+
+    internal void Focus()
+    {
+        Invoke(
+            () =>
+            {
+                form!.Show();
+                form.Activate();
+                form.Focus();
+            });
+
+        var handle = RequireLiveHandle();
+        for (var attempt = 1; attempt <= 3; attempt++)
+        {
+            var foreground = WindowControl.GetForegroundWindowInfo();
+            if (foreground.ProcessName.Equals("ShellExperienceHost", StringComparison.OrdinalIgnoreCase)
+                && foreground.Title.Equals("New notification", StringComparison.OrdinalIgnoreCase))
+            {
+                DismissNotification(foreground.Hwnd);
+            }
+
+            WindowControl.TryBringToForeground(handle);
+            var fixtureBounds = WindowHelper.GetWindowBounds(handle);
+            if (fixtureBounds.Right > fixtureBounds.Left && fixtureBounds.Bottom > fixtureBounds.Top)
+            {
+                MouseHelper.LeftClickAt((fixtureBounds.Left + fixtureBounds.Right) / 2, fixtureBounds.Top + 16);
+            }
+
+            if (WindowControl.WaitForForeground(handle, timeoutMS: 2_000, requiredConsecutiveMatches: 2))
+            {
+                return;
+            }
+        }
+
+        var currentForeground = WindowControl.GetForegroundWindowInfo();
+        throw new InvalidOperationException(
+            $"The fixture HWND {handle} could not own foreground. Current foreground: " +
+            $"HWND={currentForeground.Hwnd}, process='{currentForeground.ProcessName}', title='{currentForeground.Title}'.");
+    }
+
+    internal void Invoke(Action action)
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+        var currentForm = form ?? throw new InvalidOperationException("The fixture window is not available.");
+        InvokeWithTimeout(
+            currentForm,
+            () =>
+            {
+                action();
+                return true;
+            });
+    }
+
+    internal T Invoke<T>(Func<T> action)
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+        var currentForm = form ?? throw new InvalidOperationException("The fixture window is not available.");
+        return InvokeWithTimeout(currentForm, action);
+    }
+
+    internal System.Windows.Forms.Form GetForm()
+    {
+        return form ?? throw new InvalidOperationException("The fixture window is not available.");
+    }
+
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+        Interlocked.Exchange(ref stopRequested, 1);
+        try
+        {
+            form?.BeginInvoke(new Action(() => form.Close()));
+        }
+        catch (InvalidOperationException)
+        {
+        }
+
+        if (windowThread.Join(TimeSpan.FromSeconds(5)))
+        {
+            ready.Dispose();
+        }
+    }
+
+    [DllImport("user32.dll", EntryPoint = "GetWindowLongPtrW", SetLastError = true)]
+    private static extern IntPtr GetWindowLongPtrW(IntPtr hWnd, int nIndex);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
+    private static extern IntPtr GetPropW(IntPtr hWnd, string lpString);
+
+    [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool PostMessageW(IntPtr hWnd, uint message, IntPtr wParam, IntPtr lParam);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool IsWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool IsIconic(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool IsZoomed(IntPtr hWnd);
+
+    [DllImport("dwmapi.dll")]
+    private static extern int DwmGetWindowAttribute(IntPtr hWnd, int dwAttribute, out Rect pvAttribute, int cbAttribute);
+
+    private const int DwmExtendedFrameBoundsAttribute = 9;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Rect
+    {
+        internal int Left;
+        internal int Top;
+        internal int Right;
+        internal int Bottom;
+    }
+
+    private IntPtr RequireLiveHandle()
+    {
+        var handle = Handle;
+        if (handle == IntPtr.Zero || !IsWindow(handle))
+        {
+            throw new InvalidOperationException("The fixture window handle is no longer valid.");
+        }
+
+        return handle;
+    }
+
+    private static void DismissNotification(IntPtr notificationHwnd)
+    {
+        var notification = WindowsFinder.WaitForWindow(
+            window => window.Hwnd == notificationHwnd.ToInt64(),
+            timeoutMS: 1_000);
+        if (notification?.Has<Button>(By.Name("No thanks"), timeoutMS: 2_000) == true)
+        {
+            notification.Find<Button>(By.Name("No thanks"), timeoutMS: 2_000).Invoke(msPostAction: 500);
+        }
+
+        if (!IsConfirmedForeground(notificationHwnd))
+        {
+            return;
+        }
+
+        _ = PostMessageW(notificationHwnd, WmClose, IntPtr.Zero, IntPtr.Zero);
+        Thread.Sleep(250);
+        if (!IsConfirmedForeground(notificationHwnd))
+        {
+            return;
+        }
+
+        var display = WindowHelper.GetDisplaySize();
+        MouseHelper.LeftClickAt(display.Width - 100, display.Height - 84);
+        Thread.Sleep(500);
+        if (!IsConfirmedForeground(notificationHwnd))
+        {
+            return;
+        }
+
+        KeyboardHelper.SendKeys(Key.Alt, Key.F4);
+        Thread.Sleep(500);
+    }
+
+    private static bool IsConfirmedForeground(IntPtr hwnd)
+    {
+        return WindowControl.GetForegroundWindowInfo().Hwnd == hwnd;
+    }
+
+    private static T InvokeWithTimeout<T>(System.Windows.Forms.Form target, Func<T> action)
+    {
+        if (!target.InvokeRequired)
+        {
+            return action();
+        }
+
+        var completion = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+        target.BeginInvoke(
+            new Action(
+                () =>
+                {
+                    try
+                    {
+                        completion.SetResult(action());
+                    }
+                    catch (Exception ex)
+                    {
+                        completion.SetException(ex);
+                    }
+                }));
+
+        if (!completion.Task.Wait(TimeSpan.FromSeconds(10)))
+        {
+            throw new TimeoutException("The fixture window UI thread did not respond within 10 seconds.");
+        }
+
+        return completion.Task.GetAwaiter().GetResult();
+    }
+
+    private void RunWindow(string title)
+    {
+        try
+        {
+            using var fixtureForm = new System.Windows.Forms.Form
+            {
+                BackColor = System.Drawing.Color.White,
+                FormBorderStyle = System.Windows.Forms.FormBorderStyle.Sizable,
+                Height = 420,
+                Left = 440,
+                MaximizeBox = true,
+                MinimizeBox = true,
+                StartPosition = System.Windows.Forms.FormStartPosition.Manual,
+                Text = title,
+                Top = 260,
+                TopMost = false,
+                Width = 680,
+            };
+
+            fixtureForm.Controls.Add(
+                new System.Windows.Forms.Label
+                {
+                    AutoSize = true,
+                    Font = new System.Drawing.Font("Segoe UI", 20),
+                    Location = new System.Drawing.Point(40, 40),
+                    Text = title,
+                });
+
+            fixtureForm.HandleCreated += (_, _) =>
+            {
+                Interlocked.Exchange(ref windowHandle, fixtureForm.Handle.ToInt64());
+            };
+            fixtureForm.HandleDestroyed += (_, _) =>
+            {
+                Interlocked.Exchange(ref windowHandle, 0);
+            };
+            fixtureForm.Shown += (_, _) =>
+            {
+                form = fixtureForm;
+                Interlocked.Exchange(ref windowHandle, fixtureForm.Handle.ToInt64());
+                if (Volatile.Read(ref stopRequested) != 0)
+                {
+                    fixtureForm.BeginInvoke(new Action(fixtureForm.Close));
+                    return;
+                }
+
+                ready.Set();
+            };
+
+            if (Volatile.Read(ref stopRequested) != 0)
+            {
+                return;
+            }
+
+            System.Windows.Forms.Application.Run(fixtureForm);
+        }
+        catch (Exception ex)
+        {
+            startupFailure = ex;
+            if (Volatile.Read(ref stopRequested) == 0)
+            {
+                ready.Set();
+            }
+        }
+    }
+}

--- a/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/TestWindow.cs
+++ b/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/TestWindow.cs
@@ -11,7 +11,6 @@ internal sealed class TestWindow : IDisposable
 {
     private const int GwlExStyle = -20;
     private const long WsExTopmost = 0x00000008L;
-    private const uint WmClose = 0x0010;
     private const string PinnedProperty = "AlwaysOnTop_Pinned";
 
     private readonly ManualResetEventSlim ready = new();
@@ -108,11 +107,7 @@ internal sealed class TestWindow : IDisposable
         for (var attempt = 1; attempt <= 3; attempt++)
         {
             var foreground = WindowControl.GetForegroundWindowInfo();
-            if (foreground.ProcessName.Equals("ShellExperienceHost", StringComparison.OrdinalIgnoreCase)
-                && foreground.Title.Equals("New notification", StringComparison.OrdinalIgnoreCase))
-            {
-                DismissNotification(foreground.Hwnd);
-            }
+            DesktopHygiene.DismissForegroundShellSurface(foreground);
 
             WindowControl.TryBringToForeground(handle);
             var fixtureBounds = WindowHelper.GetWindowBounds(handle);
@@ -187,10 +182,6 @@ internal sealed class TestWindow : IDisposable
     [DllImport("user32.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
     private static extern IntPtr GetPropW(IntPtr hWnd, string lpString);
 
-    [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool PostMessageW(IntPtr hWnd, uint message, IntPtr wParam, IntPtr lParam);
-
     [DllImport("user32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool IsWindow(IntPtr hWnd);
@@ -226,45 +217,6 @@ internal sealed class TestWindow : IDisposable
         }
 
         return handle;
-    }
-
-    private static void DismissNotification(IntPtr notificationHwnd)
-    {
-        var notification = WindowsFinder.WaitForWindow(
-            window => window.Hwnd == notificationHwnd.ToInt64(),
-            timeoutMS: 1_000);
-        if (notification?.Has<Button>(By.Name("No thanks"), timeoutMS: 2_000) == true)
-        {
-            notification.Find<Button>(By.Name("No thanks"), timeoutMS: 2_000).Invoke(msPostAction: 500);
-        }
-
-        if (!IsConfirmedForeground(notificationHwnd))
-        {
-            return;
-        }
-
-        _ = PostMessageW(notificationHwnd, WmClose, IntPtr.Zero, IntPtr.Zero);
-        Thread.Sleep(250);
-        if (!IsConfirmedForeground(notificationHwnd))
-        {
-            return;
-        }
-
-        var display = WindowHelper.GetDisplaySize();
-        MouseHelper.LeftClickAt(display.Width - 100, display.Height - 84);
-        Thread.Sleep(500);
-        if (!IsConfirmedForeground(notificationHwnd))
-        {
-            return;
-        }
-
-        KeyboardHelper.SendKeys(Key.Alt, Key.F4);
-        Thread.Sleep(500);
-    }
-
-    private static bool IsConfirmedForeground(IntPtr hwnd)
-    {
-        return WindowControl.GetForegroundWindowInfo().Hwnd == hwnd;
     }
 
     private static T InvokeWithTimeout<T>(System.Windows.Forms.Form target, Func<T> action)

--- a/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/VirtualDesktopHelper.cs
+++ b/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/VirtualDesktopHelper.cs
@@ -9,31 +9,28 @@ namespace Microsoft.AlwaysOnTop.UITests;
 internal static class VirtualDesktopHelper
 {
     private static readonly Guid VirtualDesktopManagerClassId = new("AA509086-5CA9-4C25-8F95-589D3C07B48A");
+    private static readonly Lazy<IVirtualDesktopManager> Manager = new(CreateManager);
 
     internal static bool IsWindowOnCurrentDesktop(IntPtr window)
     {
-        var managerType = Type.GetTypeFromCLSID(VirtualDesktopManagerClassId, throwOnError: true)
-            ?? throw new InvalidOperationException("The virtual desktop manager COM type is unavailable.");
-        var managerObject = Activator.CreateInstance(managerType)
-            ?? throw new InvalidOperationException("The virtual desktop manager could not be created.");
-
-        try
+        var result = Manager.Value.IsWindowOnCurrentVirtualDesktop(window, out var isCurrent);
+        if (result < 0)
         {
-            var manager = (IVirtualDesktopManager)managerObject;
-            var result = manager.IsWindowOnCurrentVirtualDesktop(window, out var isCurrent);
-            if (result < 0)
-            {
-                Marshal.ThrowExceptionForHR(result);
-            }
+            Marshal.ThrowExceptionForHR(result);
+        }
 
-            return isCurrent;
-        }
-        finally
-        {
-            Marshal.FinalReleaseComObject(managerObject);
-        }
+        return isCurrent;
     }
 
+    private static IVirtualDesktopManager CreateManager()
+    {
+        var managerType = Type.GetTypeFromCLSID(VirtualDesktopManagerClassId, throwOnError: true)
+            ?? throw new InvalidOperationException("The virtual desktop manager COM type is unavailable.");
+        return (IVirtualDesktopManager)(Activator.CreateInstance(managerType)
+            ?? throw new InvalidOperationException("The virtual desktop manager could not be created."));
+    }
+
+    // Keep the complete public IVirtualDesktopManager vtable in declaration order.
     [ComImport]
     [Guid("A5CD92FF-29BE-454C-8D04-D82879FB3F1B")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]

--- a/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/VirtualDesktopHelper.cs
+++ b/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/VirtualDesktopHelper.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace Microsoft.AlwaysOnTop.UITests;
+
+internal static class VirtualDesktopHelper
+{
+    private static readonly Guid VirtualDesktopManagerClassId = new("AA509086-5CA9-4C25-8F95-589D3C07B48A");
+
+    internal static bool IsWindowOnCurrentDesktop(IntPtr window)
+    {
+        var managerType = Type.GetTypeFromCLSID(VirtualDesktopManagerClassId, throwOnError: true)
+            ?? throw new InvalidOperationException("The virtual desktop manager COM type is unavailable.");
+        var managerObject = Activator.CreateInstance(managerType)
+            ?? throw new InvalidOperationException("The virtual desktop manager could not be created.");
+
+        try
+        {
+            var manager = (IVirtualDesktopManager)managerObject;
+            var result = manager.IsWindowOnCurrentVirtualDesktop(window, out var isCurrent);
+            if (result < 0)
+            {
+                Marshal.ThrowExceptionForHR(result);
+            }
+
+            return isCurrent;
+        }
+        finally
+        {
+            Marshal.FinalReleaseComObject(managerObject);
+        }
+    }
+
+    [ComImport]
+    [Guid("A5CD92FF-29BE-454C-8D04-D82879FB3F1B")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IVirtualDesktopManager
+    {
+        [PreserveSig]
+        int IsWindowOnCurrentVirtualDesktop(
+            IntPtr topLevelWindow,
+            [MarshalAs(UnmanagedType.Bool)] out bool onCurrentDesktop);
+
+        [PreserveSig]
+        int GetWindowDesktopId(IntPtr topLevelWindow, out Guid desktopId);
+
+        [PreserveSig]
+        int MoveWindowToDesktop(IntPtr topLevelWindow, ref Guid desktopId);
+    }
+}

--- a/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/app.manifest
+++ b/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/app.manifest
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="AlwaysOnTop.UITests.app"/>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/app.manifest
+++ b/src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/app.manifest
@@ -4,12 +4,14 @@
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
+      <!-- Windows 10+ feature support for unpackaged apps. -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
     </application>
   </compatibility>
 
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
+      <!-- winappcli exposes physical-pixel bounds, so native input must use the same coordinate space. -->
       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
     </windowsSettings>
   </application>


### PR DESCRIPTION
## Summary of the Pull Request

Adds a greenfield `AlwaysOnTop.UITests` project using `Microsoft.PowerToys.UITest.Next` and winappcli. Seven end-to-end scenarios automate all nine Always On Top sign-off checks from #40669, including topmost state, border rendering and live customization, virtual desktops, window state changes, sound gating, exclusions, and Game Mode.

Closes #40669

## PR Checklist

- [x] Closes: #40669
- [x] **Communication:** Implements the test plan tracked in #40669
- [x] **Tests:** Added and all pass
- [x] **Localization:** N/A - test-only change with no end-user-facing strings
- [x] **Dev docs:** Updated `doc/devdocs/modules/alwaysontop.md` with the automated suite and runtime prerequisites
- [x] **New binaries:** N/A - no shipping binaries added; the test project is registered in `PowerToys.slnx` and discovered by the UI-test pipeline
- [x] **Documentation updated:** N/A - no public documentation changes

## Detailed Description of the Pull Request / Additional comments

- Adds `src/modules/alwaysontop/Tests/AlwaysOnTop.UITests/AlwaysOnTop.UITests.csproj` with PerMonitorV2 DPI awareness and x64/ARM64 solution mappings.
- Uses deterministic module settings and a native WinForms fixture to assert `WS_EX_TOPMOST`, `AlwaysOnTop_Pinned`, and `AlwaysOnTop_Border` behavior.
- Verifies custom border color and thickness through composed screen pixels and border geometry.
- Uses `IVirtualDesktopManager` to confirm desktop transitions before checking border visibility or cleaning up the created desktop.
- Uses Direct3D 9 full-screen exclusive mode to exercise the Game Mode block.
- Uses an NTFS oplock on the configured WAV path to verify that sound playback is attempted only when enabled, without requiring an audio endpoint.
- Unpins fixtures before destroying their windows so the product border timer cannot retain a stale target.

## Validation Steps Performed

- Built `AlwaysOnTop.UITests` in Release for x64 and ARM64.
- Ran the complete 7/7 suite in persistent local VMs on Windows 10 and Windows 11 under both default and constrained (1 vCPU / 4 GB) profiles.
- Ran Azure DevOps UI Test Automation build [156249158](https://dev.azure.com/microsoft/c93e867a-8815-43c1-92c4-e7dd5404f1e1/_build/results?buildId=156249158) against current head `3eae3f81ac`: all five ARM64/x64 full-build stages succeeded and all 21/21 test executions passed across ARM64, Windows 10, and Windows 11.

- Completed [PowerToys CI build 387751](https://dev.azure.com/shine-oss/62769a65-d989-45e3-803c-9ad21fcf2ea2/_build/results?buildId=387751): x64 and ARM64 Release builds and the Windows 10, Windows 11, and ARM64 UI-test jobs all passed.

![Test Explorer showing seven passing Always On Top UI tests](https://github.com/user-attachments/assets/793b60ea-86c0-4b14-9358-dd8079eb03ec)



