### PR TITLE
CmdPal: show file results before loading thumbnails

### DIFF
--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Indexer.UnitTests/IndexerThumbnailTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Indexer.UnitTests/IndexerThumbnailTests.cs
@@ -1,0 +1,522 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CmdPal.Ext.Indexer.Data;
+using Microsoft.CmdPal.Ext.Indexer.Indexer;
+using Microsoft.CmdPal.Ext.Indexer.Properties;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Storage.Streams;
+
+namespace Microsoft.CmdPal.Ext.Indexer.UnitTests;
+
+[TestClass]
+public sealed class IndexerThumbnailTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(15);
+    private static readonly int[] ExpectedPageOffsets = [0, 20];
+
+    [TestMethod]
+    public async Task Search_PublishesTextBeforeDemandedThumbnailCompletes()
+    {
+        using var engine = new TestSearchEngine(25);
+        var started = NewSignal();
+        var release = new TaskCompletionSource<IconInfo?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var requests = 0;
+        using var page = new IndexerPage(
+            () => engine,
+            (_, _) =>
+            {
+                Interlocked.Increment(ref requests);
+                started.TrySetResult();
+                return release.Task;
+            });
+        var itemChanges = 0;
+        page.ItemsChanged += (_, _) => Interlocked.Increment(ref itemChanges);
+
+        try
+        {
+            page.UpdateSearchText(string.Empty, "query");
+            await page.SearchTask.WaitAsync(TestTimeout);
+            var items = page.GetItems();
+
+            Assert.AreEqual(20, items.Length);
+            Assert.AreEqual("File 0", items[0].Title);
+            Assert.AreEqual(engine.Items[0].FilePath, items[0].Subtitle);
+            Assert.AreEqual(0, requests);
+            Assert.IsFalse(page.IsLoading);
+            Assert.IsTrue(page.HasMoreItems);
+            Assert.AreSame(Icons.DocumentIcon, items[0].Icon);
+            Assert.AreSame(Icons.DocumentIcon, items[0].Icon);
+            await started.Task.WaitAsync(TestTimeout);
+            Assert.AreEqual(1, requests);
+            Assert.IsFalse(release.Task.IsCompleted);
+            page.LoadMore();
+            Assert.AreEqual(25, page.GetItems().Length);
+            Assert.AreEqual(1, requests);
+            var changesBeforeThumbnail = itemChanges;
+
+            var changes = new List<string>();
+            items[0].PropChanged += (_, args) => changes.Add(args.PropertyName);
+            var icon = new IconInfo("loaded");
+            release.SetResult(icon);
+            await page.ThumbnailTask.WaitAsync(TestTimeout);
+
+            Assert.AreSame(items[0], page.GetItems()[0]);
+            Assert.AreSame(icon, items[0].Icon);
+            CollectionAssert.AreEqual(new[] { nameof(IListItem.Icon) }, changes);
+            Assert.AreEqual(changesBeforeThumbnail, itemChanges);
+        }
+        finally
+        {
+            release.TrySetResult(null);
+            await page.ThumbnailTask.WaitAsync(TestTimeout);
+        }
+    }
+
+    [TestMethod]
+    public async Task LoadMore_PreservesOrderNoticeAndExistingItemsWithoutRequestingIcons()
+    {
+        using var engine = new TestSearchEngine(25)
+        {
+            Notice = new SearchNoticeInfo("Indexing", "Please wait"),
+        };
+        var requests = 0;
+        using var page = new IndexerPage(
+            () => engine,
+            (_, _) =>
+            {
+                Interlocked.Increment(ref requests);
+                return Task.FromResult<IconInfo?>(null);
+            });
+        page.UpdateSearchText(string.Empty, "query");
+        await page.SearchTask.WaitAsync(TestTimeout);
+        var firstPage = page.GetItems();
+
+        page.LoadMore();
+        var items = page.GetItems();
+        page.LoadMore();
+
+        Assert.AreEqual(26, items.Length);
+        Assert.AreEqual("Indexing", items[0].Title);
+        Assert.AreSame(firstPage[0], items[0]);
+        Assert.AreSame(firstPage[1], items[1]);
+        CollectionAssert.AreEqual(engine.Items.Select(item => item.Title).ToArray(), items.Skip(1).Select(item => item.Title).ToArray());
+        CollectionAssert.AreEqual(ExpectedPageOffsets, engine.Offsets);
+        Assert.AreEqual(0, requests);
+        Assert.IsFalse(page.HasMoreItems);
+        Assert.IsFalse(page.IsLoading);
+    }
+
+    [TestMethod]
+    public async Task NewQuery_DoesNotApplyOldThumbnailOrRequestUndemandedIcons()
+    {
+        using var firstEngine = new TestSearchEngine(2);
+        using var secondEngine = new TestSearchEngine(1);
+        var engines = new Queue<IIndexerSearchEngine>([firstEngine, secondEngine]);
+        var started = NewSignal();
+        var release = new TaskCompletionSource<IconInfo?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var requests = 0;
+        using var page = new IndexerPage(
+            () => engines.Dequeue(),
+            (_, _) =>
+            {
+                if (Interlocked.Increment(ref requests) > 1)
+                {
+                    return Task.FromResult<IconInfo?>(new IconInfo("current"));
+                }
+
+                started.TrySetResult();
+                return release.Task;
+            });
+
+        try
+        {
+            page.UpdateSearchText(string.Empty, "first");
+            await page.SearchTask.WaitAsync(TestTimeout);
+            var oldItem = page.GetItems()[0];
+            _ = oldItem.Icon;
+            await started.Task.WaitAsync(TestTimeout);
+
+            page.UpdateSearchText("first", "second");
+            await page.SearchTask.WaitAsync(TestTimeout);
+            var newItem = page.GetItems()[0];
+            release.SetResult(new IconInfo("obsolete"));
+            await page.ThumbnailTask.WaitAsync(TestTimeout);
+
+            Assert.AreSame(Icons.DocumentIcon, oldItem.Icon);
+            Assert.AreSame(secondEngine.Items[0], newItem);
+            Assert.AreNotSame(oldItem, newItem);
+            Assert.IsTrue(firstEngine.Disposed);
+            _ = firstEngine.Items[1].Icon;
+            Assert.AreEqual(1, requests);
+            _ = newItem.Icon;
+            await page.ThumbnailTask.WaitAsync(TestTimeout);
+            Assert.AreEqual("current", newItem.Icon?.Light?.Icon);
+        }
+        finally
+        {
+            release.TrySetResult(null);
+            await page.ThumbnailTask.WaitAsync(TestTimeout);
+        }
+    }
+
+    [TestMethod]
+    public async Task NewQuery_DiscardsInFlightRowsBeforePublishingTheNextGeneration()
+    {
+        var started = NewSignal();
+        using var release = new ManualResetEventSlim();
+        using var firstEngine = new TestSearchEngine(20)
+        {
+            BeforeFetch = _ =>
+            {
+                started.TrySetResult();
+                if (!release.Wait(TestTimeout))
+                {
+                    throw new TimeoutException("The test did not release the row fetch.");
+                }
+            },
+        };
+        using var secondEngine = new TestSearchEngine(1);
+        var engines = new Queue<IIndexerSearchEngine>([firstEngine, secondEngine]);
+        using var page = new IndexerPage(() => engines.Dequeue());
+        try
+        {
+            page.UpdateSearchText(string.Empty, "first");
+            var oldSearch = page.SearchTask;
+            await started.Task.WaitAsync(TestTimeout);
+            page.UpdateSearchText("first", "second");
+
+            Assert.IsEmpty(page.GetItems());
+            Assert.IsFalse(firstEngine.Disposed);
+            release.Set();
+            await oldSearch.WaitAsync(TestTimeout);
+            await page.SearchTask.WaitAsync(TestTimeout);
+
+            Assert.AreEqual(1, page.GetItems().Length);
+            Assert.AreSame(secondEngine.Items[0], page.GetItems()[0]);
+            Assert.IsTrue(firstEngine.Disposed);
+            Assert.IsFalse(page.IsLoading);
+        }
+        finally
+        {
+            release.Set();
+            await page.SearchTask.WaitAsync(TestTimeout);
+        }
+    }
+
+    [TestMethod]
+    public async Task LoadMore_FailurePreservesExistingRowsAndSurfacesSearchNotice()
+    {
+        using var engine = new TestSearchEngine(25)
+        {
+            BeforeFetch = offset =>
+            {
+                if (offset > 0)
+                {
+                    throw new IOException("Row fetch failed");
+                }
+            },
+        };
+        using var page = new IndexerPage(() => engine);
+        page.UpdateSearchText(string.Empty, "query");
+        await page.SearchTask.WaitAsync(TestTimeout);
+
+        page.LoadMore();
+
+        Assert.AreEqual(21, page.GetItems().Length);
+        Assert.AreEqual(Resources.Indexer_SearchFailedMessage, page.GetItems()[0].Title);
+        Assert.AreSame(engine.Items[0], page.GetItems()[1]);
+        Assert.IsFalse(page.HasMoreItems);
+        Assert.IsFalse(page.IsLoading);
+    }
+
+    [TestMethod]
+    public async Task EmptyQueryAndDispose_CancelDemandAndReleaseTheSearchEngine()
+    {
+        using var engine = new TestSearchEngine(25);
+        var requests = 0;
+        using var page = new IndexerPage(
+            () => engine,
+            (_, _) =>
+            {
+                Interlocked.Increment(ref requests);
+                return Task.FromResult<IconInfo?>(null);
+            });
+        page.UpdateSearchText(string.Empty, "query");
+        await page.SearchTask.WaitAsync(TestTimeout);
+        var oldItem = page.GetItems()[0];
+
+        page.UpdateSearchText("query", string.Empty);
+        await page.SearchTask.WaitAsync(TestTimeout);
+        _ = oldItem.Icon;
+        page.Dispose();
+        page.LoadMore();
+        page.UpdateSearchText(string.Empty, "ignored");
+
+        Assert.IsEmpty(page.GetItems());
+        Assert.IsTrue(engine.Disposed);
+        Assert.IsFalse(page.HasMoreItems);
+        Assert.IsFalse(page.IsLoading);
+        Assert.AreEqual(0, requests);
+        Assert.IsTrue(page.ThumbnailTask.IsCompletedSuccessfully);
+    }
+
+    [TestMethod]
+    public async Task Request_BoundsConcurrencyAcrossCanceledGenerationsAndDropsPendingWork()
+    {
+        var gate = new Lock();
+        using var oldQuery = new CancellationTokenSource();
+        using var newQuery = new CancellationTokenSource();
+        var started = NewSignal();
+        var release = NewSignal();
+        var paths = new ConcurrentQueue<string>();
+        var active = 0;
+        var peak = 0;
+        using var loader = new IndexerThumbnailLoader(
+            gate,
+            async (path, _) =>
+            {
+                var count = Interlocked.Increment(ref active);
+                UpdateMaximum(ref peak, count);
+                paths.Enqueue(path);
+                if (count == IndexerThumbnailLoader.MaxConcurrency)
+                {
+                    started.TrySetResult();
+                }
+
+                await release.Task;
+                Interlocked.Decrement(ref active);
+                return new IconInfo("loaded");
+            });
+        var oldItems = Enumerable.Range(0, 20).Select(CreateItem).ToArray();
+        var current = CreateItem(99);
+
+        try
+        {
+            foreach (var item in oldItems)
+            {
+                loader.Request(item, oldQuery.Token);
+            }
+
+            await started.Task.WaitAsync(TestTimeout);
+            lock (gate)
+            {
+                oldQuery.Cancel();
+                loader.ClearPending();
+                loader.Request(current, newQuery.Token);
+            }
+
+            Assert.AreEqual(IndexerThumbnailLoader.MaxConcurrency, paths.Count);
+            release.SetResult();
+            await loader.Completion.WaitAsync(TestTimeout);
+
+            Assert.AreEqual(IndexerThumbnailLoader.MaxConcurrency, peak);
+            Assert.AreEqual(IndexerThumbnailLoader.MaxConcurrency + 1, paths.Count);
+            Assert.AreEqual(current.FilePath, paths.Last());
+            Assert.AreEqual("loaded", current.Icon?.Light?.Icon);
+            foreach (var item in oldItems)
+            {
+                Assert.AreSame(Icons.DocumentIcon, item.Icon);
+            }
+        }
+        finally
+        {
+            release.TrySetResult();
+            await loader.Completion.WaitAsync(TestTimeout);
+        }
+    }
+
+    [TestMethod]
+    public async Task Request_ReportsFailureAndKeepsPlaceholderWhileOtherItemsLoad()
+    {
+        var failure = new IOException("Thumbnail unavailable");
+        var errors = new ConcurrentQueue<Exception>();
+        using var loader = new IndexerThumbnailLoader(
+            new Lock(),
+            (path, _) => path.EndsWith('0')
+                ? Task.FromException<IconInfo?>(failure)
+                : Task.FromResult<IconInfo?>(new IconInfo("loaded")),
+            errors.Enqueue);
+        var failed = CreateItem(0);
+        var success = CreateItem(1);
+        loader.Request(failed, CancellationToken.None);
+        loader.Request(success, CancellationToken.None);
+        await loader.Completion.WaitAsync(TestTimeout);
+
+        Assert.AreSame(Icons.DocumentIcon, failed.Icon);
+        Assert.AreEqual("loaded", success.Icon?.Light?.Icon);
+        Assert.AreEqual(1, errors.Count);
+        Assert.AreSame(failure, errors.Single());
+    }
+
+    [TestMethod]
+    public async Task Dispose_DrainsRunningWorkWithoutApplyingItOrStartingPendingWork()
+    {
+        var started = NewSignal();
+        var release = NewSignal();
+        var calls = 0;
+        using var loader = new IndexerThumbnailLoader(
+            new Lock(),
+            async (_, _) =>
+            {
+                if (Interlocked.Increment(ref calls) == IndexerThumbnailLoader.MaxConcurrency)
+                {
+                    started.SetResult();
+                }
+
+                await release.Task;
+                return new IconInfo("obsolete");
+            });
+        var items = Enumerable.Range(0, 20).Select(CreateItem).ToArray();
+        try
+        {
+            foreach (var item in items)
+            {
+                loader.Request(item, CancellationToken.None);
+            }
+
+            await started.Task.WaitAsync(TestTimeout);
+            loader.Dispose();
+            loader.Request(CreateItem(99), CancellationToken.None);
+            release.SetResult();
+            await loader.Completion.WaitAsync(TestTimeout);
+
+            Assert.AreEqual(IndexerThumbnailLoader.MaxConcurrency, calls);
+            foreach (var item in items)
+            {
+                Assert.AreSame(Icons.DocumentIcon, item.Icon);
+            }
+        }
+        finally
+        {
+            release.TrySetResult();
+            await loader.Completion.WaitAsync(TestTimeout);
+        }
+    }
+
+    [TestMethod]
+    public async Task LoadThumbnail_CancellationDisposesReturnedStream()
+    {
+        using var source = new MemoryStream([1, 2, 3]);
+        using var cancellation = new CancellationTokenSource();
+        var release = new TaskCompletionSource<IRandomAccessStream?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var load = IndexerThumbnailLoader.LoadThumbnailAsync(() => release.Task, cancellation.Token);
+
+        cancellation.Cancel();
+        release.SetResult(source.AsRandomAccessStream());
+        await Assert.ThrowsExactlyAsync<OperationCanceledException>(() => load.WaitAsync(TestTimeout));
+
+        Assert.IsFalse(source.CanRead);
+    }
+
+    [TestMethod]
+    public async Task LoadThumbnail_CanceledQueryDoesNotAcquireStream()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsExactlyAsync<OperationCanceledException>(
+            () => IndexerThumbnailLoader.LoadThumbnailAsync(
+                () => throw new AssertFailedException("Canceled work acquired a stream."),
+                cancellation.Token));
+    }
+
+    [TestMethod]
+    public async Task LoadThumbnail_MissingThumbnailPreservesTheDefaultIcon()
+    {
+        using var loader = new IndexerThumbnailLoader(new Lock(), (_, _) => Task.FromResult<IconInfo?>(null));
+        var item = CreateItem(0);
+        loader.Request(item, CancellationToken.None);
+        await loader.Completion.WaitAsync(TestTimeout);
+
+        Assert.AreSame(Icons.DocumentIcon, item.Icon);
+    }
+
+    [TestMethod]
+    public async Task CreateIcon_HostCanReadAfterSourceIsDisposedAndReopenAfterReadIsClosed()
+    {
+        IconInfo icon;
+        using (var source = new InMemoryRandomAccessStream())
+        {
+            using var writer = new DataWriter(source);
+            writer.WriteBytes([1, 2, 3]);
+            await writer.StoreAsync();
+            icon = IndexerThumbnailLoader.CreateIcon(source);
+        }
+
+        for (var index = 0; index < 2; index++)
+        {
+            using var read = await icon.Light.Data!.OpenReadAsync();
+            using var reader = new DataReader(read);
+            Assert.AreEqual(3u, await reader.LoadAsync(3));
+            var bytes = new byte[3];
+            reader.ReadBytes(bytes);
+            CollectionAssert.AreEqual(new byte[] { 1, 2, 3 }, bytes);
+        }
+    }
+
+    private static TaskCompletionSource NewSignal() => new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private static IndexerListItem CreateItem(int index) => new(new IndexerItem
+    {
+        FileName = $"File {index}",
+        FullPath = $@"C:\CmdPalThumbnailTests\missing-{index}",
+    })
+    {
+        Icon = Icons.DocumentIcon,
+    };
+
+    private static void UpdateMaximum(ref int location, int value)
+    {
+        var observed = Volatile.Read(ref location);
+        while (value > observed)
+        {
+            var previous = Interlocked.CompareExchange(ref location, value, observed);
+            if (previous == observed)
+            {
+                return;
+            }
+
+            observed = previous;
+        }
+    }
+
+    private sealed class TestSearchEngine(int count) : IIndexerSearchEngine
+    {
+        internal IndexerListItem[] Items { get; } = Enumerable.Range(0, count).Select(CreateItem).ToArray();
+
+        internal List<int> Offsets { get; } = [];
+
+        internal SearchNoticeInfo? Notice { get; init; }
+
+        internal Action<int>? BeforeFetch { get; init; }
+
+        internal bool Disposed { get; private set; }
+
+        public SearchNoticeInfo? Query(string query, uint queryCookie) => Notice;
+
+        public IList<IListItem> FetchItems(int offset, int limit, uint queryCookie, out bool hasMore, out SearchNoticeInfo? notice, CancellationToken cancellationToken = default)
+        {
+            ObjectDisposedException.ThrowIf(Disposed, this);
+            BeforeFetch?.Invoke(offset);
+            Offsets.Add(offset);
+            hasMore = offset + limit < Items.Length;
+            notice = Notice;
+            return Items.Skip(offset).Take(limit).Cast<IListItem>().ToArray();
+        }
+
+        public void Dispose() => Disposed = true;
+    }
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/Data/IndexerListItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/Data/IndexerListItem.cs
@@ -2,14 +2,17 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using Microsoft.CmdPal.Common.Commands;
 using Microsoft.CmdPal.Ext.Indexer.Commands;
 using Microsoft.CmdPal.Ext.Indexer.Helpers;
 using Microsoft.CmdPal.Ext.Indexer.Pages;
 using Microsoft.CmdPal.Ext.Indexer.Properties;
+using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using Windows.Foundation.Metadata;
 using FileAttributes = System.IO.FileAttributes;
@@ -20,6 +23,8 @@ internal sealed partial class IndexerListItem : ListItem
 {
     internal static readonly bool IsActionsFeatureEnabled = GetFeatureFlag();
 
+    private Action<IndexerListItem> _requestThumbnail;
+
     private static bool GetFeatureFlag()
     {
         var env = System.Environment.GetEnvironmentVariable("CMDPAL_ENABLE_ACTIONS_LIST");
@@ -28,6 +33,22 @@ internal sealed partial class IndexerListItem : ListItem
     }
 
     internal string FilePath { get; private set; }
+
+    public override IIconInfo Icon
+    {
+        get
+        {
+            Interlocked.Exchange(ref _requestThumbnail, null)?.Invoke(this);
+            return base.Icon;
+        }
+
+        set => base.Icon = value;
+    }
+
+    internal void LoadThumbnailOnDemand(Action<IndexerListItem> requestThumbnail)
+    {
+        _requestThumbnail = requestThumbnail;
+    }
 
     public IndexerListItem(
         IndexerItem indexerItem,

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/FallbackOpenFileItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/FallbackOpenFileItem.cs
@@ -120,7 +120,7 @@ internal sealed partial class FallbackOpenFileItem : FallbackCommandItem, IDispo
             ct.ThrowIfCancellationRequested();
 
             // We only need to know whether there are 0, 1, or more than one result
-            var results = searchEngine.FetchItems(0, 2, queryCookie: HardQueryCookie, out _, out var notice, noIcons: true);
+            var results = searchEngine.FetchItems(0, 2, queryCookie: HardQueryCookie, out _, out var notice, ct);
             var count = results.Count;
 
             if (count == 0)

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/IIndexerSearchEngine.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/IIndexerSearchEngine.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.CmdPal.Ext.Indexer.Indexer;
+using Microsoft.CommandPalette.Extensions;
+
+namespace Microsoft.CmdPal.Ext.Indexer;
+
+internal interface IIndexerSearchEngine : IDisposable
+{
+    SearchNoticeInfo? Query(string query, uint queryCookie);
+
+    IList<IListItem> FetchItems(int offset, int limit, uint queryCookie, out bool hasMore, out SearchNoticeInfo? notice, CancellationToken cancellationToken = default);
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/IndexerThumbnailLoader.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/IndexerThumbnailLoader.cs
@@ -1,0 +1,164 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ManagedCommon;
+using Microsoft.CmdPal.Ext.Indexer.Data;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Windows.Storage.Streams;
+
+namespace Microsoft.CmdPal.Ext.Indexer;
+
+internal sealed partial class IndexerThumbnailLoader : IDisposable
+{
+    internal const int MaxConcurrency = 4;
+
+    private readonly Lock _gate;
+    private readonly Func<string, CancellationToken, Task<IconInfo?>> _loadThumbnail;
+    private readonly Action<Exception> _reportError;
+    private readonly Queue<(IndexerListItem Item, CancellationToken Token)> _pending = new();
+    private TaskCompletionSource _idle = CompletedSource();
+    private int _workers;
+    private bool _disposed;
+
+    internal IndexerThumbnailLoader(
+        Lock gate,
+        Func<string, CancellationToken, Task<IconInfo?>>? loadThumbnail = null,
+        Action<Exception>? reportError = null)
+    {
+        _gate = gate;
+        _loadThumbnail = loadThumbnail ?? LoadThumbnailAsync;
+        _reportError = reportError ?? (ex => Logger.LogError("Failed to get the icon.", ex));
+    }
+
+    internal Task Completion
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _idle.Task;
+            }
+        }
+    }
+
+    internal void Request(IndexerListItem item, CancellationToken token)
+    {
+        lock (_gate)
+        {
+            if (_disposed || token.IsCancellationRequested)
+            {
+                return;
+            }
+
+            _pending.Enqueue((item, token));
+            if (_workers < MaxConcurrency)
+            {
+                if (_workers++ == 0)
+                {
+                    _idle = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                }
+
+                _ = Task.Run(ProcessQueueAsync, CancellationToken.None);
+            }
+        }
+    }
+
+    internal void ClearPending()
+    {
+        lock (_gate)
+        {
+            _pending.Clear();
+        }
+    }
+
+    private async Task ProcessQueueAsync()
+    {
+        while (true)
+        {
+            (IndexerListItem Item, CancellationToken Token) request;
+            lock (_gate)
+            {
+                if (_disposed || !_pending.TryDequeue(out request))
+                {
+                    if (--_workers == 0)
+                    {
+                        _idle.TrySetResult();
+                    }
+
+                    return;
+                }
+            }
+
+            try
+            {
+                request.Token.ThrowIfCancellationRequested();
+                var icon = await _loadThumbnail(request.Item.FilePath, request.Token).ConfigureAwait(false);
+                lock (_gate)
+                {
+                    if (!_disposed && !request.Token.IsCancellationRequested && icon is not null)
+                    {
+                        request.Item.Icon = icon;
+                    }
+                }
+            }
+            catch (OperationCanceledException) when (request.Token.IsCancellationRequested)
+            {
+            }
+            catch (Exception ex)
+            {
+                _reportError(ex);
+            }
+        }
+    }
+
+    private static Task<IconInfo?> LoadThumbnailAsync(string path, CancellationToken token)
+    {
+        return LoadThumbnailAsync(() => ThumbnailHelper.GetThumbnail(path), token);
+    }
+
+    internal static async Task<IconInfo?> LoadThumbnailAsync(Func<Task<IRandomAccessStream?>> getThumbnail, CancellationToken token)
+    {
+        token.ThrowIfCancellationRequested();
+        using var stream = await getThumbnail().ConfigureAwait(false);
+        token.ThrowIfCancellationRequested();
+        return stream is null ? null : CreateIcon(stream);
+    }
+
+    internal static IconInfo CreateIcon(IRandomAccessStream stream)
+    {
+        // The reference retains its own clone so closing the source cannot interrupt a host read.
+        var clone = stream.CloneStream();
+        try
+        {
+            return IconInfo.FromStream(clone);
+        }
+        catch
+        {
+            clone.Dispose();
+            throw;
+        }
+    }
+
+    private static TaskCompletionSource CompletedSource()
+    {
+        var source = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        source.SetResult();
+        return source;
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            _disposed = true;
+            _pending.Clear();
+        }
+    }
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/Pages/IndexerPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/Pages/IndexerPage.cs
@@ -10,7 +10,9 @@ using System.Globalization;
 using System.Text.Encodings.Web;
 using System.Threading;
 using System.Threading.Tasks;
+using ManagedCommon;
 using Microsoft.CmdPal.Common;
+using Microsoft.CmdPal.Ext.Indexer.Data;
 using Microsoft.CmdPal.Ext.Indexer.Indexer;
 using Microsoft.CmdPal.Ext.Indexer.Properties;
 using Microsoft.CommandPalette.Extensions;
@@ -26,8 +28,11 @@ internal sealed partial class IndexerPage : DynamicListPage, IDisposable
 
     private readonly List<IListItem> _indexerListItems = [];
     private readonly Lock _searchLock = new();
+    private readonly Lock _queryLock = new();
+    private readonly Func<IIndexerSearchEngine> _createSearchEngine;
+    private readonly IndexerThumbnailLoader _thumbnails;
 
-    private SearchEngine? _searchEngine;
+    private IIndexerSearchEngine? _searchEngine;
 
     private CancellationTokenSource? _searchCts;
     private string _initialQuery = string.Empty;
@@ -40,17 +45,29 @@ internal sealed partial class IndexerPage : DynamicListPage, IDisposable
     private SearchNoticeInfo? _currentNotice;
 
     private bool _deferredLoad;
+    private bool _disposed;
+
+    internal Task SearchTask { get; private set; } = Task.CompletedTask;
+
+    internal Task ThumbnailTask => _thumbnails.Completion;
 
     public override ICommandItem EmptyContent => _isEmptyQuery ? _noSearchEmptyContent! : _currentNotice is null ? _nothingFoundEmptyContent! : _noticeEmptyContent!;
 
     public IndexerPage()
+        : this(() => new SearchEngine())
     {
         Id = BuiltInCommandIds.FileSearch;
+        PlaceholderText = Resources.Indexer_PlaceholderText;
+    }
+
+    internal IndexerPage(
+        Func<IIndexerSearchEngine> createSearchEngine,
+        Func<string, CancellationToken, Task<IconInfo?>>? loadThumbnail = null)
+    {
+        _createSearchEngine = createSearchEngine;
+        _thumbnails = new(_searchLock, loadThumbnail);
         Icon = Icons.FileExplorerIcon;
         Name = Resources.Indexer_Title;
-        PlaceholderText = Resources.Indexer_PlaceholderText;
-
-        _searchEngine = new();
 
         var filters = new SearchFilters();
         filters.PropChanged += Filters_PropChanged;
@@ -60,20 +77,10 @@ internal sealed partial class IndexerPage : DynamicListPage, IDisposable
     }
 
     public IndexerPage(string query)
+        : this(() => new SearchEngine())
     {
-        Icon = Icons.FileExplorerIcon;
-        Name = Resources.Indexer_Title;
-
-        _searchEngine = new();
-
         _initialQuery = query;
         SearchText = query;
-
-        var filters = new SearchFilters();
-        filters.PropChanged += Filters_PropChanged;
-        Filters = filters;
-
-        CreateEmptyContent();
         IsLoading = true;
         _deferredLoad = true;
     }
@@ -138,15 +145,18 @@ internal sealed partial class IndexerPage : DynamicListPage, IDisposable
 
     public override IListItem[] GetItems()
     {
-        if (_deferredLoad)
+        lock (_searchLock)
         {
-            PerformSearch(_initialQuery);
-            _deferredLoad = false;
-        }
+            if (_deferredLoad && !_disposed)
+            {
+                _deferredLoad = false;
+                PerformSearch(_initialQuery);
+            }
 
-        return _currentNotice is null
-            ? [.. _indexerListItems]
-            : [_noticeListItem!, .. _indexerListItems];
+            return _currentNotice is null
+                ? [.. _indexerListItems]
+                : [_noticeListItem!, .. _indexerListItems];
+        }
     }
 
     private string FullSearchString(string query)
@@ -165,143 +175,190 @@ internal sealed partial class IndexerPage : DynamicListPage, IDisposable
 
     public override void LoadMore()
     {
-        var ct = Volatile.Read(ref _searchCts)?.Token;
-
-        IsLoading = true;
-
-        var hasMore = false;
-        SearchEngine? searchEngine;
-        int offset;
-
+        CancellationToken ct;
         lock (_searchLock)
         {
-            searchEngine = _searchEngine;
-            offset = _indexerListItems.Count;
-        }
-
-        SearchNoticeInfo? notice = null;
-        var results = searchEngine?.FetchItems(offset, 20, queryCookie: HardQueryCookie, out hasMore, out notice) ?? [];
-
-        if (ct?.IsCancellationRequested == true)
-        {
-            IsLoading = false;
-            return;
-        }
-
-        lock (_searchLock)
-        {
-            if (ct?.IsCancellationRequested == true)
+            if (_disposed || _searchCts is null || !HasMoreItems)
             {
-                IsLoading = false;
                 return;
             }
 
-            ApplyNotice(notice);
-            _indexerListItems.AddRange(results);
-            HasMoreItems = hasMore;
-            IsLoading = false;
-            RaiseItemsChanged(GetVisibleItemCount());
+            ct = _searchCts.Token;
         }
+
+        LoadMore(ct);
     }
 
-    private void Query(string query)
+    private void LoadMore(CancellationToken ct)
     {
-        lock (_searchLock)
+        try
         {
-            _indexerListItems.Clear();
-            var notice = _searchEngine?.Query(query, queryCookie: HardQueryCookie);
-            ApplyNotice(notice);
+            lock (_queryLock)
+            {
+                IIndexerSearchEngine? searchEngine;
+                int offset;
+                lock (_searchLock)
+                {
+                    if (_disposed || ct.IsCancellationRequested || !HasMoreItems)
+                    {
+                        return;
+                    }
+
+                    searchEngine = _searchEngine;
+                    offset = _indexerListItems.Count;
+                    IsLoading = true;
+                }
+
+                if (searchEngine is null)
+                {
+                    return;
+                }
+
+                var results = searchEngine.FetchItems(offset, 20, HardQueryCookie, out var hasMore, out var notice, ct);
+
+                lock (_searchLock)
+                {
+                    if (_disposed || ct.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
+                    // Icon reads are our demand signal; extensions do not receive viewport visibility.
+                    foreach (var result in results)
+                    {
+                        if (result is IndexerListItem item)
+                        {
+                            var thumbnails = _thumbnails;
+                            item.LoadThumbnailOnDemand(resultItem => thumbnails.Request(resultItem, ct));
+                        }
+                    }
+
+                    ApplyNotice(notice);
+                    _indexerListItems.AddRange(results);
+                    HasMoreItems = hasMore;
+                    IsLoading = false;
+                    RaiseItemsChanged(GetVisibleItemCount());
+                }
+            }
         }
-    }
-
-    private void ReplaceSearchEngine(SearchEngine newSearchEngine)
-    {
-        SearchEngine? oldEngine;
-
-        lock (_searchLock)
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
-            oldEngine = _searchEngine;
-            _searchEngine = newSearchEngine;
         }
-
-        oldEngine?.Dispose();
+        catch (Exception ex)
+        {
+            ReportSearchFailure(ex, ct);
+        }
     }
 
     private void PerformSearch(string newSearch)
     {
         var actualSearch = FullSearchString(newSearch);
 
-        var newCts = new CancellationTokenSource();
-        var oldCts = Interlocked.Exchange(ref _searchCts, newCts);
-        oldCts?.Cancel();
-        oldCts?.Dispose();
+        lock (_searchLock)
+        {
+            if (_disposed)
+            {
+                return;
+            }
 
-        var ct = newCts.Token;
+            _searchCts?.Cancel();
+            _searchCts?.Dispose();
+            _searchCts = new();
+            var ct = _searchCts.Token;
+            _thumbnails.ClearPending();
+            _indexerListItems.Clear();
+            ApplyNotice(null);
+            _isEmptyQuery = string.IsNullOrWhiteSpace(newSearch);
+            _initialQuery = _isEmptyQuery ? string.Empty : newSearch;
+            HasMoreItems = false;
+            IsLoading = !_isEmptyQuery;
+            RaiseItemsChanged(0);
+            OnPropertyChanged(nameof(EmptyContent));
+            var isEmptyQuery = _isEmptyQuery;
+            SearchTask = Task.Run(() => RunSearch(actualSearch, isEmptyQuery, ct));
+        }
+    }
 
-        _ = Task.Run(
-            () =>
+    private void RunSearch(string query, bool isEmptyQuery, CancellationToken ct)
+    {
+        try
+        {
+            lock (_queryLock)
             {
                 ct.ThrowIfCancellationRequested();
-
-                lock (_searchLock)
+                _searchEngine?.Dispose();
+                _searchEngine = null;
+                if (isEmptyQuery)
                 {
-                    // If the user hasn't provided any base query text, results should be empty
-                    // regardless of the currently selected filter.
-                    _isEmptyQuery = string.IsNullOrWhiteSpace(newSearch);
-                    ApplyNotice(null);
-
-                    if (_isEmptyQuery)
-                    {
-                        _indexerListItems.Clear();
-                        HasMoreItems = false;
-                        IsLoading = false;
-                        RaiseItemsChanged(0);
-                        OnPropertyChanged(nameof(EmptyContent));
-                        _initialQuery = string.Empty;
-                        return;
-                    }
-
-                    // Track the most recent query we initiated, so UpdateSearchText doesn't
-                    // spuriously suppress a search when SearchText gets set programmatically.
-                    _initialQuery = newSearch;
+                    return;
                 }
 
+                var searchEngine = _createSearchEngine();
+                _searchEngine = searchEngine;
                 ct.ThrowIfCancellationRequested();
-                ReplaceSearchEngine(new SearchEngine());
-
-                ct.ThrowIfCancellationRequested();
-                Query(actualSearch);
-
-                ct.ThrowIfCancellationRequested();
-                LoadMore();
-
-                ct.ThrowIfCancellationRequested();
+                var notice = searchEngine.Query(query, HardQueryCookie);
 
                 lock (_searchLock)
                 {
-                    RaiseItemsChanged(GetVisibleItemCount());
+                    ct.ThrowIfCancellationRequested();
+                    ApplyNotice(notice);
+                    HasMoreItems = true;
+                }
+
+                LoadMore(ct);
+                ct.ThrowIfCancellationRequested();
+                lock (_searchLock)
+                {
+                    ct.ThrowIfCancellationRequested();
                     OnPropertyChanged(nameof(EmptyContent));
                 }
-            },
-            ct);
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            ReportSearchFailure(ex, ct);
+        }
+    }
+
+    private void ReportSearchFailure(Exception exception, CancellationToken ct)
+    {
+        Logger.LogError("Failed to search for files.", exception);
+        lock (_searchLock)
+        {
+            if (!ct.IsCancellationRequested)
+            {
+                ApplyNotice(new(Resources.Indexer_SearchFailedMessage!, Resources.Indexer_SearchFailedMessageTip!));
+                HasMoreItems = false;
+                IsLoading = false;
+                RaiseItemsChanged(GetVisibleItemCount());
+                OnPropertyChanged(nameof(EmptyContent));
+            }
+        }
     }
 
     public void Dispose()
     {
-        var cts = Interlocked.Exchange(ref _searchCts, null);
-        cts?.Cancel();
-        cts?.Dispose();
-
-        SearchEngine? searchEngine;
-
         lock (_searchLock)
         {
-            searchEngine = _searchEngine;
-            _searchEngine = null;
+            _disposed = true;
+            _searchCts?.Cancel();
+            _searchCts?.Dispose();
+            _searchCts = null;
+            _thumbnails.Dispose();
             _indexerListItems.Clear();
+            ApplyNotice(null);
+            HasMoreItems = false;
+            IsLoading = false;
         }
 
-        searchEngine?.Dispose();
+        lock (_queryLock)
+        {
+            _searchEngine?.Dispose();
+            _searchEngine = null;
+        }
 
         GC.SuppressFinalize(this);
     }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/SearchEngine.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/SearchEngine.cs
@@ -7,16 +7,15 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 using ManagedCommon;
 using Microsoft.CmdPal.Ext.Indexer.Data;
 using Microsoft.CmdPal.Ext.Indexer.Indexer;
 using Microsoft.CommandPalette.Extensions;
-using Microsoft.CommandPalette.Extensions.Toolkit;
-using Windows.Storage.Streams;
 
 namespace Microsoft.CmdPal.Ext.Indexer;
 
-public sealed partial class SearchEngine : IDisposable
+public sealed partial class SearchEngine : IIndexerSearchEngine
 {
     private SearchQuery? _searchQuery = new();
 
@@ -47,7 +46,7 @@ public sealed partial class SearchEngine : IDisposable
         return BuildNotice(searchQuery);
     }
 
-    public IList<IListItem> FetchItems(int offset, int limit, uint queryCookie, out bool hasMore, out SearchNoticeInfo? notice, bool noIcons = false)
+    public IList<IListItem> FetchItems(int offset, int limit, uint queryCookie, out bool hasMore, out SearchNoticeInfo? notice, CancellationToken cancellationToken = default)
     {
         hasMore = false;
         notice = null;
@@ -66,36 +65,22 @@ public sealed partial class SearchEngine : IDisposable
 
         var results = new List<IListItem>();
         var index = 0;
+        cancellationToken.ThrowIfCancellationRequested();
         var hasMoreItems = searchQuery.FetchRows(offset, limit);
+        cancellationToken.ThrowIfCancellationRequested();
         notice = BuildNotice(searchQuery);
 
-        while (!searchQuery.SearchResults.IsEmpty && searchQuery.SearchResults.TryDequeue(out var result) && ++index <= limit)
+        while (index++ < limit && searchQuery.SearchResults.TryDequeue(out var result))
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var indexerListItem = new IndexerListItem(new IndexerItem
             {
                 FileName = result.ItemDisplayName,
                 FullPath = result.LaunchUri,
-            });
-
-            if (!noIcons)
+            })
             {
-                IconInfo? icon = null;
-                try
-                {
-                    var stream = ThumbnailHelper.GetThumbnail(result.LaunchUri).Result;
-                    if (stream is not null)
-                    {
-                        var data = new IconData(RandomAccessStreamReference.CreateFromStream(stream));
-                        icon = new IconInfo(data, data);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogError("Failed to get the icon.", ex);
-                }
-
-                indexerListItem.Icon = icon;
-            }
+                Icon = Icons.DocumentIcon,
+            };
 
             results.Add(indexerListItem);
         }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

File search waited for thumbnails before showing results. Results now appear with placeholders, and each page limits thumbnail loading to four workers across query generations.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: N/A (no linked issue)
- [x] **Communication:** Implementation approved for this task
- [x] **Tests:** Added 13 regression tests; all 48 Indexer tests pass
- [x] **Localization:** No new UI strings
- [ ] **Dev docs:** N/A
- [ ] **New binaries:** N/A
- [ ] **Documentation updated:** N/A

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Thumbnail requests follow existing icon access, not true viewport visibility; native calls already in progress can finish, but canceled queries cannot publish rows or icons. Published icons retain independent stream clones so closing the source cannot interrupt a host read, without changing extension contracts.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- CmdPal x64 Debug build completed with exit code 0 after the prescribed essentials restore.
- Ran all 19 CmdPal unit projects with `dotnet test -p:Platform=x64 -c Debug --no-build`: 18 runnable projects succeeded, with 2,807 passed and 2 existing skips (a flaky Shell test and unsupported emoji matching).
- WindowWalker exited nonzero with zero tests; its project explicitly contains shared helpers only and no test methods.
- UI tests were not run because they are opt-in; no XAML changed.