### PR TITLE
CmdPal: filter static pages in the background

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/Helpers/SupersedingAsyncGate.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/Helpers/SupersedingAsyncGate.cs
@@ -12,16 +12,26 @@ namespace Microsoft.CmdPal.Common.Helpers;
 public sealed partial class SupersedingAsyncGate : IDisposable
 {
     private readonly Func<CancellationToken, Task> _action;
+    private readonly TaskFactory _taskFactory;
     private readonly Lock _lock = new();
     private int _callId;
     private TaskCompletionSource<bool>? _currentTcs;
+    private CancellationToken _currentExternalCancellationToken;
     private CancellationTokenSource? _currentCancellationSource;
-    private Task? _executingTask;
+    private bool _isExecuting;
+    private bool _isDisposed;
 
     public SupersedingAsyncGate(Func<CancellationToken, Task> action)
+        : this(action, TaskScheduler.Default)
+    {
+    }
+
+    public SupersedingAsyncGate(Func<CancellationToken, Task> action, TaskScheduler scheduler)
     {
         ArgumentNullException.ThrowIfNull(action);
+        ArgumentNullException.ThrowIfNull(scheduler);
         _action = action;
+        _taskFactory = new(CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskContinuationOptions.None, scheduler);
     }
 
     /// <summary>
@@ -35,72 +45,86 @@ public sealed partial class SupersedingAsyncGate : IDisposable
 
         lock (_lock)
         {
-            _currentCancellationSource?.Cancel();
-            _currentTcs?.TrySetException(new OperationCanceledException("Superseded by newer call"));
+            ObjectDisposedException.ThrowIf(_isDisposed, this);
+            cancellationToken.ThrowIfCancellationRequested();
 
-            tcs = new();
+            var superseded = _currentTcs;
+            tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
             _currentTcs = tcs;
+            _currentExternalCancellationToken = cancellationToken;
             _callId++;
 
-            var shouldStartExecution = _executingTask is null;
-            if (shouldStartExecution)
+            superseded?.TrySetCanceled(CancellationToken.None);
+            _currentCancellationSource?.Cancel();
+
+            if (!_isExecuting && _currentTcs is not null)
             {
-                _executingTask = Task.Run(ExecuteLoop, CancellationToken.None);
+                _isExecuting = true;
+                try
+                {
+                    _ = _taskFactory.StartNew(ExecuteLoop).Unwrap();
+                }
+                catch (TaskSchedulerException)
+                {
+                    _isExecuting = false;
+                    _currentTcs = null;
+                    _currentExternalCancellationToken = default;
+                    throw;
+                }
             }
         }
 
         await using var ctr = cancellationToken.Register(() => tcs.TrySetCanceled(cancellationToken));
-        await tcs.Task;
+        await tcs.Task.ConfigureAwait(false);
     }
 
     private async Task ExecuteLoop()
     {
-        try
+        while (true)
         {
-            while (true)
-            {
-                TaskCompletionSource<bool>? currentTcs;
-                CancellationTokenSource? currentCts;
-                int currentCallId;
+            TaskCompletionSource<bool>? currentTcs;
+            CancellationTokenSource currentCts;
+            int currentCallId;
 
-                lock (_lock)
-                {
-                    currentTcs = _currentTcs;
-                    currentCallId = _callId;
-
-                    if (currentTcs is null)
-                    {
-                        break;
-                    }
-
-                    _currentCancellationSource?.Dispose();
-                    _currentCancellationSource = new();
-                    currentCts = _currentCancellationSource;
-                }
-
-                try
-                {
-                    await _action(currentCts.Token);
-                    CompleteIfCurrent(currentTcs, currentCallId, static t => t.TrySetResult(true));
-                }
-                catch (OperationCanceledException)
-                {
-                    CompleteIfCurrent(currentTcs, currentCallId, tcs => tcs.TrySetCanceled(currentCts.Token));
-                }
-                catch (Exception ex)
-                {
-                    CompleteIfCurrent(currentTcs, currentCallId, tcs => tcs.TrySetException(ex));
-                }
-            }
-        }
-        finally
-        {
             lock (_lock)
             {
-                _currentTcs = null;
-                _currentCancellationSource?.Dispose();
-                _currentCancellationSource = null;
-                _executingTask = null;
+                currentTcs = _currentTcs;
+                currentCallId = _callId;
+
+                if (currentTcs is null)
+                {
+                    // Retire under the request lock so a new call cannot be lost during shutdown.
+                    _isExecuting = false;
+                    _currentExternalCancellationToken = default;
+                    return;
+                }
+
+                currentCts = CancellationTokenSource.CreateLinkedTokenSource(_currentExternalCancellationToken);
+                _currentCancellationSource = currentCts;
+            }
+
+            try
+            {
+                currentCts.Token.ThrowIfCancellationRequested();
+                await _action(currentCts.Token).ConfigureAwait(false);
+                currentCts.Token.ThrowIfCancellationRequested();
+                CompleteIfCurrent(currentTcs, currentCallId, static t => t.TrySetResult(true));
+            }
+            catch (OperationCanceledException)
+            {
+                CompleteIfCurrent(currentTcs, currentCallId, tcs => tcs.TrySetCanceled(currentCts.Token));
+            }
+            catch (Exception ex)
+            {
+                CompleteIfCurrent(currentTcs, currentCallId, tcs => tcs.TrySetException(ex));
+            }
+            finally
+            {
+                lock (_lock)
+                {
+                    _currentCancellationSource = null;
+                    currentCts.Dispose();
+                }
             }
         }
     }
@@ -124,10 +148,11 @@ public sealed partial class SupersedingAsyncGate : IDisposable
     {
         lock (_lock)
         {
+            _isDisposed = true;
             _currentCancellationSource?.Cancel();
-            _currentCancellationSource?.Dispose();
             _currentTcs?.TrySetException(new ObjectDisposedException(nameof(SupersedingAsyncGate)));
             _currentTcs = null;
+            _currentExternalCancellationToken = default;
         }
 
         GC.SuppressFinalize(this);

--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/Helpers/SupersedingAsyncGate.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/Helpers/SupersedingAsyncGate.cs
@@ -123,8 +123,9 @@ public sealed partial class SupersedingAsyncGate : IDisposable
                 lock (_lock)
                 {
                     _currentCancellationSource = null;
-                    currentCts.Dispose();
                 }
+
+                currentCts.Dispose();
             }
         }
     }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using CommunityToolkit.Mvvm.Input;
@@ -25,8 +26,19 @@ public partial class ListViewModel : PageViewModel, IDisposable
     private static readonly IEqualityComparer<IListItem> VmCacheComparer = new ProxyReferenceEqualityComparer();
 
     private readonly TaskFactory filterTaskFactory = new(new ConcurrentExclusiveSchedulerPair().ExclusiveScheduler);
+    private readonly TaskFactory _staticFilterTaskFactory;
 
     private Dictionary<IListItem, ListItemViewModel> _vmCache = new(VmCacheComparer);
+    private Dictionary<ListItemViewModel, StaticFilterItem> _staticFilterItems = new(ReferenceEqualityComparer.Instance);
+    private StaticFilterRequest? _pendingStaticFilter;
+    private CancellationTokenSource? _staticFilterCancellationTokenSource;
+    private long _staticFilterVersion;
+    private int _itemsFetchGeneration;
+    private bool _staticFilterWorkerQueued;
+    private bool _staticFilterForceFirstPending;
+    private bool _staticFilterEnsureSelectionVisible;
+    private string _staticFilterQuery = string.Empty;
+    private volatile bool _isDisposed;
 
     // TODO: Do we want a base "ItemsPageViewModel" for anything that's going to have items?
 
@@ -36,7 +48,7 @@ public partial class ListViewModel : PageViewModel, IDisposable
 
     public FiltersViewModel? Filters { get; set; }
 
-    private ObservableCollection<ListItemViewModel> Items { get; set; } = [];
+    private List<ListItemViewModel> Items { get; } = [];
 
     private readonly ExtensionObject<IListPage> _model;
 
@@ -130,10 +142,16 @@ public partial class ListViewModel : PageViewModel, IDisposable
     }
 
     public ListViewModel(IListPage model, TaskScheduler scheduler, AppExtensionHost host, ICommandProviderContext providerContext, IContextMenuFactory contextMenuFactory)
+        : this(model, scheduler, host, providerContext, contextMenuFactory, TaskScheduler.Default)
+    {
+    }
+
+    internal ListViewModel(IListPage model, TaskScheduler scheduler, AppExtensionHost host, ICommandProviderContext providerContext, IContextMenuFactory contextMenuFactory, TaskScheduler staticFilterScheduler)
         : base(model, scheduler, host, providerContext)
     {
         _model = new(model);
         _contextMenuFactory = contextMenuFactory;
+        _staticFilterTaskFactory = new(staticFilterScheduler);
         EmptyContent = new(new(null), PageContext, contextMenuFactory: null);
     }
 
@@ -162,6 +180,11 @@ public partial class ListViewModel : PageViewModel, IDisposable
 
     protected override void OnSearchTextBoxUpdated(string searchTextBox)
     {
+        if (_isDisposed)
+        {
+            return;
+        }
+
         // Dynamic pages will handler their own filtering. They will tell us if
         // something needs to change, by raising ItemsChanged.
         if (_isDynamic)
@@ -201,15 +224,11 @@ public partial class ListViewModel : PageViewModel, IDisposable
         }
         else
         {
-            // But for all normal pages, we should run our fuzzy match on them.
             lock (_listLock)
             {
-                RunFilteredItemsUpdate(ApplyFilterUnderLock);
+                _staticFilterQuery = searchTextBox;
+                RequestStaticFilterUnderLock(forceFirstItem: true, ensureSelectionVisible: true);
             }
-
-            ItemsUpdated?.Invoke(this, new ItemsUpdatedEventArgs(forceFirstItem: true, ensureSelectionVisible: true));
-            UpdateEmptyContent();
-            _isLoadingMore.Clear();
         }
     }
 
@@ -308,23 +327,34 @@ public partial class ListViewModel : PageViewModel, IDisposable
     {
         System.Diagnostics.Debug.Assert(!IsCurrentThreadUiThread(), "FetchItems should not run on the UI thread.");
 
-        // If this fetch should reset selection, remember that intent even if
-        // a later incremental fetch cancels us.
-        if (!keepSelection)
-        {
-            _forceFirstItemPending = true;
-        }
-
         CancellationToken cancellationToken;
         int fetchGeneration;
         lock (_fetchStateLock)
         {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            if (!keepSelection)
+            {
+                _forceFirstItemPending = true;
+            }
+
             // Cancel any previous FetchItems operation
             CancelAndDisposeTokenSource(ref _fetchItemsCancellationTokenSource);
             _fetchItemsCancellationTokenSource = new CancellationTokenSource();
 
             cancellationToken = _fetchItemsCancellationTokenSource.Token;
             fetchGeneration = Interlocked.Increment(ref _latestFetchGeneration);
+
+            if (!_isDynamic)
+            {
+                lock (_listLock)
+                {
+                    InvalidateStaticFilterUnderLock();
+                }
+            }
         }
 
         // Declared outside try so catch blocks can reference them
@@ -425,15 +455,13 @@ public partial class ListViewModel : PageViewModel, IDisposable
                 item?.SafeInitializeProperties();
             }
 
-            // Cancel any ongoing property initialization for the previous list.
-            CancelAndDisposeTokenSource(ref _cancellationTokenSource);
-
             ThrowIfFetchCanceledOrStale(fetchGeneration, cancellationToken);
 
             List<ListItemViewModel> removedItems;
             lock (_fetchStateLock)
             {
                 ThrowIfFetchCanceledOrStale(fetchGeneration, cancellationToken);
+                CancelAndDisposeTokenSource(ref _cancellationTokenSource);
 
                 lock (_listLock)
                 {
@@ -442,14 +470,20 @@ public partial class ListViewModel : PageViewModel, IDisposable
                     ListHelpers.InPlaceUpdateList(Items, newViewModels, out removedItems);
 
                     PublishVmCache(nextCache);
+                    _itemsFetchGeneration = fetchGeneration;
+                    itemsTransferredToList = true;
+
+                    if (!_isDynamic)
+                    {
+                        UpdateStaticFilterItemsUnderLock(newViewModels);
+                        RequestStaticFilterUnderLock(forceFirstItem: false, ensureSelectionVisible);
+                    }
 
                     // DO NOT ThrowIfCancellationRequested AFTER THIS! If you do,
                     // you'll clean up list items that we've now transferred into
                     // .Items
                 }
             }
-
-            itemsTransferredToList = true;
 
             // If we removed items, we need to clean them up, to remove our event handlers
             foreach (var removedItem in removedItems)
@@ -497,22 +531,31 @@ public partial class ListViewModel : PageViewModel, IDisposable
             }
         }
 
-        var initializeItemsCts = new CancellationTokenSource();
-        _cancellationTokenSource = initializeItemsCts;
-        var initializeItemsToken = initializeItemsCts.Token;
-
-        _initializeItemsTask = new Task(() =>
+        lock (_fetchStateLock)
         {
-            InitializeItemsTask(initializeItemsToken);
-        });
-        _initializeItemsTask.Start();
+            if (_isDisposed || !IsLatestFetchGeneration(fetchGeneration))
+            {
+                return;
+            }
+
+            var initializeItemsCts = new CancellationTokenSource();
+            _cancellationTokenSource = initializeItemsCts;
+            var initializeItemsToken = initializeItemsCts.Token;
+
+            _initializeItemsTask = Task.Run(() => InitializeItemsTask(initializeItemsToken));
+        }
+
+        if (!_isDynamic)
+        {
+            return;
+        }
 
         DoOnUiThread(
             () =>
             {
                 lock (_fetchStateLock)
                 {
-                    if (!IsLatestFetchGeneration(fetchGeneration))
+                    if (_isDisposed || !IsLatestFetchGeneration(fetchGeneration))
                     {
                         return;
                     }
@@ -524,20 +567,8 @@ public partial class ListViewModel : PageViewModel, IDisposable
                             return;
                         }
 
-                        // Now that our Items contains everything we want, it's time for us to
-                        // re-evaluate our Filter on those items.
-                        if (!_isDynamic)
-                        {
-                            // A static list? Great! Just run the filter.
-                            RunFilteredItemsUpdate(ApplyFilterUnderLock);
-                        }
-                        else
-                        {
-                            // A dynamic list? Even better! Just stick everything into
-                            // FilteredItems. The extension already did any filtering it cared about.
-                            var snapshot = Items.Where(i => !i.IsInErrorState).ToList();
-                            RunFilteredItemsUpdate(() => ListHelpers.InPlaceUpdateList(FilteredItems, snapshot));
-                        }
+                        var snapshot = Items.Where(i => !i.IsInErrorState).ToList();
+                        RunFilteredItemsUpdate(() => ListHelpers.InPlaceUpdateList(FilteredItems, snapshot));
 
                         UpdateEmptyContent();
                     }
@@ -583,12 +614,8 @@ public partial class ListViewModel : PageViewModel, IDisposable
                 return;
             }
 
-            // TODO: GH #502
-            // We should probably remove the item from the list if it
-            // entered the error state. I had issues doing that without having
-            // multiple threads muck with `Items` (and possibly FilteredItems!)
-            // at once.
             item.SafeInitializeProperties();
+            RefreshStaticFilterItem(item);
 
             if (ct.IsCancellationRequested)
             {
@@ -597,11 +624,212 @@ public partial class ListViewModel : PageViewModel, IDisposable
         }
     }
 
-    /// <summary>
-    /// Apply our current filter text to the list of items, and update
-    /// FilteredItems to match the results.
-    /// </summary>
-    private void ApplyFilterUnderLock() => ListHelpers.InPlaceUpdateList(FilteredItems, FilterList(Items, SearchTextBox));
+    private void UpdateStaticFilterItemsUnderLock(List<ListItemViewModel> items)
+    {
+        var snapshots = new Dictionary<ListItemViewModel, StaticFilterItem>(items.Count, ReferenceEqualityComparer.Instance);
+        foreach (var item in items)
+        {
+            if (snapshots.ContainsKey(item))
+            {
+                continue;
+            }
+
+            if (!_staticFilterItems.ContainsKey(item))
+            {
+                item.PropertyChangedBackground += StaticFilterItemPropertyChanged;
+            }
+
+            snapshots.Add(item, StaticFilterItem.Capture(item));
+        }
+
+        foreach (var item in _staticFilterItems.Keys)
+        {
+            if (!snapshots.ContainsKey(item))
+            {
+                item.PropertyChangedBackground -= StaticFilterItemPropertyChanged;
+            }
+        }
+
+        _staticFilterItems = snapshots;
+    }
+
+    private void StaticFilterItemPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (sender is ListItemViewModel item &&
+            (string.IsNullOrEmpty(e.PropertyName) ||
+             e.PropertyName is nameof(ListItemViewModel.Title) or nameof(ListItemViewModel.Subtitle) or
+                 nameof(ListItemViewModel.Name) or nameof(ListItemViewModel.IsInErrorState) or nameof(IsInitialized)))
+        {
+            RefreshStaticFilterItem(item);
+        }
+    }
+
+    private void RefreshStaticFilterItem(ListItemViewModel item)
+    {
+        lock (_listLock)
+        {
+            if (_isDisposed || !_staticFilterItems.TryGetValue(item, out var previous))
+            {
+                return;
+            }
+
+            var current = StaticFilterItem.Capture(item);
+            if (current == previous)
+            {
+                return;
+            }
+
+            _staticFilterItems[item] = current;
+            RequestStaticFilterUnderLock(forceFirstItem: false, ensureSelectionVisible: false);
+        }
+    }
+
+    private void InvalidateStaticFilterUnderLock()
+    {
+        _staticFilterVersion++;
+        _pendingStaticFilter = null;
+        CancelAndDisposeTokenSource(ref _staticFilterCancellationTokenSource);
+    }
+
+    private void RequestStaticFilterUnderLock(bool forceFirstItem, bool ensureSelectionVisible)
+    {
+        if (_isDisposed || _isDynamic)
+        {
+            return;
+        }
+
+        _staticFilterForceFirstPending |= forceFirstItem;
+        _staticFilterEnsureSelectionVisible |= ensureSelectionVisible;
+        InvalidateStaticFilterUnderLock();
+
+        if (_itemsFetchGeneration != Volatile.Read(ref _latestFetchGeneration))
+        {
+            return;
+        }
+
+        _staticFilterCancellationTokenSource = new();
+        _pendingStaticFilter = new(
+            _staticFilterVersion,
+            _itemsFetchGeneration,
+            _staticFilterQuery,
+            _staticFilterCancellationTokenSource.Token);
+        if (!_staticFilterWorkerQueued)
+        {
+            _staticFilterWorkerQueued = true;
+            _ = _staticFilterTaskFactory.StartNew(ProcessStaticFilters);
+        }
+    }
+
+    private void ProcessStaticFilters()
+    {
+        while (true)
+        {
+            StaticFilterRequest request;
+            StaticFilterItem[] snapshot;
+            lock (_listLock)
+            {
+                if (_isDisposed || _isDynamic || _pendingStaticFilter is null)
+                {
+                    _staticFilterWorkerQueued = false;
+                    return;
+                }
+
+                request = _pendingStaticFilter;
+                _pendingStaticFilter = null;
+                snapshot = Items.Select(item => _staticFilterItems[item]).ToArray();
+            }
+
+            try
+            {
+                var filtered = FilterSnapshot(snapshot, request.Query, request.CancellationToken);
+                request.CancellationToken.ThrowIfCancellationRequested();
+                DoOnUiThread(() => PublishStaticFilter(request, filtered));
+            }
+            catch (OperationCanceledException) when (request.CancellationToken.IsCancellationRequested)
+            {
+            }
+            catch (Exception ex)
+            {
+                ShowException(ex);
+            }
+        }
+    }
+
+    private bool IsCurrentStaticFilter(StaticFilterRequest request) =>
+        !_isDisposed &&
+        !_isDynamic &&
+        request.Version == _staticFilterVersion &&
+        request.FetchGeneration == _itemsFetchGeneration &&
+        IsLatestFetchGeneration(request.FetchGeneration);
+
+    private void PublishStaticFilter(StaticFilterRequest request, ListItemViewModel[] filtered)
+    {
+        lock (_fetchStateLock)
+        {
+            lock (_listLock)
+            {
+                if (!IsCurrentStaticFilter(request))
+                {
+                    return;
+                }
+
+                RunFilteredItemsUpdate(() =>
+                {
+                    // A renderer callback can change the query or navigate away before this action runs.
+                    if (!IsCurrentStaticFilter(request))
+                    {
+                        return;
+                    }
+
+                    ListHelpers.InPlaceUpdateList(FilteredItems, filtered);
+                    if (!IsCurrentStaticFilter(request))
+                    {
+                        return;
+                    }
+
+                    var forceFirst = _staticFilterForceFirstPending || (IsRootPage && _forceFirstItemPending);
+                    var ensureVisible = _staticFilterEnsureSelectionVisible;
+                    _staticFilterForceFirstPending = false;
+                    _staticFilterEnsureSelectionVisible = false;
+                    _forceFirstItemPending = false;
+                    _isLoadingMore.Clear();
+                    UpdateEmptyContent();
+                    ItemsUpdated?.Invoke(this, new ItemsUpdatedEventArgs(forceFirst, ensureVisible));
+                });
+            }
+        }
+    }
+
+    private sealed record StaticFilterRequest(long Version, int FetchGeneration, string Query, CancellationToken CancellationToken);
+
+    internal readonly record struct StaticFilterItem(ListItemViewModel ViewModel, string Title, string Subtitle, bool IsInErrorState)
+    {
+        internal static StaticFilterItem Capture(ListItemViewModel item) => new(item, item.Title, item.Subtitle, item.IsInErrorState);
+    }
+
+    internal static ListItemViewModel[] FilterSnapshot(StaticFilterItem[] items, string query, CancellationToken cancellationToken)
+    {
+        var scores = new List<ScoredListItemViewModel>(items.Length);
+        foreach (var item in items)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (item.IsInErrorState)
+            {
+                continue;
+            }
+
+            var score = ScoreListItem(query, item.Title, item.Subtitle);
+            if (score > 0)
+            {
+                scores.Add(new() { ViewModel = item.ViewModel, Score = score });
+            }
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var result = scores.OrderByDescending(item => item.Score).Select(item => item.ViewModel).ToArray();
+        cancellationToken.ThrowIfCancellationRequested();
+        return result;
+    }
 
     /// <summary>
     /// Executes an action that mutates <see cref="FilteredItems"/> with a
@@ -730,7 +958,7 @@ public partial class ListViewModel : PageViewModel, IDisposable
     private void ThrowIfFetchCanceledOrStale(int fetchGeneration, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        if (Volatile.Read(ref _latestFetchGeneration) != fetchGeneration)
+        if (_isDisposed || Volatile.Read(ref _latestFetchGeneration) != fetchGeneration)
         {
             throw new OperationCanceledException();
         }
@@ -751,16 +979,16 @@ public partial class ListViewModel : PageViewModel, IDisposable
     /// subtitle, etc. Largely a copy of the version in ListHelpers, but
     /// operating on ViewModels instead of extension objects.
     /// </summary>
-    private static int ScoreListItem(string query, CommandItemViewModel listItem)
+    private static int ScoreListItem(string query, string title, string subtitle)
     {
         if (string.IsNullOrEmpty(query))
         {
             return 1;
         }
 
-        var nameMatch = FuzzyStringMatcher.ScoreFuzzy(query, listItem.Title);
-        var descriptionMatch = FuzzyStringMatcher.ScoreFuzzy(query, listItem.Subtitle);
-        return new[] { nameMatch, (descriptionMatch - 4) / 2, 0 }.Max();
+        var nameMatch = FuzzyStringMatcher.ScoreFuzzy(query, title);
+        var descriptionMatch = FuzzyStringMatcher.ScoreFuzzy(query, subtitle);
+        return Math.Max(Math.Max(nameMatch, (descriptionMatch - 4) / 2), 0);
     }
 
     private struct ScoredListItemViewModel
@@ -774,7 +1002,7 @@ public partial class ListViewModel : PageViewModel, IDisposable
     {
         var scores = items
             .Where(i => !i.IsInErrorState)
-            .Select(li => new ScoredListItemViewModel() { ViewModel = li, Score = ScoreListItem(query, li) })
+            .Select(li => new ScoredListItemViewModel() { ViewModel = li, Score = string.IsNullOrEmpty(query) ? 1 : ScoreListItem(query, li.Title, li.Subtitle) })
             .Where(score => score.Score > 0)
             .OrderByDescending(score => score.Score);
         return scores
@@ -859,6 +1087,7 @@ public partial class ListViewModel : PageViewModel, IDisposable
 
                 if (!item.SafeSlowInit())
                 {
+                    RefreshStaticFilterItem(item);
                     if (ct.IsCancellationRequested)
                     {
                         return;
@@ -941,6 +1170,11 @@ public partial class ListViewModel : PageViewModel, IDisposable
 
     public override void InitializeProperties()
     {
+        if (_isDisposed)
+        {
+            return;
+        }
+
         base.InitializeProperties();
 
         var model = _model.Unsafe;
@@ -985,7 +1219,13 @@ public partial class ListViewModel : PageViewModel, IDisposable
         }
 
         FetchItems(keepSelection: true, ensureSelectionVisible: true);
-        model.ItemsChanged += Model_ItemsChanged;
+        lock (_fetchStateLock)
+        {
+            if (!_isDisposed)
+            {
+                model.ItemsChanged += Model_ItemsChanged;
+            }
+        }
     }
 
     private static IGridPropertiesViewModel? LoadGridPropertiesViewModel(IGridProperties? gridProperties)
@@ -1133,23 +1373,34 @@ public partial class ListViewModel : PageViewModel, IDisposable
     public void Dispose()
     {
         GC.SuppressFinalize(this);
-        CancelAndDisposeTokenSource(ref _cancellationTokenSource);
-        CancelAndDisposeTokenSource(ref filterCancellationTokenSource);
-        CancelAndDisposeTokenSource(ref _fetchItemsCancellationTokenSource);
-        CancelAndDisposeTokenSource(ref _selectedItemCts);
+        lock (_fetchStateLock)
+        {
+            lock (_listLock)
+            {
+                _isDisposed = true;
+                InvalidateStaticFilterUnderLock();
+                foreach (var item in _staticFilterItems.Keys)
+                {
+                    item.PropertyChangedBackground -= StaticFilterItemPropertyChanged;
+                }
+
+                _staticFilterItems.Clear();
+            }
+
+            CancelAndDisposeTokenSource(ref _cancellationTokenSource);
+            CancelAndDisposeTokenSource(ref filterCancellationTokenSource);
+            CancelAndDisposeTokenSource(ref _fetchItemsCancellationTokenSource);
+            CancelAndDisposeTokenSource(ref _selectedItemCts);
+        }
     }
 
     protected override void UnsafeCleanup()
     {
+        Dispose();
         base.UnsafeCleanup();
 
         EmptyContent?.SafeCleanup();
         EmptyContent = new(new(null), PageContext, contextMenuFactory: null); // necessary?
-
-        CancelAndDisposeTokenSource(ref _cancellationTokenSource);
-        CancelAndDisposeTokenSource(ref filterCancellationTokenSource);
-        CancelAndDisposeTokenSource(ref _fetchItemsCancellationTokenSource);
-        CancelAndDisposeTokenSource(ref _selectedItemCts);
 
         lock (_listLock)
         {
@@ -1159,16 +1410,23 @@ public partial class ListViewModel : PageViewModel, IDisposable
             }
 
             Items.Clear();
-            RunFilteredItemsUpdate(() =>
-            {
-                foreach (var item in FilteredItems)
-                {
-                    item.SafeCleanup();
-                }
-
-                FilteredItems.Clear();
-            });
         }
+
+        DoOnUiThread(() =>
+        {
+            lock (_listLock)
+            {
+                RunFilteredItemsUpdate(() =>
+                {
+                    foreach (var item in FilteredItems)
+                    {
+                        item.SafeCleanup();
+                    }
+
+                    FilteredItems.Clear();
+                });
+            }
+        });
 
         PublishVmCache(new(VmCacheComparer));
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
@@ -26,11 +26,10 @@ public partial class ListViewModel : PageViewModel, IDisposable
     private static readonly IEqualityComparer<IListItem> VmCacheComparer = new ProxyReferenceEqualityComparer();
 
     private readonly TaskFactory filterTaskFactory = new(new ConcurrentExclusiveSchedulerPair().ExclusiveScheduler);
-    private readonly TaskFactory _staticFilterTaskFactory;
+    private readonly SupersedingAsyncGate _staticFilterGate;
 
     private Dictionary<IListItem, ListItemViewModel> _vmCache = new(VmCacheComparer);
     private Dictionary<ListItemViewModel, StaticFilterItem> _staticFilterItems = new(ReferenceEqualityComparer.Instance);
-    private StaticFilterRequest? _pendingStaticFilter;
     private CancellationTokenSource? _staticFilterCancellationTokenSource;
     private long _staticFilterVersion;
     private long _publishedStaticFilterVersion = -1;
@@ -38,7 +37,6 @@ public partial class ListViewModel : PageViewModel, IDisposable
     private PendingStaticActivation? _pendingStaticActivation;
     private int _itemsFetchGeneration;
     private int _settledFetchGeneration;
-    private bool _staticFilterWorkerQueued;
     private bool _staticFilterForceFirstPending;
     private bool _staticFilterEnsureSelectionVisible;
     private string _staticFilterQuery = string.Empty;
@@ -157,7 +155,7 @@ public partial class ListViewModel : PageViewModel, IDisposable
     {
         _model = new(model);
         _contextMenuFactory = contextMenuFactory;
-        _staticFilterTaskFactory = new(staticFilterScheduler);
+        _staticFilterGate = new(FilterStaticItemsAsync, staticFilterScheduler);
         EmptyContent = new(new(null), PageContext, contextMenuFactory: null);
     }
 
@@ -712,7 +710,6 @@ public partial class ListViewModel : PageViewModel, IDisposable
     private void InvalidateStaticFilterUnderLock()
     {
         _staticFilterVersion++;
-        _pendingStaticFilter = null;
         CancelAndDisposeTokenSource(ref _staticFilterCancellationTokenSource);
     }
 
@@ -733,51 +730,47 @@ public partial class ListViewModel : PageViewModel, IDisposable
         }
 
         _staticFilterCancellationTokenSource = new();
-        _pendingStaticFilter = new(
-            _staticFilterVersion,
-            _itemsFetchGeneration,
-            _staticFilterQuery,
-            _staticFilterCancellationTokenSource.Token);
-        if (!_staticFilterWorkerQueued)
+        _ = RunStaticFilterAsync(_staticFilterCancellationTokenSource.Token);
+    }
+
+    private async Task RunStaticFilterAsync(CancellationToken cancellationToken)
+    {
+        try
         {
-            _staticFilterWorkerQueued = true;
-            _ = _staticFilterTaskFactory.StartNew(ProcessStaticFilters);
+            await _staticFilterGate.ExecuteAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (ObjectDisposedException) when (_isDisposed)
+        {
+        }
+        catch (Exception ex)
+        {
+            ShowException(ex);
         }
     }
 
-    private void ProcessStaticFilters()
+    private Task FilterStaticItemsAsync(CancellationToken cancellationToken)
     {
-        while (true)
+        StaticFilterRequest request;
+        StaticFilterItem[] snapshot;
+        lock (_listLock)
         {
-            StaticFilterRequest request;
-            StaticFilterItem[] snapshot;
-            lock (_listLock)
+            cancellationToken.ThrowIfCancellationRequested();
+            if (_isDisposed || _isDynamic || !IsLatestFetchGeneration(_settledFetchGeneration))
             {
-                if (_isDisposed || _isDynamic || _pendingStaticFilter is null)
-                {
-                    _staticFilterWorkerQueued = false;
-                    return;
-                }
-
-                request = _pendingStaticFilter;
-                _pendingStaticFilter = null;
-                snapshot = Items.Select(item => _staticFilterItems[item]).ToArray();
+                return Task.CompletedTask;
             }
 
-            try
-            {
-                var filtered = FilterSnapshot(snapshot, request.Query, request.CancellationToken);
-                request.CancellationToken.ThrowIfCancellationRequested();
-                DoOnUiThread(() => PublishStaticFilter(request, filtered));
-            }
-            catch (OperationCanceledException) when (request.CancellationToken.IsCancellationRequested)
-            {
-            }
-            catch (Exception ex)
-            {
-                ShowException(ex);
-            }
+            request = new(_staticFilterVersion, _itemsFetchGeneration, _staticFilterQuery);
+            snapshot = Items.Select(item => _staticFilterItems[item]).ToArray();
         }
+
+        var filtered = FilterSnapshot(snapshot, request.Query, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+        DoOnUiThread(() => PublishStaticFilter(request, filtered));
+        return Task.CompletedTask;
     }
 
     private bool IsCurrentStaticFilter(StaticFilterRequest request) =>
@@ -931,7 +924,7 @@ public partial class ListViewModel : PageViewModel, IDisposable
 
     private readonly record struct PendingStaticActivation(StaticActivationKind Kind, ListItemViewModel? Target, bool HasTarget);
 
-    private sealed record StaticFilterRequest(long Version, int FetchGeneration, string Query, CancellationToken CancellationToken);
+    private sealed record StaticFilterRequest(long Version, int FetchGeneration, string Query);
 
     internal readonly record struct StaticFilterItem(ListItemViewModel ViewModel, string Title, string Subtitle, bool IsInErrorState)
     {
@@ -1546,6 +1539,7 @@ public partial class ListViewModel : PageViewModel, IDisposable
                 _isDisposed = true;
                 _pendingStaticActivation = null;
                 InvalidateStaticFilterUnderLock();
+                _staticFilterGate.Dispose();
                 foreach (var item in _staticFilterItems.Keys)
                 {
                     item.PropertyChangedBackground -= StaticFilterItemPropertyChanged;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
@@ -33,7 +33,11 @@ public partial class ListViewModel : PageViewModel, IDisposable
     private StaticFilterRequest? _pendingStaticFilter;
     private CancellationTokenSource? _staticFilterCancellationTokenSource;
     private long _staticFilterVersion;
+    private long _publishedStaticFilterVersion = -1;
+    private long _selectedStaticFilterVersion = -1;
+    private StaticActivationKind? _pendingStaticActivation;
     private int _itemsFetchGeneration;
+    private int _settledFetchGeneration;
     private bool _staticFilterWorkerQueued;
     private bool _staticFilterForceFirstPending;
     private bool _staticFilterEnsureSelectionVisible;
@@ -45,6 +49,8 @@ public partial class ListViewModel : PageViewModel, IDisposable
     // Observable from MVVM Toolkit will auto create public properties that use INotifyPropertyChange change
     // https://learn.microsoft.com/dotnet/communitytoolkit/mvvm/observablegroupedcollections for grouping support
     public ObservableCollection<ListItemViewModel> FilteredItems { get; } = [];
+
+    public long PublishedFilterVersion => Volatile.Read(ref _publishedStaticFilterVersion);
 
     public FiltersViewModel? Filters { get; set; }
 
@@ -226,6 +232,7 @@ public partial class ListViewModel : PageViewModel, IDisposable
         {
             lock (_listLock)
             {
+                _pendingStaticActivation = null;
                 _staticFilterQuery = searchTextBox;
                 RequestStaticFilterUnderLock(forceFirstItem: true, ensureSelectionVisible: true);
             }
@@ -471,6 +478,7 @@ public partial class ListViewModel : PageViewModel, IDisposable
 
                     PublishVmCache(nextCache);
                     _itemsFetchGeneration = fetchGeneration;
+                    _settledFetchGeneration = fetchGeneration;
                     itemsTransferredToList = true;
 
                     if (!_isDynamic)
@@ -528,6 +536,21 @@ public partial class ListViewModel : PageViewModel, IDisposable
             if (fetchCountIncremented && Interlocked.Decrement(ref _activeFetchCount) == 0)
             {
                 UpdateEmptyContent();
+            }
+
+            if (!itemsTransferredToList && !_isDynamic)
+            {
+                lock (_fetchStateLock)
+                {
+                    if (!_isDisposed && IsLatestFetchGeneration(fetchGeneration))
+                    {
+                        lock (_listLock)
+                        {
+                            _settledFetchGeneration = fetchGeneration;
+                            RequestStaticFilterUnderLock(forceFirstItem: false, ensureSelectionVisible);
+                        }
+                    }
+                }
             }
         }
 
@@ -702,7 +725,7 @@ public partial class ListViewModel : PageViewModel, IDisposable
         _staticFilterEnsureSelectionVisible |= ensureSelectionVisible;
         InvalidateStaticFilterUnderLock();
 
-        if (_itemsFetchGeneration != Volatile.Read(ref _latestFetchGeneration))
+        if (_settledFetchGeneration != Volatile.Read(ref _latestFetchGeneration))
         {
             return;
         }
@@ -760,7 +783,7 @@ public partial class ListViewModel : PageViewModel, IDisposable
         !_isDynamic &&
         request.Version == _staticFilterVersion &&
         request.FetchGeneration == _itemsFetchGeneration &&
-        IsLatestFetchGeneration(request.FetchGeneration);
+        IsLatestFetchGeneration(_settledFetchGeneration);
 
     private void PublishStaticFilter(StaticFilterRequest request, ListItemViewModel[] filtered)
     {
@@ -794,10 +817,84 @@ public partial class ListViewModel : PageViewModel, IDisposable
                     _forceFirstItemPending = false;
                     _isLoadingMore.Clear();
                     UpdateEmptyContent();
+                    _publishedStaticFilterVersion = request.Version;
                     ItemsUpdated?.Invoke(this, new ItemsUpdatedEventArgs(forceFirst, ensureVisible));
                 });
+
+                TryInvokePendingStaticActivation();
             }
         }
+    }
+
+    public bool CompleteStaticFilterSelection(long version, ListItemViewModel? item)
+    {
+        lock (_fetchStateLock)
+        {
+            lock (_listLock)
+            {
+                if (_isDisposed || _isDynamic ||
+                    version != _staticFilterVersion || version != _publishedStaticFilterVersion)
+                {
+                    return true;
+                }
+
+                if (!ReferenceEquals(item, _lastSelectedItem) ||
+                    (item is not null && (!item.IsInteractive || !FilteredItems.Contains(item, ReferenceEqualityComparer.Instance))) ||
+                    (item is null && FilteredItems.Any(candidate => candidate.IsInteractive)))
+                {
+                    return false;
+                }
+
+                _selectedStaticFilterVersion = version;
+                TryInvokePendingStaticActivation();
+                return true;
+            }
+        }
+    }
+
+    public void CancelPendingActivation()
+    {
+        lock (_listLock)
+        {
+            _pendingStaticActivation = null;
+            _selectedStaticFilterVersion = -1;
+        }
+    }
+
+    private bool IsStaticFilterSelectionCurrent =>
+        !_isUpdatingFilteredItems &&
+        _publishedStaticFilterVersion == _staticFilterVersion &&
+        _selectedStaticFilterVersion == _staticFilterVersion &&
+        IsLatestFetchGeneration(_settledFetchGeneration);
+
+    private void TryInvokePendingStaticActivation()
+    {
+        lock (_fetchStateLock)
+        {
+            lock (_listLock)
+            {
+                if (_isDisposed || _pendingStaticActivation is not { } activation || !IsStaticFilterSelectionCurrent)
+                {
+                    return;
+                }
+
+                var item = _lastSelectedItem;
+                if (activation == StaticActivationKind.Secondary && item is not null &&
+                    !item.Initialized.HasFlag(InitializedState.SelectionInitialized))
+                {
+                    return;
+                }
+
+                _pendingStaticActivation = null;
+                InvokeListItem(item, activation);
+            }
+        }
+    }
+
+    private enum StaticActivationKind
+    {
+        Primary,
+        Secondary,
     }
 
     private sealed record StaticFilterRequest(long Version, int FetchGeneration, string Query, CancellationToken CancellationToken);
@@ -1012,42 +1109,63 @@ public partial class ListViewModel : PageViewModel, IDisposable
     // InvokeItemCommand is what this will be in Xaml due to source generator
     // This is what gets invoked when the user presses <enter>
     [RelayCommand]
-    private void InvokeItem(ListItemViewModel? item)
-    {
-        if (item is not null)
-        {
-            WeakReferenceMessenger.Default.Send<PerformCommandMessage>(new(item.Command.Model, item.Model));
-        }
-        else if (ShowEmptyContent && EmptyContent.PrimaryCommand?.Model.Unsafe is not null)
-        {
-            WeakReferenceMessenger.Default.Send<PerformCommandMessage>(new(
-                EmptyContent.PrimaryCommand.Command.Model,
-                EmptyContent.PrimaryCommand.Model));
-        }
-    }
+    private void InvokeItem(ListItemViewModel? item) => InvokeListItem(item, StaticActivationKind.Primary);
 
     // This is what gets invoked when the user presses <ctrl+enter>
     [RelayCommand]
-    private void InvokeSecondaryCommand(ListItemViewModel? item)
+    private void InvokeSecondaryCommand(ListItemViewModel? item) => InvokeListItem(item, StaticActivationKind.Secondary);
+
+    private void InvokeListItem(ListItemViewModel? item, StaticActivationKind activation)
     {
-        if (item is not null)
+        lock (_fetchStateLock)
         {
-            if (item.SecondaryCommand is not null)
+            lock (_listLock)
             {
-                WeakReferenceMessenger.Default.Send<PerformCommandMessage>(new(item.SecondaryCommand.Command.Model, item.Model));
+                if (_isDisposed)
+                {
+                    return;
+                }
+
+                if (!_isDynamic && !IsStaticFilterSelectionCurrent)
+                {
+                    _pendingStaticActivation = activation;
+                    return;
+                }
+
+                _pendingStaticActivation = null;
+                if (item is not null)
+                {
+                    if (!_isDynamic && (item.IsInErrorState || !item.IsInteractive || !FilteredItems.Contains(item, ReferenceEqualityComparer.Instance)))
+                    {
+                        return;
+                    }
+
+                    var command = activation == StaticActivationKind.Secondary ? item.SecondaryCommand?.Command : item.Command;
+                    if (command is not null)
+                    {
+                        WeakReferenceMessenger.Default.Send<PerformCommandMessage>(new(command.Model, item.Model));
+                    }
+                }
+                else if (ShowEmptyContent)
+                {
+                    var command = activation == StaticActivationKind.Secondary ? EmptyContent.SecondaryCommand : EmptyContent.PrimaryCommand;
+                    if (command?.Model.Unsafe is not null)
+                    {
+                        WeakReferenceMessenger.Default.Send<PerformCommandMessage>(new(command.Command.Model, command.Model));
+                    }
+                }
             }
-        }
-        else if (ShowEmptyContent && EmptyContent.SecondaryCommand?.Model.Unsafe is not null)
-        {
-            WeakReferenceMessenger.Default.Send<PerformCommandMessage>(new(
-                EmptyContent.SecondaryCommand.Command.Model,
-                EmptyContent.SecondaryCommand.Model));
         }
     }
 
     [RelayCommand]
     private void UpdateSelectedItem(ListItemViewModel? item)
     {
+        if (_selectedStaticFilterVersion == _staticFilterVersion && !ReferenceEquals(item, _lastSelectedItem))
+        {
+            _pendingStaticActivation = null;
+        }
+
         if (_lastSelectedItem is not null)
         {
             _lastSelectedItem.PropertyChanged -= SelectedItemPropertyChanged;
@@ -1119,6 +1237,7 @@ public partial class ListViewModel : PageViewModel, IDisposable
                 {
                     TextToSuggest = suggestion;
                     WeakReferenceMessenger.Default.Send<UpdateSuggestionMessage>(new(suggestion));
+                    TryInvokePendingStaticActivation();
                 });
             },
             ct);
@@ -1160,6 +1279,7 @@ public partial class ListViewModel : PageViewModel, IDisposable
 
     private void ClearSelectedItem()
     {
+        _lastSelectedItem = null;
         CancelAndDisposeTokenSource(ref _selectedItemCts);
 
         WeakReferenceMessenger.Default.Send<UpdateCommandBarMessage>(new(null));
@@ -1378,6 +1498,7 @@ public partial class ListViewModel : PageViewModel, IDisposable
             lock (_listLock)
             {
                 _isDisposed = true;
+                _pendingStaticActivation = null;
                 InvalidateStaticFilterUnderLock();
                 foreach (var item in _staticFilterItems.Keys)
                 {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
@@ -35,7 +35,7 @@ public partial class ListViewModel : PageViewModel, IDisposable
     private long _staticFilterVersion;
     private long _publishedStaticFilterVersion = -1;
     private long _selectedStaticFilterVersion = -1;
-    private StaticActivationKind? _pendingStaticActivation;
+    private PendingStaticActivation? _pendingStaticActivation;
     private int _itemsFetchGeneration;
     private int _settledFetchGeneration;
     private bool _staticFilterWorkerQueued;
@@ -674,6 +674,7 @@ public partial class ListViewModel : PageViewModel, IDisposable
         }
 
         _staticFilterItems = snapshots;
+        CancelInvalidStaticActivationUnderLock();
     }
 
     private void StaticFilterItemPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -703,6 +704,7 @@ public partial class ListViewModel : PageViewModel, IDisposable
             }
 
             _staticFilterItems[item] = current;
+            CancelInvalidStaticActivationUnderLock();
             RequestStaticFilterUnderLock(forceFirstItem: false, ensureSelectionVisible: false);
         }
     }
@@ -810,6 +812,12 @@ public partial class ListViewModel : PageViewModel, IDisposable
                         return;
                     }
 
+                    if (_pendingStaticActivation is { Target: { } target } &&
+                        !FilteredItems.Contains(target, ReferenceEqualityComparer.Instance))
+                    {
+                        _pendingStaticActivation = null;
+                    }
+
                     var forceFirst = _staticFilterForceFirstPending || (IsRootPage && _forceFirstItemPending);
                     var ensureVisible = _staticFilterEnsureSelectionVisible;
                     _staticFilterForceFirstPending = false;
@@ -846,6 +854,11 @@ public partial class ListViewModel : PageViewModel, IDisposable
                 }
 
                 _selectedStaticFilterVersion = version;
+                if (_pendingStaticActivation is { HasTarget: false } activation)
+                {
+                    _pendingStaticActivation = activation with { Target = item, HasTarget = true };
+                }
+
                 TryInvokePendingStaticActivation();
                 return true;
             }
@@ -863,9 +876,21 @@ public partial class ListViewModel : PageViewModel, IDisposable
 
     private bool IsStaticFilterSelectionCurrent =>
         !_isUpdatingFilteredItems &&
+        IsStaticFilterSelectionConfirmed;
+
+    private bool IsStaticFilterSelectionConfirmed =>
         _publishedStaticFilterVersion == _staticFilterVersion &&
         _selectedStaticFilterVersion == _staticFilterVersion &&
         IsLatestFetchGeneration(_settledFetchGeneration);
+
+    private void CancelInvalidStaticActivationUnderLock()
+    {
+        if (_pendingStaticActivation is { Target: { } target } &&
+            (target.IsInErrorState || !_staticFilterItems.ContainsKey(target)))
+        {
+            _pendingStaticActivation = null;
+        }
+    }
 
     private void TryInvokePendingStaticActivation()
     {
@@ -873,20 +898,27 @@ public partial class ListViewModel : PageViewModel, IDisposable
         {
             lock (_listLock)
             {
-                if (_isDisposed || _pendingStaticActivation is not { } activation || !IsStaticFilterSelectionCurrent)
+                CancelInvalidStaticActivationUnderLock();
+                if (_isDisposed || _pendingStaticActivation is not { HasTarget: true } activation || !IsStaticFilterSelectionCurrent)
                 {
                     return;
                 }
 
-                var item = _lastSelectedItem;
-                if (activation == StaticActivationKind.Secondary && item is not null &&
+                var item = activation.Target;
+                if (!ReferenceEquals(item, _lastSelectedItem))
+                {
+                    _pendingStaticActivation = null;
+                    return;
+                }
+
+                if (activation.Kind == StaticActivationKind.Secondary && item is not null &&
                     !item.Initialized.HasFlag(InitializedState.SelectionInitialized))
                 {
                     return;
                 }
 
                 _pendingStaticActivation = null;
-                InvokeListItem(item, activation);
+                InvokeListItem(item, activation.Kind);
             }
         }
     }
@@ -896,6 +928,8 @@ public partial class ListViewModel : PageViewModel, IDisposable
         Primary,
         Secondary,
     }
+
+    private readonly record struct PendingStaticActivation(StaticActivationKind Kind, ListItemViewModel? Target, bool HasTarget);
 
     private sealed record StaticFilterRequest(long Version, int FetchGeneration, string Query, CancellationToken CancellationToken);
 
@@ -1128,7 +1162,8 @@ public partial class ListViewModel : PageViewModel, IDisposable
 
                 if (!_isDynamic && !IsStaticFilterSelectionCurrent)
                 {
-                    _pendingStaticActivation = activation;
+                    var confirmed = IsStaticFilterSelectionConfirmed;
+                    _pendingStaticActivation = new(activation, confirmed ? _lastSelectedItem : null, confirmed);
                     return;
                 }
 
@@ -1158,12 +1193,23 @@ public partial class ListViewModel : PageViewModel, IDisposable
         }
     }
 
+    public void SynchronizeSelection(ListItemViewModel? item, bool forceUpdate = false)
+    {
+        if (forceUpdate || item is null || !ReferenceEquals(item, _lastSelectedItem))
+        {
+            UpdateSelectedItem(item);
+        }
+    }
+
     [RelayCommand]
     private void UpdateSelectedItem(ListItemViewModel? item)
     {
-        if (_selectedStaticFilterVersion == _staticFilterVersion && !ReferenceEquals(item, _lastSelectedItem))
+        lock (_listLock)
         {
-            _pendingStaticActivation = null;
+            if (_pendingStaticActivation is { HasTarget: true } activation && !ReferenceEquals(item, activation.Target))
+            {
+                _pendingStaticActivation = null;
+            }
         }
 
         if (_lastSelectedItem is not null)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListItemsView.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListItemsView.xaml.cs
@@ -97,6 +97,7 @@ public sealed partial class ListItemsView : UserControl,
     private void OnUnloaded(object sender, RoutedEventArgs e)
     {
         _isLoaded = false;
+        ViewModel?.CancelPendingActivation();
 
         // Release before the native panel tears down. A reattached grid rebuilds
         // its groups from the source, which is what it does after any teardown.
@@ -151,12 +152,22 @@ public sealed partial class ListItemsView : UserControl,
     /// </summary>
     public void EnsureInitialSelection()
     {
+        var viewModel = ViewModel;
+        var version = Volatile.Read(ref _itemsUpdatedVersion);
+        var filterVersion = viewModel?.PublishedFilterVersion ?? -1;
+
         // Must dispatch the selection to run at a lower priority; otherwise, GetFirstSelectableIndex
         // may return an incorrect index because item containers are not yet rendered.
         _ = DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {
-            if (!_isLoaded)
+            if (!_isLoaded || version != Volatile.Read(ref _itemsUpdatedVersion) || !ReferenceEquals(viewModel, ViewModel))
             {
+                return;
+            }
+
+            if (viewModel is not null && filterVersion >= 0 && _forceFirstPending)
+            {
+                ProcessItemsUpdated(viewModel, new ItemsUpdatedEventArgs(forceFirstItem: false, ensureSelectionVisible: true), version);
                 return;
             }
 
@@ -182,6 +193,10 @@ public sealed partial class ListItemsView : UserControl,
 
             // Ensure the command bar refreshes with the restored page's commands.
             PushSelectionToVm();
+            if (!CompleteFilterSelection(viewModel, version, filterVersion) && viewModel is not null)
+            {
+                ProcessItemsUpdated(viewModel, new ItemsUpdatedEventArgs(forceFirstItem: false, ensureSelectionVisible: true), version);
+            }
         });
     }
 
@@ -497,9 +512,9 @@ public sealed partial class ListItemsView : UserControl,
         {
             ViewModel?.InvokeItemCommand.Execute(null);
         }
-        else if (ItemView.SelectedItem is ListItemViewModel item)
+        else
         {
-            ViewModel?.InvokeItemCommand.Execute(item);
+            ViewModel?.InvokeItemCommand.Execute(ItemView.SelectedItem as ListItemViewModel);
         }
     }
 
@@ -509,9 +524,9 @@ public sealed partial class ListItemsView : UserControl,
         {
             ViewModel?.InvokeSecondaryCommandCommand.Execute(null);
         }
-        else if (ItemView.SelectedItem is ListItemViewModel item)
+        else
         {
-            ViewModel?.InvokeSecondaryCommandCommand.Execute(item);
+            ViewModel?.InvokeSecondaryCommandCommand.Execute(ItemView.SelectedItem as ListItemViewModel);
         }
     }
 
@@ -715,6 +730,7 @@ public sealed partial class ListItemsView : UserControl,
             @this.CancelPendingContextMenuOpen();
             if (e.OldValue is ListViewModel old)
             {
+                old.CancelPendingActivation();
                 old.ItemsUpdated -= @this.Page_ItemsUpdated;
             }
 
@@ -782,6 +798,7 @@ public sealed partial class ListItemsView : UserControl,
         _forceFirstPending |= args.ForceFirstItem;
         var forceFirstItem = _forceFirstPending;
         var ensureSelectionVisible = args.EnsureSelectionVisible;
+        var filterVersion = sender.PublishedFilterVersion;
 
         if (_isLoaded)
         {
@@ -792,7 +809,7 @@ public sealed partial class ListItemsView : UserControl,
         // The grouped CollectionViewSource may still be processing its changes.
         // TrySetSelectionAfterUpdate clears _forceFirstPending internally once
         // selection stabilizes (no repair needed), so we don't clear it here.
-        if (TrySetSelectionAfterUpdate(sender, version, forceFirstItem, ensureSelectionVisible))
+        if (TrySetSelectionAfterUpdate(sender, version, forceFirstItem, ensureSelectionVisible, filterVersion))
         {
             return;
         }
@@ -807,7 +824,7 @@ public sealed partial class ListItemsView : UserControl,
                     return;
                 }
 
-                TrySetSelectionAfterUpdate(sender, version, forceFirstItem, ensureSelectionVisible);
+                TrySetSelectionAfterUpdate(sender, version, forceFirstItem, ensureSelectionVisible, filterVersion);
             });
     }
 
@@ -822,7 +839,7 @@ public sealed partial class ListItemsView : UserControl,
     /// <param name="ensureSelectionVisible">
     /// When true, scroll a preserved selection into view after a soft refresh.
     /// </param>
-    private bool TrySetSelectionAfterUpdate(ListViewModel sender, long version, bool forceFirstItem, bool ensureSelectionVisible)
+    private bool TrySetSelectionAfterUpdate(ListViewModel sender, long version, bool forceFirstItem, bool ensureSelectionVisible, long filterVersion)
     {
         if (version != Volatile.Read(ref _itemsUpdatedVersion))
         {
@@ -830,7 +847,7 @@ public sealed partial class ListItemsView : UserControl,
         }
 
         var vm = ViewModel;
-        if (vm is null)
+        if (!_isLoaded || vm is null || !ReferenceEquals(sender, vm))
         {
             return true;
         }
@@ -852,7 +869,7 @@ public sealed partial class ListItemsView : UserControl,
             }
 
             PushSelectionToVm();
-            return true;
+            return CompleteFilterSelection(vm, version, filterVersion);
         }
 
         // If ItemView.Items hasn't caught up with the ObservableCollection yet,
@@ -874,7 +891,7 @@ public sealed partial class ListItemsView : UserControl,
             }
 
             PushSelectionToVm();
-            return true;
+            return CompleteFilterSelection(vm, version, filterVersion);
         }
 
         var shouldUpdateSelection = forceFirstItem;
@@ -980,6 +997,16 @@ public sealed partial class ListItemsView : UserControl,
         }
 
         PushSelectionToVm();
+        return CompleteFilterSelection(vm, version, filterVersion);
+    }
+
+    private bool CompleteFilterSelection(ListViewModel? viewModel, long version, long filterVersion)
+    {
+        if (_isLoaded && version == Volatile.Read(ref _itemsUpdatedVersion) && ReferenceEquals(viewModel, ViewModel))
+        {
+            return viewModel?.CompleteStaticFilterSelection(filterVersion, ItemView.SelectedItem as ListItemViewModel) ?? true;
+        }
+
         return true;
     }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListItemsView.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListItemsView.xaml.cs
@@ -47,7 +47,6 @@ public sealed partial class ListItemsView : UserControl,
     private bool _scrollOnNextSelectionChange;
 
     private ListItemViewModel? _stickySelectedItem;
-    private ListItemViewModel? _lastPushedToVm;
     private long _pendingContextMenuOpenRequestId;
     private Action? _cancelPendingContextMenuOpen;
 
@@ -192,7 +191,7 @@ public sealed partial class ListItemsView : UserControl,
             }
 
             // Ensure the command bar refreshes with the restored page's commands.
-            PushSelectionToVm();
+            PushSelectionToVm(forceUpdate: true);
             if (!CompleteFilterSelection(viewModel, version, filterVersion) && viewModel is not null)
             {
                 ProcessItemsUpdated(viewModel, new ItemsUpdatedEventArgs(forceFirstItem: false, ensureSelectionVisible: true), version);
@@ -230,7 +229,7 @@ public sealed partial class ListItemsView : UserControl,
                 // Click-driven selection should scroll into view (but only once).
                 _scrollOnNextSelectionChange = true;
 
-                ViewModel?.UpdateSelectedItemCommand.Execute(item);
+                PushSelectionToVm(item);
                 WeakReferenceMessenger.Default.Send<FocusSearchBoxMessage>();
             }
         }
@@ -256,7 +255,6 @@ public sealed partial class ListItemsView : UserControl,
             return;
         }
 
-        var vm = ViewModel;
         var li = ItemView.SelectedItem as ListItemViewModel;
 
         // Transient null/separator selection can happen during in-place updates.
@@ -277,7 +275,7 @@ public sealed partial class ListItemsView : UserControl,
         _forceFirstPending = false;
 
         // Do not Task.Run (it reorders selection updates).
-        vm?.UpdateSelectedItemCommand.Execute(li);
+        PushSelectionToVm(li);
 
         // Only scroll when explicitly requested by navigation/click handlers.
         if (_scrollOnNextSelectionChange)
@@ -340,7 +338,7 @@ public sealed partial class ListItemsView : UserControl,
                 }
             }
 
-            ViewModel?.UpdateSelectedItemCommand.Execute(item);
+            PushSelectionToVm(item);
 
             var pos = e.GetPosition(element);
             RequestContextMenuOpen(item, element, pos);
@@ -410,27 +408,23 @@ public sealed partial class ListItemsView : UserControl,
     // Message-driven navigation should count as keyboard.
     private void MarkKeyboardNavigation() => _lastInputSource = InputSource.Keyboard;
 
-    private void PushSelectionToVm()
+    private void PushSelectionToVm(bool forceUpdate = false) => PushSelectionToVm(ItemView.SelectedItem as ListItemViewModel, forceUpdate);
+
+    private void PushSelectionToVm(ListItemViewModel? item, bool forceUpdate = false)
     {
         if (ViewModel is null)
         {
             return;
         }
 
-        if (ItemView.SelectedItem is not ListItemViewModel li || IsSeparator(li))
+        if (item is null || IsSeparator(item))
         {
-            ViewModel.UpdateSelectedItemCommand.Execute(null);
+            ViewModel.SynchronizeSelection(null);
             return;
         }
 
-        if (ReferenceEquals(_lastPushedToVm, li))
-        {
-            return;
-        }
-
-        _lastPushedToVm = li;
-        _stickySelectedItem = li;
-        ViewModel.UpdateSelectedItemCommand.Execute(li);
+        _stickySelectedItem = item;
+        ViewModel.SynchronizeSelection(item, forceUpdate);
     }
 
     public void Receive(NavigateNextCommand message)
@@ -734,11 +728,9 @@ public sealed partial class ListItemsView : UserControl,
                 old.ItemsUpdated -= @this.Page_ItemsUpdated;
             }
 
-            // Reset latched state — selection sticky/last-pushed only make sense
-            // for the previous ViewModel's items.
+            // Sticky selection belongs to the previous page.
             @this._forceFirstPending = false;
             @this._stickySelectedItem = null;
-            @this._lastPushedToVm = null;
 
             if (@this._isLoaded || e.NewValue is null)
             {
@@ -865,7 +857,6 @@ public sealed partial class ListItemsView : UserControl,
             {
                 ItemView.SelectedIndex = -1;
                 _stickySelectedItem = null;
-                _lastPushedToVm = null;
             }
 
             PushSelectionToVm();
@@ -887,7 +878,6 @@ public sealed partial class ListItemsView : UserControl,
             {
                 ItemView.SelectedIndex = -1;
                 _stickySelectedItem = null;
-                _lastPushedToVm = null;
             }
 
             PushSelectionToVm();
@@ -1066,7 +1056,7 @@ public sealed partial class ListItemsView : UserControl,
             pos = new(0, element.ActualHeight);
         }
 
-        ViewModel?.UpdateSelectedItemCommand.Execute(item);
+        PushSelectionToVm(item);
         RequestContextMenuOpen(item, element, pos);
         e.Handled = true;
     }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Common.UnitTests/Helpers/SupersedingAsyncGateTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Common.UnitTests/Helpers/SupersedingAsyncGateTests.cs
@@ -1,0 +1,475 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CmdPal.Common.Helpers;
+
+namespace Microsoft.CmdPal.Common.UnitTests.Helpers;
+
+[TestClass]
+public sealed class SupersedingAsyncGateTests
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+
+    [TestMethod]
+    public async Task ExecuteAsync_QueuedCallsCoalesceOnWorkerScheduler()
+    {
+        var scheduler = new QueuedScheduler();
+        var calls = 0;
+        using var gate = new SupersedingAsyncGate(
+            _ =>
+            {
+                Assert.AreSame(scheduler, TaskScheduler.Current);
+                calls++;
+                return Task.CompletedTask;
+            },
+            scheduler);
+
+        var first = gate.ExecuteAsync();
+        var second = gate.ExecuteAsync();
+        var latest = gate.ExecuteAsync();
+
+        Assert.AreEqual(0, calls);
+        Assert.AreEqual(1, scheduler.Count);
+        scheduler.ExecuteAll();
+        await latest.WaitAsync(Timeout);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => first.WaitAsync(Timeout));
+        await Assert.ThrowsAsync<OperationCanceledException>(() => second.WaitAsync(Timeout));
+        Assert.IsTrue(first.IsCanceled);
+        Assert.IsTrue(second.IsCanceled);
+        Assert.AreEqual(1, calls);
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_RunningCallsStaySerializedAndSkipSupersededWork()
+    {
+        var scheduler = new QueuedScheduler();
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        var runningToken = CancellationToken.None;
+        using var gate = new SupersedingAsyncGate(
+            token =>
+            {
+                calls++;
+                if (calls == 1)
+                {
+                    runningToken = token;
+                    return release.Task;
+                }
+
+                return Task.CompletedTask;
+            },
+            scheduler);
+
+        try
+        {
+            var first = gate.ExecuteAsync();
+            scheduler.ExecuteAll();
+            var second = gate.ExecuteAsync();
+            var latest = gate.ExecuteAsync();
+
+            Assert.IsTrue(runningToken.IsCancellationRequested);
+            Assert.AreEqual(1, calls);
+            Assert.AreEqual(0, scheduler.Count);
+            Assert.IsFalse(latest.IsCompleted);
+            release.SetResult();
+            await latest.WaitAsync(Timeout);
+
+            await Assert.ThrowsAsync<OperationCanceledException>(() => first.WaitAsync(Timeout));
+            await Assert.ThrowsAsync<OperationCanceledException>(() => second.WaitAsync(Timeout));
+            Assert.AreEqual(2, calls);
+        }
+        finally
+        {
+            release.TrySetResult();
+        }
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_ReentrantRequestSurvivesPreviousCompletion()
+    {
+        var scheduler = new QueuedScheduler();
+        var calls = 0;
+        Task? latest = null;
+        SupersedingAsyncGate? gate = null;
+        gate = new(
+            _ =>
+            {
+                if (++calls == 1)
+                {
+                    latest = gate!.ExecuteAsync(CancellationToken.None);
+                }
+
+                return Task.CompletedTask;
+            },
+            scheduler);
+
+        using (gate)
+        {
+            var first = gate.ExecuteAsync();
+            scheduler.ExecuteAll();
+
+            Assert.IsNotNull(latest);
+            await latest.WaitAsync(Timeout);
+            await Assert.ThrowsAsync<OperationCanceledException>(() => first.WaitAsync(Timeout));
+            Assert.AreEqual(2, calls);
+            Assert.AreEqual(0, scheduler.Count);
+        }
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_CancellationCallbackCanSupersedeTheCancelingRequest()
+    {
+        var scheduler = new QueuedScheduler();
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var runningToken = CancellationToken.None;
+        var calls = 0;
+        using var gate = new SupersedingAsyncGate(
+            token =>
+            {
+                if (++calls == 1)
+                {
+                    runningToken = token;
+                    return release.Task;
+                }
+
+                return Task.CompletedTask;
+            },
+            scheduler);
+
+        try
+        {
+            var first = gate.ExecuteAsync();
+            scheduler.ExecuteAll();
+            Task? latest = null;
+            using var registration = runningToken.Register(() => latest = gate.ExecuteAsync());
+
+            var superseded = gate.ExecuteAsync();
+            Assert.IsNotNull(latest);
+            release.SetResult();
+            await latest.WaitAsync(Timeout);
+
+            await Assert.ThrowsAsync<OperationCanceledException>(() => first.WaitAsync(Timeout));
+            await Assert.ThrowsAsync<OperationCanceledException>(() => superseded.WaitAsync(Timeout));
+            Assert.AreEqual(2, calls);
+        }
+        finally
+        {
+            release.TrySetResult();
+        }
+    }
+
+    [TestMethod]
+    public async Task Dispose_FromCancellationCallbackCannotRevivePendingWork()
+    {
+        var scheduler = new QueuedScheduler();
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var runningToken = CancellationToken.None;
+        var calls = 0;
+        using var gate = new SupersedingAsyncGate(
+            token =>
+            {
+                calls++;
+                runningToken = token;
+                return release.Task;
+            },
+            scheduler);
+
+        try
+        {
+            var first = gate.ExecuteAsync();
+            scheduler.ExecuteAll();
+            using var registration = runningToken.Register(gate.Dispose);
+
+            var rejected = gate.ExecuteAsync();
+            await Assert.ThrowsExactlyAsync<ObjectDisposedException>(() => rejected.WaitAsync(Timeout));
+            await Assert.ThrowsAsync<OperationCanceledException>(() => first.WaitAsync(Timeout));
+            await Assert.ThrowsExactlyAsync<ObjectDisposedException>(() => gate.ExecuteAsync());
+            Assert.AreEqual(1, calls);
+        }
+        finally
+        {
+            release.TrySetResult();
+        }
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_CompletedWorkerCanRestart()
+    {
+        var scheduler = new QueuedScheduler();
+        var calls = 0;
+        using var gate = new SupersedingAsyncGate(
+            _ =>
+            {
+                calls++;
+                return Task.CompletedTask;
+            },
+            scheduler);
+
+        for (var i = 1; i <= 3; i++)
+        {
+            var execution = gate.ExecuteAsync();
+            Assert.AreEqual(1, scheduler.Count);
+            scheduler.ExecuteAll();
+            await execution.WaitAsync(Timeout);
+            Assert.AreEqual(i, calls);
+        }
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public async Task ExecuteAsync_FailureReachesCallerAndAllowsNextRequest(bool throwSynchronously)
+    {
+        var scheduler = new QueuedScheduler();
+        var failure = new InvalidOperationException("The operation failed.");
+        var calls = 0;
+        using var gate = new SupersedingAsyncGate(
+            _ =>
+            {
+                if (++calls == 1)
+                {
+                    return throwSynchronously ? throw failure : Task.FromException(failure);
+                }
+
+                return Task.CompletedTask;
+            },
+            scheduler);
+
+        var first = gate.ExecuteAsync();
+        scheduler.ExecuteAll();
+        var actual = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => first.WaitAsync(Timeout));
+        Assert.AreSame(failure, actual);
+
+        var next = gate.ExecuteAsync();
+        scheduler.ExecuteAll();
+        await next.WaitAsync(Timeout);
+        Assert.AreEqual(2, calls);
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_CanceledQueuedRequestDoesNotRun()
+    {
+        var scheduler = new QueuedScheduler();
+        var calls = 0;
+        using var cancellation = new CancellationTokenSource();
+        using var gate = new SupersedingAsyncGate(
+            _ =>
+            {
+                calls++;
+                return Task.CompletedTask;
+            },
+            scheduler);
+
+        var canceled = gate.ExecuteAsync(cancellation.Token);
+        cancellation.Cancel();
+        scheduler.ExecuteAll();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => canceled.WaitAsync(Timeout));
+        Assert.AreEqual(0, calls);
+
+        var next = gate.ExecuteAsync();
+        scheduler.ExecuteAll();
+        await next.WaitAsync(Timeout);
+        Assert.AreEqual(1, calls);
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_PreCanceledRequestDoesNotSupersedePendingWork()
+    {
+        var scheduler = new QueuedScheduler();
+        var calls = 0;
+        using var gate = new SupersedingAsyncGate(
+            _ =>
+            {
+                calls++;
+                return Task.CompletedTask;
+            },
+            scheduler);
+
+        var pending = gate.ExecuteAsync();
+        await Assert.ThrowsAsync<OperationCanceledException>(() => gate.ExecuteAsync(new CancellationToken(true)));
+        scheduler.ExecuteAll();
+        await pending.WaitAsync(Timeout);
+
+        Assert.AreEqual(1, calls);
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_ExternalCancellationReachesRunningWork()
+    {
+        var scheduler = new QueuedScheduler();
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var runningToken = CancellationToken.None;
+        var calls = 0;
+        using var cancellation = new CancellationTokenSource();
+        using var gate = new SupersedingAsyncGate(
+            token =>
+            {
+                calls++;
+                if (calls == 1)
+                {
+                    runningToken = token;
+                    return release.Task;
+                }
+
+                Assert.IsFalse(token.IsCancellationRequested);
+                return Task.CompletedTask;
+            },
+            scheduler);
+
+        try
+        {
+            var first = gate.ExecuteAsync(cancellation.Token);
+            scheduler.ExecuteAll();
+            cancellation.Cancel();
+            await Assert.ThrowsAsync<OperationCanceledException>(() => first.WaitAsync(Timeout));
+            Assert.IsTrue(runningToken.IsCancellationRequested);
+
+            var next = gate.ExecuteAsync();
+            Assert.AreEqual(1, calls);
+            release.SetResult();
+            await next.WaitAsync(Timeout);
+            Assert.AreEqual(2, calls);
+        }
+        finally
+        {
+            release.TrySetResult();
+        }
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_OldExternalCancellationDoesNotCancelLatestRequest()
+    {
+        var scheduler = new QueuedScheduler();
+        using var cancellation = new CancellationTokenSource();
+        using var gate = new SupersedingAsyncGate(
+            token =>
+            {
+                Assert.IsFalse(token.IsCancellationRequested);
+                return Task.CompletedTask;
+            },
+            scheduler);
+
+        var first = gate.ExecuteAsync(cancellation.Token);
+        var latest = gate.ExecuteAsync();
+        cancellation.Cancel();
+        scheduler.ExecuteAll();
+
+        await latest.WaitAsync(Timeout);
+        await Assert.ThrowsAsync<OperationCanceledException>(() => first.WaitAsync(Timeout));
+    }
+
+    [TestMethod]
+    public async Task Dispose_RejectsQueuedAndFutureWork()
+    {
+        var scheduler = new QueuedScheduler();
+        var calls = 0;
+        using var gate = new SupersedingAsyncGate(
+            _ =>
+            {
+                calls++;
+                return Task.CompletedTask;
+            },
+            scheduler);
+
+        var pending = gate.ExecuteAsync();
+        gate.Dispose();
+        scheduler.ExecuteAll();
+
+        await Assert.ThrowsExactlyAsync<ObjectDisposedException>(() => pending.WaitAsync(Timeout));
+        await Assert.ThrowsExactlyAsync<ObjectDisposedException>(() => gate.ExecuteAsync());
+        gate.Dispose();
+        Assert.AreEqual(0, calls);
+        Assert.AreEqual(0, scheduler.Count);
+    }
+
+    [TestMethod]
+    public async Task Dispose_KeepsRunningTokenUsableUntilActionReturns()
+    {
+        var scheduler = new QueuedScheduler();
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var finished = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var gate = new SupersedingAsyncGate(
+            async token =>
+            {
+                await release.Task.ConfigureAwait(false);
+                try
+                {
+                    Assert.IsTrue(token.IsCancellationRequested);
+                    using var registration = token.Register(() => { });
+                    Assert.IsNotNull(token.WaitHandle);
+                    finished.SetResult();
+                }
+                catch (Exception ex)
+                {
+                    finished.SetException(ex);
+                    throw;
+                }
+            },
+            scheduler);
+
+        try
+        {
+            var pending = gate.ExecuteAsync();
+            scheduler.ExecuteAll();
+            gate.Dispose();
+            await Assert.ThrowsExactlyAsync<ObjectDisposedException>(() => pending.WaitAsync(Timeout));
+
+            release.SetResult();
+            await finished.Task.WaitAsync(Timeout);
+        }
+        finally
+        {
+            release.TrySetResult();
+        }
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_SchedulerFailureDoesNotLeaveGateRunning()
+    {
+        var scheduler = new QueuedScheduler { RejectNextTask = true };
+        using var gate = new SupersedingAsyncGate(_ => Task.CompletedTask, scheduler);
+
+        await Assert.ThrowsExactlyAsync<TaskSchedulerException>(() => gate.ExecuteAsync());
+        var next = gate.ExecuteAsync();
+        scheduler.ExecuteAll();
+        await next.WaitAsync(Timeout);
+    }
+
+    private sealed class QueuedScheduler : TaskScheduler
+    {
+        private readonly Queue<Task> _tasks = [];
+
+        internal int Count => _tasks.Count;
+
+        internal bool RejectNextTask { get; set; }
+
+        protected override IEnumerable<Task> GetScheduledTasks() => _tasks.ToArray();
+
+        protected override void QueueTask(Task task)
+        {
+            if (RejectNextTask)
+            {
+                RejectNextTask = false;
+                throw new InvalidOperationException("The scheduler rejected the task.");
+            }
+
+            _tasks.Enqueue(task);
+        }
+
+        protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued) => false;
+
+        internal void ExecuteAll()
+        {
+            while (_tasks.TryDequeue(out var task))
+            {
+                Assert.IsTrue(TryExecuteTask(task));
+                task.GetAwaiter().GetResult();
+            }
+        }
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Common.UnitTests/Helpers/SupersedingAsyncGateTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Common.UnitTests/Helpers/SupersedingAsyncGateTests.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CmdPal.Common.Helpers;
@@ -338,6 +339,76 @@ public sealed class SupersedingAsyncGateTests
         finally
         {
             release.TrySetResult();
+        }
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_ExternalCallbackCanReenterDuringSourceDisposal()
+    {
+        var scheduler = new QueuedScheduler();
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var callbackEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var runningToken = CancellationToken.None;
+        var calls = 0;
+        using var cancellation = new CancellationTokenSource();
+        using var gate = new SupersedingAsyncGate(
+            token =>
+            {
+                if (++calls == 1)
+                {
+                    runningToken = token;
+                    return release.Task;
+                }
+
+                return Task.CompletedTask;
+            },
+            scheduler);
+
+        // Observe cleanup directly so this race does not depend on thread timing.
+        var sourceField = typeof(SupersedingAsyncGate).GetField("_currentCancellationSource", BindingFlags.Instance | BindingFlags.NonPublic);
+        var lockField = typeof(SupersedingAsyncGate).GetField("_lock", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.IsNotNull(sourceField);
+        Assert.IsNotNull(lockField);
+        Assert.IsInstanceOfType<Lock>(lockField.GetValue(gate), out var gateLock);
+
+        var first = gate.ExecuteAsync(cancellation.Token);
+        scheduler.ExecuteAll();
+        Task? latest = null;
+        using var registration = runningToken.Register(() =>
+        {
+            callbackEntered.SetResult();
+            Assert.IsTrue(
+                SpinWait.SpinUntil(() => sourceField.GetValue(gate) is null, Timeout),
+                "Cleanup must retire the source while its cancellation callback is still running.");
+            Assert.IsTrue(
+                gateLock.TryEnter(Timeout),
+                "Source disposal must not hold the lock needed by the cancellation callback.");
+            try
+            {
+                latest = gate.ExecuteAsync();
+            }
+            finally
+            {
+                gateLock.Exit();
+            }
+        });
+        var cancelTask = Task.Run(cancellation.Cancel);
+
+        try
+        {
+            await callbackEntered.Task.WaitAsync(Timeout);
+            release.SetResult();
+            await cancelTask.WaitAsync(Timeout + Timeout);
+            await Assert.ThrowsAsync<OperationCanceledException>(() => first.WaitAsync(Timeout));
+
+            Assert.IsNotNull(latest);
+            await latest.WaitAsync(Timeout);
+            Assert.AreEqual(2, calls);
+        }
+        finally
+        {
+            release.TrySetResult();
+            await cancelTask.WaitAsync(Timeout + Timeout);
         }
     }
 

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/StaticPageFilteringActivationTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/StaticPageFilteringActivationTests.cs
@@ -210,9 +210,11 @@ public sealed partial class StaticPageFilteringTests
     }
 
     [TestMethod]
-    [DataRow(false)]
-    [DataRow(true)]
-    public async Task DeferredSecondaryActivation_WaitsForHydrationUnlessSelectionChanges(bool changeSelection)
+    [DataRow(false, false)]
+    [DataRow(true, false)]
+    [DataRow(false, true)]
+    [DataRow(true, true)]
+    public async Task DeferredSecondaryActivation_WaitsForHydrationUnlessSelectionChanges(bool changeSelection, bool refreshWhileHydrating)
     {
         using var release = new ManualResetEventSlim();
         var secondary = new NoOpCommand { Name = "Secondary" };
@@ -225,14 +227,7 @@ public sealed partial class StaticPageFilteringTests
         fixture.ViewModel.InvokeSecondaryCommandCommand.Execute(previous);
         fixture.Drain();
         var selected = fixture.ViewModel.FilteredItems.First(item => ReferenceEquals(item.Model.Unsafe, beta));
-        var hydrated = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        selected.PropertyChanged += (_, args) =>
-        {
-            if (args.PropertyName == nameof(ListItemViewModel.TextToSuggest))
-            {
-                hydrated.TrySetResult();
-            }
-        };
+        var hydrated = ObserveHydration(selected);
 
         fixture.CompleteSelection(selected);
         try
@@ -241,14 +236,24 @@ public sealed partial class StaticPageFilteringTests
             fixture.Ui.ExecuteAll();
             Assert.HasCount(0, commands.Messages);
 
+            if (refreshWhileHydrating)
+            {
+                fixture.Page.Refresh(ListViewModel.IncrementalRefresh);
+                fixture.Drain();
+            }
+
             if (changeSelection)
             {
                 fixture.CompleteSelection(fixture.ViewModel.FilteredItems.First(item => !ReferenceEquals(item, selected)));
             }
+            else
+            {
+                fixture.CompleteSelection(selected);
+            }
 
             release.Set();
             using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-            while (!hydrated.Task.IsCompleted || (!changeSelection && commands.Messages.Count == 0))
+            while (!hydrated.IsCompleted || (!changeSelection && commands.Messages.Count == 0))
             {
                 await fixture.Ui.WhenQueued.WaitAsync(timeout.Token);
                 fixture.Ui.ExecuteAll();
@@ -264,6 +269,225 @@ public sealed partial class StaticPageFilteringTests
         finally
         {
             release.Set();
+        }
+    }
+
+    [TestMethod]
+    public async Task DeferredSecondaryActivation_FailedHydrationDoesNotActivateReplacement()
+    {
+        using var release = new ManualResetEventSlim();
+        var beta = new DeferredCommandsItem(release, new NoOpCommand(), failHydration: true) { Title = "Beta" };
+        var fallbackCommand = new NoOpCommand { Name = "Fallback secondary" };
+        var fallback = Item("Beta other");
+        fallback.MoreCommands = [new CommandContextItem(fallbackCommand)];
+        using var fixture = new Fixture(Item("Alpha"), beta, fallback);
+        using var commands = new CommandObserver();
+        var fallbackVm = fixture.ViewModel.FilteredItems[2];
+        Assert.IsTrue(fallbackVm.SafeSlowInit());
+        fixture.CompleteSelection(fixture.ViewModel.FilteredItems[0]);
+        fixture.ViewModel.SearchTextBox = "Beta";
+        fixture.ViewModel.InvokeSecondaryCommandCommand.Execute(fixture.ViewModel.FilteredItems[0]);
+        fixture.Drain();
+        var selected = fixture.ViewModel.FilteredItems.First(item => ReferenceEquals(item.Model.Unsafe, beta));
+
+        fixture.CompleteSelection(selected);
+        try
+        {
+            await beta.Entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.HasCount(0, commands.Messages);
+            release.Set();
+            await fixture.Worker.WhenQueued.WaitAsync(TimeSpan.FromSeconds(5));
+            fixture.Drain();
+
+            Assert.IsTrue(selected.IsInErrorState);
+            Assert.AreSame(fallbackVm, fixture.ViewModel.FilteredItems.Single());
+            fixture.CompleteSelection(fallbackVm);
+            Assert.HasCount(0, commands.Messages);
+
+            fixture.ViewModel.InvokeSecondaryCommandCommand.Execute(fallbackVm);
+            Assert.HasCount(1, commands.Messages);
+            Assert.AreSame(fallbackCommand, commands.Messages[0].Command.Unsafe);
+            Assert.AreSame(fallback, commands.Messages[0].Context);
+        }
+        finally
+        {
+            release.Set();
+        }
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public async Task DeferredSecondaryActivation_RemovedTargetDoesNotActivateReplacement(bool filterOut)
+    {
+        using var release = new ManualResetEventSlim();
+        var beta = new DeferredCommandsItem(release, new NoOpCommand()) { Title = "Beta" };
+        var fallback = Item("Beta other");
+        fallback.MoreCommands = [new CommandContextItem(new NoOpCommand())];
+        using var fixture = new Fixture(Item("Alpha"), beta, fallback);
+        using var commands = new CommandObserver();
+        var fallbackVm = fixture.ViewModel.FilteredItems[2];
+        Assert.IsTrue(fallbackVm.SafeSlowInit());
+        fixture.CompleteSelection(fixture.ViewModel.FilteredItems[0]);
+        fixture.ViewModel.SearchTextBox = "Beta";
+        fixture.ViewModel.InvokeSecondaryCommandCommand.Execute(fixture.ViewModel.FilteredItems[0]);
+        fixture.Drain();
+        var selected = fixture.ViewModel.FilteredItems.First(item => ReferenceEquals(item.Model.Unsafe, beta));
+        var hydrated = ObserveHydration(selected);
+
+        fixture.CompleteSelection(selected);
+        try
+        {
+            await beta.Entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            if (filterOut)
+            {
+                beta.Title = "Unrelated";
+                selected.ApplyPendingUpdates();
+            }
+            else
+            {
+                fixture.Page.SetItems(fallback);
+                fixture.Page.Refresh(ListViewModel.IncrementalRefresh);
+            }
+
+            fixture.Drain();
+            Assert.AreSame(fallbackVm, fixture.ViewModel.FilteredItems.Single());
+            fixture.CompleteSelection(fallbackVm);
+            Assert.HasCount(0, commands.Messages);
+
+            release.Set();
+            await DrainUntilHydrated(fixture, hydrated);
+            Assert.HasCount(0, commands.Messages);
+        }
+        finally
+        {
+            release.Set();
+        }
+    }
+
+    [TestMethod]
+    public async Task DeferredSecondaryActivation_FilteredOutTargetCannotResumeWhenItReturns()
+    {
+        using var release = new ManualResetEventSlim();
+        var beta = new DeferredCommandsItem(release, new NoOpCommand()) { Title = "Beta" };
+        using var fixture = new Fixture(Item("Alpha"), beta, Item("Beta other"));
+        using var commands = new CommandObserver();
+        fixture.CompleteSelection(fixture.ViewModel.FilteredItems[0]);
+        fixture.ViewModel.SearchTextBox = "Beta";
+        fixture.ViewModel.InvokeSecondaryCommandCommand.Execute(fixture.ViewModel.FilteredItems[0]);
+        fixture.Drain();
+        var selected = fixture.ViewModel.FilteredItems.First(item => ReferenceEquals(item.Model.Unsafe, beta));
+        var hydrated = ObserveHydration(selected);
+
+        fixture.CompleteSelection(selected);
+        try
+        {
+            await beta.Entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            beta.Title = "Unrelated";
+            selected.ApplyPendingUpdates();
+            fixture.Drain();
+            Assert.IsFalse(fixture.ViewModel.FilteredItems.Contains(selected));
+            beta.Title = "Beta";
+            selected.ApplyPendingUpdates();
+            fixture.Drain();
+            fixture.CompleteSelection(selected);
+            release.Set();
+            await DrainUntilHydrated(fixture, hydrated);
+            Assert.IsTrue(fixture.ViewModel.CompleteStaticFilterSelection(fixture.ViewModel.PublishedFilterVersion, selected));
+
+            Assert.HasCount(0, commands.Messages);
+        }
+        finally
+        {
+            release.Set();
+        }
+    }
+
+    [TestMethod]
+    [DataRow(false, false)]
+    [DataRow(true, false)]
+    [DataRow(false, true)]
+    [DataRow(true, true)]
+    public void SelectionSynchronization_AfterPointerSelection_ReleasesActivation(bool secondary, bool clearSelection)
+    {
+        var alpha = Item("Alpha");
+        var secondaryCommand = new NoOpCommand { Name = "Alpha secondary" };
+        alpha.MoreCommands = [new CommandContextItem(secondaryCommand)];
+        using var fixture = new Fixture(alpha, Item("Beta"));
+        using var commands = new CommandObserver();
+        var alphaVm = fixture.ViewModel.FilteredItems[0];
+        var betaVm = fixture.ViewModel.FilteredItems[1];
+        Assert.IsTrue(alphaVm.SafeSlowInit());
+        fixture.CompleteSelection(alphaVm);
+        fixture.ViewModel.SynchronizeSelection(betaVm);
+        Assert.IsTrue(fixture.ViewModel.CompleteStaticFilterSelection(fixture.ViewModel.PublishedFilterVersion, betaVm));
+        if (clearSelection)
+        {
+            fixture.ViewModel.SynchronizeSelection(null);
+        }
+
+        fixture.ViewModel.SearchTextBox = "a";
+        Activate(fixture, betaVm, secondary);
+        fixture.Drain();
+        Assert.HasCount(2, fixture.ViewModel.FilteredItems);
+        Assert.AreSame(alphaVm, fixture.ViewModel.FilteredItems[0]);
+        fixture.ViewModel.SynchronizeSelection(alphaVm);
+
+        Assert.IsTrue(fixture.ViewModel.CompleteStaticFilterSelection(fixture.ViewModel.PublishedFilterVersion, alphaVm));
+        Assert.HasCount(1, commands.Messages);
+        Assert.AreSame(secondary ? secondaryCommand : alpha.Command, commands.Messages[0].Command.Unsafe);
+        Assert.AreSame(alpha, commands.Messages[0].Context);
+    }
+
+    [TestMethod]
+    public void SelectionSynchronization_SameItemRefreshesOnlyWhenRequested()
+    {
+        using var fixture = new Fixture(Item("Alpha"), Item("Beta"));
+        var alpha = fixture.ViewModel.FilteredItems[0];
+        var beta = fixture.ViewModel.FilteredItems[1];
+        Assert.IsTrue(alpha.SafeSlowInit());
+        fixture.CompleteSelection(alpha);
+        var recipient = new object();
+        var updates = 0;
+        WeakReferenceMessenger.Default.Register<UpdateCommandBarMessage>(recipient, (_, _) => updates++);
+        try
+        {
+            fixture.ViewModel.SynchronizeSelection(alpha);
+            Assert.AreEqual(0, updates);
+            fixture.ViewModel.SynchronizeSelection(alpha, forceUpdate: true);
+            Assert.AreEqual(1, updates);
+
+            fixture.ViewModel.UpdateSelectedItemCommand.Execute(beta);
+            fixture.ViewModel.SynchronizeSelection(alpha);
+            Assert.AreEqual(3, updates);
+            Assert.IsTrue(fixture.ViewModel.CompleteStaticFilterSelection(fixture.ViewModel.PublishedFilterVersion, alpha));
+        }
+        finally
+        {
+            WeakReferenceMessenger.Default.UnregisterAll(recipient);
+        }
+    }
+
+    private static Task ObserveHydration(ListItemViewModel item)
+    {
+        var hydrated = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        item.PropertyChanged += (_, args) =>
+        {
+            if (args.PropertyName == nameof(ListItemViewModel.TextToSuggest))
+            {
+                hydrated.TrySetResult();
+            }
+        };
+        return hydrated.Task;
+    }
+
+    private static async Task DrainUntilHydrated(Fixture fixture, Task hydrated)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        while (!hydrated.IsCompleted)
+        {
+            await fixture.Ui.WhenQueued.WaitAsync(timeout.Token);
+            fixture.Ui.ExecuteAll();
         }
     }
 
@@ -293,7 +517,7 @@ public sealed partial class StaticPageFilteringTests
         public void Dispose() => WeakReferenceMessenger.Default.UnregisterAll(this);
     }
 
-    private sealed partial class DeferredCommandsItem(ManualResetEventSlim release, ICommand command) : ListItem(new NoOpCommand())
+    private sealed partial class DeferredCommandsItem(ManualResetEventSlim release, ICommand command, bool failHydration = false) : ListItem(new NoOpCommand())
     {
         internal TaskCompletionSource Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -305,6 +529,11 @@ public sealed partial class StaticPageFilteringTests
                 if (!release.Wait(TimeSpan.FromSeconds(5)))
                 {
                     throw new TimeoutException("Command hydration was not released.");
+                }
+
+                if (failHydration)
+                {
+                    throw new InvalidOperationException("Command hydration failed.");
                 }
 
                 return [new CommandContextItem(command)];

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/StaticPageFilteringActivationTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/StaticPageFilteringActivationTests.cs
@@ -1,0 +1,316 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.CmdPal.UI.ViewModels.Messages;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+public sealed partial class StaticPageFilteringTests
+{
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void Activation_WaitsForPublishedQueryAndItsSelection(bool secondary)
+    {
+        var alpha = Item("Alpha");
+        var beta = Item("Beta");
+        var secondaryCommand = new NoOpCommand { Name = "Beta secondary" };
+        beta.MoreCommands = [new CommandContextItem(secondaryCommand)];
+        using var fixture = new Fixture(alpha, beta);
+        using var commands = new CommandObserver();
+        var alphaVm = fixture.ViewModel.FilteredItems[0];
+        var betaVm = fixture.ViewModel.FilteredItems[1];
+        Assert.IsTrue(betaVm.SafeSlowInit());
+        fixture.CompleteSelection(alphaVm);
+        var oldVersion = fixture.ViewModel.PublishedFilterVersion;
+
+        fixture.ViewModel.SearchTextBox = "Beta";
+        Activate(fixture, alphaVm, secondary);
+        Assert.HasCount(0, commands.Messages);
+        fixture.Worker.ExecuteAll();
+        Assert.HasCount(0, commands.Messages);
+        fixture.Ui.ExecuteAll();
+        Assert.HasCount(0, commands.Messages);
+        fixture.ViewModel.CompleteStaticFilterSelection(oldVersion, alphaVm);
+        Assert.IsFalse(fixture.ViewModel.CompleteStaticFilterSelection(fixture.ViewModel.PublishedFilterVersion, alphaVm));
+        Assert.HasCount(0, commands.Messages);
+
+        fixture.CompleteSelection(betaVm);
+
+        Assert.HasCount(1, commands.Messages);
+        Assert.AreSame(secondary ? secondaryCommand : beta.Command, commands.Messages[0].Command.Unsafe);
+        Assert.AreSame(beta, commands.Messages[0].Context);
+        fixture.ViewModel.CompleteStaticFilterSelection(fixture.ViewModel.PublishedFilterVersion, betaVm);
+        Assert.HasCount(1, commands.Messages);
+    }
+
+    [TestMethod]
+    public void Activation_WithNoPreviousSelection_WaitsForMatchingItem()
+    {
+        var beta = Item("Beta");
+        using var fixture = new Fixture(beta);
+        using var commands = new CommandObserver();
+
+        fixture.ViewModel.SearchTextBox = "Beta";
+        fixture.ViewModel.InvokeItemCommand.Execute(null);
+        fixture.Drain();
+        Assert.HasCount(0, commands.Messages);
+        Assert.IsFalse(fixture.ViewModel.CompleteStaticFilterSelection(fixture.ViewModel.PublishedFilterVersion, null));
+        Assert.HasCount(0, commands.Messages);
+
+        fixture.CompleteSelection(fixture.ViewModel.FilteredItems.Single());
+
+        Assert.HasCount(1, commands.Messages);
+        Assert.AreSame(beta, commands.Messages[0].Context);
+    }
+
+    [TestMethod]
+    public void Activation_WithNoMatches_DoesNotRunPreviousSelection()
+    {
+        using var fixture = new Fixture(Item("Alpha"));
+        using var commands = new CommandObserver();
+        var previous = fixture.ViewModel.FilteredItems.Single();
+        fixture.CompleteSelection(previous);
+
+        fixture.ViewModel.SearchTextBox = "no matching item";
+        fixture.ViewModel.InvokeItemCommand.Execute(previous);
+        fixture.Drain();
+        fixture.CompleteSelection(null);
+
+        Assert.HasCount(0, fixture.ViewModel.FilteredItems);
+        Assert.HasCount(0, commands.Messages);
+        fixture.ViewModel.SearchTextBox = string.Empty;
+        fixture.Drain();
+        fixture.CompleteSelection(fixture.ViewModel.FilteredItems.Single());
+        Assert.HasCount(0, commands.Messages);
+    }
+
+    [TestMethod]
+    public void NewQuery_CancelsDeferredActivation()
+    {
+        using var fixture = new Fixture(Item("Alpha"), Item("Beta"), Item("Gamma"));
+        using var commands = new CommandObserver();
+        var previous = fixture.ViewModel.FilteredItems[0];
+        fixture.CompleteSelection(previous);
+
+        fixture.ViewModel.SearchTextBox = "Beta";
+        fixture.ViewModel.InvokeItemCommand.Execute(previous);
+        fixture.Worker.ExecuteAll();
+        fixture.ViewModel.SearchTextBox = "Gamma";
+        fixture.Drain();
+        fixture.CompleteSelection(fixture.ViewModel.FilteredItems.Single());
+
+        CollectionAssert.AreEqual(GammaTitles, fixture.Titles);
+        Assert.HasCount(0, commands.Messages);
+    }
+
+    [TestMethod]
+    public void ItemRefresh_ResolvesDeferredActivationAgainstNewGeneration()
+    {
+        var replacement = Item("Beta replacement");
+        using var fixture = new Fixture(Item("Alpha"), Item("Beta"));
+        using var commands = new CommandObserver();
+        var previous = fixture.ViewModel.FilteredItems[0];
+        fixture.CompleteSelection(previous);
+
+        fixture.ViewModel.SearchTextBox = "Beta";
+        fixture.ViewModel.InvokeItemCommand.Execute(previous);
+        fixture.Worker.ExecuteAll();
+        fixture.Page.SetItems(replacement);
+        fixture.Page.Refresh();
+        fixture.Drain();
+        Assert.HasCount(0, commands.Messages);
+
+        fixture.CompleteSelection(fixture.ViewModel.FilteredItems.Single());
+
+        Assert.HasCount(1, commands.Messages);
+        Assert.AreSame(replacement, commands.Messages[0].Context);
+    }
+
+    [TestMethod]
+    public void ReentrantActivation_WaitsUntilPublicationCompletes()
+    {
+        var beta = Item("Beta");
+        using var fixture = new Fixture(Item("Alpha"), beta);
+        using var commands = new CommandObserver();
+        var previous = fixture.ViewModel.FilteredItems[0];
+        fixture.CompleteSelection(previous);
+        NotifyCollectionChangedEventHandler onCollectionChanged = (_, _) =>
+        {
+            fixture.ViewModel.InvokeItemCommand.Execute(previous);
+            Assert.HasCount(0, commands.Messages);
+        };
+        fixture.ViewModel.FilteredItems.CollectionChanged += onCollectionChanged;
+        fixture.ViewModel.ItemsUpdated += (_, _) =>
+        {
+            fixture.CompleteSelection(fixture.ViewModel.FilteredItems.Single());
+            Assert.HasCount(0, commands.Messages);
+        };
+
+        fixture.ViewModel.SearchTextBox = "Beta";
+        fixture.Drain();
+        fixture.ViewModel.FilteredItems.CollectionChanged -= onCollectionChanged;
+
+        Assert.HasCount(1, commands.Messages);
+        Assert.AreSame(beta, commands.Messages[0].Context);
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void RendererDetachOrDisposal_CancelsDeferredActivation(bool dispose)
+    {
+        using var fixture = new Fixture(Item("Alpha"), Item("Beta"));
+        using var commands = new CommandObserver();
+        var previous = fixture.ViewModel.FilteredItems[0];
+        fixture.CompleteSelection(previous);
+        fixture.ViewModel.SearchTextBox = "Beta";
+        fixture.ViewModel.InvokeItemCommand.Execute(previous);
+        fixture.Worker.ExecuteAll();
+
+        if (dispose)
+        {
+            fixture.ViewModel.Dispose();
+        }
+        else
+        {
+            fixture.ViewModel.CancelPendingActivation();
+        }
+
+        fixture.Ui.ExecuteAll();
+        fixture.CompleteSelection(fixture.ViewModel.FilteredItems[0]);
+
+        Assert.HasCount(0, commands.Messages);
+    }
+
+    [TestMethod]
+    public void CurrentSelection_ActivatesImmediately()
+    {
+        var alpha = Item("Alpha");
+        using var fixture = new Fixture(alpha);
+        using var commands = new CommandObserver();
+        var selected = fixture.ViewModel.FilteredItems.Single();
+        fixture.CompleteSelection(selected);
+
+        fixture.ViewModel.InvokeItemCommand.Execute(selected);
+
+        Assert.HasCount(1, commands.Messages);
+        Assert.AreSame(alpha, commands.Messages[0].Context);
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public async Task DeferredSecondaryActivation_WaitsForHydrationUnlessSelectionChanges(bool changeSelection)
+    {
+        using var release = new ManualResetEventSlim();
+        var secondary = new NoOpCommand { Name = "Secondary" };
+        var beta = new DeferredCommandsItem(release, secondary) { Title = "Beta" };
+        using var fixture = new Fixture(Item("Alpha"), beta, Item("Beta other"));
+        using var commands = new CommandObserver();
+        var previous = fixture.ViewModel.FilteredItems[0];
+        fixture.CompleteSelection(previous);
+        fixture.ViewModel.SearchTextBox = "Beta";
+        fixture.ViewModel.InvokeSecondaryCommandCommand.Execute(previous);
+        fixture.Drain();
+        var selected = fixture.ViewModel.FilteredItems.First(item => ReferenceEquals(item.Model.Unsafe, beta));
+        var hydrated = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        selected.PropertyChanged += (_, args) =>
+        {
+            if (args.PropertyName == nameof(ListItemViewModel.TextToSuggest))
+            {
+                hydrated.TrySetResult();
+            }
+        };
+
+        fixture.CompleteSelection(selected);
+        try
+        {
+            await beta.Entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            fixture.Ui.ExecuteAll();
+            Assert.HasCount(0, commands.Messages);
+
+            if (changeSelection)
+            {
+                fixture.CompleteSelection(fixture.ViewModel.FilteredItems.First(item => !ReferenceEquals(item, selected)));
+            }
+
+            release.Set();
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            while (!hydrated.Task.IsCompleted || (!changeSelection && commands.Messages.Count == 0))
+            {
+                await fixture.Ui.WhenQueued.WaitAsync(timeout.Token);
+                fixture.Ui.ExecuteAll();
+            }
+
+            Assert.HasCount(changeSelection ? 0 : 1, commands.Messages);
+            if (!changeSelection)
+            {
+                Assert.AreSame(secondary, commands.Messages[0].Command.Unsafe);
+                Assert.AreSame(beta, commands.Messages[0].Context);
+            }
+        }
+        finally
+        {
+            release.Set();
+        }
+    }
+
+    private static void Activate(Fixture fixture, ListItemViewModel? item, bool secondary)
+    {
+        if (secondary)
+        {
+            fixture.ViewModel.InvokeSecondaryCommandCommand.Execute(item);
+        }
+        else
+        {
+            fixture.ViewModel.InvokeItemCommand.Execute(item);
+        }
+    }
+
+    private sealed class CommandObserver : IDisposable
+    {
+        internal List<PerformCommandMessage> Messages { get; } = [];
+
+        internal CommandObserver()
+        {
+            WeakReferenceMessenger.Default.Register<CommandObserver, PerformCommandMessage>(
+                this,
+                static (observer, message) => observer.Messages.Add(message));
+        }
+
+        public void Dispose() => WeakReferenceMessenger.Default.UnregisterAll(this);
+    }
+
+    private sealed partial class DeferredCommandsItem(ManualResetEventSlim release, ICommand command) : ListItem(new NoOpCommand())
+    {
+        internal TaskCompletionSource Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override IContextItem[] MoreCommands
+        {
+            get
+            {
+                Entered.TrySetResult();
+                if (!release.Wait(TimeSpan.FromSeconds(5)))
+                {
+                    throw new TimeoutException("Command hydration was not released.");
+                }
+
+                return [new CommandContextItem(command)];
+            }
+
+            set => throw new NotSupportedException();
+        }
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/StaticPageFilteringRefreshTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/StaticPageFilteringRefreshTests.cs
@@ -1,0 +1,159 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+public sealed partial class StaticPageFilteringTests
+{
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void FailedRefresh_ResumesPendingAndFutureQueries(bool canceledByProvider)
+    {
+        using var fixture = new Fixture(Item("Alpha"), Item("Beta"));
+        var updatesDuringFetch = -1;
+        fixture.Page.BeforeGetItems = () =>
+        {
+            fixture.ViewModel.SearchTextBox = "Beta";
+            fixture.Drain();
+            updatesDuringFetch = fixture.Updates.Count;
+            if (canceledByProvider)
+            {
+                throw new OperationCanceledException();
+            }
+
+            throw new InvalidOperationException("Provider refresh failed.");
+        };
+
+        fixture.Page.Refresh();
+        fixture.Drain();
+        Assert.AreEqual(0, updatesDuringFetch);
+        CollectionAssert.AreEqual(BetaTitles, fixture.Titles);
+        Assert.HasCount(1, fixture.Updates);
+        Assert.IsTrue(fixture.Updates[0].ForceFirstItem);
+        if (!canceledByProvider)
+        {
+            StringAssert.Contains(fixture.ViewModel.ErrorMessage, "Provider refresh failed.");
+        }
+
+        fixture.ViewModel.SearchTextBox = "Alpha";
+        fixture.Drain();
+        CollectionAssert.AreEqual(AlphaTitles, fixture.Titles);
+
+        fixture.Page.BeforeGetItems = null;
+        fixture.Page.SetItems(Item("Gamma"));
+        fixture.Page.Refresh();
+        fixture.ViewModel.SearchTextBox = "Gamma";
+        fixture.Drain();
+        CollectionAssert.AreEqual(GammaTitles, fixture.Titles);
+    }
+
+    [TestMethod]
+    public void FailedRefresh_ReplaysActivationOnlyAfterRecoveredSelection()
+    {
+        var beta = Item("Beta");
+        using var fixture = new Fixture(Item("Alpha"), beta);
+        using var commands = new CommandObserver();
+        var previous = fixture.ViewModel.FilteredItems[0];
+        fixture.CompleteSelection(previous);
+        fixture.Page.BeforeGetItems = () =>
+        {
+            fixture.ViewModel.SearchTextBox = "Beta";
+            fixture.ViewModel.InvokeItemCommand.Execute(previous);
+            throw new InvalidOperationException("Provider refresh failed.");
+        };
+
+        fixture.Page.Refresh();
+        fixture.Drain();
+        StringAssert.Contains(fixture.ViewModel.ErrorMessage, "Provider refresh failed.");
+        Assert.HasCount(0, commands.Messages);
+        fixture.CompleteSelection(fixture.ViewModel.FilteredItems.Single());
+
+        Assert.HasCount(1, commands.Messages);
+        Assert.AreSame(beta, commands.Messages[0].Context);
+    }
+
+    [TestMethod]
+    public async Task OlderFailedRefresh_DoesNotReleaseQueriesDuringNewerFetch()
+    {
+        using var fixture = new Fixture(Item("Alpha"), Item("Beta"));
+        using var releaseOld = new ManualResetEventSlim();
+        using var releaseNew = new ManualResetEventSlim();
+        var oldEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var newEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        fixture.Page.BeforeGetItems = () =>
+        {
+            if (Interlocked.Increment(ref calls) == 1)
+            {
+                oldEntered.SetResult();
+                Assert.IsTrue(releaseOld.Wait(TimeSpan.FromSeconds(5)));
+                throw new InvalidOperationException("Old refresh failed.");
+            }
+
+            newEntered.SetResult();
+            Assert.IsTrue(releaseNew.Wait(TimeSpan.FromSeconds(5)));
+        };
+
+        var oldFetch = Task.Run(() => fixture.Page.Refresh());
+        Task? newFetch = null;
+        try
+        {
+            await oldEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            newFetch = Task.Run(() => fixture.Page.Refresh());
+            await newEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            fixture.ViewModel.SearchTextBox = "Beta";
+            releaseOld.Set();
+            await oldFetch.WaitAsync(TimeSpan.FromSeconds(5));
+            fixture.Drain();
+
+            StringAssert.Contains(fixture.ViewModel.ErrorMessage, "Old refresh failed.");
+            Assert.HasCount(0, fixture.Updates);
+            CollectionAssert.AreEqual(InitialTitles, fixture.Titles);
+
+            releaseNew.Set();
+            await newFetch.WaitAsync(TimeSpan.FromSeconds(5));
+            fixture.Drain();
+
+            CollectionAssert.AreEqual(BetaTitles, fixture.Titles);
+            Assert.HasCount(1, fixture.Updates);
+        }
+        finally
+        {
+            releaseOld.Set();
+            releaseNew.Set();
+            await oldFetch.WaitAsync(TimeSpan.FromSeconds(5));
+            if (newFetch is not null)
+            {
+                await newFetch.WaitAsync(TimeSpan.FromSeconds(5));
+            }
+        }
+    }
+
+    [TestMethod]
+    public void FailedRefresh_AfterDisposal_DoesNotRestartFiltering()
+    {
+        using var fixture = new Fixture(Item("Alpha"));
+        fixture.Page.BeforeGetItems = () =>
+        {
+            fixture.ViewModel.SearchTextBox = "Beta";
+            fixture.ViewModel.Dispose();
+            throw new InvalidOperationException("Provider refresh failed.");
+        };
+
+        fixture.Page.Refresh();
+        fixture.Drain();
+
+        StringAssert.Contains(fixture.ViewModel.ErrorMessage, "Provider refresh failed.");
+        Assert.AreEqual(0, fixture.Worker.Count);
+        Assert.HasCount(0, fixture.Updates);
+        CollectionAssert.AreEqual(AlphaTitles, fixture.Titles);
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/StaticPageFilteringTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/StaticPageFilteringTests.cs
@@ -1,0 +1,541 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+[TestClass]
+public sealed partial class StaticPageFilteringTests
+{
+    private static readonly string[] AlphaTitles = ["Alpha"];
+    private static readonly string[] BetaTitles = ["Beta"];
+    private static readonly string[] GammaTitles = ["Gamma"];
+    private static readonly string[] InitialTitles = ["Alpha", "Beta"];
+    private static readonly string[] ReplacementTitles = ["Alpha replacement"];
+
+    [TestMethod]
+    public void QueryChanges_CoalesceBeforeScoringAndPublishOnlyOnUiScheduler()
+    {
+        using var fixture = new Fixture(Item("Alpha"), Item("Beta"), Item("Gamma"));
+        var original = fixture.ViewModel.FilteredItems.ToArray();
+        var notifications = 0;
+        fixture.ViewModel.FilteredItems.CollectionChanged += (_, _) =>
+        {
+            Assert.AreSame(fixture.Ui, TaskScheduler.Current);
+            notifications++;
+        };
+        fixture.ViewModel.ItemsUpdated += (_, _) => Assert.AreSame(fixture.Ui, TaskScheduler.Current);
+
+        fixture.ViewModel.SearchTextBox = "Alpha";
+        fixture.ViewModel.SearchTextBox = "Beta";
+        fixture.ViewModel.SearchTextBox = "Gamma";
+
+        Assert.AreEqual(1, fixture.Worker.Count);
+        CollectionAssert.AreEqual(original, fixture.ViewModel.FilteredItems.ToArray());
+        fixture.Worker.ExecuteAll();
+        CollectionAssert.AreEqual(original, fixture.ViewModel.FilteredItems.ToArray());
+        Assert.AreEqual(0, notifications);
+        fixture.Ui.ExecuteAll();
+
+        CollectionAssert.AreEqual(GammaTitles, fixture.Titles);
+        Assert.AreEqual(1, fixture.Updates.Count);
+        Assert.IsTrue(fixture.Updates[0].ForceFirstItem);
+        Assert.IsTrue(fixture.Updates[0].EnsureSelectionVisible);
+    }
+
+    [TestMethod]
+    public void CompletedQuery_BecomesStaleBeforePublication()
+    {
+        using var fixture = new Fixture(Item("Alpha"), Item("Beta"));
+        fixture.ViewModel.SearchTextBox = "Alpha";
+        fixture.Worker.ExecuteAll();
+
+        fixture.ViewModel.SearchTextBox = "Beta";
+        fixture.Ui.ExecuteAll();
+
+        CollectionAssert.AreEqual(InitialTitles, fixture.Titles);
+        Assert.AreEqual(0, fixture.Updates.Count);
+        fixture.Drain();
+        CollectionAssert.AreEqual(BetaTitles, fixture.Titles);
+        Assert.AreEqual(1, fixture.Updates.Count);
+    }
+
+    [TestMethod]
+    public void ItemRefresh_InvalidatesCompletedQueryAndRetainsSelectionIntent()
+    {
+        using var fixture = new Fixture(Item("Alpha"));
+        fixture.ViewModel.SearchTextBox = "Alpha";
+        fixture.Worker.ExecuteAll();
+
+        fixture.Page.SetItems(Item("Alpha replacement"));
+        fixture.Page.Refresh();
+        fixture.Page.Refresh(ListViewModel.IncrementalRefresh);
+        fixture.Ui.ExecuteAll();
+
+        Assert.AreEqual(0, fixture.Updates.Count);
+        fixture.Drain();
+        CollectionAssert.AreEqual(ReplacementTitles, fixture.Titles);
+        Assert.AreEqual(1, fixture.Updates.Count);
+        Assert.IsTrue(fixture.Updates[0].ForceFirstItem);
+    }
+
+    [TestMethod]
+    public void QueryDuringFetch_WaitsForNewItems()
+    {
+        using var fixture = new Fixture(Item("Alpha"));
+        fixture.ViewModel.SearchTextBox = "Alpha";
+        fixture.Worker.ExecuteAll();
+        fixture.Page.SetItems(Item("Beta"));
+        fixture.Page.BeforeGetItems = () =>
+        {
+            fixture.ViewModel.SearchTextBox = "Beta";
+            fixture.Drain();
+            Assert.AreEqual(0, fixture.Updates.Count);
+            CollectionAssert.AreEqual(AlphaTitles, fixture.Titles);
+        };
+
+        fixture.Page.Refresh();
+        fixture.Drain();
+
+        CollectionAssert.AreEqual(BetaTitles, fixture.Titles);
+        Assert.AreEqual(1, fixture.Updates.Count);
+        Assert.IsTrue(fixture.Updates[0].ForceFirstItem);
+    }
+
+    [TestMethod]
+    public void NestedPage_ResetsSelectionForQueryButNotRefresh()
+    {
+        using var fixture = new Fixture(Item("Alpha"), Item("Beta"));
+        fixture.ViewModel.IsRootPage = false;
+        fixture.Page.Refresh();
+        fixture.Drain();
+        Assert.IsFalse(fixture.Updates.Single().ForceFirstItem);
+        fixture.Updates.Clear();
+
+        fixture.ViewModel.SearchTextBox = "Beta";
+        fixture.Drain();
+
+        Assert.IsTrue(fixture.Updates.Single().ForceFirstItem);
+    }
+
+    [TestMethod]
+    public async Task DynamicPage_UsesProviderFilteringInsteadOfStaticWorker()
+    {
+        var ui = new QueuedScheduler();
+        var worker = new QueuedScheduler();
+        var page = new TestDynamicPage();
+        using var viewModel = new ListViewModel(page, ui, new TestHost(), CommandProviderContext.Empty, DefaultContextMenuFactory.Instance, worker);
+        try
+        {
+            viewModel.SearchTextBox = "Before initialization";
+            viewModel.InitializeProperties();
+            worker.ExecuteAll();
+            ui.ExecuteAll();
+            viewModel.SearchTextBox = "Alpha";
+
+            var query = await page.SearchUpdated.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            ui.ExecuteAll();
+
+            Assert.AreEqual("Alpha", query);
+            Assert.AreEqual(0, worker.Count);
+            CollectionAssert.AreEqual(InitialTitles, viewModel.FilteredItems.Select(i => i.Title).ToArray());
+        }
+        finally
+        {
+            viewModel.SafeCleanup();
+            ui.ExecuteAll();
+        }
+    }
+
+    [TestMethod]
+    public void ItemTextChange_RefiltersWithoutResettingSelection()
+    {
+        var item = Item("Alpha");
+        using var fixture = new Fixture(item);
+        var viewModel = fixture.ViewModel.FilteredItems[0];
+        fixture.ViewModel.SearchTextBox = "Beta";
+        fixture.Drain();
+        Assert.AreEqual(0, fixture.Titles.Length);
+        fixture.Updates.Clear();
+
+        item.Subtitle = "Beta";
+        viewModel.ApplyPendingUpdates();
+        fixture.Drain();
+
+        CollectionAssert.AreEqual(AlphaTitles, fixture.Titles);
+        Assert.AreEqual(1, fixture.Updates.Count);
+        Assert.IsFalse(fixture.Updates[0].ForceFirstItem);
+        Assert.IsFalse(fixture.Updates[0].EnsureSelectionVisible);
+
+        item.Subtitle = string.Empty;
+        item.Title = "Beta";
+        viewModel.ApplyPendingUpdates();
+        fixture.Drain();
+        CollectionAssert.AreEqual(BetaTitles, fixture.Titles);
+    }
+
+    [TestMethod]
+    public void ItemTextChange_InvalidatesAlreadyScoredSnapshot()
+    {
+        var item = Item("Alpha");
+        using var fixture = new Fixture(item);
+        var viewModel = fixture.ViewModel.FilteredItems[0];
+        fixture.ViewModel.SearchTextBox = "Alpha";
+        fixture.Worker.ExecuteAll();
+
+        item.Title = "Beta";
+        viewModel.ApplyPendingUpdates();
+        fixture.Ui.ExecuteAll();
+
+        Assert.AreEqual(0, fixture.Updates.Count);
+        fixture.Drain();
+        Assert.AreEqual(0, fixture.Titles.Length);
+        Assert.AreEqual(1, fixture.Updates.Count);
+        Assert.IsTrue(fixture.Updates[0].ForceFirstItem);
+    }
+
+    [TestMethod]
+    public async Task LateHydrationFailure_RemovesItemWithoutAnotherQuery()
+    {
+        using var release = new ManualResetEventSlim();
+        var lateItem = new FailingHydrationItem(release) { Title = "Late item" };
+        var items = Enumerable.Range(0, 20).Select(i => Item($"Item {i}")).Append(lateItem).ToArray();
+        using var fixture = new Fixture(items);
+        try
+        {
+            await lateItem.Entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.AreEqual(21, fixture.Titles.Length);
+
+            release.Set();
+            await fixture.Worker.WhenQueued.WaitAsync(TimeSpan.FromSeconds(5));
+            fixture.Drain();
+
+            Assert.AreEqual(20, fixture.Titles.Length);
+            Assert.IsFalse(fixture.Titles.Contains("Error"));
+            Assert.AreEqual(1, fixture.Updates.Count);
+            Assert.IsFalse(fixture.Updates[0].ForceFirstItem);
+        }
+        finally
+        {
+            release.Set();
+        }
+    }
+
+    [TestMethod]
+    public void ReentrantPublication_DefersMutationsAndRejectsStaleDeferredResult()
+    {
+        using var fixture = new Fixture(Item("Alpha"), Item("Beta"), Item("Gamma"));
+        var reentered = false;
+        var inNotification = false;
+        fixture.ViewModel.FilteredItems.CollectionChanged += (_, _) =>
+        {
+            Assert.IsFalse(inNotification, "Collection mutations must not overlap during native renderer callbacks.");
+            if (reentered)
+            {
+                return;
+            }
+
+            reentered = true;
+            inNotification = true;
+            try
+            {
+                fixture.ViewModel.SearchTextBox = "Beta";
+                fixture.Drain();
+                fixture.ViewModel.SearchTextBox = "Gamma";
+            }
+            finally
+            {
+                inNotification = false;
+            }
+        };
+
+        fixture.ViewModel.SearchTextBox = "Alpha";
+        fixture.Drain();
+        Assert.IsTrue(reentered);
+        Assert.AreEqual(0, fixture.Updates.Count);
+        fixture.Drain();
+
+        CollectionAssert.AreEqual(GammaTitles, fixture.Titles);
+        Assert.AreEqual(1, fixture.Updates.Count);
+        Assert.IsTrue(fixture.Updates[0].ForceFirstItem);
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void Dispose_RejectsQueuedAndCompletedWork(bool completeScoring)
+    {
+        using var fixture = new Fixture(Item("Alpha"), Item("Beta"));
+        fixture.ViewModel.SearchTextBox = "Alpha";
+        if (completeScoring)
+        {
+            fixture.Worker.ExecuteAll();
+        }
+
+        fixture.ViewModel.Dispose();
+        fixture.ViewModel.SearchTextBox = "Beta";
+        fixture.Page.Refresh();
+        fixture.Drain();
+
+        CollectionAssert.AreEqual(InitialTitles, fixture.Titles);
+        Assert.AreEqual(0, fixture.Updates.Count);
+        Assert.AreEqual(0, fixture.Worker.Count);
+    }
+
+    [TestMethod]
+    public void CleanupDuringPublication_ClearsListAfterMutationAndDoesNotRepublish()
+    {
+        using var fixture = new Fixture(Item("Alpha"), Item("Beta"));
+        var cleaned = false;
+        fixture.ViewModel.FilteredItems.CollectionChanged += (_, _) =>
+        {
+            if (!cleaned)
+            {
+                cleaned = true;
+                fixture.ViewModel.SafeCleanup();
+                fixture.Ui.ExecuteAll();
+            }
+        };
+
+        fixture.ViewModel.SearchTextBox = "Alpha";
+        fixture.Drain();
+
+        Assert.IsTrue(cleaned);
+        Assert.AreEqual(0, fixture.Titles.Length);
+        Assert.AreEqual(0, fixture.Updates.Count);
+        fixture.Page.Refresh();
+        fixture.Drain();
+        Assert.AreEqual(0, fixture.Titles.Length);
+    }
+
+    [TestMethod]
+    [DataRow("")]
+    [DataRow("alpha")]
+    [DataRow("bt")]
+    [DataRow("hidden")]
+    [DataRow("no matches")]
+    [DataRow(" ")]
+    public void SnapshotScoring_PreservesLegacyScoresAndStableOrdering(string query)
+    {
+        using var fixture = new Fixture(Item("Alpha"), Item("Alpha"), Item("Beta"), Item(string.Empty), Item("Hidden"));
+        var viewModels = fixture.ViewModel.FilteredItems.ToArray();
+        ListViewModel.StaticFilterItem[] snapshot =
+        [
+            new(viewModels[0], "Alpha", "Beta", false),
+            new(viewModels[1], "Alpha", "Beta", false),
+            new(viewModels[2], "Beta", "Alpha", false),
+            new(viewModels[3], string.Empty, string.Empty, false),
+            new(viewModels[4], "Hidden", "Alpha", true),
+        ];
+        var expected = snapshot.Where(i => !i.IsInErrorState)
+            .Select(i => (i.ViewModel, Score: string.IsNullOrEmpty(query) ? 1 : new[]
+            {
+                FuzzyStringMatcher.ScoreFuzzy(query, i.Title),
+                (FuzzyStringMatcher.ScoreFuzzy(query, i.Subtitle) - 4) / 2,
+                0,
+            }.Max()))
+            .Where(i => i.Score > 0)
+            .OrderByDescending(i => i.Score)
+            .Select(i => i.ViewModel)
+            .ToArray();
+
+        var actual = ListViewModel.FilterSnapshot(snapshot, query, CancellationToken.None);
+
+        CollectionAssert.AreEqual(expected, actual);
+        if (query is "" or "alpha")
+        {
+            Assert.AreSame(viewModels[0], actual[0]);
+            Assert.AreSame(viewModels[1], actual[1]);
+        }
+    }
+
+    [TestMethod]
+    public void SnapshotScoring_DoesNotRereadMutableViewModels()
+    {
+        var item = Item("Alpha");
+        using var fixture = new Fixture(item);
+        var viewModel = fixture.ViewModel.FilteredItems[0];
+        var snapshot = new[] { ListViewModel.StaticFilterItem.Capture(viewModel) };
+
+        item.Title = "Beta";
+        viewModel.SafeCleanup();
+        var actual = ListViewModel.FilterSnapshot(snapshot, "Alpha", CancellationToken.None);
+
+        Assert.AreEqual("Beta", viewModel.Title);
+        Assert.AreEqual(1, actual.Length);
+        Assert.AreSame(viewModel, actual[0]);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        Assert.ThrowsExactly<OperationCanceledException>(() => ListViewModel.FilterSnapshot(snapshot, "Alpha", cancellation.Token));
+    }
+
+    private static ListItem Item(string title) => new(new NoOpCommand()) { Title = title };
+
+    private sealed class Fixture : IDisposable
+    {
+        internal QueuedScheduler Ui { get; } = new();
+
+        internal QueuedScheduler Worker { get; } = new();
+
+        internal TestPage Page { get; }
+
+        internal ListViewModel ViewModel { get; }
+
+        internal List<ItemsUpdatedEventArgs> Updates { get; } = [];
+
+        internal string[] Titles => ViewModel.FilteredItems.Select(i => i.Title).ToArray();
+
+        internal Fixture(params ListItem[] items)
+        {
+            Page = new(items);
+            ViewModel = new(Page, Ui, new TestHost(), CommandProviderContext.Empty, DefaultContextMenuFactory.Instance, Worker);
+            ViewModel.InitializeProperties();
+            Drain();
+            ViewModel.ItemsUpdated += (_, args) => Updates.Add(args);
+        }
+
+        internal void Drain()
+        {
+            Worker.ExecuteAll();
+            Ui.ExecuteAll();
+        }
+
+        public void Dispose()
+        {
+            ViewModel.SafeCleanup();
+            Drain();
+        }
+    }
+
+    private sealed partial class TestHost : AppExtensionHost
+    {
+        public override string? GetExtensionDisplayName() => "Static filter tests";
+    }
+
+    private sealed partial class TestPage(IListItem[] items) : ListPage
+    {
+        private IListItem[] _items = items;
+
+        internal Action? BeforeGetItems { get; set; }
+
+        public override IListItem[] GetItems()
+        {
+            BeforeGetItems?.Invoke();
+            return _items;
+        }
+
+        internal void SetItems(params IListItem[] items) => _items = items;
+
+        internal void Refresh(int totalItems = 0) => RaiseItemsChanged(totalItems);
+    }
+
+    private sealed partial class TestDynamicPage : DynamicListPage
+    {
+        internal TaskCompletionSource<string> SearchUpdated { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override IListItem[] GetItems() => [Item("Alpha"), Item("Beta")];
+
+        public override void UpdateSearchText(string oldSearch, string newSearch) => SearchUpdated.TrySetResult(newSearch);
+    }
+
+    private sealed partial class FailingHydrationItem(ManualResetEventSlim release) : ListItem(new NoOpCommand())
+    {
+        internal TaskCompletionSource Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override ITag[] Tags
+        {
+            get
+            {
+                Entered.TrySetResult();
+                if (!release.Wait(TimeSpan.FromSeconds(5)))
+                {
+                    throw new TimeoutException("Hydration was not released.");
+                }
+
+                throw new InvalidOperationException("The extension failed to hydrate this item.");
+            }
+
+            set => throw new NotSupportedException();
+        }
+    }
+
+    private sealed class QueuedScheduler : TaskScheduler
+    {
+        private readonly Lock _gate = new();
+        private readonly Queue<Task> _tasks = [];
+        private TaskCompletionSource _queued = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal int Count
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _tasks.Count;
+                }
+            }
+        }
+
+        internal Task WhenQueued
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _tasks.Count > 0 ? Task.CompletedTask : _queued.Task;
+                }
+            }
+        }
+
+        protected override IEnumerable<Task> GetScheduledTasks()
+        {
+            lock (_gate)
+            {
+                return _tasks.ToArray();
+            }
+        }
+
+        protected override void QueueTask(Task task)
+        {
+            lock (_gate)
+            {
+                _tasks.Enqueue(task);
+                _queued.TrySetResult();
+            }
+        }
+
+        protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued) => false;
+
+        internal void ExecuteAll()
+        {
+            while (true)
+            {
+                Task task;
+                lock (_gate)
+                {
+                    if (!_tasks.TryDequeue(out task!))
+                    {
+                        return;
+                    }
+
+                    if (_tasks.Count == 0)
+                    {
+                        _queued = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                    }
+                }
+
+                Assert.IsTrue(TryExecuteTask(task));
+                task.GetAwaiter().GetResult();
+            }
+        }
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/StaticPageFilteringTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/StaticPageFilteringTests.cs
@@ -409,6 +409,12 @@ public sealed partial class StaticPageFilteringTests
             Ui.ExecuteAll();
         }
 
+        internal void CompleteSelection(ListItemViewModel? item)
+        {
+            ViewModel.UpdateSelectedItemCommand.Execute(item);
+            ViewModel.CompleteStaticFilterSelection(ViewModel.PublishedFilterVersion, item);
+        }
+
         public void Dispose()
         {
             ViewModel.SafeCleanup();

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/StaticPageFilteringTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/StaticPageFilteringTests.cs
@@ -411,7 +411,7 @@ public sealed partial class StaticPageFilteringTests
 
         internal void CompleteSelection(ListItemViewModel? item)
         {
-            ViewModel.UpdateSelectedItemCommand.Execute(item);
+            ViewModel.SynchronizeSelection(item);
             ViewModel.CompleteStaticFilterSelection(ViewModel.PublishedFilterVersion, item);
         }
 


### PR DESCRIPTION
CmdPal now filters static lists in the background so large lists don't hold up typing. It keeps the same matching and ranking, makes Enter wait for the right selection, and keeps search working when an extension refresh fails.

The new background filtering applies only to static `ListPage` pages. `DynamicListPage`, including CmdPal's main page, still handles its own searches; the shared selection and cancellation changes don't alter dynamic-page filtering or ranking.