### PR TITLE
CmdPal: Marshal handling of UI messages in MainWindow to the dispatcher queue

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Messages/TelemetryCommandStartedMessage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Messages/TelemetryCommandStartedMessage.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CmdPal.UI.ViewModels.Messages;
+
+/// <summary>
+/// Counts a command or page navigation before it can hide the palette and end the session.
+/// </summary>
+public record TelemetryCommandStartedMessage;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ShellViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ShellViewModel.cs
@@ -399,20 +399,30 @@ public partial class ShellViewModel : ObservableObject,
 
         try
         {
-            // Call out to extension process.
-            // * May fail!
-            // * May never return!
-            var result = invokable.Invoke(message.Context);
+            ICommandResult? result;
+            try
+            {
+                // Call out to extension process.
+                // * May fail!
+                // * May never return!
+                result = invokable.Invoke(message.Context);
+                success = true;
+            }
+            finally
+            {
+                // Count the invocation before handling a result that can end the session!
+                stopwatch.Stop();
+                WeakReferenceMessenger.Default.Send<TelemetryExtensionInvokedMessage>(
+                    new(extensionId, commandId, commandName, success, (ulong)stopwatch.ElapsedMilliseconds));
+            }
 
             // But if it did succeed, we need to handle the result.
             UnsafeHandleCommandResult(result, message.OnBeforeShowConfirmation);
 
-            success = true;
             _handleInvokeTask = null;
         }
         catch (Exception ex)
         {
-            success = false;
             _handleInvokeTask = null;
 
             // Telemetry: Track errors for session metrics
@@ -421,13 +431,6 @@ public partial class ShellViewModel : ObservableObject,
             // TODO: It would be better to do this as a page exception, rather
             // than a silent log message.
             host?.Log(ex.Message);
-        }
-        finally
-        {
-            // Telemetry: Send extension invocation metrics (always sent, even on failure)
-            stopwatch.Stop();
-            WeakReferenceMessenger.Default.Send<TelemetryExtensionInvokedMessage>(
-                new(extensionId, commandId, commandName, success, (ulong)stopwatch.ElapsedMilliseconds));
         }
     }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ShellViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ShellViewModel.cs
@@ -312,6 +312,7 @@ public partial class ShellViewModel : ObservableObject,
                     var extensionId = host.GetExtensionDisplayName() ?? "builtin";
                     var commandId = command?.Id ?? "unknown";
                     var commandName = command?.Name ?? "unknown";
+                    WeakReferenceMessenger.Default.Send<TelemetryCommandStartedMessage>();
                     WeakReferenceMessenger.Default.Send<TelemetryExtensionInvokedMessage>(
                         new(extensionId, commandId, commandName, true, 0));
                 }
@@ -379,6 +380,8 @@ public partial class ShellViewModel : ObservableObject,
             }
             else
             {
+                // Count only accepted invocations, before Invoke can hide the palette and end the session.
+                WeakReferenceMessenger.Default.Send<TelemetryCommandStartedMessage>();
                 _handleInvokeTask = Task.Run(() =>
                 {
                     SafeHandleInvokeCommandSynchronous(message, invokable, host);
@@ -410,7 +413,7 @@ public partial class ShellViewModel : ObservableObject,
             }
             finally
             {
-                // Count the invocation before handling a result that can end the session!
+                // Report the invocation outcome before processing its result.
                 stopwatch.Stop();
                 WeakReferenceMessenger.Default.Send<TelemetryExtensionInvokedMessage>(
                     new(extensionId, commandId, commandName, success, (ulong)stopwatch.ElapsedMilliseconds));

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/TelemetryForwarder.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/TelemetryForwarder.cs
@@ -54,12 +54,6 @@ internal sealed class TelemetryForwarder :
             message.CommandName,
             message.Success,
             message.ExecutionTimeMs));
-
-        // Increment session counter for commands executed
-        if (App.Current.AppWindow is MainWindow mainWindow)
-        {
-            mainWindow.IncrementCommandsExecuted();
-        }
     }
 
     public void Receive(TelemetryDockConfigurationMessage message)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
@@ -945,56 +945,77 @@ public sealed partial class MainWindow : WindowEx,
         return DisplayArea.Primary;
     }
 
+    private void RunOnUiThread(Action action)
+    {
+        if (DispatcherQueue.HasThreadAccess)
+        {
+            action();
+        }
+        else
+        {
+            DispatcherQueue.TryEnqueue(() => action());
+        }
+    }
+
     public void Receive(ShowWindowMessage message)
     {
-        _isLoadedFromDock = false;
+        RunOnUiThread(() =>
+        {
+            _isLoadedFromDock = false;
 
-        var settings = App.Current.Services.GetRequiredService<ISettingsService>().Settings;
+            var settings = App.Current.Services.GetRequiredService<ISettingsService>().Settings;
 
-        // Start session tracking
-        _sessionStopwatch = Stopwatch.StartNew();
-        _sessionCommandsExecuted = 0;
-        _sessionPagesVisited = 0;
+            // Start session tracking
+            _sessionStopwatch = Stopwatch.StartNew();
+            _sessionCommandsExecuted = 0;
+            _sessionPagesVisited = 0;
 
-        ShowHwnd(message.Hwnd, settings.SummonOn);
+            ShowHwnd(message.Hwnd, settings.SummonOn);
+        });
     }
 
     internal void Receive(ShowPaletteAtMessage message)
     {
-        _isLoadedFromDock = true;
+        RunOnUiThread(() =>
+        {
+            _isLoadedFromDock = true;
 
-        // Reset the size in case users have resized a dock window.
-        // Ideally in the future, we'll have defined sizes that opening
-        // a dock window will adhere to, but alas, that's the future.
-        RestoreWindowPositionFromMemory();
+            // Reset the size in case users have resized a dock window.
+            // Ideally in the future, we'll have defined sizes that opening
+            // a dock window will adhere to, but alas, that's the future.
+            RestoreWindowPositionFromMemory();
 
-        ShowHwnd(HWND.Null, message.PosPixels, message.Anchor);
+            ShowHwnd(HWND.Null, message.PosPixels, message.Anchor);
+        });
     }
 
     public void Receive(HideWindowMessage message)
     {
         // This might come in off the UI thread. Make sure to hop back.
-        DispatcherQueue.TryEnqueue(() =>
+        RunOnUiThread(() =>
         {
             EndSession("Hide");
             HideWindow();
         });
     }
 
-    public void Receive(QuitMessage message) =>
-
-        // This might come in on a background thread
+    public void Receive(QuitMessage message)
+    {
+        // Always defer, even on the UI thread. This can be sent from the window procedure and
+        // is broadcast to multiple windows. MainWindow_Closed exits the process, so closing
+        // inline could terminate while the window procedure or message broadcast is still active.
         DispatcherQueue.TryEnqueue(() => Close());
+    }
 
     public void Receive(DismissMessage message)
     {
         if (message.ForceGoHome)
         {
-            WeakReferenceMessenger.Default.Send(new GoHomeMessage(false, false));
+            RunOnUiThread(() => WeakReferenceMessenger.Default.Send(new GoHomeMessage(false, false)));
         }
 
         // This might come in off the UI thread. Make sure to hop back.
-        DispatcherQueue.TryEnqueue(() =>
+        RunOnUiThread(() =>
         {
             EndSession("Dismiss");
             HideWindow();
@@ -1005,25 +1026,28 @@ public sealed partial class MainWindow : WindowEx,
     // These receivers increment counters that are sent when EndSession is called
     public void Receive(NavigateToPageMessage message)
     {
-        _sessionPagesVisited++;
+        RunOnUiThread(() => _sessionPagesVisited++);
     }
 
     public void Receive(NavigationDepthMessage message)
     {
-        if (message.Depth > _sessionMaxNavigationDepth)
+        RunOnUiThread(() =>
         {
-            _sessionMaxNavigationDepth = message.Depth;
-        }
+            if (message.Depth > _sessionMaxNavigationDepth)
+            {
+                _sessionMaxNavigationDepth = message.Depth;
+            }
+        });
     }
 
     public void Receive(SearchQueryMessage message)
     {
-        _sessionSearchQueriesCount++;
+        RunOnUiThread(() => _sessionSearchQueriesCount++);
     }
 
     public void Receive(ErrorOccurredMessage message)
     {
-        _sessionErrorCount++;
+        RunOnUiThread(() => _sessionErrorCount++);
     }
 
     /// <summary>
@@ -1054,7 +1078,7 @@ public sealed partial class MainWindow : WindowEx,
     /// </summary>
     internal void IncrementCommandsExecuted()
     {
-        _sessionCommandsExecuted++;
+        RunOnUiThread(() => _sessionCommandsExecuted++);
     }
 
     private void HideWindow()
@@ -1914,20 +1938,23 @@ public sealed partial class MainWindow : WindowEx,
 
     public void Receive(ToggleDevRibbonMessage message)
     {
-        _devRibbon?.Visibility = _devRibbon.Visibility == Visibility.Visible ? Visibility.Collapsed : Visibility.Visible;
+        RunOnUiThread(() =>
+        {
+            _devRibbon?.Visibility = _devRibbon.Visibility == Visibility.Visible ? Visibility.Collapsed : Visibility.Visible;
+        });
     }
 
     public void Receive(DragStartedMessage message)
     {
-        _preventHideWhenDeactivated = true;
+        RunOnUiThread(() => _preventHideWhenDeactivated = true);
     }
 
     public void Receive(DragCompletedMessage message)
     {
-        _preventHideWhenDeactivated = false;
-        Task.Delay(200).ContinueWith(_ =>
+        RunOnUiThread(() =>
         {
-            DispatcherQueue.TryEnqueue(StealForeground);
+            _preventHideWhenDeactivated = false;
+            Task.Delay(200).ContinueWith(_ => RunOnUiThread(StealForeground));
         });
     }
 
@@ -1959,16 +1986,21 @@ public sealed partial class MainWindow : WindowEx,
 
     public void Receive(GetHwndMessage message)
     {
-        message.Hwnd = this.GetWindowHandle();
+        message.Hwnd = (nint)_hwnd;
     }
 
     public void Receive(ExpandCompactModeMessage message)
     {
+        // Always defer so this runs after the current message delivery, alongside ShellPage's
+        // queued compact-state reconciliation. Running inline could apply host constraints before
+        // ShellPage resolves the authoritative navigation and search state.
         this.DispatcherQueue.TryEnqueue(() => HandleExpandCompactOnUiThread(message.Expanded));
     }
 
     public void Receive(MaximizeForDialogMessage message)
     {
+        // Keep this deferred to preserve the dialog and layout ordering established by ShellPage.
+        // Running inline would apply host constraints in the middle of dialog setup or teardown.
         this.DispatcherQueue.TryEnqueue(() =>
         {
             _dialogFullExpandActive = message.Maximize;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
@@ -52,6 +52,7 @@ public sealed partial class MainWindow : WindowEx,
     IRecipient<NavigationDepthMessage>,
     IRecipient<SearchQueryMessage>,
     IRecipient<ErrorOccurredMessage>,
+    IRecipient<TelemetryCommandStartedMessage>,
     IRecipient<DragStartedMessage>,
     IRecipient<DragCompletedMessage>,
     IRecipient<ToggleDevRibbonMessage>,
@@ -195,6 +196,7 @@ public sealed partial class MainWindow : WindowEx,
         WeakReferenceMessenger.Default.Register<NavigationDepthMessage>(this);
         WeakReferenceMessenger.Default.Register<SearchQueryMessage>(this);
         WeakReferenceMessenger.Default.Register<ErrorOccurredMessage>(this);
+        WeakReferenceMessenger.Default.Register<TelemetryCommandStartedMessage>(this);
         WeakReferenceMessenger.Default.Register<DragStartedMessage>(this);
         WeakReferenceMessenger.Default.Register<DragCompletedMessage>(this);
         WeakReferenceMessenger.Default.Register<ToggleDevRibbonMessage>(this);
@@ -1072,11 +1074,7 @@ public sealed partial class MainWindow : WindowEx,
         }
     }
 
-    /// <summary>
-    /// Increments the session commands executed counter for telemetry.
-    /// Called by TelemetryForwarder when an extension command is invoked.
-    /// </summary>
-    internal void IncrementCommandsExecuted()
+    public void Receive(TelemetryCommandStartedMessage message)
     {
         RunOnUiThread(() => _sessionCommandsExecuted++);
     }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ShellViewModelTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ShellViewModelTests.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.CmdPal.UI.ViewModels.Messages;
+using Microsoft.CmdPal.UI.ViewModels.Models;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+[TestClass]
+[DoNotParallelize]
+public partial class ShellViewModelTests
+{
+    private sealed partial class TestAppExtensionHost : AppExtensionHost
+    {
+        public override string? GetExtensionDisplayName() => "Test Host";
+    }
+
+    private sealed partial class TestCommand(CommandResult result) : InvokableCommand
+    {
+        public override ICommandResult Invoke() => result;
+    }
+
+    [TestMethod]
+    [DataRow(CommandResultKind.Dismiss)]
+    [DataRow(CommandResultKind.Hide)]
+    public async Task PerformCommand_ReportsInvocationBeforeDismissal(CommandResultKind resultKind)
+    {
+        var host = new TestAppExtensionHost();
+        var appHostService = new Mock<IAppHostService>();
+        appHostService.Setup(service => service.GetDefaultHost()).Returns(host);
+        appHostService.Setup(service => service.GetHostForCommand(It.IsAny<object?>(), It.IsAny<AppExtensionHost?>())).Returns(host);
+        appHostService.Setup(service => service.GetProviderContextForCommand(It.IsAny<object?>(), It.IsAny<ICommandProviderContext?>())).Returns(CommandProviderContext.Empty);
+
+        var viewModel = new ShellViewModel(
+            TaskScheduler.Default,
+            Mock.Of<IRootPageService>(),
+            Mock.Of<IPageViewModelFactoryService>(),
+            appHostService.Object);
+        var recipient = new object();
+        var dismissed = new TaskCompletionSource<TelemetryExtensionInvokedMessage?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        TelemetryExtensionInvokedMessage? invocation = null;
+        WeakReferenceMessenger.Default.Register<TelemetryExtensionInvokedMessage>(recipient, (_, message) => invocation = message);
+        WeakReferenceMessenger.Default.Register<DismissMessage>(recipient, (_, _) => dismissed.TrySetResult(invocation));
+
+        try
+        {
+            var command = new TestCommand(resultKind == CommandResultKind.Dismiss ? CommandResult.Dismiss() : CommandResult.Hide())
+            {
+                Id = "test.command",
+            };
+            viewModel.Receive(new PerformCommandMessage(new ExtensionObject<ICommand>(command)));
+
+            var reportedInvocation = await dismissed.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.IsNotNull(reportedInvocation, "The session must count the invocation before dismissal is queued.");
+            Assert.IsTrue(reportedInvocation.Success);
+            Assert.AreEqual(command.Id, reportedInvocation.CommandId);
+        }
+        finally
+        {
+            WeakReferenceMessenger.Default.UnregisterAll(recipient);
+            WeakReferenceMessenger.Default.UnregisterAll(viewModel);
+        }
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ShellViewModelTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ShellViewModelTests.cs
@@ -3,8 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.CmdPal.Common.Messages;
 using Microsoft.CmdPal.UI.ViewModels.Messages;
 using Microsoft.CmdPal.UI.ViewModels.Models;
 using Microsoft.CommandPalette.Extensions;
@@ -23,15 +26,185 @@ public partial class ShellViewModelTests
         public override string? GetExtensionDisplayName() => "Test Host";
     }
 
-    private sealed partial class TestCommand(CommandResult result) : InvokableCommand
+    private sealed partial class TestCommand(CommandResult result, Action? onInvoke = null) : InvokableCommand
     {
-        public override ICommandResult Invoke() => result;
+        public override ICommandResult Invoke()
+        {
+            onInvoke?.Invoke();
+            return result;
+        }
+    }
+
+    private sealed partial class TestPage : ListPage
+    {
+        public override IListItem[] GetItems() => [];
+    }
+
+    private sealed partial class TestPageViewModel : PageViewModel
+    {
+        public TestPageViewModel(AppExtensionHost host)
+            : base(null, TaskScheduler.Default, host, CommandProviderContext.Empty)
+        {
+            IsInitialized = true;
+        }
     }
 
     [TestMethod]
-    [DataRow(CommandResultKind.Dismiss)]
-    [DataRow(CommandResultKind.Hide)]
-    public async Task PerformCommand_ReportsInvocationBeforeDismissal(CommandResultKind resultKind)
+    [DataRow(CommandResultKind.Dismiss, false, false)]
+    [DataRow(CommandResultKind.Hide, false, false)]
+    [DataRow(CommandResultKind.KeepOpen, false, false)]
+    [DataRow(CommandResultKind.KeepOpen, true, false)]
+    [DataRow(CommandResultKind.KeepOpen, false, true)]
+    [DataRow(CommandResultKind.KeepOpen, true, true)]
+    public async Task PerformCommand_CountsInvocationBeforeSessionEnds(CommandResultKind resultKind, bool hideDuringInvoke, bool throwDuringInvoke)
+    {
+        var viewModel = CreateViewModel();
+        var recipient = new object();
+        var events = new List<string>();
+        var finished = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        TelemetryExtensionInvokedMessage? invocation = null;
+        WeakReferenceMessenger.Default.Register<TelemetryCommandStartedMessage>(recipient, (_, _) => events.Add("started"));
+        WeakReferenceMessenger.Default.Register<HideWindowMessage>(recipient, (_, _) => events.Add("hide"));
+        WeakReferenceMessenger.Default.Register<TelemetryExtensionInvokedMessage>(recipient, (_, message) =>
+        {
+            events.Add("completed");
+            invocation = message;
+        });
+        WeakReferenceMessenger.Default.Register<DismissMessage>(recipient, (_, _) =>
+        {
+            events.Add("dismiss");
+            finished.TrySetResult();
+        });
+        WeakReferenceMessenger.Default.Register<ErrorOccurredMessage>(recipient, (_, _) => finished.TrySetResult());
+        WeakReferenceMessenger.Default.Register<TelemetryInvokeResultMessage>(recipient, (_, message) =>
+        {
+            if (message.Kind == CommandResultKind.KeepOpen)
+            {
+                finished.TrySetResult();
+            }
+        });
+
+        try
+        {
+            var result = resultKind switch
+            {
+                CommandResultKind.Dismiss => CommandResult.Dismiss(),
+                CommandResultKind.Hide => CommandResult.Hide(),
+                _ => CommandResult.KeepOpen(),
+            };
+            var command = new TestCommand(result, () =>
+            {
+                if (hideDuringInvoke)
+                {
+                    WeakReferenceMessenger.Default.Send<HideWindowMessage>();
+                }
+
+                if (throwDuringInvoke)
+                {
+                    throw new InvalidOperationException("Test invocation failure");
+                }
+            })
+            {
+                Id = "test.command",
+            };
+            viewModel.Receive(new PerformCommandMessage(new ExtensionObject<ICommand>(command)));
+
+            await finished.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            var expected = new List<string> { "started" };
+            if (hideDuringInvoke)
+            {
+                expected.Add("hide");
+            }
+
+            expected.Add("completed");
+            if (resultKind is CommandResultKind.Dismiss or CommandResultKind.Hide)
+            {
+                expected.Add("dismiss");
+            }
+
+            CollectionAssert.AreEqual(expected, events);
+            Assert.IsNotNull(invocation);
+            Assert.AreEqual(!throwDuringInvoke, invocation.Success);
+            Assert.AreEqual(command.Id, invocation.CommandId);
+        }
+        finally
+        {
+            WeakReferenceMessenger.Default.UnregisterAll(recipient);
+            WeakReferenceMessenger.Default.UnregisterAll(viewModel);
+        }
+    }
+
+    [TestMethod]
+    public async Task PerformCommand_DoesNotCountAnInvocationRejectedWhileBusy()
+    {
+        var viewModel = CreateViewModel();
+        var recipient = new object();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var completed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var release = new ManualResetEventSlim();
+        var started = 0;
+        WeakReferenceMessenger.Default.Register<TelemetryCommandStartedMessage>(recipient, (_, _) => Interlocked.Increment(ref started));
+        WeakReferenceMessenger.Default.Register<TelemetryExtensionInvokedMessage>(recipient, (_, _) => completed.TrySetResult());
+
+        try
+        {
+            var command = new TestCommand(CommandResult.KeepOpen(), () =>
+            {
+                entered.TrySetResult();
+                if (!release.Wait(TimeSpan.FromSeconds(10)))
+                {
+                    throw new TimeoutException("Test did not release the invocation");
+                }
+            });
+            var message = new PerformCommandMessage(new ExtensionObject<ICommand>(command));
+            viewModel.Receive(message);
+            await entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            viewModel.Receive(message);
+
+            Assert.AreEqual(1, Volatile.Read(ref started));
+        }
+        finally
+        {
+            release.Set();
+            try
+            {
+                await completed.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            }
+            finally
+            {
+                WeakReferenceMessenger.Default.UnregisterAll(recipient);
+                WeakReferenceMessenger.Default.UnregisterAll(viewModel);
+            }
+        }
+    }
+
+    [TestMethod]
+    public void PerformCommand_CountsPageNavigationOnceAfterShowingWindow()
+    {
+        var viewModel = CreateViewModel();
+        var recipient = new object();
+        var events = new List<string>();
+        WeakReferenceMessenger.Default.Register<ShowWindowMessage>(recipient, (_, _) => events.Add("show"));
+        WeakReferenceMessenger.Default.Register<TelemetryCommandStartedMessage>(recipient, (_, _) => events.Add("started"));
+        WeakReferenceMessenger.Default.Register<TelemetryExtensionInvokedMessage>(recipient, (_, _) => events.Add("completed"));
+        WeakReferenceMessenger.Default.Register<NavigateToPageMessage>(recipient, (_, _) => events.Add("navigate"));
+
+        try
+        {
+            viewModel.Receive(new PerformCommandMessage(new ExtensionObject<ICommand>(new TestPage())) { ShowWindowIfPage = true });
+
+            string[] expected = ["show", "started", "completed", "navigate"];
+            CollectionAssert.AreEqual(expected, events);
+        }
+        finally
+        {
+            WeakReferenceMessenger.Default.UnregisterAll(recipient);
+            WeakReferenceMessenger.Default.UnregisterAll(viewModel);
+        }
+    }
+
+    private static ShellViewModel CreateViewModel()
     {
         var host = new TestAppExtensionHost();
         var appHostService = new Mock<IAppHostService>();
@@ -39,34 +212,14 @@ public partial class ShellViewModelTests
         appHostService.Setup(service => service.GetHostForCommand(It.IsAny<object?>(), It.IsAny<AppExtensionHost?>())).Returns(host);
         appHostService.Setup(service => service.GetProviderContextForCommand(It.IsAny<object?>(), It.IsAny<ICommandProviderContext?>())).Returns(CommandProviderContext.Empty);
 
-        var viewModel = new ShellViewModel(
+        var pageFactory = new Mock<IPageViewModelFactoryService>();
+        pageFactory.Setup(factory => factory.TryCreatePageViewModel(It.IsAny<IPage>(), It.IsAny<bool>(), It.IsAny<AppExtensionHost>(), It.IsAny<ICommandProviderContext>()))
+            .Returns(new TestPageViewModel(host));
+
+        return new ShellViewModel(
             TaskScheduler.Default,
             Mock.Of<IRootPageService>(),
-            Mock.Of<IPageViewModelFactoryService>(),
+            pageFactory.Object,
             appHostService.Object);
-        var recipient = new object();
-        var dismissed = new TaskCompletionSource<TelemetryExtensionInvokedMessage?>(TaskCreationOptions.RunContinuationsAsynchronously);
-        TelemetryExtensionInvokedMessage? invocation = null;
-        WeakReferenceMessenger.Default.Register<TelemetryExtensionInvokedMessage>(recipient, (_, message) => invocation = message);
-        WeakReferenceMessenger.Default.Register<DismissMessage>(recipient, (_, _) => dismissed.TrySetResult(invocation));
-
-        try
-        {
-            var command = new TestCommand(resultKind == CommandResultKind.Dismiss ? CommandResult.Dismiss() : CommandResult.Hide())
-            {
-                Id = "test.command",
-            };
-            viewModel.Receive(new PerformCommandMessage(new ExtensionObject<ICommand>(command)));
-
-            var reportedInvocation = await dismissed.Task.WaitAsync(TimeSpan.FromSeconds(10));
-            Assert.IsNotNull(reportedInvocation, "The session must count the invocation before dismissal is queued.");
-            Assert.IsTrue(reportedInvocation.Success);
-            Assert.AreEqual(command.Id, reportedInvocation.CommandId);
-        }
-        finally
-        {
-            WeakReferenceMessenger.Default.UnregisterAll(recipient);
-            WeakReferenceMessenger.Default.UnregisterAll(viewModel);
-        }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

This PR updates handling of messages registered received by MainWindow to consistently handle marshaling to UI thread.

- Adds `RunOnUiThread` for MainWindow UI handlers and session-counter updates: if invoked on UI thread, executes action synchronously, otherwise queues it on the dispatcher thread.
- Some handlers still enqueue even when called on the UI thread.
- Changes to telemetry are to preserve ordering and behavior. Changes to queuing in this PR breaks that and without update the telemetry counter would be off.
- Paste commands hide the window before returning, that closes the session and telemetry would count that action after - so TelemetryCommandStartedMessage is born.

- Use RunOnUiThread (inline on UI, queued otherwise):
  - ShowWindowMessage
  - ShowPaletteAtMessage
  - HideWindowMessage
  - DismissMessage
  - NavigateToPageMessage
  - NavigationDepthMessage
  - SearchQueryMessage
  - ErrorOccurredMessage
  - ToggleDevRibbonMessage
  - DragStartedMessage
  - DragCompletedMessage
- Remain always queued, with explanatory comments:
  - QuitMessage (closing inline could exit the process while the window procedure or messenger broadcast is still running)
  - ExpandCompactModeMessage (preserves ordering with ShellPage’s queued compact-state reconciliation)
  - MaximizeForDialogMessage (preserves ordering with dialog setup and teardown)
- Keep a synchronous reply:
  - GetHwndMessage: now returns the cached HWND.
- Telemetry changes:
  - TelemetryCommandStartedMessage: new notification; updates the session counter through RunOnUiThread.
  - TelemetryExtensionInvokedMessage: reports invocation outcome before result handling; no longer increments the session counter.
- Forwarding change:
  - GoHomeMessage: its send during forced dismissal now runs through RunOnUiThread.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #50388
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

