### PR TITLE
[UITests] Test framework windows management improvements

### DIFF
--- a/.github/skills/ui-tests-migration/references/api-mapping.md
+++ b/.github/skills/ui-tests-migration/references/api-mapping.md
@@ -142,6 +142,8 @@ is the `Microsoft.PowerToys.UITest.Next` equivalent. "—" means no direct membe
 | Wait for consecutive stable observations | `WaitHelper.WaitForStable(observe, isMatch, timeoutMS, requiredConsecutiveMatches, …)` |
 | Wait for exact HWND foreground | `WindowControl.WaitForForeground(hwnd, timeoutMS, stableSamples)` |
 | Diagnose current foreground owner | `WindowControl.GetForegroundWindowInfo()` |
+| Read DWM cloak state / physical visible frame bounds | `WindowHelper.IsWindowCloaked(hwnd)` / `WindowHelper.GetVisibleBounds(hwnd)` |
+| Resolve an HWND's monitor and work area | `MonitorInfo.GetFromWindow(hwnd)` (`WorkLeft`, `WorkTop`, `WorkRight`, `WorkBottom`) |
 | Stop an exact process tree and await exit | `WindowControl.TryKillProcessTreeByNameAndWait(name, timeoutMS)` |
 | Set/read exact Explorer Shell selection | `ExplorerShell.SetSelectionAndWaitForStable(...)` / `TryGetSelection(hwnd)` |
 | Set/read Explorer view mode + icon size | `ExplorerShell.SetViewModeAndIconSizeAndWait(hwnd, ViewMode.Icons, iconSize)` | Uses Shell automation, not a timing-sensitive keyboard shortcut. |

--- a/src/common/UITestAutomation.Next.UnitTests/MonitorInfoTests.cs
+++ b/src/common/UITestAutomation.Next.UnitTests/MonitorInfoTests.cs
@@ -1,0 +1,137 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.PowerToys.UITest.Next;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.PowerToys.UITestAutomationNext.UnitTests;
+
+[TestClass]
+public sealed class MonitorInfoTests
+{
+    private const uint MonitorDefaultToNearest = 0x2;
+    private static readonly IntPtr TestWindow = new(0x1234);
+
+    [TestMethod]
+    public void GetFromWindowReturnsMappedMonitorAndWorkArea()
+    {
+        var monitors = new[]
+        {
+            (
+                Handle: new IntPtr(1),
+                Monitor: new MonitorInfo.Monitor(
+                    "\\\\.\\DISPLAY1",
+                    0,
+                    0,
+                    1920,
+                    1080,
+                    0,
+                    0,
+                    1920,
+                    1040,
+                    true)),
+            (
+                Handle: new IntPtr(2),
+                Monitor: new MonitorInfo.Monitor(
+                    "\\\\.\\DISPLAY2",
+                    -2880,
+                    0,
+                    0,
+                    1620,
+                    -2880,
+                    0,
+                    0,
+                    1560,
+                    false)),
+        };
+
+        foreach (var expected in monitors)
+        {
+            var actual = MonitorInfo.GetFromWindow(
+                TestWindow,
+                _ => true,
+                (hWnd, flags) =>
+                {
+                    Assert.AreEqual(TestWindow, hWnd);
+                    Assert.AreEqual(MonitorDefaultToNearest, flags);
+                    return expected.Handle;
+                },
+                hMonitor =>
+                {
+                    Assert.AreEqual(expected.Handle, hMonitor);
+                    return expected.Monitor;
+                });
+
+            Assert.AreEqual(expected.Monitor, actual);
+            Assert.AreEqual(expected.Monitor.WorkRight - expected.Monitor.WorkLeft, actual.WorkWidth);
+            Assert.AreEqual(expected.Monitor.WorkBottom - expected.Monitor.WorkTop, actual.WorkHeight);
+        }
+    }
+
+    [TestMethod]
+    public void GetFromWindowRejectsInvalidWindowBeforeNativeLookup()
+    {
+        var monitorLookupCalled = false;
+
+        var exception = Assert.ThrowsExactly<InvalidOperationException>(
+            () => MonitorInfo.GetFromWindow(
+                TestWindow,
+                _ => false,
+                (_, _) =>
+                {
+                    monitorLookupCalled = true;
+                    return new IntPtr(1);
+                },
+                _ => throw new AssertFailedException("Monitor details should not be queried.")));
+
+        Assert.IsFalse(monitorLookupCalled);
+        StringAssert.Contains(exception.Message, "invalid or destroyed");
+        StringAssert.Contains(exception.Message, "0x1234");
+    }
+
+    [TestMethod]
+    public void GetFromWindowRejectsWindowDestroyedDuringLookup()
+    {
+        var windowChecks = new Queue<bool>([true, false]);
+
+        var exception = Assert.ThrowsExactly<InvalidOperationException>(
+            () => MonitorInfo.GetFromWindow(
+                TestWindow,
+                _ => windowChecks.Dequeue(),
+                (_, flags) =>
+                {
+                    Assert.AreEqual(MonitorDefaultToNearest, flags);
+                    return new IntPtr(1);
+                },
+                _ => new MonitorInfo.Monitor(
+                    "\\\\.\\DISPLAY1",
+                    0,
+                    0,
+                    1920,
+                    1080,
+                    0,
+                    0,
+                    1920,
+                    1040,
+                    true)));
+
+        Assert.AreEqual(0, windowChecks.Count);
+        StringAssert.Contains(exception.Message, "destroyed during");
+        StringAssert.Contains(exception.Message, "0x1234");
+    }
+
+    [TestMethod]
+    public void GetFromWindowReportsMissingMonitor()
+    {
+        var exception = Assert.ThrowsExactly<InvalidOperationException>(
+            () => MonitorInfo.GetFromWindow(
+                TestWindow,
+                _ => true,
+                (_, _) => IntPtr.Zero,
+                _ => throw new AssertFailedException("Monitor details should not be queried.")));
+
+        StringAssert.Contains(exception.Message, "MonitorFromWindow failed");
+        StringAssert.Contains(exception.Message, "0x1234");
+    }
+}

--- a/src/common/UITestAutomation.Next.UnitTests/WindowHelperTests.cs
+++ b/src/common/UITestAutomation.Next.UnitTests/WindowHelperTests.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.PowerToys.UITest.Next;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.PowerToys.UITestAutomationNext.UnitTests;
+
+[TestClass]
+public sealed class WindowHelperTests
+{
+    private const int EHandle = unchecked((int)0x80070006);
+    private static readonly IntPtr TestWindow = new(0x1234);
+
+    [TestMethod]
+    [DataRow(0, false)]
+    [DataRow(1, true)]
+    [DataRow(2, true)]
+    [DataRow(4, true)]
+    public void IsWindowCloakedMapsEveryDwmCloakFlag(int cloakState, bool expected)
+    {
+        var actual = WindowHelper.IsWindowCloaked(
+            TestWindow,
+            hWnd =>
+            {
+                Assert.AreEqual(TestWindow, hWnd);
+                return (0, cloakState);
+            });
+
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void IsWindowCloakedReportsInvalidOrDestroyedWindow()
+    {
+        var exception = Assert.ThrowsExactly<InvalidOperationException>(
+            () => WindowHelper.IsWindowCloaked(TestWindow, _ => (EHandle, 0)));
+
+        StringAssert.Contains(exception.Message, "DWMWA_CLOAKED");
+        StringAssert.Contains(exception.Message, "0x80070006");
+        StringAssert.Contains(exception.Message, "0x1234");
+    }
+
+    [TestMethod]
+    public void GetVisibleBoundsPreservesPhysicalDwmCoordinates()
+    {
+        var expected = (Left: -2880, Top: 144, Right: -960, Bottom: 1224);
+
+        var actual = WindowHelper.GetVisibleBounds(TestWindow, _ => (0, expected));
+
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void GetVisibleBoundsReportsInvalidOrDestroyedWindow()
+    {
+        var exception = Assert.ThrowsExactly<InvalidOperationException>(
+            () => WindowHelper.GetVisibleBounds(TestWindow, _ => (EHandle, default)));
+
+        StringAssert.Contains(exception.Message, "DWMWA_EXTENDED_FRAME_BOUNDS");
+        StringAssert.Contains(exception.Message, "0x80070006");
+        StringAssert.Contains(exception.Message, "0x1234");
+    }
+
+    [TestMethod]
+    public void GetVisibleBoundsRejectsEmptyDwmFrame()
+    {
+        var exception = Assert.ThrowsExactly<InvalidOperationException>(
+            () => WindowHelper.GetVisibleBounds(
+                TestWindow,
+                _ => (0, (Left: 20, Top: 30, Right: 20, Bottom: 80))));
+
+        StringAssert.Contains(exception.Message, "invalid bounds");
+        StringAssert.Contains(exception.Message, "(20,30)-(20,80)");
+    }
+}

--- a/src/common/UITestAutomation.Next/DisplayHelper.cs
+++ b/src/common/UITestAutomation.Next/DisplayHelper.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
+using System.Windows.Forms;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.PowerToys.UITest.Next;
@@ -42,17 +43,18 @@ public static class DisplayHelper
     {
         try
         {
+            var primary = Screen.PrimaryScreen;
+            if (primary is not null && primary.Bounds.Width == width && primary.Bounds.Height == height)
+            {
+                return;
+            }
+
             var devMode = default(DEVMODE);
             devMode.DmDeviceName = new string('\0', 32);
             devMode.DmFormName = new string('\0', 32);
             devMode.DmSize = (short)Marshal.SizeOf<DEVMODE>();
 
             if (EnumDisplaySettings(null, ENUM_CURRENT_SETTINGS, ref devMode) == 0)
-            {
-                return;
-            }
-
-            if (devMode.DmPelsWidth == width && devMode.DmPelsHeight == height)
             {
                 return;
             }

--- a/src/common/UITestAutomation.Next/DisplayHelper.cs
+++ b/src/common/UITestAutomation.Next/DisplayHelper.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
-using System.Windows.Forms;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.PowerToys.UITest.Next;
@@ -43,18 +42,17 @@ public static class DisplayHelper
     {
         try
         {
-            var primary = Screen.PrimaryScreen;
-            if (primary is not null && primary.Bounds.Width == width && primary.Bounds.Height == height)
-            {
-                return;
-            }
-
             var devMode = default(DEVMODE);
             devMode.DmDeviceName = new string('\0', 32);
             devMode.DmFormName = new string('\0', 32);
             devMode.DmSize = (short)Marshal.SizeOf<DEVMODE>();
 
             if (EnumDisplaySettings(null, ENUM_CURRENT_SETTINGS, ref devMode) == 0)
+            {
+                return;
+            }
+
+            if (devMode.DmPelsWidth == width && devMode.DmPelsHeight == height)
             {
                 return;
             }

--- a/src/common/UITestAutomation.Next/MonitorInfo.cs
+++ b/src/common/UITestAutomation.Next/MonitorInfo.cs
@@ -31,9 +31,16 @@ public static class MonitorInfo
 
         /// <summary>Full monitor height in pixels.</summary>
         public int Height => Bottom - Top;
+
+        /// <summary>Usable work-area width in pixels.</summary>
+        public int WorkWidth => WorkRight - WorkLeft;
+
+        /// <summary>Usable work-area height in pixels.</summary>
+        public int WorkHeight => WorkBottom - WorkTop;
     }
 
     private const uint MONITORINFOF_PRIMARY = 0x1;
+    private const uint MONITOR_DEFAULTTONEAREST = 0x2;
 
     private delegate bool MonitorEnumProc(IntPtr hMonitor, IntPtr hdc, ref RECT lprcMonitor, IntPtr dwData);
 
@@ -41,9 +48,16 @@ public static class MonitorInfo
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool EnumDisplayMonitors(IntPtr hdc, IntPtr lprcClip, MonitorEnumProc lpfnEnum, IntPtr dwData);
 
-    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool GetMonitorInfo(IntPtr hMonitor, ref MONITORINFOEX lpmi);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool IsWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr MonitorFromWindow(IntPtr hWnd, uint dwFlags);
 
     /// <summary>All connected displays, in enumeration order.</summary>
     public static IReadOnlyList<Monitor> GetAll()
@@ -58,17 +72,7 @@ public static class MonitorInfo
             var mi = new MONITORINFOEX { CbSize = Marshal.SizeOf<MONITORINFOEX>() };
             if (GetMonitorInfo(hMonitor, ref mi))
             {
-                list.Add(new Monitor(
-                    mi.SzDevice,
-                    mi.RcMonitor.Left,
-                    mi.RcMonitor.Top,
-                    mi.RcMonitor.Right,
-                    mi.RcMonitor.Bottom,
-                    mi.RcWork.Left,
-                    mi.RcWork.Top,
-                    mi.RcWork.Right,
-                    mi.RcWork.Bottom,
-                    (mi.DwFlags & MONITORINFOF_PRIMARY) != 0));
+                list.Add(CreateMonitor(mi));
             }
 
             return true;
@@ -80,6 +84,79 @@ public static class MonitorInfo
 
     /// <summary>Number of connected displays.</summary>
     public static int Count => GetAll().Count;
+
+    /// <summary>
+    /// The monitor containing most of <paramref name="hWnd"/>, or the nearest monitor when the
+    /// window is currently outside every monitor.
+    /// </summary>
+    /// <remarks>
+    /// Monitor and work-area coordinates match physical DWM bounds only from a per-monitor-DPI-aware
+    /// test host. Every UITestAutomation.Next test executable should embed the framework's
+    /// PerMonitorV2 application manifest.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// <paramref name="hWnd"/> is invalid, was destroyed during the lookup, or its monitor
+    /// information could not be read.
+    /// </exception>
+    public static Monitor GetFromWindow(IntPtr hWnd) =>
+        GetFromWindow(hWnd, IsWindow, MonitorFromWindow, GetMonitor);
+
+    internal static Monitor GetFromWindow(
+        IntPtr hWnd,
+        Func<IntPtr, bool> isWindow,
+        Func<IntPtr, uint, IntPtr> monitorFromWindow,
+        Func<IntPtr, Monitor> getMonitor)
+    {
+        ArgumentNullException.ThrowIfNull(isWindow);
+        ArgumentNullException.ThrowIfNull(monitorFromWindow);
+        ArgumentNullException.ThrowIfNull(getMonitor);
+
+        if (hWnd == IntPtr.Zero || !isWindow(hWnd))
+        {
+            throw new InvalidOperationException($"Cannot query a monitor for invalid or destroyed HWND {FormatHandle(hWnd)}.");
+        }
+
+        var hMonitor = monitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
+        if (hMonitor == IntPtr.Zero)
+        {
+            throw new InvalidOperationException($"MonitorFromWindow failed for HWND {FormatHandle(hWnd)}.");
+        }
+
+        var monitor = getMonitor(hMonitor);
+        if (!isWindow(hWnd))
+        {
+            throw new InvalidOperationException($"HWND {FormatHandle(hWnd)} was destroyed during its monitor lookup.");
+        }
+
+        return monitor;
+    }
+
+    private static Monitor GetMonitor(IntPtr hMonitor)
+    {
+        var mi = new MONITORINFOEX { CbSize = Marshal.SizeOf<MONITORINFOEX>() };
+        if (!GetMonitorInfo(hMonitor, ref mi))
+        {
+            throw new InvalidOperationException(
+                $"GetMonitorInfo failed for HMONITOR {FormatHandle(hMonitor)} with Win32 error {Marshal.GetLastWin32Error()}.");
+        }
+
+        return CreateMonitor(mi);
+    }
+
+    private static Monitor CreateMonitor(MONITORINFOEX mi) =>
+        new(
+            mi.SzDevice,
+            mi.RcMonitor.Left,
+            mi.RcMonitor.Top,
+            mi.RcMonitor.Right,
+            mi.RcMonitor.Bottom,
+            mi.RcWork.Left,
+            mi.RcWork.Top,
+            mi.RcWork.Right,
+            mi.RcWork.Bottom,
+            (mi.DwFlags & MONITORINFOF_PRIMARY) != 0);
+
+    private static string FormatHandle(IntPtr handle) => $"0x{handle.ToInt64():X}";
 
     [StructLayout(LayoutKind.Sequential)]
     private struct RECT

--- a/src/common/UITestAutomation.Next/MonitorInfo.cs
+++ b/src/common/UITestAutomation.Next/MonitorInfo.cs
@@ -39,8 +39,8 @@ public static class MonitorInfo
         public int WorkHeight => WorkBottom - WorkTop;
     }
 
-    private const uint MONITORINFOF_PRIMARY = 0x1;
-    private const uint MONITOR_DEFAULTTONEAREST = 0x2;
+    private const uint MonitorInfoPrimary = 0x1;
+    private const uint MonitorDefaultToNearest = 0x2;
 
     private delegate bool MonitorEnumProc(IntPtr hMonitor, IntPtr hdc, ref RECT lprcMonitor, IntPtr dwData);
 
@@ -116,7 +116,7 @@ public static class MonitorInfo
             throw new InvalidOperationException($"Cannot query a monitor for invalid or destroyed HWND {FormatHandle(hWnd)}.");
         }
 
-        var hMonitor = monitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
+        var hMonitor = monitorFromWindow(hWnd, MonitorDefaultToNearest);
         if (hMonitor == IntPtr.Zero)
         {
             throw new InvalidOperationException($"MonitorFromWindow failed for HWND {FormatHandle(hWnd)}.");
@@ -154,7 +154,7 @@ public static class MonitorInfo
             mi.RcWork.Top,
             mi.RcWork.Right,
             mi.RcWork.Bottom,
-            (mi.DwFlags & MONITORINFOF_PRIMARY) != 0);
+            (mi.DwFlags & MonitorInfoPrimary) != 0);
 
     private static string FormatHandle(IntPtr handle) => $"0x{handle.ToInt64():X}";
 

--- a/src/common/UITestAutomation.Next/WindowHelper.cs
+++ b/src/common/UITestAutomation.Next/WindowHelper.cs
@@ -61,6 +61,7 @@ public static class WindowHelper
     private const int SW_MAXIMIZE = 3;
     private const int SW_RESTORE = 9;
     private const int SW_MINIMIZE = 6;
+    private const int DwmCloakedAttribute = 14;
     private const int DwmExtendedFrameBoundsAttribute = 9;
 
     [DllImport("user32.dll", SetLastError = true)]
@@ -97,8 +98,11 @@ public static class WindowHelper
     [DllImport("gdi32.dll")]
     private static extern uint GetPixel(IntPtr hdc, int x, int y);
 
-    [DllImport("dwmapi.dll")]
-    private static extern int DwmGetWindowAttribute(IntPtr hWnd, int dwAttribute, out RECT pvAttribute, int cbAttribute);
+    [DllImport("dwmapi.dll", EntryPoint = "DwmGetWindowAttribute")]
+    private static extern int DwmGetWindowIntAttribute(IntPtr hWnd, int dwAttribute, out int pvAttribute, int cbAttribute);
+
+    [DllImport("dwmapi.dll", EntryPoint = "DwmGetWindowAttribute")]
+    private static extern int DwmGetWindowRectAttribute(IntPtr hWnd, int dwAttribute, out RECT pvAttribute, int cbAttribute);
 
     [DllImport("dwmapi.dll")]
     private static extern int DwmFlush();
@@ -172,6 +176,65 @@ public static class WindowHelper
         return (0, 0, 0, 0);
     }
 
+    /// <summary>
+    /// Whether DWM currently cloaks a window. Cloaking is independent of Win32 visibility and is
+    /// commonly used to keep a WinUI window rendered while hiding its composed output.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The DWM query failed, including when <paramref name="hWnd"/> was destroyed during the query.
+    /// Callers polling a replaceable window should treat this exception as transient and reacquire
+    /// the current HWND before retrying.
+    /// </exception>
+    public static bool IsWindowCloaked(IntPtr hWnd) =>
+        IsWindowCloaked(hWnd, QueryCloakedState);
+
+    internal static bool IsWindowCloaked(
+        IntPtr hWnd,
+        Func<IntPtr, (int HResult, int CloakedState)> query)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var (hResult, cloakedState) = query(hWnd);
+        ThrowIfDwmQueryFailed(hWnd, "DWMWA_CLOAKED", hResult);
+        return cloakedState != 0;
+    }
+
+    /// <summary>
+    /// DWM extended-frame bounds (Left, Top, Right, Bottom) in physical screen pixels. Unlike
+    /// <see cref="GetWindowBounds"/>, these bounds exclude invisible resize borders and are not
+    /// DPI-virtualized.
+    /// </summary>
+    /// <remarks>
+    /// Compare these bounds with monitor geometry only from a per-monitor-DPI-aware test host.
+    /// Every UITestAutomation.Next test executable should embed the framework's PerMonitorV2
+    /// application manifest.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// The DWM query failed or returned an empty frame, including when <paramref name="hWnd"/> was
+    /// destroyed during the query. Callers polling a replaceable window should treat this exception
+    /// as transient and reacquire the current HWND before retrying.
+    /// </exception>
+    public static (int Left, int Top, int Right, int Bottom) GetVisibleBounds(IntPtr hWnd) =>
+        GetVisibleBounds(hWnd, QueryVisibleBounds);
+
+    internal static (int Left, int Top, int Right, int Bottom) GetVisibleBounds(
+        IntPtr hWnd,
+        Func<IntPtr, (int HResult, (int Left, int Top, int Right, int Bottom) Bounds)> query)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var (hResult, bounds) = query(hWnd);
+        ThrowIfDwmQueryFailed(hWnd, "DWMWA_EXTENDED_FRAME_BOUNDS", hResult);
+        if (bounds.Right <= bounds.Left || bounds.Bottom <= bounds.Top)
+        {
+            throw new InvalidOperationException(
+                $"DwmGetWindowAttribute(DWMWA_EXTENDED_FRAME_BOUNDS) returned invalid bounds " +
+                $"({bounds.Left},{bounds.Top})-({bounds.Right},{bounds.Bottom}) for HWND {FormatHandle(hWnd)}.");
+        }
+
+        return bounds;
+    }
+
     /// <summary>Read a named Win32 property stamped on a window, or zero when it is absent.</summary>
     public static long GetWindowPropertyValue(IntPtr hWnd, string propertyName)
     {
@@ -185,15 +248,7 @@ public static class WindowHelper
     /// </summary>
     public static void CaptureVisibleWindow(IntPtr hWnd, string outputPath)
     {
-        var result = DwmGetWindowAttribute(
-            hWnd,
-            DwmExtendedFrameBoundsAttribute,
-            out var bounds,
-            Marshal.SizeOf<RECT>());
-        if (result != 0 || bounds.Right <= bounds.Left || bounds.Bottom <= bounds.Top)
-        {
-            throw new InvalidOperationException($"Unable to read visible frame bounds for HWND {hWnd} (HRESULT 0x{result:X8}).");
-        }
+        var bounds = GetVisibleBounds(hWnd);
 
         var wasTopmost = (GetWindowLongPtr(hWnd, GWL_EXSTYLE).ToInt64() & WS_EX_TOPMOST) != 0;
         var noMoveOrResize = SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE;
@@ -225,6 +280,38 @@ public static class WindowHelper
             }
         }
     }
+
+    private static (int HResult, int CloakedState) QueryCloakedState(IntPtr hWnd)
+    {
+        var hResult = DwmGetWindowIntAttribute(
+            hWnd,
+            DwmCloakedAttribute,
+            out var cloakedState,
+            sizeof(int));
+        return (hResult, cloakedState);
+    }
+
+    private static (int HResult, (int Left, int Top, int Right, int Bottom) Bounds) QueryVisibleBounds(IntPtr hWnd)
+    {
+        var hResult = DwmGetWindowRectAttribute(
+            hWnd,
+            DwmExtendedFrameBoundsAttribute,
+            out var bounds,
+            Marshal.SizeOf<RECT>());
+        return (hResult, (bounds.Left, bounds.Top, bounds.Right, bounds.Bottom));
+    }
+
+    private static void ThrowIfDwmQueryFailed(IntPtr hWnd, string attributeName, int hResult)
+    {
+        if (hResult != 0)
+        {
+            throw new InvalidOperationException(
+                $"DwmGetWindowAttribute({attributeName}) failed for HWND {FormatHandle(hWnd)} " +
+                $"with HRESULT 0x{hResult:X8}.");
+        }
+    }
+
+    private static string FormatHandle(IntPtr hWnd) => $"0x{hWnd.ToInt64():X}";
 
     /// <summary>Center point of the window in screen pixels.</summary>
     public static (int CenterX, int CenterY) GetWindowCenter(IntPtr hWnd)

--- a/src/modules/poweraccent/PowerAccent.UITests/PowerAccentTestHelper.cs
+++ b/src/modules/poweraccent/PowerAccent.UITests/PowerAccentTestHelper.cs
@@ -22,18 +22,10 @@ internal static class PowerAccentTestHelper
     internal static readonly string[] CurrencySCharacters = ["$", "₪"];
     internal static readonly string[] FrenchACharacters = ["à", "â", "á", "ä", "ã", "æ"];
 
-    private const int DwmCloakedAttribute = 14;
-    private const int DwmExtendedFrameBoundsAttribute = 9;
     private const int EnglishUnitedStatesLanguageId = 0x0409;
     private const int OverlayStartupTimeoutMs = 30_000;
     private const int SettingsReloadTimeoutMs = 30_000;
     private const int VkCapital = 0x14;
-
-    [DllImport("dwmapi.dll")]
-    private static extern int DwmGetWindowAttribute(IntPtr hwnd, int attribute, out int value, int valueSize);
-
-    [DllImport("dwmapi.dll", EntryPoint = "DwmGetWindowAttribute")]
-    private static extern int DwmGetWindowRectAttribute(IntPtr hwnd, int attribute, out NativeRect value, int valueSize);
 
     [DllImport("user32.dll")]
     private static extern uint GetDpiForWindow(IntPtr hwnd);
@@ -43,15 +35,6 @@ internal static class PowerAccentTestHelper
 
     [DllImport("user32.dll")]
     private static extern short GetKeyState(int virtualKey);
-
-    [StructLayout(LayoutKind.Sequential)]
-    private struct NativeRect
-    {
-        public int Left;
-        public int Top;
-        public int Right;
-        public int Bottom;
-    }
 
     internal enum ActivationKey
     {
@@ -584,7 +567,7 @@ internal static class PowerAccentTestHelper
     {
         var bounds = GetStableVisibleBounds(toolbar);
         var handle = new IntPtr(toolbar.WindowHandle);
-        var workArea = System.Windows.Forms.Screen.FromHandle(handle).WorkingArea;
+        var monitor = MonitorInfo.GetFromWindow(handle);
         var centerY = bounds.Top + ((bounds.Bottom - bounds.Top) / 2);
         var characterList = toolbar.Find<Element>(By.AccessibilityId("QuickAccentCharacterList"), 5_000);
         var dpiScale = Math.Max(1d, GetDpiForWindow(handle) / 96d);
@@ -598,9 +581,9 @@ internal static class PowerAccentTestHelper
         var positioningWidth = characterList.Width + (int)Math.Ceiling(horizontalChromeDip * dpiScale);
         var horizontalExpected = horizontalAnchor switch
         {
-            "Left" => workArea.Left + edgeOffset,
-            "Center" => workArea.Left + (int)Math.Round((workArea.Width - positioningWidth) / 2d),
-            "Right" => workArea.Right - positioningWidth - edgeOffset,
+            "Left" => monitor.WorkLeft + edgeOffset,
+            "Center" => monitor.WorkLeft + (int)Math.Round((monitor.WorkWidth - positioningWidth) / 2d),
+            "Right" => monitor.WorkRight - positioningWidth - edgeOffset,
             _ => throw new ArgumentOutOfRangeException(nameof(horizontalAnchor), horizontalAnchor, "Unknown horizontal anchor."),
         };
 
@@ -613,12 +596,15 @@ internal static class PowerAccentTestHelper
         };
         var verticalExpected = verticalAnchor switch
         {
-            "Top" => workArea.Top + edgeOffset,
-            "Center" => workArea.Top + (workArea.Height / 2),
-            "Bottom" => workArea.Bottom - edgeOffset,
+            "Top" => monitor.WorkTop + edgeOffset,
+            "Center" => monitor.WorkTop + (monitor.WorkHeight / 2),
+            "Bottom" => monitor.WorkBottom - edgeOffset,
             _ => throw new ArgumentOutOfRangeException(nameof(verticalAnchor), verticalAnchor, "Unknown vertical anchor."),
         };
 
+        var workArea = $"{monitor.DeviceName} " +
+                       $"({monitor.WorkLeft},{monitor.WorkTop})-({monitor.WorkRight},{monitor.WorkBottom}) " +
+                       $"{monitor.WorkWidth}x{monitor.WorkHeight}";
         var placementDetails = $"Toolbar visible bounds are ({bounds.Left},{bounds.Top})-({bounds.Right},{bounds.Bottom}); " +
                                $"character list=({characterList.X},{characterList.Y}) {characterList.Width}x{characterList.Height}; " +
                                $"positioning width={positioningWidth}; work area={workArea}";
@@ -724,7 +710,7 @@ internal static class PowerAccentTestHelper
         var hasPrevious = false;
         var previous = default((int Left, int Top, int Right, int Bottom));
         var result = WaitHelper.WaitForStable(
-            () => GetVisibleBounds(handle),
+            () => WindowHelper.GetVisibleBounds(handle),
             bounds =>
             {
                 var valid = bounds.Right > bounds.Left && bounds.Bottom > bounds.Top;
@@ -743,22 +729,6 @@ internal static class PowerAccentTestHelper
             result.Succeeded,
             failure);
         return result.LastObservation;
-    }
-
-    private static (int Left, int Top, int Right, int Bottom) GetVisibleBounds(IntPtr hwnd)
-    {
-        var result = DwmGetWindowRectAttribute(
-            hwnd,
-            DwmExtendedFrameBoundsAttribute,
-            out var bounds,
-            Marshal.SizeOf<NativeRect>());
-        if (result != 0)
-        {
-            throw new InvalidOperationException(
-                $"DwmGetWindowAttribute(DWMWA_EXTENDED_FRAME_BOUNDS) failed for HWND {hwnd} with HRESULT 0x{result:X8}.");
-        }
-
-        return (bounds.Left, bounds.Top, bounds.Right, bounds.Bottom);
     }
 
     private static OverlayObservation? ObserveOverlay()
@@ -782,20 +752,9 @@ internal static class PowerAccentTestHelper
                 return null;
             }
 
-            var result = DwmGetWindowAttribute(
-                window.Hwnd,
-                DwmCloakedAttribute,
-                out var cloaked,
-                sizeof(int));
-            if (result != 0)
-            {
-                throw new InvalidOperationException(
-                    $"DwmGetWindowAttribute(DWMWA_CLOAKED) failed for HWND {window.Hwnd} with HRESULT 0x{result:X8}.");
-            }
-
             return new OverlayObservation(
                 window,
-                IsCloaked: cloaked != 0,
+                IsCloaked: WindowHelper.IsWindowCloaked(window.Hwnd),
                 WindowHelper.GetWindowBounds(window.Hwnd));
         }
         finally


### PR DESCRIPTION
## Summary of the Pull Request

Consolidates reusable native window-management behavior in `UITestAutomation.Next` so module UI tests no longer need their own DWM and monitor interop.

- Adds retry-friendly DWM cloak-state and physical visible-frame queries to `WindowHelper`.
- Adds an HWND-to-monitor/work-area lookup to `MonitorInfo`, including protection against windows destroyed during the native lookup.
- Routes visible-window capture through the shared frame-bounds API.
- Migrates Quick Accent placement and cloak assertions away from duplicated P/Invoke and `System.Windows.Forms.Screen`.
- Adds deterministic unit coverage and documents the shared APIs in the UI-test migration guidance.

This follows up the non-blocking consolidation request from [the Quick Accent UI-test review](https://github.com/microsoft/PowerToys/pull/50289#discussion_r3906581827).

## PR Checklist

- [x] **Communication:** The consolidation was discussed in the Quick Accent UI-test review.
- [x] **Tests:** Added/updated and all pass.
- [x] **Dev docs:** Updated the `ui-tests-migration` API mapping.

## Detailed Description of the Pull Request / Additional comments

`src/common/UITestAutomation.Next/WindowHelper.cs` now exposes:

- `IsWindowCloaked(IntPtr)` for DWM cloak state, which is independent of ordinary Win32 visibility.
- `GetVisibleBounds(IntPtr)` for `DWMWA_EXTENDED_FRAME_BOUNDS` in physical pixels.

Both APIs surface detailed `InvalidOperationException` diagnostics for invalid or disappearing HWNDs, allowing stable polling callers to classify the failure as transient, reacquire the current window, and retry. `CaptureVisibleWindow` uses the same bounds implementation, keeping Mouse Jump, Peek, and Preview Pane capture behavior consistent.

`src/common/UITestAutomation.Next/MonitorInfo.cs` now resolves the containing or nearest monitor for an HWND and exposes work-area dimensions. It validates the HWND before and after `MonitorFromWindow`/`GetMonitorInfo` so a window destroyed mid-query cannot silently resolve to the primary monitor.

`src/modules/poweraccent/PowerAccent.UITests/PowerAccentTestHelper.cs` consumes these shared APIs for Quick Accent cloak checks, stable visible bounds, and monitor-aware toolbar placement. The module-specific DWM declarations, native rectangle, and `Screen.FromHandle` dependency are removed.

`src/common/UITestAutomation.Next.UnitTests/WindowHelperTests.cs` and `MonitorInfoTests.cs` cover DWM cloak flags, physical/negative coordinates, native failures, empty frames, invalid/destroyed HWNDs, nearest-monitor flags, and multi-monitor work areas without requiring a composed desktop in ordinary unit-test CI.

## Validation Steps Performed

- Built `UITestAutomation.Next.UnitTests`, `PowerAccent.UITests`, `MouseUtils.UITests.Next`, `Peek.UITests.Next`, and `PreviewPane.UITests` for x64 and ARM64.
- Shared unit suite: **31/31 passed** in x64 Debug and Release.
- Quick Accent local VMs: **22/22 passed** on Windows 10 and Windows 11 under both default (4 vCPU/8 GB) and constrained (1 vCPU/4 GB) profiles.
- Focused shared-capture regressions passed for Mouse Jump, Peek visual capture, and Preview Pane visible-window capture.
- Combined Azure DevOps [UI Test Automation build 156529959](https://microsoft.visualstudio.com/Dart/_build/results?buildId=156529959), run on the equivalent pre-rebase consolidation diff:
  - ARM64: **86/86 passed**
  - x64 / Windows 10: **86/86 passed**
  - x64 / Windows 11: **86/86 passed**
  - Aggregate: **258/258 passed**, covering Mouse Utils (40), Peek (15), Quick Accent (22), and Preview Pane (9) on each platform.
- After replaying only the consolidation commits onto current `main`, rebuilt the shared unit project and Quick Accent Release project; the shared suite remained **31/31 passed**.
