### PR TITLE
CmdPal: Preserve search editing shortcuts in list/grid view

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml.cs
@@ -207,6 +207,11 @@ public sealed partial class SearchBar : UserControl,
 
     private void FilterBox_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
     {
+        if (e.Handled)
+        {
+            return;
+        }
+
         if (e.Key == VirtualKey.Back)
         {
             if (string.IsNullOrEmpty(FilterBox.Text))
@@ -262,26 +267,14 @@ public sealed partial class SearchBar : UserControl,
                 }
             }
         }
-        else if (e.Key == VirtualKey.Up)
-        {
-            WeakReferenceMessenger.Default.Send<NavigatePreviousCommand>();
-
-            e.Handled = true;
-        }
-        else if (e.Key == VirtualKey.Left)
-        {
-            // Check if we're in a grid view, and if so, send grid navigation command
-            var isGridView = CurrentPageViewModel is ListViewModel { IsGridView: true };
-
-            // Special handling is required if we're in grid view.
-            if (isGridView)
-            {
-                WeakReferenceMessenger.Default.Send<NavigateLeftCommand>();
-                e.Handled = true;
-            }
-        }
         else if (e.Key == VirtualKey.Right)
         {
+            // Only unmodified Right accepts suggestions.
+            if (!KeyModifiers.GetCurrent().None)
+            {
+                return;
+            }
+
             // Check if the "replace search text with suggestion" feature from 0.4-0.5 is enabled.
             // If it isn't, then only use the suggestion when the caret is at the end of the input.
             if (!IsTextToSuggestEnabled)
@@ -303,40 +296,21 @@ public sealed partial class SearchBar : UserControl,
                 _lastText = null;
                 DoFilterBoxUpdate();
             }
-
-            // Wouldn't want to perform text completion *and* move the selected item, so only perform this if text suggestion wasn't performed.
-            if (!e.Handled)
-            {
-                // Check if we're in a grid view, and if so, send grid navigation command
-                var isGridView = CurrentPageViewModel is ListViewModel { IsGridView: true };
-
-                // Special handling is required if we're in grid view.
-                if (isGridView)
-                {
-                    WeakReferenceMessenger.Default.Send<NavigateRightCommand>();
-                    e.Handled = true;
-                }
-            }
         }
-        else if (e.Key == VirtualKey.Down)
-        {
-            WeakReferenceMessenger.Default.Send<NavigateNextCommand>();
 
-            e.Handled = true;
-        }
-        else if (e.Key == VirtualKey.PageDown)
+        if (!e.Handled && TryHandleListNavigation(e.Key))
         {
-            WeakReferenceMessenger.Default.Send<NavigatePageDownCommand>();
-            e.Handled = true;
-        }
-        else if (e.Key == VirtualKey.PageUp)
-        {
-            WeakReferenceMessenger.Default.Send<NavigatePageUpCommand>();
             e.Handled = true;
         }
 
         if (InSuggestion)
         {
+            // Preserve the inline suggestion when paging is left to the TextBox.
+            if (!e.Handled && (e.Key is VirtualKey.PageUp or VirtualKey.PageDown))
+            {
+                return;
+            }
+
             if (
                  e.Key == VirtualKey.Back ||
                  e.Key == VirtualKey.Delete
@@ -380,6 +354,41 @@ public sealed partial class SearchBar : UserControl,
             _inSuggestion = false;
             _lastText = null;
         }
+    }
+
+    private bool TryHandleListNavigation(VirtualKey key)
+    {
+        switch (key)
+        {
+            case VirtualKey.Up when IsNoneModifierDown():
+                WeakReferenceMessenger.Default.Send<NavigatePreviousCommand>();
+                return true;
+
+            case VirtualKey.Down when IsNoneModifierDown():
+                WeakReferenceMessenger.Default.Send<NavigateNextCommand>();
+                return true;
+
+            case VirtualKey.Left when CurrentPageViewModel is ListViewModel { IsGridView: true } && IsNoneModifierDown():
+                WeakReferenceMessenger.Default.Send<NavigateLeftCommand>();
+                return true;
+
+            case VirtualKey.Right when CurrentPageViewModel is ListViewModel { IsGridView: true } && IsNoneModifierDown():
+                WeakReferenceMessenger.Default.Send<NavigateRightCommand>();
+                return true;
+
+            case VirtualKey.PageUp when IsNoneModifierDown():
+                WeakReferenceMessenger.Default.Send<NavigatePageUpCommand>();
+                return true;
+
+            case VirtualKey.PageDown when IsNoneModifierDown():
+                WeakReferenceMessenger.Default.Send<NavigatePageDownCommand>();
+                return true;
+
+            default:
+                return false;
+        }
+
+        static bool IsNoneModifierDown() => KeyModifiers.GetCurrent().None;
     }
 
     // TextCommandBarFlyout rebuilds its commands on every open, so re-append ours each time.
@@ -743,7 +752,8 @@ public sealed partial class SearchBar : UserControl,
 
     private void ListParameter_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
     {
-        if (sender is not TextBox textBox ||
+        if (e.Handled ||
+            sender is not TextBox textBox ||
             CurrentPageViewModel is not ParametersPageViewModel parametersPage)
         {
             return;
@@ -777,24 +787,8 @@ public sealed partial class SearchBar : UserControl,
                 parametersPage.SetActiveListParameter(null);
             }
         }
-        else if (e.Key == VirtualKey.Up)
+        else if (TryHandleListNavigation(e.Key))
         {
-            WeakReferenceMessenger.Default.Send<NavigatePreviousCommand>();
-            e.Handled = true;
-        }
-        else if (e.Key == VirtualKey.Down)
-        {
-            WeakReferenceMessenger.Default.Send<NavigateNextCommand>();
-            e.Handled = true;
-        }
-        else if (e.Key == VirtualKey.PageDown)
-        {
-            WeakReferenceMessenger.Default.Send<NavigatePageDownCommand>();
-            e.Handled = true;
-        }
-        else if (e.Key == VirtualKey.PageUp)
-        {
-            WeakReferenceMessenger.Default.Send<NavigatePageUpCommand>();
             e.Handled = true;
         }
     }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml.cs
@@ -352,6 +352,13 @@ public sealed partial class SearchBar : UserControl,
 
     private bool TryHandleListNavigation(VirtualKey key)
     {
+        var listViewModel = CurrentPageViewModel switch
+        {
+            ListViewModel listPage => listPage,
+            ParametersPageViewModel parametersPage => parametersPage.ActiveListViewModel,
+            _ => null,
+        };
+
         switch (key)
         {
             case VirtualKey.Up when IsNoneModifierDown():
@@ -362,11 +369,11 @@ public sealed partial class SearchBar : UserControl,
                 WeakReferenceMessenger.Default.Send<NavigateNextCommand>();
                 return true;
 
-            case VirtualKey.Left when CurrentPageViewModel is ListViewModel { IsGridView: true } && IsNoneModifierDown():
+            case VirtualKey.Left when listViewModel is { IsGridView: true } && IsNoneModifierDown():
                 WeakReferenceMessenger.Default.Send<NavigateLeftCommand>();
                 return true;
 
-            case VirtualKey.Right when CurrentPageViewModel is ListViewModel { IsGridView: true } && IsNoneModifierDown():
+            case VirtualKey.Right when listViewModel is { IsGridView: true } && IsNoneModifierDown():
                 WeakReferenceMessenger.Default.Send<NavigateRightCommand>();
                 return true;
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml.cs
@@ -305,12 +305,6 @@ public sealed partial class SearchBar : UserControl,
 
         if (InSuggestion)
         {
-            // Preserve the inline suggestion when paging is left to the TextBox.
-            if (!e.Handled && (e.Key is VirtualKey.PageUp or VirtualKey.PageDown))
-            {
-                return;
-            }
-
             if (
                  e.Key == VirtualKey.Back ||
                  e.Key == VirtualKey.Delete

--- a/src/modules/cmdpal/ext/SamplePagesExtension/Pages/ParameterSamples.cs
+++ b/src/modules/cmdpal/ext/SamplePagesExtension/Pages/ParameterSamples.cs
@@ -193,8 +193,10 @@ public sealed partial class CreateNoteParametersPage : ParametersPage
 
     public override IconInfo Icon => new("\uE70B"); // QuickNote
 
-    public CreateNoteParametersPage()
+    public CreateNoteParametersPage(IGridProperties? gridProperties = null)
     {
+        _selectFolderPage.GridProperties = gridProperties;
+
         _titleParameter = new StringParameterRun()
         {
             PlaceholderText = "Note title",

--- a/src/modules/cmdpal/ext/SamplePagesExtension/SamplesListPage.cs
+++ b/src/modules/cmdpal/ext/SamplePagesExtension/SamplesListPage.cs
@@ -165,11 +165,16 @@ public partial class SamplesListPage : ListPage
             Subtitle = "A demo of a command that takes multiple types of parameters",
         },
 
-        // List parameters aren't yet supported
+        // List parameters
         new ListItem(new CreateNoteParametersPage())
         {
             Title = "Create note sample",
             Subtitle = "A parameter page with both a string and list parameter",
+        },
+        new ListItem(new CreateNoteParametersPage(gridProperties: new MediumGridLayout { ShowTitle = true }))
+        {
+            Title = "Create note sample (grid view)",
+            Subtitle = "A parameter page with a string and a grid of folders",
         },
 
         // Evil edge cases


### PR DESCRIPTION
## Summary of the Pull Request

This PR improves keyboard navigation in list and grid views:
- modified arrow/page keys no longer move selection, 
- Shift/Ctrl+Right no longer accepts suggestions, 
- `Handled` keys from `ShellPage` are no longer double-processed.
- Left/Right arrow now works in grid through ParametersPageViewModel.ActiveListViewModel

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #50321
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

