### PR TITLE
[Shortcut Guide] Support symlinked and unlocalized manifests

### DIFF
--- a/src/modules/ShortcutGuide/ShortcutGuide.IndexYmlGenerator/IndexYmlGenerator.cs
+++ b/src/modules/ShortcutGuide/ShortcutGuide.IndexYmlGenerator/IndexYmlGenerator.cs
@@ -2,11 +2,13 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using ShortcutGuide.Helpers;
 using ShortcutGuide.Models;
+using YamlDotNet.Core;
 using YamlDotNet.Serialization;
 
 // This class should be moved to WinGet in the future
@@ -19,10 +21,13 @@ namespace ShortcutGuide.IndexYmlGenerator
             CreateIndexYmlFile();
         }
 
-        // Todo: Exception handling
         public static void CreateIndexYmlFile()
         {
-            string path = ManifestInterpreter.PathOfManifestFiles;
+            CreateIndexYmlFile(ManifestInterpreter.PathOfManifestFiles);
+        }
+
+        public static void CreateIndexYmlFile(string path)
+        {
             if (File.Exists(Path.Combine(path, "index.yml")))
             {
                 File.Delete(Path.Combine(path, "index.yml"));
@@ -33,21 +38,33 @@ namespace ShortcutGuide.IndexYmlGenerator
 
             foreach (string file in Directory.EnumerateFiles(path, "*.yml"))
             {
-                string content = File.ReadAllText(file);
-                Deserializer deserializer = new();
-                ShortcutFile shortcutFile = deserializer.Deserialize<ShortcutFile>(content);
-                if (processes.TryGetValue((shortcutFile.WindowFilter, shortcutFile.BackgroundProcess), out List<string>? apps))
+                try
                 {
-                    if (apps.Contains(shortcutFile.PackageName))
+                    string content = File.ReadAllText(file);
+                    Deserializer deserializer = new();
+                    ShortcutFile shortcutFile = deserializer.Deserialize<ShortcutFile>(content);
+                    if (processes.TryGetValue((shortcutFile.WindowFilter, shortcutFile.BackgroundProcess), out List<string>? apps))
                     {
+                        if (apps.Contains(shortcutFile.PackageName))
+                        {
+                            continue;
+                        }
+
+                        apps.Add(shortcutFile.PackageName);
                         continue;
                     }
 
-                    apps.Add(shortcutFile.PackageName);
-                    continue;
+                    processes[(shortcutFile.WindowFilter, shortcutFile.BackgroundProcess)] = [shortcutFile.PackageName];
                 }
-
-                processes[(shortcutFile.WindowFilter, shortcutFile.BackgroundProcess)] = [shortcutFile.PackageName];
+                catch (IOException)
+                {
+                }
+                catch (UnauthorizedAccessException)
+                {
+                }
+                catch (YamlException)
+                {
+                }
             }
 
             indexFile.Index = processes.Select(item => new IndexFile.IndexItem

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Helpers/ManifestInterpreter.cs
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Helpers/ManifestInterpreter.cs
@@ -36,9 +36,21 @@ namespace ShortcutGuide.Helpers
         /// <exception cref="FileNotFoundException">The requested file was not found.</exception>
         public static ShortcutFile GetShortcutsOfApplication(string applicationName)
         {
-            string path = PathOfManifestFiles;
+            return GetShortcutsOfApplication(applicationName, PathOfManifestFiles);
+        }
+
+        /// <summary>
+        /// Returns the shortcuts for a specific application from a specified manifest directory.
+        /// </summary>
+        /// <param name="applicationName">The manifest id.</param>
+        /// <param name="path">The directory containing manifest files.</param>
+        /// <returns>The deserialized shortcuts file.</returns>
+        /// <exception cref="FileNotFoundException">The requested file was not found.</exception>
+        public static ShortcutFile GetShortcutsOfApplication(string applicationName, string path)
+        {
             string localizedPath = Path.Combine(path, applicationName + $".{Language}.yml");
             string fallbackPath = Path.Combine(path, applicationName + ".en-US.yml");
+            string unlocalizedPath = Path.Combine(path, applicationName + ".yml");
 
             if (File.Exists(localizedPath))
             {
@@ -48,6 +60,11 @@ namespace ShortcutGuide.Helpers
             if (File.Exists(fallbackPath))
             {
                 return YamlToShortcutList(File.ReadAllText(fallbackPath));
+            }
+
+            if (File.Exists(unlocalizedPath))
+            {
+                return YamlToShortcutList(File.ReadAllText(unlocalizedPath));
             }
 
             throw new FileNotFoundException($"The file for the application '{applicationName}' was not found in '{path}' with the language '{Language}' or 'en-US'.");

--- a/src/modules/ShortcutGuide/ShortcutGuide.UnitTests/ManifestTests/ManifestDiscoveryAndLoadingTests.cs
+++ b/src/modules/ShortcutGuide/ShortcutGuide.UnitTests/ManifestTests/ManifestDiscoveryAndLoadingTests.cs
@@ -137,7 +137,7 @@ BackgroundProcess: false
             {
                 File.CreateSymbolicLink(symlinkPath, targetFilePath);
             }
-            catch (UnauthorizedAccessException)
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
             {
                 // In non-elevated CI environments or environments without Developer Mode,
                 // symlink creation is not permitted by Windows. Skip gracefully.

--- a/src/modules/ShortcutGuide/ShortcutGuide.UnitTests/ManifestTests/ManifestDiscoveryAndLoadingTests.cs
+++ b/src/modules/ShortcutGuide/ShortcutGuide.UnitTests/ManifestTests/ManifestDiscoveryAndLoadingTests.cs
@@ -1,0 +1,174 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ShortcutGuide.Helpers;
+using ShortcutGuide.IndexYmlGenerator;
+using ShortcutGuide.Models;
+
+namespace ShortcutGuide.UnitTests.ManifestTests;
+
+[TestClass]
+public sealed class ManifestDiscoveryAndLoadingTests
+{
+    private string _tempDirectory = null!;
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        _tempDirectory = Path.Combine(Path.GetTempPath(), "ShortcutGuide_ManifestTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    [TestCleanup]
+    public void TestCleanup()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            try
+            {
+                Directory.Delete(_tempDirectory, true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+
+    [TestMethod]
+    public void CreateIndexYmlFile_WithMalformedManifest_SkipsBadFileAndIndexesValidManifest()
+    {
+        // 1. Arrange a valid manifest
+        string validManifestContent = @"
+PackageName: Test.ValidApp
+Name: Valid App
+WindowFilter: 'ValidApp.exe'
+BackgroundProcess: false
+Shortcuts:
+  - SectionName: General
+    Properties:
+      - Name: Open
+        Shortcut:
+        - Win: false
+          Ctrl: true
+          Alt: false
+          Shift: false
+          Keys:
+            - O
+";
+        File.WriteAllText(Path.Combine(_tempDirectory, "Test.ValidApp.en-US.yml"), validManifestContent);
+
+        // 2. Arrange a corrupted/malformed YAML manifest that previously aborted index generation with CLR exception
+        string malformedManifestContent = "PackageName: [invalid: yaml: syntax:::";
+        File.WriteAllText(Path.Combine(_tempDirectory, "Corrupt.Manifest.yml"), malformedManifestContent);
+
+        // 3. Act: Generate index.yml
+        IndexYmlGenerator.IndexYmlGenerator.CreateIndexYmlFile(_tempDirectory);
+
+        // 4. Assert: index.yml was generated and contains the valid manifest
+        string indexPath = Path.Combine(_tempDirectory, "index.yml");
+        Assert.IsTrue(File.Exists(indexPath), "index.yml should be generated even when malformed manifests exist.");
+
+        string indexContent = File.ReadAllText(indexPath);
+        StringAssert.Contains(indexContent, "Test.ValidApp");
+    }
+
+    [TestMethod]
+    public void GetShortcutsOfApplication_UnlocalizedManifest_LoadsSuccessfully()
+    {
+        // Arrange: create an unlocalized manifest (+WindowsNT.Notepad-custom.yml)
+        string manifestContent = @"
+PackageName: +WindowsNT.Notepad-custom
+Name: Custom Notepad
+WindowFilter: 'Notepad.exe'
+BackgroundProcess: false
+Shortcuts:
+  - SectionName: Edit
+    Properties:
+      - Name: Custom Shortcut
+        Shortcut:
+        - Win: false
+          Ctrl: true
+          Alt: true
+          Shift: false
+          Keys:
+            - C
+";
+        File.WriteAllText(Path.Combine(_tempDirectory, "+WindowsNT.Notepad-custom.yml"), manifestContent);
+
+        // Act: load using GetShortcutsOfApplication with unlocalized name
+        ShortcutFile result = ManifestInterpreter.GetShortcutsOfApplication("+WindowsNT.Notepad-custom", _tempDirectory);
+
+        // Assert: manifest fields deserialized correctly
+        Assert.AreEqual("+WindowsNT.Notepad-custom", result.PackageName);
+        Assert.AreEqual("Custom Notepad", result.Name);
+        Assert.AreEqual("Notepad.exe", result.WindowFilter);
+    }
+
+    [TestMethod]
+    public void CreateIndexYmlFile_WithValidSymbolicLink_SuccessfullyIndexesTarget()
+    {
+        // Arrange: create a manifest outside the target folder
+        string outsideDir = Path.Combine(Path.GetTempPath(), "ShortcutGuide_TargetDir_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outsideDir);
+
+        try
+        {
+            string targetFilePath = Path.Combine(outsideDir, "TargetApp.en-US.yml");
+            string manifestContent = @"
+PackageName: Target.App
+Name: Target App
+WindowFilter: 'TargetApp.exe'
+BackgroundProcess: false
+";
+            File.WriteAllText(targetFilePath, manifestContent);
+
+            string symlinkPath = Path.Combine(_tempDirectory, "SymlinkedApp.en-US.yml");
+
+            try
+            {
+                File.CreateSymbolicLink(symlinkPath, targetFilePath);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // In non-elevated CI environments or environments without Developer Mode,
+                // symlink creation is not permitted by Windows. Skip gracefully.
+                Assert.Inconclusive("Skipping symlink test: privilege to create symbolic links is not held in this environment.");
+                return;
+            }
+
+            // Act
+            IndexYmlGenerator.IndexYmlGenerator.CreateIndexYmlFile(_tempDirectory);
+
+            // Assert
+            string indexPath = Path.Combine(_tempDirectory, "index.yml");
+            Assert.IsTrue(File.Exists(indexPath), "index.yml should be generated.");
+            string indexContent = File.ReadAllText(indexPath);
+            StringAssert.Contains(indexContent, "Target.App");
+        }
+        finally
+        {
+            if (Directory.Exists(outsideDir))
+            {
+                try
+                {
+                    Directory.Delete(outsideDir, true);
+                }
+                catch (IOException)
+                {
+                }
+                catch (UnauthorizedAccessException)
+                {
+                }
+            }
+        }
+    }
+}

--- a/src/modules/ShortcutGuide/ShortcutGuide.UnitTests/ShortcutGuide.UnitTests.csproj
+++ b/src/modules/ShortcutGuide/ShortcutGuide.UnitTests/ShortcutGuide.UnitTests.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\ShortcutGuide.IndexYmlGenerator\ShortcutGuide.IndexYmlGenerator.csproj" />
     <ProjectReference Include="..\ShortcutGuide.Ui\ShortcutGuide.Ui.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary of the Pull Request

Support symlinked and unlocalized shortcut manifests in Shortcut Guide.

## PR Checklist

* [x] Closes: #50354
* [ ] Communication: I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
* [x] Tests: Added/updated and all pass
* [x] Localization: All end-user-facing strings can be localized
* [ ] Dev docs: Added/updated
* [ ] New binaries: Added on the required places
* [ ] Documentation updated: If checked, please file a pull request on our docs repo and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

Shortcut Guide currently fails when a problematic manifest prevents index generation, and unlocalized custom manifests are not found during application shortcut lookup.

This change:

* Skips invalid or unreadable manifests during index generation so other valid manifests can still be indexed.
* Adds a fallback for unlocalized `.yml` manifests after the localized and `en-US` lookups.
* Adds unit test coverage for malformed manifests, unlocalized manifests, and valid symbolic links.

The existing non-recursive manifest discovery behavior is preserved. This change does not add recursive directory traversal or Windows-specific reparse-point handling.

## Validation Steps Performed

* `git diff --check` — passed.
* Built the Shortcut Guide unit-test project successfully with 0 errors using:
  `tools\build\build.ps1 -Path src\modules\ShortcutGuide\ShortcutGuide.UnitTests -Platform x64 -Configuration Debug`
* Ran the full Shortcut Guide unit-test assembly with the native PowerToys output directory on `PATH` so `PowerToys.Interop.dll` can be resolved by CsWinRT.
* Full Shortcut Guide unit-test result: **51 total, 50 passed, 1 skipped/inconclusive, 0 failed**.
* The PR-specific manifest tests passed:

  * `CreateIndexYmlFile_WithMalformedManifest_SkipsBadFileAndIndexesValidManifest`
  * `GetShortcutsOfApplication_UnlocalizedManifest_LoadsSuccessfully`
* `CreateIndexYmlFile_WithValidSymbolicLink_SuccessfullyIndexesTarget` was skipped/inconclusive because creating symbolic links requires a Windows privilege that is unavailable in the current test environment.
* An initial isolated VSTest invocation produced `REGDB_E_CLASSNOTREG` for `PowerToys.Interop.LayoutMapManaged` because `PowerToys.Interop.dll` was not available to the test process. Running the tests with the solution's `x64\Debug` output directory on `PATH` resolved the native dependency, and the full suite then completed with 0 failures.
* No code change was required for the `PowerToys.Interop.LayoutMapManaged` test-environment issue.


