### PR TITLE
[Runner] Log Windows session-end reason

### DIFF
--- a/src/runner/tray_icon.cpp
+++ b/src/runner/tray_icon.cpp
@@ -52,6 +52,48 @@ namespace
     static ThemeListener theme_listener;
     static bool theme_adaptive_enabled = false;
     static bool update_available = false;
+
+    void log_session_end_message(UINT message, WPARAM wparam, LPARAM lparam)
+    {
+        if (message != WM_QUERYENDSESSION && message != WM_ENDSESSION)
+        {
+            return;
+        }
+
+        const auto flags = static_cast<DWORD>(lparam);
+        const bool close_app = (flags & ENDSESSION_CLOSEAPP) != 0;
+        const bool critical = (flags & ENDSESSION_CRITICAL) != 0;
+        const bool logoff = (flags & ENDSESSION_LOGOFF) != 0;
+        const wchar_t* reason = L"shutdown_or_restart";
+        if (close_app)
+        {
+            reason = L"restart_manager_close_app";
+        }
+        else if (logoff)
+        {
+            reason = L"logoff";
+        }
+
+        if (message == WM_QUERYENDSESSION)
+        {
+            Logger::info(L"Runner received WM_QUERYENDSESSION: reason={}, flags={:#010x}, close_app={}, critical={}, logoff={}",
+                         reason,
+                         flags,
+                         close_app,
+                         critical,
+                         logoff);
+        }
+        else
+        {
+            Logger::info(L"Runner received WM_ENDSESSION: session_ending={}, reason={}, flags={:#010x}, close_app={}, critical={}, logoff={}",
+                         wparam != FALSE,
+                         reason,
+                         flags,
+                         close_app,
+                         critical,
+                         logoff);
+        }
+    }
 }
 
 // Struct to fill with callback and the data. The window_proc is responsible for cleaning it.
@@ -160,6 +202,8 @@ void click_timer_elapsed()
 
 LRESULT __stdcall tray_icon_window_proc(HWND window, UINT message, WPARAM wparam, LPARAM lparam)
 {
+    log_session_end_message(message, wparam, lparam);
+
     LRESULT session_end_result = 0;
     if (handle_stateless_session_end_message(window, message, wparam, lparam, session_end_result, &g_system_session_ending))
     {


### PR DESCRIPTION
## Summary of the Pull Request

Adds diagnostic logging for Windows session-end messages received by the PowerToys Runner tray window.

- Logs WM_QUERYENDSESSION and WM_ENDSESSION.
- Decodes ENDSESSION_CLOSEAPP, ENDSESSION_CRITICAL, and ENDSESSION_LOGOFF.
- Records whether WM_ENDSESSION confirms or cancels session termination.
- Keeps the existing session-end behavior unchanged.

Related investigation: #50169.

## PR Checklist

- [ ] Closes: #50169
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** No end-user-facing strings were added
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
- [ ] **Documentation updated:** If checked, please file a pull request on the docs repo and link it here

## Detailed Description of the Pull Request / Additional comments

PowerToys 0.100.2 reports show the Runner disappearing without a crash event while Command Palette remains active. One hypothesis is that the Runner receives a Windows session-end or Restart Manager close-app request.

The Runner tray window owns the main message loop and already handles these messages through handle_stateless_session_end_message. This change logs the message phase, raw flags, decoded reason, and confirmed/cancelled state before the existing handler runs. Runner log entries already include process and thread identifiers.

## Validation Steps Performed

- Ran git diff --check successfully.
- Reviewed the change against the existing Runner session-end handling.
- Build not run; this is a diagnostic logging-only change.