### PR TITLE
Update thirdPartyRunPlugins.md to add New Chat for Claude

### DIFF
--- a/doc/thirdPartyRunPlugins.md
+++ b/doc/thirdPartyRunPlugins.md
@@ -84,3 +84,4 @@ Below are community created plugins that target a website or software.  They are
 | [PerplexitySearchShortcut](https://github.com/0x6f677548/PowerToys-Run-PerplexitySearchShortcut) | [0x6f677548](https://github.com/0x6f677548) | Search Perplexity |
 | [SpeedTest](https://github.com/ruslanlap/PowerToysRun-SpeedTest) | [ruslanlap](https://github.com/ruslanlap) | One-command internet speed tests with real-time results, modern UI, and shareable links. |
 | [DiskAnalyzer](https://github.com/valley-soft/powertoys-diskanalyzer) | [ValleySoft](https://github.com/valley-soft) | Scan folders, find the largest files, and view drive space usage. |
+| [New Chat for Claude](https://github.com/tit-exe/PowerToys-Run-for-Claude) | [tit-exe](https://github.com/tit-exe) | Start a new Claude conversation in the desktop app or the browser. |


### PR DESCRIPTION
## Summary of the Pull Request

Adds **New Chat for Claude** to the *Extending software plugins* table in `doc/thirdPartyRunPlugins.md`.

The plugin opens a new Claude conversation from PowerToys Run, in the Claude desktop app or in the browser. It is an unofficial community plugin, not affiliated with or endorsed by Anthropic.

Repository: https://github.com/tit-exe/PowerToys-Run-for-Claude

## PR Checklist

Documentation only: a single row added to an existing table. No code, binaries, tests, installer entries or localizable strings are affected, so the items in the template checklist do not apply.

## Validation Steps Performed

Checked that the row renders correctly in the table and that both links resolve.