### PR TITLE
CmdPal: Make DockControl animation closer to win11

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockItemControl.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockItemControl.xaml
@@ -83,7 +83,7 @@
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 CornerRadius="{TemplateBinding CornerRadius}">
                                 <Grid.BackgroundTransition>
-                                    <BrushTransition Duration="0:0:0.15" />
+                                    <BrushTransition Duration="0:0:0.083" />
                                 </Grid.BackgroundTransition>
                                 <Grid
                                     x:Name="ContentGrid"

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockItemControl.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockItemControl.xaml
@@ -50,6 +50,7 @@
 
     <CornerRadius x:Key="DockItemCornerRadius">4</CornerRadius>
     <Thickness x:Key="DockItemPadding">4,0,4,0</Thickness>
+
     <Style BasedOn="{StaticResource DefaultDockItemControlStyle}" TargetType="local:DockItemControl" />
 
     <Style x:Key="DefaultDockItemControlStyle" TargetType="local:DockItemControl">
@@ -58,7 +59,7 @@
             <Setter Property="Background" Value="{ThemeResource DockItemBackground}" />
             <Setter Property="BorderBrush" Value="{ThemeResource DockItemBorderBrush}" />
             <Setter Property="Padding" Value="{StaticResource DockItemPadding}" />
-            <Setter Property="BorderThickness" Value="{ThemeResource ButtonBorderThemeThickness}" />
+            <Setter Property="BorderThickness" Value="1" />
             <Setter Property="CornerRadius" Value="{StaticResource DockItemCornerRadius}" />
             <Setter Property="TextVisibility" Value="Visible" />
             <Setter Property="IsTabStop" Value="True" />
@@ -72,19 +73,6 @@
                             x:Name="PART_RootGrid"
                             Padding="{TemplateBinding InnerMargin}"
                             Background="Transparent">
-                            <!--  Hover/pressed chrome lives on its own layer so it can cross-fade instead of popping in  -->
-                            <Border
-                                x:Name="HoverLayer"
-                                Background="{ThemeResource DockItemBackgroundPointerOver}"
-                                BorderBrush="{ThemeResource DockItemBorderBrushPointerOver}"
-                                BorderThickness="{TemplateBinding BorderThickness}"
-                                CornerRadius="{TemplateBinding CornerRadius}"
-                                IsHitTestVisible="False"
-                                Opacity="0">
-                                <Border.OpacityTransition>
-                                    <ScalarTransition Duration="0:0:0.15" />
-                                </Border.OpacityTransition>
-                            </Border>
                             <Grid
                                 x:Name="PART_BackPlate"
                                 MinWidth="32"
@@ -94,6 +82,9 @@
                                 BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 CornerRadius="{TemplateBinding CornerRadius}">
+                                <Grid.BackgroundTransition>
+                                    <BrushTransition Duration="0:0:0.15" />
+                                </Grid.BackgroundTransition>
                                 <Grid
                                     x:Name="ContentGrid"
                                     AutomationProperties.Name="{TemplateBinding Title}"
@@ -155,18 +146,34 @@
                                 <VisualStateGroup x:Name="CommonStates">
                                     <VisualStateGroup.Transitions>
                                         <!--  Ease the icon back to full size when the press ends  -->
-                                        <VisualTransition GeneratedDuration="0:0:0.15" From="Pressed" />
+                                        <VisualTransition From="Pressed">
+                                            <Storyboard>
+                                                <DoubleAnimation
+                                                    Storyboard.TargetName="IconScaleTransform"
+                                                    Storyboard.TargetProperty="ScaleX"
+                                                    To="1"
+                                                    Duration="0:0:0.15">
+                                                    <DoubleAnimation.EasingFunction>
+                                                        <CubicEase EasingMode="EaseOut" />
+                                                    </DoubleAnimation.EasingFunction>
+                                                </DoubleAnimation>
+                                                <DoubleAnimation
+                                                    Storyboard.TargetName="IconScaleTransform"
+                                                    Storyboard.TargetProperty="ScaleY"
+                                                    To="1"
+                                                    Duration="0:0:0.15">
+                                                    <DoubleAnimation.EasingFunction>
+                                                        <CubicEase EasingMode="EaseOut" />
+                                                    </DoubleAnimation.EasingFunction>
+                                                </DoubleAnimation>
+                                            </Storyboard>
+                                        </VisualTransition>
                                     </VisualStateGroup.Transitions>
-                                    <!--  Every state sets HoverLayer explicitly; relying on the VSM to revert the setter leaves the chrome stuck on  -->
-                                    <VisualState x:Name="Normal">
-                                        <VisualState.Setters>
-                                            <Setter Target="HoverLayer.Opacity" Value="0" />
-                                        </VisualState.Setters>
-                                    </VisualState>
+                                    <VisualState x:Name="Normal" />
                                     <VisualState x:Name="PointerOver">
                                         <VisualState.Setters>
-                                            <Setter Target="HoverLayer.Opacity" Value="1" />
-                                            <Setter Target="HoverLayer.BorderBrush" Value="{ThemeResource DockItemBorderBrushPointerOver}" />
+                                            <Setter Target="PART_BackPlate.Background" Value="{ThemeResource DockItemBackgroundPointerOver}" />
+                                            <Setter Target="PART_BackPlate.BorderBrush" Value="{ThemeResource DockItemBorderBrushPointerOver}" />
                                         </VisualState.Setters>
                                     </VisualState>
                                     <VisualState x:Name="Pressed">
@@ -192,15 +199,14 @@
                                             </DoubleAnimation>
                                         </Storyboard>
                                         <VisualState.Setters>
-                                            <Setter Target="HoverLayer.Opacity" Value="1" />
-                                            <Setter Target="HoverLayer.BorderBrush" Value="{ThemeResource DockItemBorderBrushPressed}" />
+                                            <Setter Target="PART_BackPlate.Background" Value="{ThemeResource DockItemBackgroundPressed}" />
+                                            <Setter Target="PART_BackPlate.BorderBrush" Value="{ThemeResource DockItemBorderBrushPressed}" />
                                         </VisualState.Setters>
                                     </VisualState>
                                     <VisualState x:Name="Disabled">
                                         <VisualState.Setters>
-                                            <Setter Target="HoverLayer.Opacity" Value="0" />
                                             <Setter Target="PART_BackPlate.Background" Value="{ThemeResource DockItemBackground}" />
-                                            <Setter Target="PART_BackPlate.BorderBrush" Value="{ThemeResource DockItemBackground}" />
+                                            <Setter Target="PART_BackPlate.BorderBrush" Value="{ThemeResource DockItemBorderBrush}" />
                                             <Setter Target="IconPresenter.Foreground" Value="{ThemeResource ButtonForegroundDisabled}" />
                                             <Setter Target="TitleText.Foreground" Value="{ThemeResource ButtonForegroundDisabled}" />
                                             <Setter Target="SubtitleText.Foreground" Value="{ThemeResource ButtonForegroundDisabled}" />

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockItemControl.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockItemControl.xaml
@@ -9,42 +9,38 @@
             <SolidColorBrush x:Key="DockItemBackground" Color="Transparent" />
             <SolidColorBrush x:Key="DockItemBorderBrush" Color="Transparent" />
             <SolidColorBrush x:Key="DockItemBackgroundPointerOver" Color="#0FFFFFFF" />
-            <SolidColorBrush x:Key="DockItemBackgroundPressed" Color="#0BFFFFFF" />
-            <!--  Same shape as the system's ControlElevationBorderBrush: a lit top edge over a flatter body  -->
+            <SolidColorBrush x:Key="DockItemBackgroundPressed" Color="#0AFFFFFF" />
             <LinearGradientBrush x:Key="DockItemBorderBrushPointerOver" MappingMode="Absolute" StartPoint="0,0" EndPoint="0,3">
                 <LinearGradientBrush.GradientStops>
-                    <GradientStop Offset="0.33" Color="#19FFFFFF" />
+                    <GradientStop Offset="0.33" Color="#1AFFFFFF" />
                     <GradientStop Offset="1.0" Color="#0FFFFFFF" />
                 </LinearGradientBrush.GradientStops>
             </LinearGradientBrush>
-            <!--  Pressed drops the elevation and goes flat, the way system buttons do  -->
-            <SolidColorBrush x:Key="DockItemBorderBrushPressed" Color="#12FFFFFF" />
+            <SolidColorBrush x:Key="DockItemBorderBrushPressed" Color="#0AFFFFFF" />
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
             <SolidColorBrush x:Key="DockItemBackground" Color="Transparent" />
             <SolidColorBrush x:Key="DockItemBorderBrush" Color="Transparent" />
             <SolidColorBrush x:Key="DockItemBackgroundPointerOver" Color="#80FFFFFF" />
-            <SolidColorBrush x:Key="DockItemBackgroundPressed" Color="#4DFFFFFF" />
-            <!--  Light theme flips the ramp so the shaded edge sits at the bottom, matching ControlElevationBorderBrush  -->
+            <SolidColorBrush x:Key="DockItemBackgroundPressed" Color="#4CFFFFFF" />
             <LinearGradientBrush x:Key="DockItemBorderBrushPointerOver" MappingMode="Absolute" StartPoint="0,0" EndPoint="0,3">
                 <LinearGradientBrush.RelativeTransform>
                     <ScaleTransform CenterY="0.5" ScaleY="-1" />
                 </LinearGradientBrush.RelativeTransform>
                 <LinearGradientBrush.GradientStops>
-                    <GradientStop Offset="0.33" Color="#17000000" />
-                    <GradientStop Offset="1.0" Color="#08000000" />
+                    <GradientStop Offset="0.33" Color="#0F000000" />
+                    <GradientStop Offset="1.0" Color="#05000000" />
                 </LinearGradientBrush.GradientStops>
             </LinearGradientBrush>
-            <!--  Pressed drops the elevation and goes flat, the way system buttons do  -->
-            <SolidColorBrush x:Key="DockItemBorderBrushPressed" Color="#0F000000" />
+            <SolidColorBrush x:Key="DockItemBorderBrushPressed" Color="#05000000" />
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
-            <SolidColorBrush x:Key="DockItemBackground" Color="Transparent" />
+            <StaticResource x:Key="DockItemBackground" ResourceKey="SystemControlPageBackgroundAltMediumBrush" />
             <SolidColorBrush x:Key="DockItemBorderBrush" Color="Transparent" />
-            <SolidColorBrush x:Key="DockItemBackgroundPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
-            <SolidColorBrush x:Key="DockItemBackgroundPressed" Color="{StaticResource SystemColorHighlightTextColor}" />
-            <SolidColorBrush x:Key="DockItemBorderBrushPointerOver" Color="{StaticResource SystemColorHighlightColor}" />
-            <SolidColorBrush x:Key="DockItemBorderBrushPressed" Color="{StaticResource SystemColorHighlightTextColor}" />
+            <StaticResource x:Key="DockItemBackgroundPointerOver" ResourceKey="SystemControlHighlightAltAccentBrush" />
+            <StaticResource x:Key="DockItemBackgroundPressed" ResourceKey="SystemControlPageBackgroundAltMediumBrush" />
+            <StaticResource x:Key="DockItemBorderBrushPointerOver" ResourceKey="SystemControlHighlightAccentBrush" />
+            <StaticResource x:Key="DockItemBorderBrushPressed" ResourceKey="SystemControlHighlightAccentBrush" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 


### PR DESCRIPTION
## Summary of the Pull Request

// WIP

This PR updates DockControl visuals to match Windows 11 even closer...
- Separates border and background animation: border changes state instantly, background animates.
- Pressed state uses a distinct background color.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #48076
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

