### PR TITLE
[UITests][QuickAccent] Add UI tests

### DIFF
--- a/.github/skills/ui-tests-pipeline-ci/scripts/Test-AzureDevOpsSetup.ps1
+++ b/.github/skills/ui-tests-pipeline-ci/scripts/Test-AzureDevOpsSetup.ps1
@@ -415,13 +415,17 @@ if ($pipelineId -ne 0)
         }
 
         $moduleAssignments = @($preview.finalYaml -split "`n" |
-                Where-Object { $_ -match "^\s*\`$modulesRaw\s*=\s*'[^']*'\s*$" } |
+                Where-Object { $_ -match '^\s*\$modulesRaw\s*=\s*''[^'']*''\s*$' } |
                 ForEach-Object { $_.Trim() })
         $expectedModuleAssignment = "`$modulesRaw = '$ProbeModule'"
-        if ($moduleAssignments.Count -eq 0 -or
-            @($moduleAssignments | Where-Object { $_ -ne $expectedModuleAssignment }).Count -ne 0)
+        if ($moduleAssignments.Count -eq 0)
         {
-            throw "Pipeline preview did not resolve only module '$ProbeModule'."
+            throw 'Pipeline preview parser found no literal $modulesRaw assignments; the template quoting or line layout may have changed.'
+        }
+
+        if (@($moduleAssignments | Where-Object { $_ -ne $expectedModuleAssignment }).Count -ne 0)
+        {
+            throw "Pipeline preview did not resolve only module '$ProbeModule'. Assignments: $($moduleAssignments -join ' | ')."
         }
 
         Add-SetupCheck `

--- a/.github/skills/ui-tests-pipeline-ci/scripts/Test-AzureDevOpsSetup.ps1
+++ b/.github/skills/ui-tests-pipeline-ci/scripts/Test-AzureDevOpsSetup.ps1
@@ -415,7 +415,7 @@ if ($pipelineId -ne 0)
         }
 
         $moduleAssignments = @($preview.finalYaml -split "`n" |
-                Where-Object { $_ -match '\$modulesRaw\s*=' } |
+                Where-Object { $_ -match "^\s*\`$modulesRaw\s*=\s*'[^']*'\s*$" } |
                 ForEach-Object { $_.Trim() })
         $expectedModuleAssignment = "`$modulesRaw = '$ProbeModule'"
         if ($moduleAssignments.Count -eq 0 -or

--- a/.pipelines/stopPowerToysProcesses.ps1
+++ b/.pipelines/stopPowerToysProcesses.ps1
@@ -1,0 +1,122 @@
+# Copyright (c) Microsoft Corporation
+# The Microsoft Corporation licenses this file to you under the MIT license.
+
+#requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [string[]] $ProcessName = @('PowerToys', 'PowerToys.Settings'),
+
+    [ValidateRange(1, 300)]
+    [int] $TimeoutSeconds = 30,
+
+    [ValidateRange(1, 20)]
+    [int] $RequiredStableSamples = 3,
+
+    [ValidateRange(10, 5000)]
+    [int] $PollIntervalMilliseconds = 250,
+
+    [ValidateRange(1, 60)]
+    [int] $ProcessExitTimeoutSeconds = 5
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$processNames = @($ProcessName | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+if ($processNames.Count -eq 0)
+{
+    throw 'At least one process name is required.'
+}
+
+$stopwatch = [Diagnostics.Stopwatch]::StartNew()
+$stableAbsentSamples = 0
+$remainingDetails = @()
+$stopFailures = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+
+do
+{
+    foreach ($name in $processNames)
+    {
+        foreach ($process in @(Get-Process -Name $name -ErrorAction SilentlyContinue))
+        {
+            try
+            {
+                if (-not $process.HasExited)
+                {
+                    Write-Host "Stopping $name (pid $($process.Id)) before Authenticode signing."
+                    $process.Kill($true)
+                    if (-not $process.WaitForExit($ProcessExitTimeoutSeconds * 1000))
+                    {
+                        $null = $stopFailures.Add(
+                            "$name pid $($process.Id) did not exit within $ProcessExitTimeoutSeconds seconds.")
+                    }
+                }
+            }
+            catch [InvalidOperationException]
+            {
+                # The process exited between enumeration and inspection.
+            }
+            catch
+            {
+                $null = $stopFailures.Add("Failed to stop $name pid $($process.Id): $($_.Exception.Message)")
+            }
+            finally
+            {
+                $process.Dispose()
+            }
+        }
+    }
+
+    Start-Sleep -Milliseconds $PollIntervalMilliseconds
+
+    $remaining = @($processNames | ForEach-Object {
+            Get-Process -Name $_ -ErrorAction SilentlyContinue
+        })
+    try
+    {
+        $remainingDetails = @($remaining | ForEach-Object { "$($_.ProcessName) pid $($_.Id)" })
+        if ($remaining.Count -eq 0)
+        {
+            $stableAbsentSamples++
+        }
+        else
+        {
+            $stableAbsentSamples = 0
+        }
+    }
+    finally
+    {
+        $remaining | ForEach-Object { $_.Dispose() }
+    }
+
+    if ($stableAbsentSamples -ge $RequiredStableSamples)
+    {
+        Write-Host (
+            "PowerToys processes remained absent for $RequiredStableSamples consecutive samples " +
+            "after $($stopwatch.Elapsed.TotalSeconds.ToString('F1')) seconds.")
+        return
+    }
+}
+while ($stopwatch.Elapsed.TotalSeconds -lt $TimeoutSeconds)
+
+$details = [Collections.Generic.List[string]]::new()
+if ($remainingDetails.Count -gt 0)
+{
+    $details.Add("Remaining: $($remainingDetails -join ', ').")
+}
+else
+{
+    $details.Add(
+        "No process was present in the final sample, but absence was stable for only " +
+        "$stableAbsentSamples/$RequiredStableSamples samples.")
+}
+
+if ($stopFailures.Count -gt 0)
+{
+    $details.Add("Stop errors: $($stopFailures -join ' ')")
+}
+
+throw (
+    "Could not stop PowerToys processes within $($stopwatch.Elapsed.TotalSeconds.ToString('F1')) seconds. " +
+    ($details -join ' '))

--- a/.pipelines/tests/stopPowerToysProcesses.Tests.ps1
+++ b/.pipelines/tests/stopPowerToysProcesses.Tests.ps1
@@ -1,0 +1,71 @@
+# Copyright (c) Microsoft Corporation
+# The Microsoft Corporation licenses this file to you under the MIT license.
+
+$scriptPath = Join-Path $PSScriptRoot '..\stopPowerToysProcesses.ps1'
+
+Describe 'stopPowerToysProcesses' {
+    It 'succeeds when the requested process is absent' {
+        $missingName = "PowerToysSigningMissing$([Guid]::NewGuid().ToString('N'))"
+
+        {
+            & $scriptPath `
+                -ProcessName $missingName `
+                -TimeoutSeconds 5 `
+                -RequiredStableSamples 2 `
+                -PollIntervalMilliseconds 10
+        } | Should Not Throw
+    }
+
+    It 'terminates the requested process tree and waits for stable absence' {
+        $helperPath = Join-Path $TestDrive 'PowerToysSigningTest.exe'
+        Copy-Item (Join-Path $env:WINDIR 'System32\timeout.exe') $helperPath
+        $process = Start-Process `
+            -FilePath $helperPath `
+            -ArgumentList '/T', '30', '/NOBREAK' `
+            -WindowStyle Hidden `
+            -PassThru
+        try
+        {
+            & $scriptPath `
+                -ProcessName 'PowerToysSigningTest' `
+                -TimeoutSeconds 10 `
+                -RequiredStableSamples 2 `
+                -PollIntervalMilliseconds 50 `
+                -ProcessExitTimeoutSeconds 2
+
+            $process.Refresh()
+            $process.HasExited | Should Be $true
+        }
+        finally
+        {
+            if (-not $process.HasExited)
+            {
+                $process.Kill()
+                $process.WaitForExit(2000)
+            }
+
+            $process.Dispose()
+        }
+    }
+
+    It 'reports stability progress when the timeout expires without a final process' {
+        $missingName = "PowerToysSigningMissing$([Guid]::NewGuid().ToString('N'))"
+        $message = $null
+
+        try
+        {
+            & $scriptPath `
+                -ProcessName $missingName `
+                -TimeoutSeconds 1 `
+                -RequiredStableSamples 20 `
+                -PollIntervalMilliseconds 500
+        }
+        catch
+        {
+            $message = $_.Exception.Message
+        }
+
+        $message | Should Match 'No process was present in the final sample'
+        $message | Should Match 'stable for only [0-9]+/20 samples'
+    }
+}

--- a/.pipelines/v2/templates/job-test-project.yml
+++ b/.pipelines/v2/templates/job-test-project.yml
@@ -236,59 +236,7 @@ jobs:
       }
 
       if ($requiredAuthenticodeFiles.Count -gt 0) {
-        $processNames = @('PowerToys', 'PowerToys.Settings')
-        $deadline = [DateTime]::UtcNow.AddSeconds(30)
-        $stableAbsentSamples = 0
-        $remainingDetails = @()
-        $stopFailures = @()
-
-        do {
-          $stopFailures = @()
-          foreach ($processName in $processNames) {
-            foreach ($process in @(Get-Process -Name $processName -ErrorAction SilentlyContinue)) {
-              try {
-                if (-not $process.HasExited) {
-                  Write-Host "Stopping $processName (pid $($process.Id)) before Authenticode signing."
-                  $process.Kill($true)
-                  if (-not $process.WaitForExit(5000)) {
-                    $stopFailures += "$processName pid $($process.Id) did not exit within 5 seconds."
-                  }
-                }
-              } catch [System.InvalidOperationException] {
-                # The process exited between enumeration and inspection.
-              } catch {
-                $stopFailures += "Failed to stop $processName pid $($process.Id): $($_.Exception.Message)"
-              } finally {
-                $process.Dispose()
-              }
-            }
-          }
-
-          Start-Sleep -Milliseconds 250
-
-          $remaining = @($processNames | ForEach-Object {
-            Get-Process -Name $_ -ErrorAction SilentlyContinue
-          })
-          try {
-            $remainingDetails = @($remaining | ForEach-Object { "$($_.ProcessName) pid $($_.Id)" })
-            if ($remaining.Count -eq 0) {
-              $stableAbsentSamples++
-            } else {
-              $stableAbsentSamples = 0
-            }
-          } finally {
-            $remaining | ForEach-Object { $_.Dispose() }
-          }
-
-          if ($stableAbsentSamples -ge 3) {
-            break
-          }
-        } while ([DateTime]::UtcNow -lt $deadline)
-
-        if ($stableAbsentSamples -lt 3) {
-          $details = @($remainingDetails + $stopFailures)
-          throw "Could not stop PowerToys processes before Authenticode signing: $($details -join ' ')"
-        }
+        & "$(build.sourcesdirectory)\.pipelines\stopPowerToysProcesses.ps1"
       }
 
       if ($requiredPackages.Count -gt 0 -or $requiredAuthenticodeFiles.Count -gt 0) {

--- a/.pipelines/v2/templates/job-test-project.yml
+++ b/.pipelines/v2/templates/job-test-project.yml
@@ -237,42 +237,57 @@ jobs:
 
       if ($requiredAuthenticodeFiles.Count -gt 0) {
         $processNames = @('PowerToys', 'PowerToys.Settings')
+        $deadline = [DateTime]::UtcNow.AddSeconds(30)
+        $stableAbsentSamples = 0
+        $remainingDetails = @()
         $stopFailures = @()
 
-        foreach ($processName in $processNames) {
-          foreach ($process in @(Get-Process -Name $processName -ErrorAction SilentlyContinue)) {
-            try {
-              if (-not $process.HasExited) {
-                Write-Host "Stopping $processName (pid $($process.Id)) before Authenticode signing."
-                $process.Kill($true)
-                if (-not $process.WaitForExit(10000)) {
-                  $stopFailures += "$processName pid $($process.Id) did not exit within 10 seconds."
+        do {
+          $stopFailures = @()
+          foreach ($processName in $processNames) {
+            foreach ($process in @(Get-Process -Name $processName -ErrorAction SilentlyContinue)) {
+              try {
+                if (-not $process.HasExited) {
+                  Write-Host "Stopping $processName (pid $($process.Id)) before Authenticode signing."
+                  $process.Kill($true)
+                  if (-not $process.WaitForExit(5000)) {
+                    $stopFailures += "$processName pid $($process.Id) did not exit within 5 seconds."
+                  }
                 }
+              } catch [System.InvalidOperationException] {
+                # The process exited between enumeration and inspection.
+              } catch {
+                $stopFailures += "Failed to stop $processName pid $($process.Id): $($_.Exception.Message)"
+              } finally {
+                $process.Dispose()
               }
-            } catch [System.InvalidOperationException] {
-              # The process exited between enumeration and inspection.
-            } catch {
-              $stopFailures += "Failed to stop $processName pid $($process.Id): $($_.Exception.Message)"
-            } finally {
-              $process.Dispose()
             }
           }
-        }
 
-        if ($stopFailures.Count -gt 0) {
-          throw "Could not prepare companion binaries for signing: $($stopFailures -join ' ')"
-        }
+          Start-Sleep -Milliseconds 250
 
-        $remaining = @($processNames | ForEach-Object {
-          Get-Process -Name $_ -ErrorAction SilentlyContinue
-        })
-        try {
-          if ($remaining.Count -gt 0) {
-            $details = $remaining | ForEach-Object { "$($_.ProcessName) pid $($_.Id)" }
-            throw "PowerToys processes remain before Authenticode signing: $($details -join ', ')"
+          $remaining = @($processNames | ForEach-Object {
+            Get-Process -Name $_ -ErrorAction SilentlyContinue
+          })
+          try {
+            $remainingDetails = @($remaining | ForEach-Object { "$($_.ProcessName) pid $($_.Id)" })
+            if ($remaining.Count -eq 0) {
+              $stableAbsentSamples++
+            } else {
+              $stableAbsentSamples = 0
+            }
+          } finally {
+            $remaining | ForEach-Object { $_.Dispose() }
           }
-        } finally {
-          $remaining | ForEach-Object { $_.Dispose() }
+
+          if ($stableAbsentSamples -ge 3) {
+            break
+          }
+        } while ([DateTime]::UtcNow -lt $deadline)
+
+        if ($stableAbsentSamples -lt 3) {
+          $details = @($remainingDetails + $stopFailures)
+          throw "Could not stop PowerToys processes before Authenticode signing: $($details -join ' ')"
         }
       }
 

--- a/.pipelines/v2/templates/job-test-project.yml
+++ b/.pipelines/v2/templates/job-test-project.yml
@@ -235,6 +235,47 @@ jobs:
         $requiredAuthenticodeFiles += 'PowerToys.exe', 'PowerToys.Settings.exe'
       }
 
+      if ($requiredAuthenticodeFiles.Count -gt 0) {
+        $processNames = @('PowerToys', 'PowerToys.Settings')
+        $stopFailures = @()
+
+        foreach ($processName in $processNames) {
+          foreach ($process in @(Get-Process -Name $processName -ErrorAction SilentlyContinue)) {
+            try {
+              if (-not $process.HasExited) {
+                Write-Host "Stopping $processName (pid $($process.Id)) before Authenticode signing."
+                $process.Kill($true)
+                if (-not $process.WaitForExit(10000)) {
+                  $stopFailures += "$processName pid $($process.Id) did not exit within 10 seconds."
+                }
+              }
+            } catch [System.InvalidOperationException] {
+              # The process exited between enumeration and inspection.
+            } catch {
+              $stopFailures += "Failed to stop $processName pid $($process.Id): $($_.Exception.Message)"
+            } finally {
+              $process.Dispose()
+            }
+          }
+        }
+
+        if ($stopFailures.Count -gt 0) {
+          throw "Could not prepare companion binaries for signing: $($stopFailures -join ' ')"
+        }
+
+        $remaining = @($processNames | ForEach-Object {
+          Get-Process -Name $_ -ErrorAction SilentlyContinue
+        })
+        try {
+          if ($remaining.Count -gt 0) {
+            $details = $remaining | ForEach-Object { "$($_.ProcessName) pid $($_.Id)" }
+            throw "PowerToys processes remain before Authenticode signing: $($details -join ', ')"
+          }
+        } finally {
+          $remaining | ForEach-Object { $_.Dispose() }
+        }
+      }
+
       if ($requiredPackages.Count -gt 0 -or $requiredAuthenticodeFiles.Count -gt 0) {
         $signingArguments = @{
           PackageRoot = $packageRoots

--- a/.pipelines/v2/templates/job-test-project.yml
+++ b/.pipelines/v2/templates/job-test-project.yml
@@ -218,7 +218,7 @@ jobs:
       $allModules = [string]::IsNullOrWhiteSpace($modulesRaw)
       $requiresModernContextMenu = '$(TestPlatform)' -ne 'x64Win10'
       $requiresPowerRename = $allModules -or @($selectedModules | Where-Object { $_ -match 'PowerRename' }).Count -gt 0
-      $requiresAuthenticatedSettingsIpc = $allModules -or @($selectedModules | Where-Object { $_ -match 'PowerRename|MouseUtils' }).Count -gt 0
+      $requiresAuthenticatedSettingsIpc = $allModules -or @($selectedModules | Where-Object { $_ -match 'PowerRename|MouseUtils|PowerAccent' }).Count -gt 0
       $requiredPackages = @()
       $requiredAuthenticodeFiles = @()
       $certificateMarkerPath = "$(Agent.WorkFolder)\PowerToysUiTestState\SigningCertificates.txt"

--- a/PowerToys.slnx
+++ b/PowerToys.slnx
@@ -944,6 +944,10 @@
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />
     </Project>
+    <Project Path="src/modules/poweraccent/PowerAccent.UITests/PowerAccent.UITests.csproj">
+      <Platform Solution="*|ARM64" Project="ARM64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
     <Project Path="src/modules/poweraccent/PowerAccentKeyboardService/PowerAccentKeyboardService.vcxproj" Id="c97d9a5d-206c-454e-997e-009e227d7f02" />
     <Project Path="src/modules/poweraccent/PowerAccentModuleInterface/PowerAccentModuleInterface.vcxproj" Id="34a354c5-23c7-4343-916c-c52daf4fc39d" />
   </Folder>

--- a/doc/devdocs/modules/quickaccent.md
+++ b/doc/devdocs/modules/quickaccent.md
@@ -15,7 +15,7 @@ Quick Accent (formerly known as Power Accent) is a PowerToys module that allows 
 
 ## Architecture
 
-The Quick Accent module consists of five projects:
+The Quick Accent module consists of six projects:
 
 ```
 poweraccent/
@@ -23,7 +23,8 @@ poweraccent/
 ├── PowerAccent.Core/               # Accent logic, settings, positioning, usage statistics
 ├── PowerAccent.UI/                 # WinUI 3 character selector app (PowerToys.PowerAccent.exe)
 ├── PowerAccentKeyboardService/     # WinRT keyboard-hook component
-└── PowerAccentModuleInterface/     # Native runner module DLL
+├── PowerAccentModuleInterface/     # Native runner module DLL
+└── PowerAccent.UITests/            # winappcli end-to-end UI tests
 ```
 
 ### Module Interface (PowerAccentModuleInterface)
@@ -67,6 +68,13 @@ This component:
 - Manages the trigger mechanism for displaying the accent toolbar
 - Handles keyboard input processing
 
+### UI Tests (PowerAccent.UITests)
+
+`PowerAccent.UITests` uses `Microsoft.PowerToys.UITest.Next` and `winappcli` to drive Quick Accent
+through the Settings UI and a real Notepad window. The suite covers activation and character
+selection, module lifecycle, language filtering, every toolbar position, input delay, excluded
+applications, usage-frequency sorting, and start-from-left behavior.
+
 ## Implementation Details
 
 ### Activation Mechanism
@@ -108,6 +116,24 @@ The module includes multiple language-specific character sets and special charac
 - Potential refinements to the activation timing mechanism
 - Additional language and special character sets
 - Improved UI positioning in different application contexts
+
+## UI tests
+
+The UI tests require a live interactive desktop with the en-US keyboard layout selected and Caps Lock
+off. Build the test executable from the repository root:
+
+```powershell
+tools\build\build.cmd -Path src\modules\poweraccent\PowerAccent.UITests -Platform x64 -Configuration Debug
+```
+
+Run the produced Microsoft Testing Platform executable with the `PowerAccent` category:
+
+```powershell
+x64\Debug\tests\PowerAccent.UITests\net10.0-windows10.0.26100.0\PowerAccent.UITests.exe `
+  --filter "TestCategory=PowerAccent"
+```
+
+See the [UI tests framework](../development/ui-tests.md) for local-VM and pipeline workflows.
 
 ## Debugging
 

--- a/src/common/UITestAutomation.Next/SettingsConfigHelper.cs
+++ b/src/common/UITestAutomation.Next/SettingsConfigHelper.cs
@@ -71,7 +71,8 @@ public static class SettingsConfigHelper
         return PreserveFile(Path.Combine(PowerToysSettingsRoot, moduleName, "settings.json"));
     }
 
-    internal static IDisposable PreserveFile(string path)
+    /// <summary>Snapshot an arbitrary file and restore its exact bytes or prior absence on disposal.</summary>
+    public static IDisposable PreserveFile(string path)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(path);
         return new FileSnapshot(path);

--- a/src/modules/poweraccent/PowerAccent.Core/Services/SettingsService.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Services/SettingsService.cs
@@ -88,9 +88,6 @@ public class SettingsService
                                 .Select(lang => lang!.Value)
                                 .ToArray();
 
-                        Logger.LogInfo(
-                            $"Languages selected: {(isAllSelected ? "ALL" : string.Join(", ", SelectedLang))}");
-
                         switch (settings.Properties.ToolbarPosition.Value)
                         {
                             case "Top center":
@@ -125,6 +122,9 @@ public class SettingsService
                         ShowUnicodeDescription = settings.Properties.ShowUnicodeDescription;
                         SortByUsageFrequency = settings.Properties.SortByUsageFrequency;
                         StartSelectionFromTheLeft = settings.Properties.StartSelectionFromTheLeft;
+
+                        Logger.LogInfo(
+                            $"Languages selected: {(isAllSelected ? "ALL" : string.Join(", ", SelectedLang))}");
                     }
                 }
                 catch (Exception ex)

--- a/src/modules/poweraccent/PowerAccent.UITests/AssemblyInfo.cs
+++ b/src/modules/poweraccent/PowerAccent.UITests/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[assembly: DoNotParallelize]

--- a/src/modules/poweraccent/PowerAccent.UITests/PowerAccent.UITests.csproj
+++ b/src/modules/poweraccent/PowerAccent.UITests/PowerAccent.UITests.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- Look at Directory.Build.props in root for common stuff as well -->
+  <Import Project="$(RepoRoot)src\Common.Dotnet.CsWinRT.props" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <RootNamespace>PowerAccent.UITests</RootNamespace>
+    <AssemblyName>PowerAccent.UITests</AssemblyName>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+
+    <IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+
+    <!-- UI tests need a live desktop; never run them as part of MSBuild. -->
+    <RunVSTest>false</RunVSTest>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputPath>$(RepoRoot)$(Platform)\$(Configuration)\tests\PowerAccent.UITests\</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\common\UITestAutomation.Next\UITestAutomation.Next.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/modules/poweraccent/PowerAccent.UITests/PowerAccentEndToEndTests.cs
+++ b/src/modules/poweraccent/PowerAccent.UITests/PowerAccentEndToEndTests.cs
@@ -21,6 +21,7 @@ public sealed class PowerAccentEndToEndTests : UITestBase
 
     protected override void PrepareTestState()
     {
+        AssertInputEnvironment();
         Assert.IsTrue(
             WindowControl.TryKillProcessTreeByNameAndWait(ProcessName, timeoutMS: 30_000),
             "A previous PowerToys.PowerAccent process did not exit before the next test launch.");
@@ -126,22 +127,23 @@ public sealed class PowerAccentEndToEndTests : UITestBase
         using var clipboard = PreserveClipboardText();
         NavigateToSettings(this);
 
-        try
-        {
-            SetModuleEnabled(this, enabled: false);
-            Assert.IsTrue(WaitForProcess(expected: false), "PowerToys.PowerAccent did not stop after disabling Quick Accent.");
+        RunWithCleanup(
+            () =>
+            {
+                SetModuleEnabled(this, enabled: false);
+                Assert.IsTrue(WaitForProcess(expected: false), "PowerToys.PowerAccent did not stop after disabling Quick Accent.");
 
-            using var notepad = NotepadFixture.Start(this);
-            Assert.AreEqual(
-                "a ",
-                RunUnmodifiedGesture(notepad, Key.A, Key.Space),
-                "With Quick Accent disabled, the letter and activation key should pass through unchanged.");
-        }
-        finally
-        {
-            SetModuleEnabled(this, enabled: true);
-            Assert.IsTrue(WaitForProcess(expected: true), "PowerToys.PowerAccent did not restart after re-enabling Quick Accent.");
-        }
+                using var notepad = NotepadFixture.Start(this);
+                Assert.AreEqual(
+                    "a ",
+                    RunUnmodifiedGesture(notepad, Key.A, Key.Space),
+                    "With Quick Accent disabled, the letter and activation key should pass through unchanged.");
+            },
+            () =>
+            {
+                SetModuleEnabled(this, enabled: true);
+                Assert.IsTrue(WaitForProcess(expected: true), "PowerToys.PowerAccent did not restart after re-enabling Quick Accent.");
+            });
     }
 
     [DataTestMethod]

--- a/src/modules/poweraccent/PowerAccent.UITests/PowerAccentEndToEndTests.cs
+++ b/src/modules/poweraccent/PowerAccent.UITests/PowerAccentEndToEndTests.cs
@@ -1,0 +1,403 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.PowerToys.UITest.Next;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static PowerAccent.UITests.PowerAccentTestHelper;
+
+namespace PowerAccent.UITests;
+
+[TestClass]
+public sealed class PowerAccentEndToEndTests : UITestBase
+{
+    private static readonly IDisposable ModuleSettings = SettingsConfigHelper.PreserveModuleSettings(ModuleName);
+    private static readonly IDisposable UsageInfo = PreserveUsageInfo();
+
+    public PowerAccentEndToEndTests()
+        : base(PowerToysModule.PowerToysSettings, enableModules: [ModuleName])
+    {
+    }
+
+    protected override void PrepareTestState()
+    {
+        Assert.IsTrue(
+            WindowControl.TryKillProcessTreeByNameAndWait(ProcessName, timeoutMS: 30_000),
+            "A previous PowerToys.PowerAccent process did not exit before the next test launch.");
+        PrepareDefaultState();
+    }
+
+    [ClassCleanup]
+    public static void RestoreClassState() => DisposeAll(ModuleSettings, UsageInfo);
+
+    [TestMethod]
+    [TestCategory("PowerAccent")]
+    public void ArrowKeysCycleAndCommitSelectedCharacter()
+    {
+        ReplaceSettings(new Settings(
+            Activation: ActivationKey.LeftRightArrow,
+            InputTimeMs: 200,
+            SelectedLanguage: "FR"));
+
+        using var clipboard = PreserveClipboardText();
+        using var notepad = NotepadFixture.Start(this);
+
+        var rightResult = RunTriggeredGesture(
+            this,
+            notepad,
+            Key.A,
+            Key.Right,
+            toolbar =>
+            {
+                Assert.AreEqual("ä", GetSelectedCharacter(toolbar, FrenchACharacters), "Right should start at the right half.");
+
+                KeyboardHelper.SendKey(Key.Right);
+                Assert.AreEqual("ã", GetSelectedCharacter(toolbar, FrenchACharacters), "Right should move to the next character.");
+
+                KeyboardHelper.SendKey(Key.Left);
+                Assert.AreEqual("ä", GetSelectedCharacter(toolbar, FrenchACharacters), "Left should move back one character.");
+            });
+        Assert.AreEqual("ä", rightResult, "Releasing the letter should commit the selected right-arrow character.");
+
+        var leftResult = RunTriggeredGesture(
+            this,
+            notepad,
+            Key.A,
+            Key.Left,
+            toolbar =>
+            {
+                Assert.AreEqual("á", GetSelectedCharacter(toolbar, FrenchACharacters), "Left should start at the left half.");
+
+                KeyboardHelper.SendKey(Key.Left);
+                Assert.AreEqual("â", GetSelectedCharacter(toolbar, FrenchACharacters), "Left should move to the previous character.");
+            });
+        Assert.AreEqual("â", leftResult, "Releasing the letter should commit the selected left-arrow character.");
+    }
+
+    [TestMethod]
+    [TestCategory("PowerAccent")]
+    public void SpaceCyclesForwardAndShiftSpaceCyclesBackward()
+    {
+        ReplaceSettings(new Settings(
+            Activation: ActivationKey.Space,
+            InputTimeMs: 200,
+            SelectedLanguage: "FR"));
+
+        using var clipboard = PreserveClipboardText();
+        using var notepad = NotepadFixture.Start(this);
+
+        var result = RunTriggeredGesture(
+            this,
+            notepad,
+            Key.A,
+            Key.Space,
+            toolbar =>
+            {
+                Assert.AreEqual("à", GetSelectedCharacter(toolbar, FrenchACharacters), "Space should start at the first character.");
+
+                KeyboardHelper.SendKey(Key.Space);
+                Assert.AreEqual("â", GetSelectedCharacter(toolbar, FrenchACharacters), "Space should move forward.");
+
+                KeyboardHelper.PressKey(Key.LShift);
+                try
+                {
+                    KeyboardHelper.SendKey(Key.Space);
+                }
+                finally
+                {
+                    KeyboardHelper.ReleaseKey(Key.LShift);
+                }
+
+                Assert.AreEqual("à", GetSelectedCharacter(toolbar, FrenchACharacters), "Shift+Space should move backward.");
+            });
+
+        Assert.AreEqual("à", result, "Releasing the letter should commit the character selected with Space.");
+    }
+
+    [TestMethod]
+    [TestCategory("PowerAccent")]
+    public void DisablingQuickAccentStopsActivation()
+    {
+        ReplaceSettings(new Settings(
+            Activation: ActivationKey.Space,
+            InputTimeMs: 200,
+            SelectedLanguage: "FR"));
+
+        using var clipboard = PreserveClipboardText();
+        NavigateToSettings(this);
+
+        try
+        {
+            SetModuleEnabled(this, enabled: false);
+            Assert.IsTrue(WaitForProcess(expected: false), "PowerToys.PowerAccent did not stop after disabling Quick Accent.");
+
+            using var notepad = NotepadFixture.Start(this);
+            Assert.AreEqual(
+                "a ",
+                RunUnmodifiedGesture(notepad, Key.A, Key.Space),
+                "With Quick Accent disabled, the letter and activation key should pass through unchanged.");
+        }
+        finally
+        {
+            SetModuleEnabled(this, enabled: true);
+            Assert.IsTrue(WaitForProcess(expected: true), "PowerToys.PowerAccent did not restart after re-enabling Quick Accent.");
+        }
+    }
+
+    [DataTestMethod]
+    [DataRow((int)ActivationKey.LeftRightArrow, "Right")]
+    [DataRow((int)ActivationKey.Space, "Space")]
+    [DataRow((int)ActivationKey.Both, "Right")]
+    [DataRow((int)ActivationKey.Both, "Space")]
+    [DataRow((int)ActivationKey.PressAndHold, "PressAndHold")]
+    [TestCategory("PowerAccent")]
+    public void ActivationKeySettingIsApplied(int activationKey, string triggerName)
+    {
+        var activation = (ActivationKey)activationKey;
+        ReplaceSettings(new Settings(
+            Activation: activation,
+            InputTimeMs: 200,
+            HoldDurationMs: 250,
+            SelectedLanguage: "SP"));
+
+        using var clipboard = PreserveClipboardText();
+        using var notepad = NotepadFixture.Start(this);
+
+        string result;
+        if (activation == ActivationKey.PressAndHold)
+        {
+            result = RunPressAndHoldGesture(
+                this,
+                notepad,
+                Key.A,
+                toolbar =>
+                {
+                    KeyboardHelper.SendKey(Key.Right);
+                    Assert.AreEqual("á", GetSelectedCharacter(toolbar, ["á"]));
+                });
+        }
+        else
+        {
+            var trigger = Enum.Parse<Key>(triggerName);
+            result = RunTriggeredGesture(
+                this,
+                notepad,
+                Key.A,
+                trigger,
+                toolbar => Assert.AreEqual("á", GetSelectedCharacter(toolbar, ["á"])));
+        }
+
+        Assert.AreEqual("á", result, $"{activation} activation through {triggerName} did not commit the Spanish accent.");
+    }
+
+    [TestMethod]
+    [TestCategory("PowerAccent")]
+    public void CurrencyLanguageLimitsAvailableCharacters()
+    {
+        ReplaceSettings(new Settings(
+            Activation: ActivationKey.Space,
+            InputTimeMs: 200,
+            SelectedLanguage: "CUR"));
+
+        using var clipboard = PreserveClipboardText();
+        using var notepad = NotepadFixture.Start(this);
+
+        Assert.AreEqual(
+            "a ",
+            RunSuppressedGesture(this, notepad, Key.A, Key.Space),
+            "Currency has no mapping for A, so the input should pass through and no toolbar should appear.");
+
+        var result = RunTriggeredGesture(
+            this,
+            notepad,
+            Key.S,
+            Key.Space,
+            toolbar =>
+            {
+                Assert.AreEqual("$", GetSelectedCharacter(toolbar, CurrencySCharacters));
+                CollectionAssert.AreEqual(
+                    CurrencySCharacters,
+                    GetCharactersInVisualOrder(toolbar, CurrencySCharacters).ToArray(),
+                    "Currency should expose only the configured S mappings in source order.");
+            });
+        Assert.AreEqual("$", result, "Currency should commit the first S currency character.");
+    }
+
+    [DataTestMethod]
+    [DataRow("Top center", "Center", "Top")]
+    [DataRow("Bottom center", "Center", "Bottom")]
+    [DataRow("Left", "Left", "Center")]
+    [DataRow("Right", "Right", "Center")]
+    [DataRow("Top right corner", "Right", "Top")]
+    [DataRow("Top left corner", "Left", "Top")]
+    [DataRow("Bottom right corner", "Right", "Bottom")]
+    [DataRow("Bottom left corner", "Left", "Bottom")]
+    [DataRow("Center", "Center", "Center")]
+    [TestCategory("PowerAccent")]
+    public void ToolbarPositionSettingIsApplied(string position, string horizontalAnchor, string verticalAnchor)
+    {
+        ReplaceSettings(new Settings(
+            Activation: ActivationKey.Space,
+            ToolbarPosition: position,
+            InputTimeMs: 200,
+            SelectedLanguage: "SP"));
+
+        using var clipboard = PreserveClipboardText();
+        using var notepad = NotepadFixture.Start(this);
+
+        var result = RunTriggeredGesture(
+            this,
+            notepad,
+            Key.A,
+            Key.Space,
+            toolbar => AssertToolbarPlacement(this, toolbar, horizontalAnchor, verticalAnchor));
+        Assert.AreEqual("á", result, $"The {position} toolbar did not commit the selected accent.");
+    }
+
+    [TestMethod]
+    [TestCategory("PowerAccent")]
+    public void InputDelayDistinguishesFalseStartFromSelection()
+    {
+        const int inputTimeMs = 900;
+        ReplaceSettings(new Settings(
+            Activation: ActivationKey.Space,
+            InputTimeMs: inputTimeMs,
+            SelectedLanguage: "FR"));
+
+        using var clipboard = PreserveClipboardText();
+        using var notepad = NotepadFixture.Start(this);
+
+        Assert.AreEqual(
+            "a ",
+            RunFalseStart(
+                this,
+                notepad,
+                Key.A,
+                Key.Space,
+                heldMs: 100,
+                verificationMs: inputTimeMs + 300),
+            "A gesture released well before the input delay should keep the base letter and Space.");
+
+        Assert.AreEqual(
+            "à",
+            RunTriggeredGesture(
+                this,
+                notepad,
+                Key.A,
+                Key.Space,
+                toolbar => Assert.AreEqual("à", GetSelectedCharacter(toolbar, FrenchACharacters))),
+            "Holding through the input delay should commit the selected accent.");
+    }
+
+    [TestMethod]
+    [TestCategory("PowerAccent")]
+    public void ExcludedApplicationDoesNotActivate()
+    {
+        ReplaceSettings(new Settings(
+            Activation: ActivationKey.Space,
+            InputTimeMs: 200,
+            SelectedLanguage: "FR",
+            ExcludedApps: "notepad.exe"));
+
+        using var clipboard = PreserveClipboardText();
+        using var notepad = NotepadFixture.Start(this);
+
+        Assert.AreEqual(
+            "a ",
+            RunSuppressedGesture(this, notepad, Key.A, Key.Space),
+            "Quick Accent should not consume input or reveal its toolbar in an excluded Notepad window.");
+    }
+
+    [TestMethod]
+    [TestCategory("PowerAccent")]
+    public void SortByFrequencyMovesUsedCharacterFirst()
+    {
+        ReplaceSettings(new Settings(
+            Activation: ActivationKey.Space,
+            InputTimeMs: 200,
+            SelectedLanguage: "FR",
+            SortByUsageFrequency: true));
+
+        using var clipboard = PreserveClipboardText();
+        using var notepad = NotepadFixture.Start(this);
+
+        var firstResult = RunTriggeredGesture(
+            this,
+            notepad,
+            Key.A,
+            Key.Space,
+            toolbar =>
+            {
+                Assert.AreEqual("à", GetSelectedCharacter(toolbar, FrenchACharacters));
+                for (var index = 1; index < FrenchACharacters.Length; index++)
+                {
+                    KeyboardHelper.SendKey(Key.Space);
+                }
+
+                Assert.AreEqual("æ", GetSelectedCharacter(toolbar, FrenchACharacters));
+            });
+        Assert.AreEqual("æ", firstResult, "The setup gesture should record usage for the last French A character.");
+
+        var sortedResult = RunTriggeredGesture(
+            this,
+            notepad,
+            Key.A,
+            Key.Space,
+            toolbar =>
+            {
+                Assert.AreEqual("æ", GetSelectedCharacter(toolbar, FrenchACharacters), "The most-used character should be selected first.");
+                Assert.AreEqual(
+                    "æ",
+                    GetCharactersInVisualOrder(toolbar, FrenchACharacters)[0],
+                    "The most-used character should move to the first visual position.");
+            });
+        Assert.AreEqual("æ", sortedResult, "The reordered first character should be committed.");
+    }
+
+    [TestMethod]
+    [TestCategory("PowerAccent")]
+    public void StartFromLeftUsesFirstCharacterForBothArrows()
+    {
+        using var clipboard = PreserveClipboardText();
+        using var notepad = NotepadFixture.Start(this);
+
+        ReplaceSettings(new Settings(
+            Activation: ActivationKey.LeftRightArrow,
+            InputTimeMs: 200,
+            SelectedLanguage: "FR",
+            StartSelectionFromTheLeft: false));
+        Assert.AreEqual(
+            "ä",
+            RunTriggeredGesture(
+                this,
+                notepad,
+                Key.A,
+                Key.Right,
+                toolbar => Assert.AreEqual("ä", GetSelectedCharacter(toolbar, FrenchACharacters))),
+            "The default right-arrow selection should start in the right half.");
+
+        ReplaceSettings(new Settings(
+            Activation: ActivationKey.LeftRightArrow,
+            InputTimeMs: 200,
+            SelectedLanguage: "FR",
+            StartSelectionFromTheLeft: true));
+        Assert.AreEqual(
+            "à",
+            RunTriggeredGesture(
+                this,
+                notepad,
+                Key.A,
+                Key.Right,
+                toolbar => Assert.AreEqual("à", GetSelectedCharacter(toolbar, FrenchACharacters))),
+            "Start-from-left should make Right select the first character.");
+        Assert.AreEqual(
+            "à",
+            RunTriggeredGesture(
+                this,
+                notepad,
+                Key.A,
+                Key.Left,
+                toolbar => Assert.AreEqual("à", GetSelectedCharacter(toolbar, FrenchACharacters))),
+            "Start-from-left should make Left select the first character.");
+    }
+}

--- a/src/modules/poweraccent/PowerAccent.UITests/PowerAccentEndToEndTests.cs
+++ b/src/modules/poweraccent/PowerAccent.UITests/PowerAccentEndToEndTests.cs
@@ -34,7 +34,7 @@ public sealed class PowerAccentEndToEndTests : UITestBase
     [TestCategory("PowerAccent")]
     public void ArrowKeysCycleAndCommitSelectedCharacter()
     {
-        ReplaceSettings(new Settings(
+        ReplaceSettings(this, new Settings(
             Activation: ActivationKey.LeftRightArrow,
             InputTimeMs: 200,
             SelectedLanguage: "FR"));
@@ -78,7 +78,7 @@ public sealed class PowerAccentEndToEndTests : UITestBase
     [TestCategory("PowerAccent")]
     public void SpaceCyclesForwardAndShiftSpaceCyclesBackward()
     {
-        ReplaceSettings(new Settings(
+        ReplaceSettings(this, new Settings(
             Activation: ActivationKey.Space,
             InputTimeMs: 200,
             SelectedLanguage: "FR"));
@@ -118,7 +118,7 @@ public sealed class PowerAccentEndToEndTests : UITestBase
     [TestCategory("PowerAccent")]
     public void DisablingQuickAccentStopsActivation()
     {
-        ReplaceSettings(new Settings(
+        ReplaceSettings(this, new Settings(
             Activation: ActivationKey.Space,
             InputTimeMs: 200,
             SelectedLanguage: "FR"));
@@ -154,7 +154,7 @@ public sealed class PowerAccentEndToEndTests : UITestBase
     public void ActivationKeySettingIsApplied(int activationKey, string triggerName)
     {
         var activation = (ActivationKey)activationKey;
-        ReplaceSettings(new Settings(
+        ReplaceSettings(this, new Settings(
             Activation: activation,
             InputTimeMs: 200,
             HoldDurationMs: 250,
@@ -194,7 +194,7 @@ public sealed class PowerAccentEndToEndTests : UITestBase
     [TestCategory("PowerAccent")]
     public void CurrencyLanguageLimitsAvailableCharacters()
     {
-        ReplaceSettings(new Settings(
+        ReplaceSettings(this, new Settings(
             Activation: ActivationKey.Space,
             InputTimeMs: 200,
             SelectedLanguage: "CUR"));
@@ -236,7 +236,7 @@ public sealed class PowerAccentEndToEndTests : UITestBase
     [TestCategory("PowerAccent")]
     public void ToolbarPositionSettingIsApplied(string position, string horizontalAnchor, string verticalAnchor)
     {
-        ReplaceSettings(new Settings(
+        ReplaceSettings(this, new Settings(
             Activation: ActivationKey.Space,
             ToolbarPosition: position,
             InputTimeMs: 200,
@@ -259,7 +259,7 @@ public sealed class PowerAccentEndToEndTests : UITestBase
     public void InputDelayDistinguishesFalseStartFromSelection()
     {
         const int inputTimeMs = 900;
-        ReplaceSettings(new Settings(
+        ReplaceSettings(this, new Settings(
             Activation: ActivationKey.Space,
             InputTimeMs: inputTimeMs,
             SelectedLanguage: "FR"));
@@ -293,7 +293,7 @@ public sealed class PowerAccentEndToEndTests : UITestBase
     [TestCategory("PowerAccent")]
     public void ExcludedApplicationDoesNotActivate()
     {
-        ReplaceSettings(new Settings(
+        ReplaceSettings(this, new Settings(
             Activation: ActivationKey.Space,
             InputTimeMs: 200,
             SelectedLanguage: "FR",
@@ -312,7 +312,7 @@ public sealed class PowerAccentEndToEndTests : UITestBase
     [TestCategory("PowerAccent")]
     public void SortByFrequencyMovesUsedCharacterFirst()
     {
-        ReplaceSettings(new Settings(
+        ReplaceSettings(this, new Settings(
             Activation: ActivationKey.Space,
             InputTimeMs: 200,
             SelectedLanguage: "FR",
@@ -361,7 +361,7 @@ public sealed class PowerAccentEndToEndTests : UITestBase
         using var clipboard = PreserveClipboardText();
         using var notepad = NotepadFixture.Start(this);
 
-        ReplaceSettings(new Settings(
+        ReplaceSettings(this, new Settings(
             Activation: ActivationKey.LeftRightArrow,
             InputTimeMs: 200,
             SelectedLanguage: "FR",
@@ -376,7 +376,7 @@ public sealed class PowerAccentEndToEndTests : UITestBase
                 toolbar => Assert.AreEqual("ä", GetSelectedCharacter(toolbar, FrenchACharacters))),
             "The default right-arrow selection should start in the right half.");
 
-        ReplaceSettings(new Settings(
+        ReplaceSettings(this, new Settings(
             Activation: ActivationKey.LeftRightArrow,
             InputTimeMs: 200,
             SelectedLanguage: "FR",

--- a/src/modules/poweraccent/PowerAccent.UITests/PowerAccentTestHelper.cs
+++ b/src/modules/poweraccent/PowerAccent.UITests/PowerAccentTestHelper.cs
@@ -698,20 +698,26 @@ internal static class PowerAccentTestHelper
 
             try
             {
-                using var launcher = Process.Start(new ProcessStartInfo
+                Session? window = null;
+                for (var attempt = 1; attempt <= 2 && window is null; attempt++)
                 {
-                    FileName = "notepad.exe",
-                    Arguments = $"\"{filePath}\"",
-                    UseShellExecute = true,
-                });
-                Assert.IsNotNull(launcher, "Could not start the Notepad fixture.");
+                    Step(testBase, $"Opening Notepad fixture (attempt {attempt}/2)");
+                    using var launcher = Process.Start(new ProcessStartInfo
+                    {
+                        FileName = "notepad.exe",
+                        Arguments = $"\"{filePath}\"",
+                        UseShellExecute = true,
+                    });
+                    Assert.IsNotNull(launcher, "Could not start the Notepad fixture.");
 
-                var window = WindowsFinder.WaitForWindowByApp(
-                    "notepad",
-                    candidate =>
-                        candidate.Title.Contains(fileName, StringComparison.OrdinalIgnoreCase) ||
-                        candidate.Title.Contains(baseFileName, StringComparison.OrdinalIgnoreCase),
-                    timeoutMS: 15_000);
+                    window = WindowsFinder.WaitForWindowByApp(
+                        "notepad",
+                        candidate =>
+                            candidate.Title.Contains(fileName, StringComparison.OrdinalIgnoreCase) ||
+                            candidate.Title.Contains(baseFileName, StringComparison.OrdinalIgnoreCase),
+                        timeoutMS: 15_000);
+                }
+
                 Assert.IsNotNull(window, $"Notepad did not open the fixture document '{fileName}'.");
                 return new NotepadFixture(testBase, filePath, window);
             }

--- a/src/modules/poweraccent/PowerAccent.UITests/PowerAccentTestHelper.cs
+++ b/src/modules/poweraccent/PowerAccent.UITests/PowerAccentTestHelper.cs
@@ -24,8 +24,10 @@ internal static class PowerAccentTestHelper
 
     private const int DwmCloakedAttribute = 14;
     private const int DwmExtendedFrameBoundsAttribute = 9;
+    private const int EnglishUnitedStatesLanguageId = 0x0409;
     private const int OverlayStartupTimeoutMs = 30_000;
-    private const int SettingsReloadDelayMs = 2_000;
+    private const int SettingsReloadTimeoutMs = 30_000;
+    private const int VkCapital = 0x14;
 
     [DllImport("dwmapi.dll")]
     private static extern int DwmGetWindowAttribute(IntPtr hwnd, int attribute, out int value, int valueSize);
@@ -35,6 +37,12 @@ internal static class PowerAccentTestHelper
 
     [DllImport("user32.dll")]
     private static extern uint GetDpiForWindow(IntPtr hwnd);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetKeyboardLayout(uint threadId);
+
+    [DllImport("user32.dll")]
+    private static extern short GetKeyState(int virtualKey);
 
     [StructLayout(LayoutKind.Sequential)]
     private struct NativeRect
@@ -70,17 +78,31 @@ internal static class PowerAccentTestHelper
 
     internal static void PrepareDefaultState()
     {
-        WriteSettings(new Settings(), waitForReload: false);
+        WriteSettings(new Settings());
         File.Delete(UsageInfoPath);
     }
 
     internal static void ReplaceSettings(UITestBase testBase, Settings settings)
     {
         WaitForOverlayState(testBase, revealed: false, timeoutMs: OverlayStartupTimeoutMs);
-        WriteSettings(settings, waitForReload: true);
+        var logOffsets = CaptureQuickAccentLogOffsets();
+        WriteSettings(settings);
+        WaitForSettingsReload(testBase, settings.SelectedLanguage, logOffsets);
     }
 
-    private static void WriteSettings(Settings settings, bool waitForReload)
+    internal static void AssertInputEnvironment()
+    {
+        var languageId = (int)(GetKeyboardLayout(0).ToInt64() & 0xFFFF);
+        Assert.AreEqual(
+            EnglishUnitedStatesLanguageId,
+            languageId,
+            $"Quick Accent UI tests require the en-US keyboard layout (0x0409), but the active layout is 0x{languageId:X4}.");
+        Assert.IsFalse(
+            (GetKeyState(VkCapital) & 1) != 0,
+            "Quick Accent UI tests require Caps Lock to be off because raw virtual-key input is asserted as lowercase text.");
+    }
+
+    private static void WriteSettings(Settings settings)
     {
         var desired = CreateSettings(settings);
         SettingsConfigHelper.UpdateModuleSettings(
@@ -94,14 +116,85 @@ internal static class PowerAccentTestHelper
                     current[property.Key] = property.Value?.DeepClone();
                 }
             });
-
-        if (waitForReload)
-        {
-            Thread.Sleep(SettingsReloadDelayMs);
-        }
     }
 
-    internal static IDisposable PreserveUsageInfo() => new FileSnapshot(UsageInfoPath);
+    private static IReadOnlyDictionary<string, long> CaptureQuickAccentLogOffsets()
+    {
+        var offsets = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
+        if (!Directory.Exists(QuickAccentLogRoot))
+        {
+            return offsets;
+        }
+
+        foreach (var path in Directory.EnumerateFiles(QuickAccentLogRoot, "*.log", SearchOption.AllDirectories))
+        {
+            try
+            {
+                offsets[path] = new FileInfo(path).Length;
+            }
+            catch (FileNotFoundException)
+            {
+                // A logger rotated the file between enumeration and inspection.
+            }
+        }
+
+        return offsets;
+    }
+
+    private static void WaitForSettingsReload(
+        UITestBase testBase,
+        string selectedLanguage,
+        IReadOnlyDictionary<string, long> logOffsets)
+    {
+        var languages = selectedLanguage
+            .Split(',', StringSplitOptions.RemoveEmptyEntries)
+            .Select(language => language.Trim().ToUpperInvariant());
+        var acknowledgement = $"Languages selected: {string.Join(", ", languages)}";
+
+        var result = WaitHelper.WaitForStable(
+            () => FindSettingsReloadAcknowledgement(logOffsets, acknowledgement),
+            matchedLog => matchedLog is not null,
+            SettingsReloadTimeoutMs,
+            pollIntervalMS: 100,
+            shouldRetryException: ex => ex is IOException or UnauthorizedAccessException);
+        var failure = $"Quick Accent did not acknowledge its settings reload within {SettingsReloadTimeoutMs} ms. " +
+                      $"Expected a new '{acknowledgement}' log entry under '{QuickAccentLogRoot}'. " +
+                      $"Last read error: {result.LastException?.Message ?? "(none)"}.";
+        Assert.IsTrue(
+            result.Succeeded,
+            failure);
+        Step(testBase, $"Quick Accent acknowledged settings reload in '{result.LastObservation}'.");
+    }
+
+    private static string? FindSettingsReloadAcknowledgement(
+        IReadOnlyDictionary<string, long> logOffsets,
+        string acknowledgement)
+    {
+        if (!Directory.Exists(QuickAccentLogRoot))
+        {
+            return null;
+        }
+
+        foreach (var path in Directory.EnumerateFiles(QuickAccentLogRoot, "*.log", SearchOption.AllDirectories))
+        {
+            using var stream = new FileStream(
+                path,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.ReadWrite | FileShare.Delete);
+            var originalLength = logOffsets.TryGetValue(path, out var length) ? length : 0;
+            stream.Position = Math.Min(originalLength, stream.Length);
+            using var reader = new StreamReader(stream);
+            if (reader.ReadToEnd().Contains(acknowledgement, StringComparison.Ordinal))
+            {
+                return path;
+            }
+        }
+
+        return null;
+    }
+
+    internal static IDisposable PreserveUsageInfo() => SettingsConfigHelper.PreserveFile(UsageInfoPath);
 
     internal static void DisposeAll(params IDisposable[] snapshots)
     {
@@ -127,6 +220,44 @@ internal static class PowerAccentTestHelper
         if (failures is not null)
         {
             throw new AggregateException("Quick Accent test state could not be fully restored.", failures);
+        }
+    }
+
+    internal static void RunWithCleanup(Action action, Action cleanup)
+    {
+        Exception? actionFailure = null;
+        try
+        {
+            action();
+        }
+        catch (Exception ex)
+        {
+            actionFailure = ex;
+        }
+
+        Exception? cleanupFailure = null;
+        try
+        {
+            cleanup();
+        }
+        catch (Exception ex)
+        {
+            cleanupFailure = ex;
+        }
+
+        if (actionFailure is not null)
+        {
+            if (cleanupFailure is not null)
+            {
+                throw new AggregateException("The test action and its state restoration both failed.", actionFailure, cleanupFailure);
+            }
+
+            ExceptionDispatchInfo.Capture(actionFailure).Throw();
+        }
+
+        if (cleanupFailure is not null)
+        {
+            ExceptionDispatchInfo.Capture(cleanupFailure).Throw();
         }
     }
 
@@ -458,7 +589,10 @@ internal static class PowerAccentTestHelper
         var characterList = toolbar.Find<Element>(By.AccessibilityId("QuickAccentCharacterList"), 5_000);
         var dpiScale = Math.Max(1d, GetDpiForWindow(handle) / 96d);
 
-        const int edgeOffset = 24;
+        const int edgeOffset = 24; // Calculation.GetRawCoordinatesFromPosition offset.
+
+        // SelectorControl.HorizontalSurfaceOverheadDip (24 + 24 margin, 1 + 1 border)
+        // plus MainWindow.LayoutRoundingDip (1).
         const int horizontalChromeDip = 51;
         const int tolerance = 4;
         var positioningWidth = characterList.Width + (int)Math.Ceiling(horizontalChromeDip * dpiScale);
@@ -512,6 +646,11 @@ internal static class PowerAccentTestHelper
         ModuleName,
         "UsageInfo.json");
 
+    private static string QuickAccentLogRoot => Path.Combine(
+        SettingsConfigHelper.PowerToysSettingsRoot,
+        ModuleName,
+        "Logs");
+
     private static JsonObject CreateSettings(Settings settings) =>
         new()
         {
@@ -543,7 +682,8 @@ internal static class PowerAccentTestHelper
             observation => observation is not null && observation.IsCloaked == !revealed,
             timeoutMs,
             requiredConsecutiveMatches: 3,
-            pollIntervalMS: 100);
+            pollIntervalMS: 100,
+            shouldRetryException: ex => ex is InvalidOperationException);
 
         var last = result.LastObservation;
         var stateName = revealed ? "revealed" : "cloaked";
@@ -595,8 +735,13 @@ internal static class PowerAccentTestHelper
             },
             timeoutMS: 5_000,
             requiredConsecutiveMatches: 3,
-            pollIntervalMS: 100);
-        Assert.IsTrue(result.Succeeded, $"Quick Accent toolbar bounds did not stabilize. Last bounds: {result.LastObservation}.");
+            pollIntervalMS: 100,
+            shouldRetryException: ex => ex is InvalidOperationException);
+        var failure = $"Quick Accent toolbar bounds did not stabilize. Last bounds: {result.LastObservation}. " +
+                      $"Last DWM error: {result.LastException?.Message ?? "(none)"}.";
+        Assert.IsTrue(
+            result.Succeeded,
+            failure);
         return result.LastObservation;
     }
 
@@ -704,7 +849,9 @@ internal static class PowerAccentTestHelper
                     Step(testBase, $"Opening Notepad fixture (attempt {attempt}/2)");
                     using var launcher = Process.Start(new ProcessStartInfo
                     {
-                        FileName = "notepad.exe",
+                        FileName = Path.Combine(
+                            Environment.GetFolderPath(Environment.SpecialFolder.System),
+                            "notepad.exe"),
                         Arguments = $"\"{filePath}\"",
                         UseShellExecute = true,
                     });
@@ -800,8 +947,12 @@ internal static class PowerAccentTestHelper
             try
             {
                 using var process = Process.GetProcessById(Window.ProcessId);
-                process.Kill(entireProcessTree: true);
-                process.WaitForExit(5_000);
+                if (!process.HasExited && (!process.CloseMainWindow() || !process.WaitForExit(3_000)))
+                {
+                    Step(testBase, $"Notepad pid {process.Id} did not close gracefully; terminating its process tree");
+                    process.Kill(entireProcessTree: true);
+                    process.WaitForExit(5_000);
+                }
             }
             catch (ArgumentException)
             {
@@ -854,40 +1005,13 @@ internal static class PowerAccentTestHelper
             }
 
             disposed = true;
-            ClipboardHelper.SetText(originalText);
-        }
-    }
-
-    private sealed class FileSnapshot : IDisposable
-    {
-        private readonly string path;
-        private readonly bool existed;
-        private readonly byte[]? content;
-        private bool disposed;
-
-        internal FileSnapshot(string path)
-        {
-            this.path = path;
-            existed = File.Exists(path);
-            content = existed ? File.ReadAllBytes(path) : null;
-        }
-
-        public void Dispose()
-        {
-            if (disposed)
+            if (string.IsNullOrEmpty(originalText))
             {
-                return;
-            }
-
-            disposed = true;
-            if (existed)
-            {
-                Directory.CreateDirectory(Path.GetDirectoryName(path)!);
-                File.WriteAllBytes(path, content!);
+                ClipboardHelper.Clear();
             }
             else
             {
-                File.Delete(path);
+                ClipboardHelper.SetText(originalText);
             }
         }
     }

--- a/src/modules/poweraccent/PowerAccent.UITests/PowerAccentTestHelper.cs
+++ b/src/modules/poweraccent/PowerAccent.UITests/PowerAccentTestHelper.cs
@@ -843,6 +843,13 @@ internal static class PowerAccentTestHelper
 
             try
             {
+                var settingsHandle = new IntPtr(testBase.Session.WindowHandle);
+                if (settingsHandle != IntPtr.Zero)
+                {
+                    Step(testBase, $"Minimizing Settings HWND {settingsHandle} before launching Notepad");
+                    WindowHelper.MinimizeWindow(settingsHandle);
+                }
+
                 Session? window = null;
                 for (var attempt = 1; attempt <= 2 && window is null; attempt++)
                 {
@@ -870,6 +877,7 @@ internal static class PowerAccentTestHelper
             }
             catch
             {
+                RestoreSettingsWindow(testBase);
                 File.Delete(filePath);
                 throw;
             }
@@ -972,6 +980,8 @@ internal static class PowerAccentTestHelper
                 catch (UnauthorizedAccessException)
                 {
                 }
+
+                RestoreSettingsWindow(testBase);
             }
         }
 
@@ -989,6 +999,15 @@ internal static class PowerAccentTestHelper
             }
 
             Thread.Sleep(50);
+        }
+
+        private static void RestoreSettingsWindow(UITestBase testBase)
+        {
+            var settingsHandle = new IntPtr(testBase.Session.WindowHandle);
+            if (settingsHandle != IntPtr.Zero)
+            {
+                WindowHelper.MaximizeWindow(settingsHandle);
+            }
         }
     }
 

--- a/src/modules/poweraccent/PowerAccent.UITests/PowerAccentTestHelper.cs
+++ b/src/modules/poweraccent/PowerAccent.UITests/PowerAccentTestHelper.cs
@@ -1,0 +1,882 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
+using System.Text.Json.Nodes;
+using Microsoft.PowerToys.UITest.Next;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace PowerAccent.UITests;
+
+internal static class PowerAccentTestHelper
+{
+    internal const string ModuleName = "QuickAccent";
+    internal const string ProcessName = "PowerToys.PowerAccent";
+    internal const string ToggleId = "Toggle_QuickAccent";
+    internal const string NavigationItemId = "QuickAccentNavItem";
+    internal const string NavigationGroupId = "InputOutputNavItem";
+
+    internal static readonly string[] CurrencySCharacters = ["$", "₪"];
+    internal static readonly string[] FrenchACharacters = ["à", "â", "á", "ä", "ã", "æ"];
+
+    private const int DwmCloakedAttribute = 14;
+    private const int DwmExtendedFrameBoundsAttribute = 9;
+    private const int OverlayStartupTimeoutMs = 30_000;
+    private const int SettingsReloadDelayMs = 600;
+
+    [DllImport("dwmapi.dll")]
+    private static extern int DwmGetWindowAttribute(IntPtr hwnd, int attribute, out int value, int valueSize);
+
+    [DllImport("dwmapi.dll", EntryPoint = "DwmGetWindowAttribute")]
+    private static extern int DwmGetWindowRectAttribute(IntPtr hwnd, int attribute, out NativeRect value, int valueSize);
+
+    [DllImport("user32.dll")]
+    private static extern uint GetDpiForWindow(IntPtr hwnd);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NativeRect
+    {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
+    }
+
+    internal enum ActivationKey
+    {
+        LeftRightArrow,
+        Space,
+        Both,
+        PressAndHold,
+    }
+
+    internal sealed record Settings(
+        ActivationKey Activation = ActivationKey.Both,
+        string ToolbarPosition = "Top center",
+        int InputTimeMs = 300,
+        int HoldDurationMs = 500,
+        string SelectedLanguage = "ALL",
+        string ExcludedApps = "",
+        bool SortByUsageFrequency = false,
+        bool StartSelectionFromTheLeft = false);
+
+    private sealed record OverlayObservation(
+        WindowControl.ProcessWindow Window,
+        bool IsCloaked,
+        (int Left, int Top, int Right, int Bottom) Bounds);
+
+    internal static void PrepareDefaultState()
+    {
+        ReplaceSettings(new Settings(), waitForReload: false);
+        File.Delete(UsageInfoPath);
+    }
+
+    internal static void ReplaceSettings(Settings settings, bool waitForReload = true)
+    {
+        var desired = CreateSettings(settings);
+        SettingsConfigHelper.UpdateModuleSettings(
+            ModuleName,
+            desired.ToJsonString(),
+            current =>
+            {
+                current.Clear();
+                foreach (var property in desired)
+                {
+                    current[property.Key] = property.Value?.DeepClone();
+                }
+            });
+
+        if (waitForReload)
+        {
+            Thread.Sleep(SettingsReloadDelayMs);
+        }
+    }
+
+    internal static IDisposable PreserveUsageInfo() => new FileSnapshot(UsageInfoPath);
+
+    internal static void DisposeAll(params IDisposable[] snapshots)
+    {
+        List<Exception>? failures = null;
+        foreach (var snapshot in snapshots.Reverse())
+        {
+            try
+            {
+                snapshot.Dispose();
+            }
+            catch (Exception ex)
+            {
+                failures ??= [];
+                failures.Add(ex);
+            }
+        }
+
+        if (failures is { Count: 1 })
+        {
+            ExceptionDispatchInfo.Capture(failures[0]).Throw();
+        }
+
+        if (failures is not null)
+        {
+            throw new AggregateException("Quick Accent test state could not be fully restored.", failures);
+        }
+    }
+
+    internal static void NavigateToSettings(UITestBase testBase)
+    {
+        Step(testBase, "Navigating to Quick Accent settings");
+        if (!testBase.Session.Has(By.AccessibilityId(NavigationItemId), 500))
+        {
+            testBase.Session.Find<NavigationViewItem>(By.AccessibilityId(NavigationGroupId), 5_000).Click(msPostAction: 500);
+        }
+
+        testBase.Session.Find<NavigationViewItem>(By.AccessibilityId(NavigationItemId), 5_000).Click(msPostAction: 800);
+    }
+
+    internal static ToggleSwitch SetModuleEnabled(UITestBase testBase, bool enabled)
+    {
+        var expectedState = enabled ? "On" : "Off";
+        Step(testBase, $"Setting Quick Accent to {expectedState}");
+
+        ToggleSwitch? toggle = null;
+        for (var attempt = 1; attempt <= 3; attempt++)
+        {
+            toggle = testBase.Session.Find<ToggleSwitch>(By.AccessibilityId(ToggleId), 10_000);
+            if (toggle.GetProperty("ToggleState").Equals(expectedState, StringComparison.OrdinalIgnoreCase))
+            {
+                return toggle;
+            }
+
+            toggle.Invoke(msPostAction: 500);
+            if (toggle.WaitForProperty("ToggleState", expectedState, 15_000))
+            {
+                return toggle;
+            }
+
+            Step(testBase, $"Quick Accent toggle did not reach {expectedState} on attempt {attempt}/3");
+        }
+
+        Assert.Fail($"Quick Accent toggle did not reach {expectedState} after three attempts.");
+        return toggle!;
+    }
+
+    internal static bool WaitForProcess(bool expected, int timeoutMs = 15_000)
+    {
+        var result = WaitHelper.WaitForStable(
+            () =>
+            {
+                var processes = Process.GetProcessesByName(ProcessName);
+                try
+                {
+                    return processes.Length > 0;
+                }
+                finally
+                {
+                    foreach (var process in processes)
+                    {
+                        process.Dispose();
+                    }
+                }
+            },
+            running => running == expected,
+            timeoutMs,
+            requiredConsecutiveMatches: 3,
+            pollIntervalMS: 150);
+        return result.Succeeded;
+    }
+
+    internal static string RunTriggeredGesture(
+        UITestBase testBase,
+        NotepadFixture notepad,
+        Key letter,
+        Key trigger,
+        Action<Session>? whileToolbarShown = null,
+        int revealTimeoutMs = 10_000)
+    {
+        notepad.Clear();
+        WaitForOverlayState(testBase, revealed: false, timeoutMs: OverlayStartupTimeoutMs);
+        notepad.Focus();
+
+        var letterDown = false;
+        var triggerDown = false;
+        try
+        {
+            Step(testBase, $"Holding {letter} and pressing {trigger}");
+            KeyboardHelper.PressKey(letter);
+            letterDown = true;
+            Thread.Sleep(50);
+            KeyboardHelper.PressKey(trigger);
+            triggerDown = true;
+
+            var toolbar = WaitForOverlayState(testBase, revealed: true, timeoutMs: revealTimeoutMs);
+            KeyboardHelper.ReleaseKey(trigger);
+            triggerDown = false;
+
+            whileToolbarShown?.Invoke(toolbar);
+
+            notepad.Focus();
+            KeyboardHelper.ReleaseKey(letter);
+            letterDown = false;
+            WaitForOverlayState(testBase, revealed: false, timeoutMs: 5_000);
+            return notepad.WaitForNonEmptyText();
+        }
+        finally
+        {
+            if (triggerDown)
+            {
+                KeyboardHelper.ReleaseKey(trigger);
+            }
+
+            if (letterDown)
+            {
+                KeyboardHelper.ReleaseKey(letter);
+            }
+        }
+    }
+
+    internal static string RunPressAndHoldGesture(
+        UITestBase testBase,
+        NotepadFixture notepad,
+        Key letter,
+        Action<Session> whileToolbarShown,
+        int revealTimeoutMs = 10_000)
+    {
+        notepad.Clear();
+        WaitForOverlayState(testBase, revealed: false, timeoutMs: OverlayStartupTimeoutMs);
+        notepad.Focus();
+
+        var letterDown = false;
+        try
+        {
+            Step(testBase, $"Holding {letter} until the Quick Accent toolbar appears");
+            KeyboardHelper.PressKey(letter);
+            letterDown = true;
+
+            var toolbar = WaitForOverlayState(testBase, revealed: true, timeoutMs: revealTimeoutMs);
+            whileToolbarShown(toolbar);
+
+            notepad.Focus();
+            KeyboardHelper.ReleaseKey(letter);
+            letterDown = false;
+            WaitForOverlayState(testBase, revealed: false, timeoutMs: 5_000);
+            return notepad.WaitForNonEmptyText();
+        }
+        finally
+        {
+            if (letterDown)
+            {
+                KeyboardHelper.ReleaseKey(letter);
+            }
+        }
+    }
+
+    internal static string RunSuppressedGesture(
+        UITestBase testBase,
+        NotepadFixture notepad,
+        Key letter,
+        Key trigger,
+        int observationMs = 800)
+    {
+        notepad.Clear();
+        WaitForOverlayState(testBase, revealed: false, timeoutMs: OverlayStartupTimeoutMs);
+        notepad.Focus();
+
+        var letterDown = false;
+        var triggerDown = false;
+        try
+        {
+            Step(testBase, $"Holding {letter} + {trigger}; the toolbar must stay cloaked");
+            KeyboardHelper.PressKey(letter);
+            letterDown = true;
+            Thread.Sleep(50);
+            KeyboardHelper.PressKey(trigger);
+            triggerDown = true;
+
+            AssertOverlayRemainsCloaked(testBase, observationMs);
+
+            KeyboardHelper.ReleaseKey(trigger);
+            triggerDown = false;
+            KeyboardHelper.ReleaseKey(letter);
+            letterDown = false;
+            return notepad.WaitForNonEmptyText();
+        }
+        finally
+        {
+            if (triggerDown)
+            {
+                KeyboardHelper.ReleaseKey(trigger);
+            }
+
+            if (letterDown)
+            {
+                KeyboardHelper.ReleaseKey(letter);
+            }
+        }
+    }
+
+    internal static string RunFalseStart(
+        UITestBase testBase,
+        NotepadFixture notepad,
+        Key letter,
+        Key trigger,
+        int heldMs,
+        int verificationMs)
+    {
+        notepad.Clear();
+        WaitForOverlayState(testBase, revealed: false, timeoutMs: OverlayStartupTimeoutMs);
+        notepad.Focus();
+
+        var letterDown = false;
+        var triggerDown = false;
+        try
+        {
+            Step(testBase, $"Sending a {heldMs} ms {letter} + {trigger} false start");
+            KeyboardHelper.PressKey(letter);
+            letterDown = true;
+            Thread.Sleep(50);
+            KeyboardHelper.PressKey(trigger);
+            triggerDown = true;
+            Thread.Sleep(heldMs);
+            KeyboardHelper.ReleaseKey(trigger);
+            triggerDown = false;
+            KeyboardHelper.ReleaseKey(letter);
+            letterDown = false;
+
+            AssertOverlayRemainsCloaked(testBase, verificationMs);
+            return notepad.WaitForNonEmptyText();
+        }
+        finally
+        {
+            if (triggerDown)
+            {
+                KeyboardHelper.ReleaseKey(trigger);
+            }
+
+            if (letterDown)
+            {
+                KeyboardHelper.ReleaseKey(letter);
+            }
+        }
+    }
+
+    internal static string RunUnmodifiedGesture(NotepadFixture notepad, Key letter, Key trigger)
+    {
+        notepad.Clear();
+        notepad.Focus();
+
+        var letterDown = false;
+        var triggerDown = false;
+        try
+        {
+            KeyboardHelper.PressKey(letter);
+            letterDown = true;
+            Thread.Sleep(50);
+            KeyboardHelper.PressKey(trigger);
+            triggerDown = true;
+            Thread.Sleep(100);
+            KeyboardHelper.ReleaseKey(trigger);
+            triggerDown = false;
+            KeyboardHelper.ReleaseKey(letter);
+            letterDown = false;
+            return notepad.WaitForNonEmptyText();
+        }
+        finally
+        {
+            if (triggerDown)
+            {
+                KeyboardHelper.ReleaseKey(trigger);
+            }
+
+            if (letterDown)
+            {
+                KeyboardHelper.ReleaseKey(letter);
+            }
+        }
+    }
+
+    internal static string GetSelectedCharacter(Session toolbar, IReadOnlyList<string> candidates, int timeoutMs = 5_000)
+    {
+        string lastObservation = string.Empty;
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTime.UtcNow < deadline)
+        {
+            foreach (var character in candidates)
+            {
+                var item = FindCharacterItem(toolbar, character);
+                if (item is not null && item.Selected)
+                {
+                    return character;
+                }
+            }
+
+            lastObservation = string.Join(
+                ", ",
+                candidates.Select(character =>
+                {
+                    var item = FindCharacterItem(toolbar, character);
+                    return $"{character}:{(item is null ? "missing" : item.GetProperty("IsSelected"))}";
+                }));
+            Thread.Sleep(150);
+        }
+
+        Assert.Fail($"No selected Quick Accent character appeared within {timeoutMs} ms. Last observation: {lastObservation}");
+        return string.Empty;
+    }
+
+    internal static IReadOnlyList<string> GetCharactersInVisualOrder(Session toolbar, IReadOnlyList<string> expectedCharacters)
+    {
+        var items = expectedCharacters
+            .Select(character => (Character: character, Item: FindCharacterItem(toolbar, character)))
+            .ToList();
+        var missing = items.Where(item => item.Item is null).Select(item => item.Character).ToList();
+        Assert.AreEqual(0, missing.Count, $"Quick Accent toolbar was missing expected characters: {string.Join(", ", missing)}");
+
+        return items
+            .OrderBy(item => item.Item!.X)
+            .Select(item => item.Character)
+            .ToList();
+    }
+
+    internal static void AssertToolbarPlacement(
+        UITestBase testBase,
+        Session toolbar,
+        string horizontalAnchor,
+        string verticalAnchor)
+    {
+        var bounds = GetStableVisibleBounds(toolbar);
+        var handle = new IntPtr(toolbar.WindowHandle);
+        var workArea = System.Windows.Forms.Screen.FromHandle(handle).WorkingArea;
+        var centerY = bounds.Top + ((bounds.Bottom - bounds.Top) / 2);
+        var characterList = toolbar.Find<Element>(By.AccessibilityId("QuickAccentCharacterList"), 5_000);
+        var dpiScale = Math.Max(1d, GetDpiForWindow(handle) / 96d);
+
+        const int edgeOffset = 24;
+        const int horizontalChromeDip = 51;
+        const int tolerance = 4;
+        var positioningWidth = characterList.Width + (int)Math.Ceiling(horizontalChromeDip * dpiScale);
+        var horizontalExpected = horizontalAnchor switch
+        {
+            "Left" => workArea.Left + edgeOffset,
+            "Center" => workArea.Left + (int)Math.Round((workArea.Width - positioningWidth) / 2d),
+            "Right" => workArea.Right - positioningWidth - edgeOffset,
+            _ => throw new ArgumentOutOfRangeException(nameof(horizontalAnchor), horizontalAnchor, "Unknown horizontal anchor."),
+        };
+
+        var verticalActual = verticalAnchor switch
+        {
+            "Top" => bounds.Top,
+            "Center" => centerY,
+            "Bottom" => bounds.Bottom,
+            _ => throw new ArgumentOutOfRangeException(nameof(verticalAnchor), verticalAnchor, "Unknown vertical anchor."),
+        };
+        var verticalExpected = verticalAnchor switch
+        {
+            "Top" => workArea.Top + edgeOffset,
+            "Center" => workArea.Top + (workArea.Height / 2),
+            "Bottom" => workArea.Bottom - edgeOffset,
+            _ => throw new ArgumentOutOfRangeException(nameof(verticalAnchor), verticalAnchor, "Unknown vertical anchor."),
+        };
+
+        var placementDetails = $"Toolbar visible bounds are ({bounds.Left},{bounds.Top})-({bounds.Right},{bounds.Bottom}); " +
+                               $"character list=({characterList.X},{characterList.Y}) {characterList.Width}x{characterList.Height}; " +
+                               $"positioning width={positioningWidth}; work area={workArea}";
+        Step(testBase, placementDetails);
+        var horizontalFailure = $"Toolbar horizontal {horizontalAnchor} coordinate was {bounds.Left}; " +
+                                $"expected {horizontalExpected} +/- {tolerance}. Visible bounds: {bounds}; " +
+                                $"character list width={characterList.Width}; work area={workArea}.";
+        Assert.IsTrue(
+            Math.Abs(bounds.Left - horizontalExpected) <= tolerance,
+            horizontalFailure);
+        var verticalFailure = $"Toolbar vertical {verticalAnchor} coordinate was {verticalActual}; " +
+                              $"expected {verticalExpected} +/- {tolerance}. Visible bounds: {bounds}; work area={workArea}.";
+        Assert.IsTrue(
+            Math.Abs(verticalActual - verticalExpected) <= tolerance,
+            verticalFailure);
+    }
+
+    internal static IDisposable PreserveClipboardText() => new ClipboardTextSnapshot();
+
+    internal static void Step(UITestBase testBase, string message) =>
+        testBase.TestContext.WriteLine($"[{DateTime.UtcNow:HH:mm:ss.fff}] {message}");
+
+    private static string UsageInfoPath => Path.Combine(
+        SettingsConfigHelper.PowerToysSettingsRoot,
+        ModuleName,
+        "UsageInfo.json");
+
+    private static JsonObject CreateSettings(Settings settings) =>
+        new()
+        {
+            ["name"] = ModuleName,
+            ["version"] = "0.0.1",
+            ["properties"] = new JsonObject
+            {
+                ["activation_key"] = (int)settings.Activation,
+                ["do_not_activate_on_game_mode"] = true,
+                ["toolbar_position"] = Value(settings.ToolbarPosition),
+                ["input_time_ms"] = Value(settings.InputTimeMs),
+                ["hold_duration_ms"] = Value(settings.HoldDurationMs),
+                ["selected_lang"] = Value(settings.SelectedLanguage),
+                ["excluded_apps"] = Value(settings.ExcludedApps),
+                ["show_description"] = false,
+                ["sort_by_usage_frequency"] = settings.SortByUsageFrequency,
+                ["start_selection_from_the_left"] = settings.StartSelectionFromTheLeft,
+            },
+        };
+
+    private static JsonObject Value(string value) => new() { ["value"] = value };
+
+    private static JsonObject Value(int value) => new() { ["value"] = value };
+
+    private static Session WaitForOverlayState(UITestBase testBase, bool revealed, int timeoutMs)
+    {
+        var result = WaitHelper.WaitForStable(
+            ObserveOverlay,
+            observation => observation is not null && observation.IsCloaked == !revealed,
+            timeoutMs,
+            requiredConsecutiveMatches: 3,
+            pollIntervalMS: 100);
+
+        var last = result.LastObservation;
+        var stateName = revealed ? "revealed" : "cloaked";
+        var timeoutFailure = $"Quick Accent overlay did not become {stateName} within {timeoutMs} ms. " +
+                             $"Last observation: {FormatObservation(last)}";
+        Assert.IsTrue(
+            result.Succeeded && last is not null,
+            timeoutFailure);
+
+        Step(testBase, $"Quick Accent overlay is {stateName}: {FormatObservation(last)}");
+        return WindowsFinder.WaitForWindowByApp(
+            ProcessName,
+            candidate => candidate.Hwnd == last!.Window.Hwnd.ToInt64(),
+            timeoutMS: 2_000)
+            ?? throw new AssertFailedException($"Could not bind winappcli to Quick Accent HWND {last!.Window.Hwnd}.");
+    }
+
+    private static void AssertOverlayRemainsCloaked(UITestBase testBase, int durationMs)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        OverlayObservation? last = null;
+        while (stopwatch.ElapsedMilliseconds < durationMs)
+        {
+            last = ObserveOverlay();
+            Assert.IsNotNull(last, $"Quick Accent process lost its overlay window while it should remain cloaked.");
+            Assert.IsTrue(
+                last.IsCloaked,
+                $"Quick Accent overlay revealed during a suppressed gesture after {stopwatch.ElapsedMilliseconds} ms: {FormatObservation(last)}");
+            Thread.Sleep(50);
+        }
+
+        Step(testBase, $"Quick Accent overlay remained cloaked for {durationMs} ms: {FormatObservation(last)}");
+    }
+
+    private static (int Left, int Top, int Right, int Bottom) GetStableVisibleBounds(Session toolbar)
+    {
+        var handle = new IntPtr(toolbar.WindowHandle);
+        var hasPrevious = false;
+        var previous = default((int Left, int Top, int Right, int Bottom));
+        var result = WaitHelper.WaitForStable(
+            () => GetVisibleBounds(handle),
+            bounds =>
+            {
+                var valid = bounds.Right > bounds.Left && bounds.Bottom > bounds.Top;
+                var unchanged = hasPrevious && bounds == previous;
+                previous = bounds;
+                hasPrevious = true;
+                return valid && unchanged;
+            },
+            timeoutMS: 5_000,
+            requiredConsecutiveMatches: 3,
+            pollIntervalMS: 100);
+        Assert.IsTrue(result.Succeeded, $"Quick Accent toolbar bounds did not stabilize. Last bounds: {result.LastObservation}.");
+        return result.LastObservation;
+    }
+
+    private static (int Left, int Top, int Right, int Bottom) GetVisibleBounds(IntPtr hwnd)
+    {
+        var result = DwmGetWindowRectAttribute(
+            hwnd,
+            DwmExtendedFrameBoundsAttribute,
+            out var bounds,
+            Marshal.SizeOf<NativeRect>());
+        if (result != 0)
+        {
+            throw new InvalidOperationException(
+                $"DwmGetWindowAttribute(DWMWA_EXTENDED_FRAME_BOUNDS) failed for HWND {hwnd} with HRESULT 0x{result:X8}.");
+        }
+
+        return (bounds.Left, bounds.Top, bounds.Right, bounds.Bottom);
+    }
+
+    private static OverlayObservation? ObserveOverlay()
+    {
+        var processes = Process.GetProcessesByName(ProcessName);
+        try
+        {
+            var ids = processes.Select(process => process.Id).ToHashSet();
+            if (ids.Count == 0)
+            {
+                return null;
+            }
+
+            var window = WindowControl.EnumerateProcessWindows(ids)
+                .Where(candidate => candidate.Width > 0 && candidate.Height > 0)
+                .OrderByDescending(candidate => candidate.Title.Equals("Quick Accent", StringComparison.OrdinalIgnoreCase))
+                .ThenByDescending(candidate => candidate.Width * candidate.Height)
+                .FirstOrDefault();
+            if (window.Hwnd == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            var result = DwmGetWindowAttribute(
+                window.Hwnd,
+                DwmCloakedAttribute,
+                out var cloaked,
+                sizeof(int));
+            if (result != 0)
+            {
+                throw new InvalidOperationException(
+                    $"DwmGetWindowAttribute(DWMWA_CLOAKED) failed for HWND {window.Hwnd} with HRESULT 0x{result:X8}.");
+            }
+
+            return new OverlayObservation(
+                window,
+                IsCloaked: cloaked != 0,
+                WindowHelper.GetWindowBounds(window.Hwnd));
+        }
+        finally
+        {
+            foreach (var process in processes)
+            {
+                process.Dispose();
+            }
+        }
+    }
+
+    private static Element? FindCharacterItem(Session toolbar, string character) =>
+        toolbar.FindAll<Element>(By.Name(character), timeoutMS: 0)
+            .FirstOrDefault(element =>
+                element.ControlType.Equals("ListItem", StringComparison.OrdinalIgnoreCase) ||
+                element.ClassName.Equals("ListViewItem", StringComparison.OrdinalIgnoreCase));
+
+    private static string FormatObservation(OverlayObservation? observation) =>
+        observation is null
+            ? "(overlay window absent)"
+            : $"hwnd={observation.Window.Hwnd}, title='{observation.Window.Title}', " +
+              $"cloaked={observation.IsCloaked}, bounds={observation.Bounds}";
+
+    internal sealed class NotepadFixture : IDisposable
+    {
+        private readonly UITestBase testBase;
+        private readonly string filePath;
+        private bool disposed;
+
+        private NotepadFixture(UITestBase testBase, string filePath, Session window)
+        {
+            this.testBase = testBase;
+            this.filePath = filePath;
+            Window = window;
+        }
+
+        internal Session Window { get; }
+
+        internal static NotepadFixture Start(UITestBase testBase)
+        {
+            var filePath = Path.Combine(Path.GetTempPath(), $"PowerToys-PowerAccent-{Guid.NewGuid():N}.txt");
+            File.WriteAllText(filePath, string.Empty);
+            var fileName = Path.GetFileName(filePath);
+            var baseFileName = Path.GetFileNameWithoutExtension(filePath);
+
+            try
+            {
+                using var launcher = Process.Start(new ProcessStartInfo
+                {
+                    FileName = "notepad.exe",
+                    Arguments = $"\"{filePath}\"",
+                    UseShellExecute = true,
+                });
+                Assert.IsNotNull(launcher, "Could not start the Notepad fixture.");
+
+                var window = WindowsFinder.WaitForWindowByApp(
+                    "notepad",
+                    candidate =>
+                        candidate.Title.Contains(fileName, StringComparison.OrdinalIgnoreCase) ||
+                        candidate.Title.Contains(baseFileName, StringComparison.OrdinalIgnoreCase),
+                    timeoutMS: 15_000);
+                Assert.IsNotNull(window, $"Notepad did not open the fixture document '{fileName}'.");
+                return new NotepadFixture(testBase, filePath, window);
+            }
+            catch
+            {
+                File.Delete(filePath);
+                throw;
+            }
+        }
+
+        internal void Focus()
+        {
+            var handle = new IntPtr(Window.WindowHandle);
+            var focused = WindowControl.WaitForForeground(handle, timeoutMS: 10_000, requiredConsecutiveMatches: 3);
+            if (!focused)
+            {
+                var (centerX, centerY) = WindowHelper.GetWindowCenter(handle);
+                Step(testBase, $"Notepad foreground handoff stalled; recovering with a guarded click at ({centerX},{centerY})");
+                var pointReady = WaitHelper.WaitForStable(
+                    () => WindowControl.IsPointOwnedByWindow(handle, centerX, centerY),
+                    owned => owned,
+                    timeoutMS: 5_000,
+                    requiredConsecutiveMatches: 2,
+                    pollIntervalMS: 100,
+                    recover: _ => WindowControl.TryBringToForeground(handle));
+                if (pointReady.Succeeded)
+                {
+                    MouseHelper.LeftClickAt(centerX, centerY);
+                    focused = WindowControl.WaitForForeground(handle, timeoutMS: 5_000, requiredConsecutiveMatches: 3);
+                }
+            }
+
+            Assert.IsTrue(
+                focused,
+                $"Notepad HWND {handle} did not become foreground. Current foreground: {WindowControl.GetForegroundWindowInfo()}");
+        }
+
+        internal void Clear()
+        {
+            Focus();
+            SendControlChord(Key.A);
+            KeyboardHelper.SendKey(Key.Backspace);
+            Thread.Sleep(100);
+        }
+
+        internal string WaitForNonEmptyText(int timeoutMs = 5_000)
+        {
+            string text = string.Empty;
+            var result = WaitHelper.WaitForStable(
+                () =>
+                {
+                    text = ReadText();
+                    return text;
+                },
+                value => !string.IsNullOrEmpty(value),
+                timeoutMs,
+                requiredConsecutiveMatches: 2,
+                pollIntervalMS: 100);
+            Assert.IsTrue(result.Succeeded, $"Notepad remained empty for {timeoutMs} ms.");
+            return text;
+        }
+
+        internal string ReadText()
+        {
+            Focus();
+            ClipboardHelper.Clear();
+            SendControlChord(Key.A);
+            SendControlChord(Key.C);
+            return ClipboardHelper.WaitForText(string.Empty, timeoutMS: 1_000);
+        }
+
+        public void Dispose()
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            disposed = true;
+            try
+            {
+                using var process = Process.GetProcessById(Window.ProcessId);
+                process.Kill(entireProcessTree: true);
+                process.WaitForExit(5_000);
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (InvalidOperationException)
+            {
+            }
+            finally
+            {
+                try
+                {
+                    File.Delete(filePath);
+                }
+                catch (IOException)
+                {
+                }
+                catch (UnauthorizedAccessException)
+                {
+                }
+            }
+        }
+
+        private static void SendControlChord(Key key)
+        {
+            KeyboardHelper.PressKey(Key.Ctrl);
+            try
+            {
+                Thread.Sleep(30);
+                KeyboardHelper.SendKey(key);
+            }
+            finally
+            {
+                KeyboardHelper.ReleaseKey(Key.Ctrl);
+            }
+
+            Thread.Sleep(50);
+        }
+    }
+
+    private sealed class ClipboardTextSnapshot : IDisposable
+    {
+        private readonly string originalText = ClipboardHelper.GetText();
+        private bool disposed;
+
+        public void Dispose()
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            disposed = true;
+            ClipboardHelper.SetText(originalText);
+        }
+    }
+
+    private sealed class FileSnapshot : IDisposable
+    {
+        private readonly string path;
+        private readonly bool existed;
+        private readonly byte[]? content;
+        private bool disposed;
+
+        internal FileSnapshot(string path)
+        {
+            this.path = path;
+            existed = File.Exists(path);
+            content = existed ? File.ReadAllBytes(path) : null;
+        }
+
+        public void Dispose()
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            disposed = true;
+            if (existed)
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+                File.WriteAllBytes(path, content!);
+            }
+            else
+            {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/src/modules/poweraccent/PowerAccent.UITests/PowerAccentTestHelper.cs
+++ b/src/modules/poweraccent/PowerAccent.UITests/PowerAccentTestHelper.cs
@@ -25,7 +25,7 @@ internal static class PowerAccentTestHelper
     private const int DwmCloakedAttribute = 14;
     private const int DwmExtendedFrameBoundsAttribute = 9;
     private const int OverlayStartupTimeoutMs = 30_000;
-    private const int SettingsReloadDelayMs = 600;
+    private const int SettingsReloadDelayMs = 2_000;
 
     [DllImport("dwmapi.dll")]
     private static extern int DwmGetWindowAttribute(IntPtr hwnd, int attribute, out int value, int valueSize);
@@ -70,11 +70,17 @@ internal static class PowerAccentTestHelper
 
     internal static void PrepareDefaultState()
     {
-        ReplaceSettings(new Settings(), waitForReload: false);
+        WriteSettings(new Settings(), waitForReload: false);
         File.Delete(UsageInfoPath);
     }
 
-    internal static void ReplaceSettings(Settings settings, bool waitForReload = true)
+    internal static void ReplaceSettings(UITestBase testBase, Settings settings)
+    {
+        WaitForOverlayState(testBase, revealed: false, timeoutMs: OverlayStartupTimeoutMs);
+        WriteSettings(settings, waitForReload: true);
+    }
+
+    private static void WriteSettings(Settings settings, bool waitForReload)
     {
         var desired = CreateSettings(settings);
         SettingsConfigHelper.UpdateModuleSettings(

--- a/src/modules/poweraccent/PowerAccent.UITests/app.manifest
+++ b/src/modules/poweraccent/PowerAccent.UITests/app.manifest
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="PowerAccent.UITests.app"/>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/src/modules/poweraccent/PowerAccentModuleInterface/dllmain.cpp
+++ b/src/modules/poweraccent/PowerAccentModuleInterface/dllmain.cpp
@@ -159,7 +159,7 @@ public:
                     Logger::warn(L"Failed to signal exit event for PowerToys QuickAccent. {}", get_last_error_or_default(GetLastError()));
                     forceTerminate = true;
                 }
-                else if (WaitForSingleObject(p_info.hProcess, 5000) != WAIT_OBJECT_0)
+                else if (WaitForSingleObject(p_info.hProcess, 1500) != WAIT_OBJECT_0)
                 {
                     Logger::warn(L"PowerToys QuickAccent did not exit after the exit event; terminating it.");
                     forceTerminate = true;
@@ -173,7 +173,7 @@ public:
                     }
                     else
                     {
-                        WaitForSingleObject(p_info.hProcess, 5000);
+                        WaitForSingleObject(p_info.hProcess, 500);
                     }
                 }
 

--- a/src/modules/poweraccent/PowerAccentModuleInterface/dllmain.cpp
+++ b/src/modules/poweraccent/PowerAccentModuleInterface/dllmain.cpp
@@ -153,13 +153,28 @@ public:
             else
             {
                 Logger::trace(L"Signaled exit event for PowerToys QuickAccent.");
+                bool forceTerminate = false;
                 if (!SetEvent(exitEvent))
                 {
                     Logger::warn(L"Failed to signal exit event for PowerToys QuickAccent. {}", get_last_error_or_default(GetLastError()));
+                    forceTerminate = true;
+                }
+                else if (WaitForSingleObject(p_info.hProcess, 5000) != WAIT_OBJECT_0)
+                {
+                    Logger::warn(L"PowerToys QuickAccent did not exit after the exit event; terminating it.");
+                    forceTerminate = true;
+                }
 
-                    // For some reason, we couldn't process the signal correctly, so we still
-                    // need to terminate the PowerAccent process.
-                    TerminateProcess(p_info.hProcess, 1);
+                if (forceTerminate && p_info.hProcess)
+                {
+                    if (!TerminateProcess(p_info.hProcess, 1))
+                    {
+                        Logger::warn(L"Failed to terminate PowerToys QuickAccent. {}", get_last_error_or_default(GetLastError()));
+                    }
+                    else
+                    {
+                        WaitForSingleObject(p_info.hProcess, 5000);
+                    }
                 }
 
                 // Auto-reset events clear when a waiter consumes the signal; resetting here can race the listener.

--- a/src/modules/poweraccent/PowerAccentModuleInterface/dllmain.cpp
+++ b/src/modules/poweraccent/PowerAccentModuleInterface/dllmain.cpp
@@ -162,7 +162,7 @@ public:
                     TerminateProcess(p_info.hProcess, 1);
                 }
 
-                ResetEvent(exitEvent);
+                // Auto-reset events clear when a waiter consumes the signal; resetting here can race the listener.
                 CloseHandle(exitEvent);
                 CloseHandle(p_info.hProcess);
             }

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerAccentPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerAccentPage.xaml
@@ -32,7 +32,10 @@
                         Name="QuickAccentEnableQuickAccent"
                         x:Uid="QuickAccent_EnableQuickAccent"
                         HeaderIcon="{ui:BitmapIcon Source=/Assets/Settings/Icons/QuickAccent.png}">
-                        <ToggleSwitch x:Uid="ToggleSwitch" IsOn="{x:Bind ViewModel.IsEnabled, Mode=TwoWay}" />
+                        <ToggleSwitch
+                            x:Uid="ToggleSwitch"
+                            AutomationProperties.AutomationId="Toggle_QuickAccent"
+                            IsOn="{x:Bind ViewModel.IsEnabled, Mode=TwoWay}" />
                     </tkcontrols:SettingsCard>
                 </controls:GPOInfoControl>
                 <controls:SettingsGroup x:Uid="QuickAccent_Activation_GroupSettings" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">


### PR DESCRIPTION
## Summary of the Pull Request

Adds a greenfield `Microsoft.PowerToys.UITest.Next` end-to-end suite for Quick Accent based on the release checklist in #40671.

The 22 test cases cover:

- Arrow and Space activation, including cycling in both directions and committing the selected character.
- All activation modes, language filtering, input delay, excluded applications, usage-frequency sorting, and start-from-left behavior.
- All nine toolbar positions using the visible DWM frame and active monitor work area.
- Settings-driven disable/re-enable behavior with an immediate Runner-owned process assertion.

Validation exposed and this PR also fixes two lifecycle/infrastructure races:

- Quick Accent shutdown now avoids resetting its auto-reset exit event and force-terminates the process if graceful shutdown does not complete.
- UI-test companion signing now repeatedly stops Runner and Settings until both are stably absent, preventing installed `PowerToys.exe`/`PowerToys.Settings.exe` file-lock failures.

## PR Checklist

- [x] Closes: #40671
- [x] **Communication:** Test scope is defined by #40671
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** N/A; no new end-user-facing strings
- [x] **New binaries:** Adds only the test executable `PowerAccent.UITests`; no shipped product binary or installer entry is required

## Detailed Description of the Pull Request / Additional comments

- Adds `src/modules/poweraccent/PowerAccent.UITests/` with a per-monitor-DPI-aware test host, deterministic module/settings setup, Notepad fixture, held-key input helpers, DWM-cloak readiness checks, and state restoration.
- Adds `AutomationProperties.AutomationId="Toggle_QuickAccent"` to the Settings enable switch.
- Registers the project in `PowerToys.slnx`; `.pipelines/resolveUiTestModules.ps1` discovers it as `PowerAccent.UITests`.
- Opts PowerAccent into the existing authenticated Settings IPC companion-signing path in `.pipelines/v2/templates/job-test-project.yml`.
- Fixes `.github/skills/ui-tests-pipeline-ci/scripts/Test-AzureDevOpsSetup.ps1` so preview validation ignores the runtime auto-selection assignment and validates only literal module assignments.
- Hardens `src/modules/poweraccent/PowerAccentModuleInterface/dllmain.cpp` against missed or incomplete shutdown signaling.

## Validation Steps Performed

- Built `PowerAccent.UITests` for x64 and ARM64.
- Built `PowerAccentModuleInterface` Release for x64 and ARM64.
- Ran XAML Styler on `PowerAccentPage.xaml`.
- Ran the pipeline helper Pester suites: 6 passed.
- Ran `SettingsConfigHelperTests`: 7 passed.
- Local Hyper-V matrix:
  - Windows 10 default: 22/22 passed.
  - Windows 10 constrained (1 vCPU / 4 GB): 22/22 passed.
  - Windows 11 default: 22/22 passed.
  - Windows 11 constrained (1 vCPU / 4 GB): 22/22 passed.
- Full-build CI [156358661](https://dev.azure.com/microsoft/Dart/_build/results?buildId=156358661): ARM64, Windows 10, and Windows 11 all passed, 66/66 tests.
- Final installed machine/per-user CI [156454340](https://dev.azure.com/microsoft/Dart/_build/results?buildId=156454340), using the review-fix product artifacts from build `156445992`: all six signing tasks succeeded and all six test runs passed, 132/132 tests.
