### PR TITLE
CmdPal: Fix repeated details loading in Command Palette

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentFormViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentFormViewModel.cs
@@ -67,7 +67,9 @@ public partial class ContentFormViewModel(IFormContent _form, WeakReference<IPag
         }
     }
 
-    public override void InitializeProperties()
+    protected override INotifyPropChanged? ObservableModel => _formModel.Unsafe;
+
+    protected override void InitializeContent()
     {
         var model = _formModel.Unsafe;
         if (model is null)
@@ -82,8 +84,6 @@ public partial class ContentFormViewModel(IFormContent _form, WeakReference<IPag
         RenderCard();
 
         UpdateProperty(nameof(Card));
-
-        model.PropChanged += Model_PropChanged;
     }
 
     private void RenderCard()
@@ -113,19 +113,7 @@ public partial class ContentFormViewModel(IFormContent _form, WeakReference<IPag
         }
     }
 
-    private void Model_PropChanged(object sender, IPropChangedEventArgs args)
-    {
-        try
-        {
-            FetchProperty(args.PropertyName);
-        }
-        catch (Exception ex)
-        {
-            ShowException(ex);
-        }
-    }
-
-    protected virtual void FetchProperty(string propertyName)
+    protected override void FetchProperty(string propertyName)
     {
         var model = this._formModel.Unsafe;
         if (model is null)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentImageViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentImageViewModel.cs
@@ -23,7 +23,9 @@ public partial class ContentImageViewModel : ContentViewModel
         Model = new ExtensionObject<IImageContent>(content);
     }
 
-    public override void InitializeProperties()
+    protected override INotifyPropChanged? ObservableModel => Model.Unsafe;
+
+    protected override void InitializeContent()
     {
         var model = Model.Unsafe;
         if (model is null)
@@ -38,23 +40,9 @@ public partial class ContentImageViewModel : ContentViewModel
         MaxHeight = model.MaxHeight <= 0 ? double.PositiveInfinity : model.MaxHeight;
 
         UpdateProperty(nameof(Image), nameof(MaxWidth), nameof(MaxHeight));
-        model.PropChanged += Model_PropChanged;
     }
 
-    private void Model_PropChanged(object sender, IPropChangedEventArgs args)
-    {
-        try
-        {
-            var propName = args.PropertyName;
-            FetchProperty(propName);
-        }
-        catch (Exception ex)
-        {
-            ShowException(ex);
-        }
-    }
-
-    private void FetchProperty(string propertyName)
+    protected override void FetchProperty(string propertyName)
     {
         var model = Model.Unsafe;
         if (model is null)
@@ -79,16 +67,6 @@ public partial class ContentImageViewModel : ContentViewModel
                 MaxHeight = model.MaxHeight <= 0 ? double.PositiveInfinity : model.MaxHeight;
                 UpdateProperty(propertyName);
                 break;
-        }
-    }
-
-    protected override void UnsafeCleanup()
-    {
-        base.UnsafeCleanup();
-        var model = Model.Unsafe;
-        if (model is not null)
-        {
-            model.PropChanged -= Model_PropChanged;
         }
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentMarkdownViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentMarkdownViewModel.cs
@@ -17,7 +17,9 @@ public partial class ContentMarkdownViewModel(IMarkdownContent _markdown, WeakRe
     // cannot be marked [ObservableProperty]
     public string Body { get; protected set; } = string.Empty;
 
-    public override void InitializeProperties()
+    protected override INotifyPropChanged? ObservableModel => Model.Unsafe;
+
+    protected override void InitializeContent()
     {
         var model = Model.Unsafe;
         if (model is null)
@@ -27,24 +29,9 @@ public partial class ContentMarkdownViewModel(IMarkdownContent _markdown, WeakRe
 
         Body = model.Body;
         UpdateProperty(nameof(Body));
-
-        model.PropChanged += Model_PropChanged;
     }
 
-    private void Model_PropChanged(object sender, IPropChangedEventArgs args)
-    {
-        try
-        {
-            var propName = args.PropertyName;
-            FetchProperty(propName);
-        }
-        catch (Exception ex)
-        {
-            ShowException(ex);
-        }
-    }
-
-    protected void FetchProperty(string propertyName)
+    protected override void FetchProperty(string propertyName)
     {
         var model = Model.Unsafe;
         if (model is null)
@@ -60,15 +47,5 @@ public partial class ContentMarkdownViewModel(IMarkdownContent _markdown, WeakRe
         }
 
         UpdateProperty(propertyName);
-    }
-
-    protected override void UnsafeCleanup()
-    {
-        base.UnsafeCleanup();
-        var model = Model.Unsafe;
-        if (model is not null)
-        {
-            model.PropChanged -= Model_PropChanged;
-        }
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentPlainTextViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentPlainTextViewModel.cs
@@ -23,7 +23,9 @@ public partial class ContentPlainTextViewModel : ContentViewModel
         Model = new ExtensionObject<IPlainTextContent>(content);
     }
 
-    public override void InitializeProperties()
+    protected override INotifyPropChanged? ObservableModel => Model.Unsafe;
+
+    protected override void InitializeContent()
     {
         var model = Model.Unsafe;
         if (model is null)
@@ -35,23 +37,9 @@ public partial class ContentPlainTextViewModel : ContentViewModel
         WordWrapEnabled = model.WrapWords;
         UseMonospace = model.FontFamily == CommandPalette.Extensions.FontFamily.Monospace;
         UpdateProperty(nameof(Text), nameof(WordWrapEnabled), nameof(UseMonospace));
-        model.PropChanged += Model_PropChanged;
     }
 
-    private void Model_PropChanged(object sender, IPropChangedEventArgs args)
-    {
-        try
-        {
-            var propName = args.PropertyName;
-            FetchProperty(propName);
-        }
-        catch (Exception ex)
-        {
-            ShowException(ex);
-        }
-    }
-
-    private void FetchProperty(string propertyName)
+    protected override void FetchProperty(string propertyName)
     {
         var model = Model.Unsafe;
         if (model is null)
@@ -99,16 +87,6 @@ public partial class ContentPlainTextViewModel : ContentViewModel
                 }
 
                 break;
-        }
-    }
-
-    protected override void UnsafeCleanup()
-    {
-        base.UnsafeCleanup();
-        var model = Model.Unsafe;
-        if (model is not null)
-        {
-            model.PropChanged -= Model_PropChanged;
         }
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentTreeViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentTreeViewModel.cs
@@ -13,6 +13,9 @@ namespace Microsoft.CmdPal.UI.ViewModels;
 public partial class ContentTreeViewModel(ITreeContent _tree, WeakReference<IPageContext> context) :
     ContentViewModel(context)
 {
+    private List<ContentViewModel> _ownedChildren = [];
+    private ITreeContent? _subscribedTree;
+
     public ExtensionObject<ITreeContent> Model { get; } = new(_tree);
 
     // Remember - "observable" properties from the model (via PropChanged)
@@ -27,7 +30,9 @@ public partial class ContentTreeViewModel(ITreeContent _tree, WeakReference<IPag
     // collection, even if the collection is just a single item.
     public ObservableCollection<ContentViewModel> Root => RootContent is not null ? [RootContent] : [];
 
-    public override void InitializeProperties()
+    protected override INotifyPropChanged? ObservableModel => Model.Unsafe;
+
+    protected override void InitializeContent()
     {
         var model = Model.Unsafe;
         if (model is null)
@@ -35,18 +40,11 @@ public partial class ContentTreeViewModel(ITreeContent _tree, WeakReference<IPag
             return;
         }
 
-        var root = model.RootContent;
-        if (root is not null)
-        {
-            RootContent = ViewModelFromContent(root, PageContext);
-            RootContent?.InitializeProperties();
-            UpdateProperty(nameof(RootContent));
-            UpdateProperty(nameof(Root));
-        }
-
-        FetchContent();
-        model.PropChanged += Model_PropChanged;
         model.ItemsChanged += Model_ItemsChanged;
+        _subscribedTree = model;
+
+        ReplaceRoot(model.RootContent);
+        FetchContent();
     }
 
     // Theoretically, we should unify this with the one in CommandPalettePageViewModelFactory
@@ -65,15 +63,11 @@ public partial class ContentTreeViewModel(ITreeContent _tree, WeakReference<IPag
         return viewModel;
     }
 
-    // TODO: Does this need to hop to a _different_ thread, so that we don't block the extension while we're fetching?
-    private void Model_ItemsChanged(object sender, IItemsChangedEventArgs args) => FetchContent();
-
-    private void Model_PropChanged(object sender, IPropChangedEventArgs args)
+    private void Model_ItemsChanged(object sender, IItemsChangedEventArgs args)
     {
         try
         {
-            var propName = args.PropertyName;
-            FetchProperty(propName);
+            Lifetime.Run(FetchContent);
         }
         catch (Exception ex)
         {
@@ -81,7 +75,7 @@ public partial class ContentTreeViewModel(ITreeContent _tree, WeakReference<IPag
         }
     }
 
-    protected void FetchProperty(string propertyName)
+    protected override void FetchProperty(string propertyName)
     {
         var model = Model.Unsafe;
         if (model is null)
@@ -92,22 +86,30 @@ public partial class ContentTreeViewModel(ITreeContent _tree, WeakReference<IPag
         switch (propertyName)
         {
             case nameof(RootContent):
-                var root = model.RootContent;
-                if (root is not null)
-                {
-                    RootContent = ViewModelFromContent(root, PageContext);
-                }
-                else
-                {
-                    root = null;
-                }
-
-                UpdateProperty(nameof(Root));
-
+                ReplaceRoot(model.RootContent);
                 break;
         }
 
         UpdateProperty(propertyName);
+    }
+
+    private void ReplaceRoot(IContent? model)
+    {
+        var replacement = model is null ? null : ViewModelFromContent(model, PageContext);
+        try
+        {
+            replacement?.InitializeProperties();
+        }
+        catch
+        {
+            replacement?.SafeCleanup();
+            throw;
+        }
+
+        var previous = RootContent;
+        RootContent = replacement;
+        previous?.SafeCleanup();
+        UpdateProperty(nameof(RootContent), nameof(Root));
     }
 
     //// Run on background thread, from InitializeAsync or Model_ItemsChanged
@@ -123,42 +125,61 @@ public partial class ContentTreeViewModel(ITreeContent _tree, WeakReference<IPag
                 var viewModel = ViewModelFromContent(item, PageContext);
                 if (viewModel is not null)
                 {
+                    newContent.Add(viewModel);
                     viewModel.InitializeProperties();
-                    newContent.Add((ContentViewModel)viewModel);
                 }
             }
         }
-        catch (Exception ex)
+        catch
         {
-            ShowException(ex);
+            newContent.ForEach(vm => vm.SafeCleanup());
             throw;
         }
 
-        // Now, back to a UI thread to update the observable collection
+        var previous = _ownedChildren;
+        Volatile.Write(ref _ownedChildren, newContent);
+        previous.ForEach(vm => vm.SafeCleanup());
+
         DoOnUiThread(
         () =>
         {
-            ListHelpers.InPlaceUpdateList(Children, newContent);
-        });
+            if (Lifetime.IsClosed || !ReferenceEquals(Volatile.Read(ref _ownedChildren), newContent))
+            {
+                return;
+            }
 
-        UpdateProperty(nameof(HasChildren));
+            ListHelpers.InPlaceUpdateList(Children, newContent);
+            UpdateProperty(nameof(HasChildren));
+        });
     }
 
-    protected override void UnsafeCleanup()
+    protected override void CleanupContent()
     {
-        base.UnsafeCleanup();
-        RootContent?.SafeCleanup();
-        foreach (var item in Children)
+        var tree = _subscribedTree;
+        _subscribedTree = null;
+        try
         {
-            item.SafeCleanup();
+            if (tree is not null)
+            {
+                tree.ItemsChanged -= Model_ItemsChanged;
+            }
         }
-
-        Children.Clear();
-        var model = Model.Unsafe;
-        if (model is not null)
+        finally
         {
-            model.PropChanged -= Model_PropChanged;
-            model.ItemsChanged -= Model_ItemsChanged;
+            RootContent?.SafeCleanup();
+            RootContent = null;
+            var previous = _ownedChildren;
+            Volatile.Write(ref _ownedChildren, []);
+            previous.ForEach(vm => vm.SafeCleanup());
+            var empty = _ownedChildren;
+            DoOnUiThread(() =>
+            {
+                if (ReferenceEquals(Volatile.Read(ref _ownedChildren), empty))
+                {
+                    Children.Clear();
+                    UpdateProperty(nameof(HasChildren));
+                }
+            });
         }
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentTreeViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentTreeViewModel.cs
@@ -67,7 +67,7 @@ public partial class ContentTreeViewModel(ITreeContent _tree, WeakReference<IPag
     {
         try
         {
-            Lifetime.Run(FetchContent);
+            Lifetime.RunNotification(FetchContent, ex => ShowException(ex));
         }
         catch (Exception ex)
         {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentViewModel.cs
@@ -2,10 +2,87 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CmdPal.UI.ViewModels.Models;
+using Microsoft.CommandPalette.Extensions;
+
 namespace Microsoft.CmdPal.UI.ViewModels;
 
 public abstract partial class ContentViewModel(WeakReference<IPageContext> context) :
     ExtensionObjectViewModel(context)
 {
+    private INotifyPropChanged? _observable;
+    private bool _initialized;
+
+    private protected ViewModelLifetime Lifetime { get; } = new();
+
+    protected abstract INotifyPropChanged? ObservableModel { get; }
+
     public bool OnlyControlOnPage { get; internal set; }
+
+    public sealed override void InitializeProperties() => Lifetime.Run(() =>
+    {
+        if (_initialized)
+        {
+            return;
+        }
+
+        try
+        {
+            var observable = ObservableModel;
+            if (observable is not null)
+            {
+                observable.PropChanged += Model_PropChanged;
+                _observable = observable;
+            }
+
+            InitializeContent();
+            _initialized = true;
+        }
+        catch
+        {
+            Lifetime.Close(Cleanup);
+            throw;
+        }
+    });
+
+    protected abstract void InitializeContent();
+
+    protected abstract void FetchProperty(string propertyName);
+
+    private void Model_PropChanged(object sender, IPropChangedEventArgs args)
+    {
+        try
+        {
+            var propertyName = args.PropertyName;
+            Lifetime.Run(() => FetchProperty(propertyName));
+        }
+        catch (Exception ex)
+        {
+            ShowException(ex);
+        }
+    }
+
+    protected sealed override void UnsafeCleanup() => Lifetime.Close(Cleanup);
+
+    private void Cleanup()
+    {
+        var observable = _observable;
+        _observable = null;
+        _initialized = false;
+        try
+        {
+            if (observable is not null)
+            {
+                observable.PropChanged -= Model_PropChanged;
+            }
+        }
+        finally
+        {
+            CleanupContent();
+        }
+    }
+
+    protected virtual void CleanupContent()
+    {
+    }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentViewModel.cs
@@ -54,7 +54,7 @@ public abstract partial class ContentViewModel(WeakReference<IPageContext> conte
         try
         {
             var propertyName = args.PropertyName;
-            Lifetime.Run(() => FetchProperty(propertyName));
+            Lifetime.RunNotification(() => FetchProperty(propertyName), ex => ShowException(ex));
         }
         catch (Exception ex)
         {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsCommandsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsCommandsViewModel.cs
@@ -27,16 +27,34 @@ public partial class DetailsCommandsViewModel(
             return;
         }
 
-        Commands = model
-            .Commands?
-            .Select(c =>
+        List<CommandViewModel> commands = [];
+        try
+        {
+            foreach (var command in model.Commands ?? [])
             {
-                var vm = new CommandViewModel(c, PageContext);
+                var vm = new CommandViewModel(command, PageContext);
+                commands.Add(vm);
                 vm.InitializeProperties();
-                return vm;
-            })
-            .ToList() ?? [];
+            }
+        }
+        catch
+        {
+            commands.ForEach(vm => vm.SafeCleanup());
+            throw;
+        }
+
+        var previous = Commands;
+        Commands = commands;
+        previous.ForEach(vm => vm.SafeCleanup());
         UpdateProperty(nameof(HasCommands));
         UpdateProperty(nameof(Commands));
+    }
+
+    protected override void UnsafeCleanup()
+    {
+        var previous = Commands;
+        Commands = [];
+        previous.ForEach(vm => vm.SafeCleanup());
+        base.UnsafeCleanup();
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsTagsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsTagsViewModel.cs
@@ -39,4 +39,12 @@ public partial class DetailsTagsViewModel(
         UpdateProperty(nameof(HasTags));
         UpdateProperty(nameof(Tags));
     }
+
+    protected override void UnsafeCleanup()
+    {
+        var previous = Tags;
+        Tags = [];
+        previous.ForEach(vm => vm.SafeCleanup());
+        base.UnsafeCleanup();
+    }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsViewModel.cs
@@ -12,8 +12,10 @@ namespace Microsoft.CmdPal.UI.ViewModels;
 public partial class DetailsViewModel : ExtensionObjectViewModel
 {
     private readonly ExtensionObject<IDetails> _detailsModel;
+    private readonly ViewModelLifetime _lifetime = new();
     private INotifyPropChanged? _observableDetails;
-    private bool _isSubscribed;
+    private bool _initialized;
+    private List<ContentViewModel> _ownedContent = [];
 
     // Remember - "observable" properties from the model (via PropChanged)
     // cannot be marked [ObservableProperty]
@@ -37,11 +39,16 @@ public partial class DetailsViewModel : ExtensionObjectViewModel
         _detailsModel = new(details);
     }
 
+    internal bool Represents(IDetails? model) => ReferenceEquals(_detailsModel.Unsafe, model);
+
+    internal bool IsObservable => _observableDetails is not null;
+
     private void Model_PropChanged(object sender, IPropChangedEventArgs args)
     {
         try
         {
-            FetchProperty(args.PropertyName);
+            var propertyName = args.PropertyName;
+            _lifetime.Run(() => FetchProperty(propertyName));
         }
         catch (Exception ex)
         {
@@ -83,61 +90,94 @@ public partial class DetailsViewModel : ExtensionObjectViewModel
             case nameof(Details.Content):
                 RebuildContent(model);
                 break;
+            case nameof(Details.Size):
+                UpdateSize(model);
+                break;
         }
     }
 
     private void RebuildMetadata(IDetails model)
     {
         var newMetadata = new List<DetailsElementViewModel>();
-        var meta = model.Metadata;
-        if (meta is not null)
+        try
         {
-            foreach (var element in meta)
+            var meta = model.Metadata;
+            if (meta is not null)
             {
-                DetailsElementViewModel? vm = element.Data switch
+                foreach (var element in meta)
                 {
-                    IDetailsSeparator => new DetailsSeparatorViewModel(element, this.PageContext),
-                    IDetailsLink => new DetailsLinkViewModel(element, this.PageContext),
-                    IDetailsCommands => new DetailsCommandsViewModel(element, this.PageContext),
-                    IDetailsTags => new DetailsTagsViewModel(element, this.PageContext),
-                    _ => null,
-                };
-                if (vm is not null)
-                {
-                    vm.InitializeProperties();
-                    newMetadata.Add(vm);
+                    DetailsElementViewModel? vm = element.Data switch
+                    {
+                        IDetailsSeparator => new DetailsSeparatorViewModel(element, this.PageContext),
+                        IDetailsLink => new DetailsLinkViewModel(element, this.PageContext),
+                        IDetailsCommands => new DetailsCommandsViewModel(element, this.PageContext),
+                        IDetailsTags => new DetailsTagsViewModel(element, this.PageContext),
+                        _ => null,
+                    };
+                    if (vm is not null)
+                    {
+                        newMetadata.Add(vm);
+                        vm.InitializeProperties();
+                    }
                 }
             }
         }
+        catch
+        {
+            newMetadata.ForEach(vm => vm.SafeCleanup());
+            throw;
+        }
 
+        var previous = Metadata;
         Metadata = newMetadata;
+        previous.ForEach(vm => vm.SafeCleanup());
     }
 
-    public override void InitializeProperties()
+    public override void InitializeProperties() => _lifetime.Run(InitializeDetails);
+
+    private void InitializeDetails()
     {
+        if (_initialized && _observableDetails is not null)
+        {
+            return;
+        }
+
         var model = _detailsModel.Unsafe;
         if (model is null)
         {
             return;
         }
 
-        // Subscribe to PropChanged if the model supports it (only subscribe once)
-        if (!_isSubscribed && model is INotifyPropChanged observable)
+        try
         {
-            observable.PropChanged += Model_PropChanged;
-            _observableDetails = observable;
-            _isSubscribed = true;
+            if (_observableDetails is null && model is INotifyPropChanged observable)
+            {
+                observable.PropChanged += Model_PropChanged;
+                _observableDetails = observable;
+            }
+
+            Title = model.Title ?? string.Empty;
+            Body = model.Body ?? string.Empty;
+            HeroImage = new(model.HeroImage);
+            HeroImage.InitializeProperties();
+
+            UpdateProperty(nameof(Title), nameof(Body), nameof(HeroImage));
+            UpdateSize(model);
+            RebuildMetadata(model);
+            UpdateProperty(nameof(Metadata));
+            RebuildContent(model);
+            _initialized = true;
         }
+        catch
+        {
+            _lifetime.Close(CleanupDetails);
+            throw;
+        }
+    }
 
-        Title = model.Title ?? string.Empty;
-        Body = model.Body ?? string.Empty;
-        HeroImage = new(model.HeroImage);
-        HeroImage.InitializeProperties();
-
-        UpdateProperty(nameof(Title));
-        UpdateProperty(nameof(Body));
-        UpdateProperty(nameof(HeroImage));
-
+    private void UpdateSize(IDetails model)
+    {
+        Size = ContentSize.Small;
         if (model is IExtendedAttributesProvider provider)
         {
             if (provider.GetProperties()?.TryGetValue("Size", out var rawValue) == true)
@@ -149,48 +189,79 @@ public partial class DetailsViewModel : ExtensionObjectViewModel
             }
         }
 
-        Size ??= ContentSize.Small;
-
         UpdateProperty(nameof(Size));
-
-        RebuildMetadata(model);
-        RebuildContent(model);
     }
 
     private void RebuildContent(IDetails model)
     {
         List<ContentViewModel> content = [];
-        if (model is IDetails2 details2)
+        try
         {
-            foreach (var item in details2.GetContent())
+            if (model is IDetails2 details2)
             {
-                var viewModel = CommandPaletteContentPageViewModel.CreateViewModel(item, PageContext);
-                if (viewModel is not null)
+                foreach (var item in details2.GetContent())
                 {
-                    viewModel.InitializeProperties();
-                    content.Add(viewModel);
+                    var viewModel = CommandPaletteContentPageViewModel.CreateViewModel(item, PageContext);
+                    if (viewModel is not null)
+                    {
+                        content.Add(viewModel);
+                        viewModel.InitializeProperties();
+                    }
                 }
             }
         }
+        catch
+        {
+            content.ForEach(vm => vm.SafeCleanup());
+            throw;
+        }
 
-        // Now, back to a UI thread to update the observable collection
+        var previous = _ownedContent;
+        Volatile.Write(ref _ownedContent, content);
+        previous.ForEach(vm => vm.SafeCleanup());
+
         DoOnUiThread(
             () =>
             {
+                if (_lifetime.IsClosed || !ReferenceEquals(Volatile.Read(ref _ownedContent), content))
+                {
+                    return;
+                }
+
                 ListHelpers.InPlaceUpdateList(Content, content);
                 UpdateProperty(nameof(Content));
             });
     }
 
-    protected override void UnsafeCleanup()
-    {
-        base.UnsafeCleanup();
+    protected override void UnsafeCleanup() => _lifetime.Close(CleanupDetails);
 
-        if (_isSubscribed && _observableDetails is not null)
+    private void CleanupDetails()
+    {
+        var observable = _observableDetails;
+        _observableDetails = null;
+        _initialized = false;
+        try
         {
-            _observableDetails.PropChanged -= Model_PropChanged;
-            _observableDetails = null;
-            _isSubscribed = false;
+            if (observable is not null)
+            {
+                observable.PropChanged -= Model_PropChanged;
+            }
+        }
+        finally
+        {
+            Metadata.ForEach(vm => vm.SafeCleanup());
+            Metadata = [];
+            var previous = _ownedContent;
+            Volatile.Write(ref _ownedContent, []);
+            previous.ForEach(vm => vm.SafeCleanup());
+            var empty = _ownedContent;
+            DoOnUiThread(() =>
+            {
+                if (ReferenceEquals(Volatile.Read(ref _ownedContent), empty))
+                {
+                    Content.Clear();
+                }
+            });
         }
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsViewModel.cs
@@ -48,7 +48,7 @@ public partial class DetailsViewModel : ExtensionObjectViewModel
         try
         {
             var propertyName = args.PropertyName;
-            _lifetime.Run(() => FetchProperty(propertyName));
+            _lifetime.RunNotification(() => FetchProperty(propertyName), ex => ShowException(ex));
         }
         catch (Exception ex)
         {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListItemViewModel.cs
@@ -14,6 +14,10 @@ public partial class ListItemViewModel : CommandItemViewModel
 {
     private const int MaxVisibleTags = 3;
 
+    private readonly ViewModelLifetime _lifetime = new();
+    private int _selectionPending;
+    private bool _selectionInitialized;
+
     public new ExtensionObject<IListItem> Model { get; }
 
     public List<TagViewModel>? Tags { get; set; }
@@ -79,7 +83,9 @@ public partial class ListItemViewModel : CommandItemViewModel
         Model = new ExtensionObject<IListItem>(model);
     }
 
-    public override void InitializeProperties()
+    public override void InitializeProperties() => _lifetime.Run(InitializeItemProperties);
+
+    private void InitializeItemProperties()
     {
         if (IsInitialized)
         {
@@ -112,28 +118,55 @@ public partial class ListItemViewModel : CommandItemViewModel
 
     public override void SlowInitializeProperties()
     {
-        base.SlowInitializeProperties();
-        var model = Model.Unsafe;
-        if (model is null)
+        if (Interlocked.Exchange(ref _selectionPending, 1) != 0)
         {
             return;
         }
 
-        var extensionDetails = model.Details;
-        if (extensionDetails is not null)
+        _lifetime.Run(() =>
         {
-            Details = new(extensionDetails, PageContext);
-            Details.InitializeProperties();
-            UpdateProperty(nameof(Details), nameof(HasDetails));
-        }
-
-        AddShowDetailsCommands();
-
-        TextToSuggest = model.TextToSuggest;
-        UpdateProperty(nameof(TextToSuggest));
+            try
+            {
+                InitializeSelectedProperties();
+            }
+            catch
+            {
+                _lifetime.Close(CleanupItem);
+                throw;
+            }
+            finally
+            {
+                Volatile.Write(ref _selectionPending, 0);
+            }
+        });
     }
 
-    protected override void FetchProperty(string propertyName)
+    private void InitializeSelectedProperties()
+    {
+        if (IsInErrorState || (_selectionInitialized && (Details is null || Details.IsObservable)))
+        {
+            return;
+        }
+
+        InitializeItemProperties();
+        base.SlowInitializeProperties();
+        var model = Model.Unsafe;
+        if (model is null || _lifetime.IsClosed)
+        {
+            return;
+        }
+
+        ReplaceDetails(model.Details);
+        AddShowDetailsCommands();
+
+        TextToSuggest = model.TextToSuggest ?? string.Empty;
+        UpdateProperty(nameof(TextToSuggest));
+        _selectionInitialized = true;
+    }
+
+    protected override void FetchProperty(string propertyName) => _lifetime.Run(() => FetchItemProperty(propertyName));
+
+    private void FetchItemProperty(string propertyName)
     {
         base.FetchProperty(propertyName);
 
@@ -162,13 +195,7 @@ public partial class ListItemViewModel : CommandItemViewModel
                 UpdateProperty(nameof(Type), nameof(IsInteractive));
                 break;
             case nameof(Details):
-                var existingReference = Details;
-                var extensionDetails = model.Details;
-                Details = extensionDetails is not null ? new(extensionDetails, PageContext) : null;
-                Details?.InitializeProperties();
-                UpdateProperty(nameof(Details), nameof(HasDetails));
-                UpdateShowDetailsCommand();
-                existingReference?.SafeCleanup();
+                ReplaceDetails(model.Details);
                 break;
             case nameof(model.MoreCommands):
                 AddShowDetailsCommands();
@@ -196,6 +223,47 @@ public partial class ListItemViewModel : CommandItemViewModel
     public override bool Equals(object? obj) => obj is ListItemViewModel vm && vm.Model.Equals(this.Model);
 
     public override int GetHashCode() => Model.GetHashCode();
+
+    private void ReplaceDetails(IDetails? model)
+    {
+        if (model is null && Details is null)
+        {
+            return;
+        }
+
+        if (Details?.Represents(model) == true)
+        {
+            Details.InitializeProperties();
+            return;
+        }
+
+        DetailsViewModel? replacement = null;
+        try
+        {
+            if (model is not null)
+            {
+                replacement = new(model, PageContext);
+                replacement.InitializeProperties();
+            }
+        }
+        catch
+        {
+            replacement?.SafeCleanup();
+            throw;
+        }
+
+        if (_lifetime.IsClosed)
+        {
+            replacement?.SafeCleanup();
+            return;
+        }
+
+        var previous = Details;
+        Details = replacement;
+        previous?.SafeCleanup();
+        UpdateProperty(nameof(Details), nameof(HasDetails));
+        UpdateShowDetailsCommand();
+    }
 
     private void AddShowDetailsCommands()
     {
@@ -238,41 +306,28 @@ public partial class ListItemViewModel : CommandItemViewModel
     // have the latest details in the show details command.
     private void UpdateShowDetailsCommand()
     {
-        // If the parent page has ShowDetails = false and we have details,
-        // then we should add a show details action in the context menu.
-        if (HasDetails &&
-            PageContext.TryGetTarget(out var pageContext) &&
-            pageContext is ListViewModel listViewModel &&
-            !listViewModel.ShowDetails)
+        CommandContextItemViewModel? oldCommand;
+        lock (MoreCommandsLock)
         {
-            CommandContextItemViewModel? oldCommand = null;
-            lock (MoreCommandsLock)
+            oldCommand = UnsafeMoreCommands
+                .OfType<CommandContextItemViewModel>()
+                .FirstOrDefault(contextItemViewModel => contextItemViewModel.Command.Id == ShowDetailsCommand.ShowDetailsCommandId);
+
+            if (oldCommand is not null)
             {
-                oldCommand = UnsafeMoreCommands
-                    .OfType<CommandContextItemViewModel>()
-                    .FirstOrDefault(contextItemViewModel => contextItemViewModel.Command.Id == ShowDetailsCommand.ShowDetailsCommandId);
-
-                if (oldCommand is not null)
-                {
-                    UnsafeMoreCommands.Remove(oldCommand);
-                }
-
-                var showDetailsCommand = new ShowDetailsCommand(Details);
-                var showDetailsContextItem = new CommandContextItem(showDetailsCommand)
-                {
-                    Icon = showDetailsCommand.Icon,
-                };
-                var showDetailsContextItemViewModel = new CommandContextItemViewModel(showDetailsContextItem, PageContext);
-                showDetailsContextItemViewModel.SlowInitializeProperties();
-                UnsafeMoreCommands.Add(showDetailsContextItemViewModel);
+                UnsafeMoreCommands.Remove(oldCommand);
                 RefreshMoreCommandStateUnsafe();
             }
+        }
 
+        if (oldCommand is not null)
+        {
             oldCommand?.SafeCleanup();
-
             UpdateProperty(nameof(MoreCommands), nameof(AllCommands));
             UpdateProperty(nameof(SecondaryCommand), nameof(SecondaryCommandName), nameof(HasMoreCommands));
         }
+
+        AddShowDetailsCommands();
     }
 
     private void UpdateTags(ITag[]? newTagsFromModel)
@@ -350,22 +405,15 @@ public partial class ListItemViewModel : CommandItemViewModel
         }
     }
 
-    protected override void UnsafeCleanup()
-    {
-        base.UnsafeCleanup();
+    protected override void UnsafeCleanup() => _lifetime.Close(CleanupItem);
 
-        // Tags don't have event handlers or anything to cleanup
+    private void CleanupItem()
+    {
         Tags?.ForEach(t => t.SafeCleanup());
         _overflowTag?.SafeCleanup();
         Details?.SafeCleanup();
-
-        var model = Model.Unsafe;
-        if (model is not null)
-        {
-            // We don't need to revoke the PropChanged event handler here,
-            // because we are just overriding CommandItem's FetchProperty and
-            // piggy-backing off their PropChanged
-        }
+        Details = null;
+        base.UnsafeCleanup();
     }
 
     protected void UpdateAccessibleName()

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListItemViewModel.cs
@@ -15,7 +15,7 @@ public partial class ListItemViewModel : CommandItemViewModel
     private const int MaxVisibleTags = 3;
 
     private readonly ViewModelLifetime _lifetime = new();
-    private int _selectionPending;
+    private TaskCompletionSource<bool>? _selectionPending;
     private bool _selectionInitialized;
 
     public new ExtensionObject<IListItem> Model { get; }
@@ -118,16 +118,31 @@ public partial class ListItemViewModel : CommandItemViewModel
 
     public override void SlowInitializeProperties()
     {
-        if (Interlocked.Exchange(ref _selectionPending, 1) != 0)
+        if (_lifetime.IsClosed || IsInErrorState)
+        {
+            return;
+        }
+
+        var pending = Volatile.Read(ref _selectionPending);
+        if (pending is not null &&
+            (!pending.Task.IsCompleted || (_selectionInitialized && (Details is null || Details.IsObservable))))
+        {
+            return;
+        }
+
+        var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        if (Interlocked.CompareExchange(ref _selectionPending, completion, pending) != pending)
         {
             return;
         }
 
         _lifetime.Run(() =>
         {
+            var initialized = false;
             try
             {
                 InitializeSelectedProperties();
+                initialized = !_lifetime.IsClosed && !IsInErrorState;
             }
             catch
             {
@@ -136,9 +151,28 @@ public partial class ListItemViewModel : CommandItemViewModel
             }
             finally
             {
-                Volatile.Write(ref _selectionPending, 0);
+                completion.TrySetResult(initialized);
             }
         });
+
+        if (_lifetime.IsClosed)
+        {
+            completion.TrySetResult(false);
+        }
+    }
+
+    public async Task<bool> SafeSlowInitAsync()
+    {
+        if (!SafeSlowInit())
+        {
+            return false;
+        }
+
+        var pending = Volatile.Read(ref _selectionPending);
+        return pending is not null &&
+            await pending.Task.ConfigureAwait(false) &&
+            !_lifetime.IsClosed &&
+            !IsInErrorState;
     }
 
     private void InitializeSelectedProperties()
@@ -164,7 +198,8 @@ public partial class ListItemViewModel : CommandItemViewModel
         _selectionInitialized = true;
     }
 
-    protected override void FetchProperty(string propertyName) => _lifetime.Run(() => FetchItemProperty(propertyName));
+    protected override void FetchProperty(string propertyName) =>
+        _lifetime.RunNotification(() => FetchItemProperty(propertyName), ex => ShowException(ex, Title));
 
     private void FetchItemProperty(string propertyName)
     {
@@ -405,7 +440,17 @@ public partial class ListItemViewModel : CommandItemViewModel
         }
     }
 
-    protected override void UnsafeCleanup() => _lifetime.Close(CleanupItem);
+    protected override void UnsafeCleanup()
+    {
+        try
+        {
+            _lifetime.Close(CleanupItem);
+        }
+        finally
+        {
+            Volatile.Read(ref _selectionPending)?.TrySetResult(false);
+        }
+    }
 
     private void CleanupItem()
     {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
@@ -827,7 +827,7 @@ public partial class ListViewModel : PageViewModel, IDisposable
 
         if (item is not null)
         {
-            SetSelectedItem(item);
+            _ = SetSelectedItemAsync(item);
         }
         else
         {
@@ -835,7 +835,7 @@ public partial class ListViewModel : PageViewModel, IDisposable
         }
     }
 
-    private void SetSelectedItem(ListItemViewModel item)
+    internal Task SetSelectedItemAsync(ListItemViewModel item)
     {
         _lastSelectedItem = item;
         _lastSelectedItem.PropertyChanged += SelectedItemPropertyChanged;
@@ -849,15 +849,15 @@ public partial class ListViewModel : PageViewModel, IDisposable
         var cts = _selectedItemCts = new CancellationTokenSource();
         var ct = cts.Token;
 
-        _ = Task.Run(
-            () =>
+        return Task.Run(
+            async () =>
             {
                 if (ct.IsCancellationRequested)
                 {
                     return;
                 }
 
-                if (!item.SafeSlowInit())
+                if (!await item.SafeSlowInitAsync().ConfigureAwait(false))
                 {
                     if (ct.IsCancellationRequested)
                     {
@@ -874,8 +874,7 @@ public partial class ListViewModel : PageViewModel, IDisposable
                     return;
                 }
 
-                // SafeSlowInit completed on a background thread — details
-                // messages will be marshalled to the UI thread by the receiver.
+                // Reselection waits for the same initialization without blocking extension callbacks.
                 if (ShowDetails && item.HasDetails)
                 {
                     WeakReferenceMessenger.Default.Send<ShowDetailsMessage>(new(item.Details));
@@ -888,6 +887,11 @@ public partial class ListViewModel : PageViewModel, IDisposable
                 var suggestion = item.TextToSuggest;
                 DoOnUiThread(() =>
                 {
+                    if (ct.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
                     TextToSuggest = suggestion;
                     WeakReferenceMessenger.Default.Send<UpdateSuggestionMessage>(new(suggestion));
                 });

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Models/ViewModelLifetime.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Models/ViewModelLifetime.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.ExceptionServices;
+
+namespace Microsoft.CmdPal.UI.ViewModels.Models;
+
+internal sealed class ViewModelLifetime
+{
+    private readonly Lock _gate = new();
+    private Queue<Action>? _pending;
+    private bool _running;
+    private volatile bool _closed;
+
+    public bool IsClosed => _closed;
+
+    public void Run(Action action) => Enqueue(action, close: false);
+
+    public void Close(Action cleanup) => Enqueue(cleanup, close: true);
+
+    private void Enqueue(Action action, bool close)
+    {
+        lock (_gate)
+        {
+            if (_closed)
+            {
+                return;
+            }
+
+            if (close)
+            {
+                _closed = true;
+                _pending?.Clear();
+            }
+
+            if (_running)
+            {
+                (_pending ??= new()).Enqueue(action);
+                return;
+            }
+
+            _running = true;
+        }
+
+        // Extension callbacks can reenter from another thread, so never hold the gate during RPC.
+        List<Exception>? failures = null;
+        while (true)
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception ex)
+            {
+                (failures ??= []).Add(ex);
+            }
+
+            lock (_gate)
+            {
+                if (_pending is null || !_pending.TryDequeue(out action!))
+                {
+                    _running = false;
+                    break;
+                }
+            }
+        }
+
+        if (failures is { Count: 1 })
+        {
+            ExceptionDispatchInfo.Capture(failures[0]).Throw();
+        }
+        else if (failures is not null)
+        {
+            throw new AggregateException(failures);
+        }
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Models/ViewModelLifetime.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Models/ViewModelLifetime.cs
@@ -17,6 +17,18 @@ internal sealed class ViewModelLifetime
 
     public void Run(Action action) => Enqueue(action, close: false);
 
+    public void RunNotification(Action action, Action<Exception> reportError) => Run(() =>
+    {
+        try
+        {
+            action();
+        }
+        catch (Exception ex)
+        {
+            reportError(ex);
+        }
+    });
+
     public void Close(Action cleanup) => Enqueue(cleanup, close: true);
 
     private void Enqueue(Action action, bool close)

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/DetailsLifecycleTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/DetailsLifecycleTests.cs
@@ -1,0 +1,668 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.CmdPal.UI.ViewModels.Commands;
+using Microsoft.CmdPal.UI.ViewModels.Messages;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Foundation;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+[TestClass]
+public sealed partial class DetailsLifecycleTests
+{
+    private readonly TestPageContext _context = new();
+    private readonly List<ExtensionObjectViewModel> _owned = [];
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        _owned.ForEach(vm => vm.SafeCleanup());
+        _context.Scheduler.RunAll();
+    }
+
+    [TestMethod]
+    public void RepeatedSelection_ReusesLiveDetailsAndReadsSnapshotOnce()
+    {
+        var markdown = new TrackedMarkdown();
+        var details = new TrackedDetails { Content = [markdown] };
+        var item = new TrackedListItem { Details = details };
+        var vm = CreateItem(item);
+
+        vm.SlowInitializeProperties();
+        var original = vm.Details;
+        for (var i = 0; i < 10; i++)
+        {
+            vm.SlowInitializeProperties();
+        }
+
+        Assert.AreSame(original, vm.Details);
+        Assert.AreEqual(1, item.DetailsReads);
+        Assert.AreEqual(1, details.BodyReads);
+        Assert.AreEqual(1, details.Adds);
+        Assert.AreEqual(1, markdown.Adds);
+
+        details.BodyValue = "live details";
+        details.Raise(nameof(IDetails.Body));
+        markdown.BodyValue = "live markdown";
+        markdown.Raise(nameof(IMarkdownContent.Body));
+        _context.Scheduler.RunAll();
+
+        Assert.AreEqual("live details", vm.Details?.Body);
+        Assert.IsInstanceOfType<ContentMarkdownViewModel>(vm.Details?.Content.Single(), out var content);
+        Assert.AreEqual("live markdown", content.Body);
+
+        vm.SafeCleanup();
+        vm.SafeCleanup();
+        Assert.AreEqual(1, details.Removes);
+        Assert.AreEqual(1, markdown.Removes);
+    }
+
+    [TestMethod]
+    public void RepeatedSelection_WithoutDetailsDoesNotRepeatExtensionReads()
+    {
+        var item = new TrackedListItem();
+        var vm = CreateItem(item);
+
+        vm.SlowInitializeProperties();
+        vm.SlowInitializeProperties();
+
+        Assert.IsNull(vm.Details);
+        Assert.AreEqual(1, item.DetailsReads);
+    }
+
+    [TestMethod]
+    public async Task OverlappingSelectionAndReplacement_OnlyPublishTheCurrentDetails()
+    {
+        using var entered = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        var previous = new TrackedDetails { OnBodyRead = () => Block(entered, release) };
+        var replacement = new TrackedDetails { BodyValue = "replacement" };
+        var item = new TrackedListItem { Details = previous };
+        var vm = CreateItem(item);
+        var initialization = Task.Run(vm.SlowInitializeProperties);
+        try
+        {
+            Assert.IsTrue(entered.Wait(TimeSpan.FromSeconds(5)));
+            vm.SlowInitializeProperties();
+            item.Details = replacement;
+            Assert.AreEqual(1, item.DetailsReads);
+        }
+        finally
+        {
+            release.Set();
+            await initialization.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+
+        Assert.AreEqual("replacement", vm.Details?.Body);
+        Assert.AreEqual(0, previous.Subscribers);
+        Assert.AreEqual(1, previous.Removes);
+        Assert.AreEqual(1, replacement.Subscribers);
+        vm.SlowInitializeProperties();
+        Assert.AreEqual(1, replacement.Adds);
+    }
+
+    [TestMethod]
+    public async Task CleanupDuringInitialization_DiscardsPendingWorkAndReleasesChildren()
+    {
+        using var entered = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        var markdown = new TrackedMarkdown { OnBodyRead = () => Block(entered, release) };
+        var details = new TrackedDetails { Content = [markdown] };
+        var vm = CreateItem(new TrackedListItem { Details = details });
+        var initialization = Task.Run(vm.SlowInitializeProperties);
+        try
+        {
+            Assert.IsTrue(entered.Wait(TimeSpan.FromSeconds(5)));
+            vm.SafeCleanup();
+            details.Raise(nameof(Details.Content));
+            vm.SlowInitializeProperties();
+        }
+        finally
+        {
+            release.Set();
+            await initialization.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+
+        _context.Scheduler.RunAll(newestFirst: true);
+        Assert.IsNull(vm.Details);
+        Assert.AreEqual(0, details.Subscribers);
+        Assert.AreEqual(0, markdown.Subscribers);
+        Assert.AreEqual(details.Adds, details.Removes);
+        Assert.AreEqual(markdown.Adds, markdown.Removes);
+    }
+
+    [TestMethod]
+    public void Selection_NonObservableDetailsRefreshWithoutLeakingPreviousContent()
+    {
+        var first = new TrackedMarkdown();
+        var second = new TrackedMarkdown();
+        var details = new SnapshotDetails { Content = [first] };
+        var vm = CreateItem(new TrackedListItem { Details = details });
+        vm.SlowInitializeProperties();
+        var original = vm.Details;
+
+        details.Body = "new snapshot";
+        details.Content = [second];
+        vm.SlowInitializeProperties();
+        _context.Scheduler.RunAll(newestFirst: true);
+
+        Assert.AreSame(original, vm.Details);
+        Assert.AreEqual("new snapshot", vm.Details?.Body);
+        Assert.AreEqual(0, first.Subscribers);
+        Assert.AreEqual(1, second.Subscribers);
+        Assert.IsInstanceOfType<ContentMarkdownViewModel>(vm.Details?.Content.Single(), out var content);
+        Assert.AreSame(second, content.Model.Unsafe);
+    }
+
+    [TestMethod]
+    public void ContentReplacementBeforeUiPublication_DetachesOldGraphAndPublishesLatest()
+    {
+        var first = new TrackedMarkdown();
+        var second = new TrackedMarkdown();
+        var details = new TrackedDetails { Content = [first] };
+        var vm = Own(new DetailsViewModel(details, new(_context)));
+        vm.InitializeProperties();
+        var lateCallback = first.Capture(nameof(IMarkdownContent.Body));
+
+        details.Content = [second];
+        details.Raise(nameof(Details.Content));
+        _context.Scheduler.RunAll(newestFirst: true);
+
+        Assert.AreEqual(0, first.Subscribers);
+        Assert.AreEqual(1, second.Subscribers);
+        Assert.IsInstanceOfType<ContentMarkdownViewModel>(vm.Content.Single(), out var content);
+        Assert.AreSame(second, content.Model.Unsafe);
+
+        var reads = first.BodyReads;
+        lateCallback();
+        Assert.AreEqual(reads, first.BodyReads);
+        second.BodyValue = "still live";
+        second.Raise(nameof(IMarkdownContent.Body));
+        Assert.AreEqual("still live", content.Body);
+
+        vm.SafeCleanup();
+        _context.Scheduler.RunAll(newestFirst: true);
+        Assert.IsEmpty(vm.Content);
+        Assert.AreEqual(0, second.Subscribers);
+    }
+
+    [TestMethod]
+    public void MetadataReplacement_CleansOnlyOwnedCommandsAndKeepsSharedModelsAlive()
+    {
+        var command = new TrackedCommand();
+        var replacement = new TrackedCommand();
+        var details = new TrackedDetails { Metadata = [Commands(command)] };
+        var first = Own(new DetailsViewModel(details, new(_context)));
+        var second = Own(new DetailsViewModel(details, new(_context)));
+        first.InitializeProperties();
+        second.InitializeProperties();
+        Assert.AreEqual(2, command.Subscribers);
+
+        first.SafeCleanup();
+        Assert.AreEqual(1, command.Subscribers);
+        command.Name = "shared model is live";
+        command.Raise(nameof(ICommand.Name));
+        Assert.IsInstanceOfType<DetailsCommandsViewModel>(second.Metadata.Single(), out var metadata);
+        Assert.AreEqual("shared model is live", metadata.Commands.Single().Name);
+
+        details.Metadata = [Commands(replacement)];
+        details.Raise(nameof(IDetails.Metadata));
+        Assert.AreEqual(0, command.Subscribers);
+        Assert.AreEqual(1, replacement.Subscribers);
+        second.SafeCleanup();
+        second.SafeCleanup();
+        Assert.AreEqual(1, replacement.Removes);
+    }
+
+    [TestMethod]
+    public void NestedTreeChanges_ReleaseReplacedRootAndUnpublishedChildren()
+    {
+        var root = new TrackedMarkdown();
+        var firstChild = new TrackedMarkdown();
+        var nextRoot = new TrackedMarkdown();
+        var nextChild = new TrackedMarkdown();
+        var tree = new TrackedTree { RootContent = root, Children = [firstChild] };
+        var details = new TrackedDetails { Content = [tree] };
+        var vm = Own(new DetailsViewModel(details, new(_context)));
+        vm.InitializeProperties();
+
+        tree.RootContent = nextRoot;
+        tree.Raise(nameof(ITreeContent.RootContent));
+        tree.Children = [nextChild];
+        tree.RaiseItemsChanged();
+        _context.Scheduler.RunAll(newestFirst: true);
+
+        Assert.AreEqual(0, root.Subscribers);
+        Assert.AreEqual(0, firstChild.Subscribers);
+        Assert.IsInstanceOfType<ContentTreeViewModel>(vm.Content.Single(), out var treeVm);
+        Assert.IsInstanceOfType<ContentMarkdownViewModel>(treeVm.RootContent, out var rootVm);
+        Assert.AreSame(nextRoot, rootVm.Model.Unsafe);
+        Assert.IsInstanceOfType<ContentMarkdownViewModel>(treeVm.Children.Single(), out var childVm);
+        Assert.AreSame(nextChild, childVm.Model.Unsafe);
+
+        tree.RootContent = null;
+        tree.Raise(nameof(ITreeContent.RootContent));
+        Assert.IsNull(treeVm.RootContent);
+        Assert.AreEqual(0, nextRoot.Subscribers);
+        var lateItemsChanged = tree.CaptureItemsChanged();
+        vm.SafeCleanup();
+        lateItemsChanged();
+        _context.Scheduler.RunAll(newestFirst: true);
+        Assert.AreEqual(0, tree.Subscribers);
+        Assert.AreEqual(0, tree.ItemsSubscribers);
+        Assert.AreEqual(0, nextChild.Subscribers);
+        Assert.IsEmpty(treeVm.Children);
+    }
+
+    [TestMethod]
+    public void FailedInitialization_ReleasesPartialGraphAndCannotResubscribe()
+    {
+        var command = new TrackedCommand();
+        var first = new TrackedMarkdown();
+        var broken = new TrackedMarkdown { OnBodyRead = () => throw new InvalidOperationException("broken content") };
+        var details = new TrackedDetails { Metadata = [Commands(command)], Content = [first, broken] };
+        var vm = Own(new DetailsViewModel(details, new(_context)));
+
+        Assert.ThrowsExactly<InvalidOperationException>(vm.InitializeProperties);
+        vm.InitializeProperties();
+        vm.SafeCleanup();
+        _context.Scheduler.RunAll(newestFirst: true);
+
+        Assert.AreEqual(1, details.Adds);
+        Assert.AreEqual(1, details.Removes);
+        Assert.AreEqual(0, command.Subscribers);
+        Assert.AreEqual(0, first.Subscribers);
+        Assert.AreEqual(1, broken.Removes);
+        Assert.IsEmpty(vm.Content);
+        Assert.IsEmpty(vm.Metadata);
+    }
+
+    [TestMethod]
+    public void FailedReplacement_PreservesPreviousDetailsAndReportsFailure()
+    {
+        var previous = new TrackedDetails();
+        var broken = new TrackedDetails { OnBodyRead = () => throw new InvalidOperationException("broken details") };
+        var item = new TrackedListItem { Details = previous };
+        var vm = CreateItem(item);
+        vm.SlowInitializeProperties();
+        var original = vm.Details;
+
+        item.Details = broken;
+
+        Assert.AreSame(original, vm.Details);
+        Assert.AreEqual(1, previous.Subscribers);
+        Assert.AreEqual(0, broken.Subscribers);
+        Assert.HasCount(1, _context.Errors);
+        Assert.IsInstanceOfType<InvalidOperationException>(_context.Errors[0]);
+        previous.BodyValue = "still available";
+        previous.Raise(nameof(IDetails.Body));
+        Assert.AreEqual("still available", original?.Body);
+    }
+
+    [TestMethod]
+    public void CrossThreadNotificationDuringRead_IsDeferredWithoutBlockingTheExtension()
+    {
+        var details = new TrackedDetails();
+        details.OnBodyRead = () =>
+        {
+            details.OnBodyRead = null;
+            var callback = Task.Run(() =>
+            {
+                details.BodyValue = "updated during read";
+                details.Raise(nameof(IDetails.Body));
+            });
+            Assert.IsTrue(callback.Wait(TimeSpan.FromSeconds(5)));
+        };
+        var vm = Own(new DetailsViewModel(details, new(_context)));
+
+        vm.InitializeProperties();
+
+        Assert.AreEqual("updated during read", vm.Body);
+        Assert.AreEqual(1, details.Subscribers);
+    }
+
+    [TestMethod]
+    public void ContentInitializationAndCleanup_AreIdempotentAndIgnoreLateCallbacks()
+    {
+        var markdown = new TrackedMarkdown();
+        var vm = Own(new ContentMarkdownViewModel(markdown, new(_context)));
+        vm.InitializeProperties();
+        vm.InitializeProperties();
+        var lateCallback = markdown.Capture(nameof(IMarkdownContent.Body));
+
+        vm.SafeCleanup();
+        vm.SafeCleanup();
+        vm.InitializeProperties();
+        lateCallback();
+
+        Assert.AreEqual(1, markdown.Adds);
+        Assert.AreEqual(1, markdown.Removes);
+        Assert.AreEqual(1, markdown.BodyReads);
+    }
+
+    [TestMethod]
+    public void FailedSelection_ReleasesAlreadyInitializedDetails()
+    {
+        var markdown = new TrackedMarkdown();
+        var details = new TrackedDetails { Content = [markdown] };
+        var item = new TrackedListItem { Details = details, FailTextToSuggest = true };
+        var vm = CreateItem(item);
+
+        Assert.IsFalse(vm.SafeSlowInit());
+        vm.SlowInitializeProperties();
+
+        Assert.IsTrue(vm.IsInErrorState);
+        Assert.IsNull(vm.Details);
+        Assert.AreEqual(1, details.Adds);
+        Assert.AreEqual(1, details.Removes);
+        Assert.AreEqual(1, markdown.Removes);
+    }
+
+    [TestMethod]
+    public void ObservableDetails_SizeUpdatesWithoutAnotherSelectionSnapshot()
+    {
+        var details = new Details { Size = ContentSize.Small };
+        var vm = Own(new DetailsViewModel(details, new(_context)));
+        vm.InitializeProperties();
+
+        details.Size = ContentSize.Large;
+
+        Assert.AreEqual(ContentSize.Large, vm.Size);
+    }
+
+    [TestMethod]
+    public void DetailsReplacement_RetargetsShowDetailsAndRemovalDropsTheCommand()
+    {
+        var page = new ListViewModel(new TestListPage(), _context.Scheduler, new TestHost(), CommandProviderContext.Empty, DefaultContextMenuFactory.Instance);
+        var item = new TrackedListItem { Details = new TrackedDetails() };
+        var vm = Own(new ListItemViewModel(item, new(page), DefaultContextMenuFactory.Instance));
+        var recipient = new DetailsRecipient();
+        WeakReferenceMessenger.Default.Register<DetailsRecipient, ShowDetailsMessage>(recipient, static (r, message) => r.Details = message.Details);
+        try
+        {
+            vm.SlowInitializeProperties();
+            item.Details = new TrackedDetails();
+            var command = vm.MoreCommands.OfType<CommandContextItemViewModel>()
+                .Single(c => c.Command.Id == ShowDetailsCommand.ShowDetailsCommandId);
+            Assert.IsInstanceOfType<ShowDetailsCommand>(command.Command.Model.Unsafe, out var showDetails);
+            showDetails.Invoke();
+            Assert.AreSame(vm.Details, recipient.Details);
+
+            item.Details = null;
+            Assert.IsNull(vm.Details);
+            Assert.IsFalse(vm.MoreCommands.OfType<CommandContextItemViewModel>()
+                .Any(c => c.Command.Id == ShowDetailsCommand.ShowDetailsCommandId));
+        }
+        finally
+        {
+            WeakReferenceMessenger.Default.UnregisterAll(recipient);
+            vm.SafeCleanup();
+            page.SafeCleanup();
+            page.Dispose();
+        }
+    }
+
+    private ListItemViewModel CreateItem(IListItem item) =>
+        Own(new ListItemViewModel(item, new(_context), DefaultContextMenuFactory.Instance));
+
+    private T Own<T>(T vm)
+        where T : ExtensionObjectViewModel
+    {
+        _owned.Add(vm);
+        return vm;
+    }
+
+    private static DetailsElement Commands(ICommand command) => new()
+    {
+        Key = "Commands",
+        Data = new DetailsCommands { Commands = [command] },
+    };
+
+    private static void Block(ManualResetEventSlim entered, ManualResetEventSlim release)
+    {
+        entered.Set();
+        Assert.IsTrue(release.Wait(TimeSpan.FromSeconds(5)));
+    }
+
+    private sealed class TestPageContext : IPageContext
+    {
+        public QueuedScheduler Scheduler { get; } = new();
+
+        TaskScheduler IPageContext.Scheduler => Scheduler;
+
+        public List<Exception> Errors { get; } = [];
+
+        public ICommandProviderContext ProviderContext => CommandProviderContext.Empty;
+
+        public void ShowException(Exception ex, string? extensionHint = null) => Errors.Add(ex);
+    }
+
+    private sealed class QueuedScheduler : TaskScheduler
+    {
+        private readonly Lock _gate = new();
+        private readonly List<Task> _tasks = [];
+
+        protected override IEnumerable<Task> GetScheduledTasks()
+        {
+            lock (_gate)
+            {
+                return _tasks.ToArray();
+            }
+        }
+
+        protected override void QueueTask(Task task)
+        {
+            lock (_gate)
+            {
+                _tasks.Add(task);
+            }
+        }
+
+        protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued) => false;
+
+        public void RunAll(bool newestFirst = false)
+        {
+            while (true)
+            {
+                Task task;
+                lock (_gate)
+                {
+                    if (_tasks.Count == 0)
+                    {
+                        return;
+                    }
+
+                    var index = newestFirst ? _tasks.Count - 1 : 0;
+                    task = _tasks[index];
+                    _tasks.RemoveAt(index);
+                }
+
+                TryExecuteTask(task);
+                task.GetAwaiter().GetResult();
+            }
+        }
+    }
+
+    private abstract partial class TrackedObservable : INotifyPropChanged
+    {
+        private TypedEventHandler<object, IPropChangedEventArgs>? _handlers;
+
+        public int Adds { get; private set; }
+
+        public int Removes { get; private set; }
+
+        public int Subscribers => _handlers?.GetInvocationList().Length ?? 0;
+
+        public event TypedEventHandler<object, IPropChangedEventArgs> PropChanged
+        {
+            add
+            {
+                Adds++;
+                _handlers += value;
+            }
+
+            remove
+            {
+                Removes++;
+                _handlers -= value;
+            }
+        }
+
+        public void Raise(string property) => _handlers?.Invoke(this, new PropChangedEventArgs(property));
+
+        public Action Capture(string property)
+        {
+            var handlers = _handlers;
+            return () => handlers?.Invoke(this, new PropChangedEventArgs(property));
+        }
+    }
+
+    private sealed partial class TrackedDetails : TrackedObservable, IDetails2
+    {
+        public IIconInfo HeroImage => null!;
+
+        public string Title => "Details";
+
+        public string BodyValue { get; set; } = "initial";
+
+        public Action? OnBodyRead { get; set; }
+
+        public int BodyReads { get; private set; }
+
+        public string Body
+        {
+            get
+            {
+                BodyReads++;
+                var value = BodyValue;
+                OnBodyRead?.Invoke();
+                return value;
+            }
+        }
+
+        public IDetailsElement[] Metadata { get; set; } = [];
+
+        public IContent[] Content { get; set; } = [];
+
+        public IContent[] GetContent() => Content;
+    }
+
+    private sealed partial class SnapshotDetails : IDetails2
+    {
+        public IIconInfo HeroImage => null!;
+
+        public string Title => "Legacy details";
+
+        public string Body { get; set; } = "initial";
+
+        public IDetailsElement[] Metadata => [];
+
+        public IContent[] Content { get; set; } = [];
+
+        public IContent[] GetContent() => Content;
+    }
+
+    private sealed partial class TrackedMarkdown : TrackedObservable, IMarkdownContent
+    {
+        public string BodyValue { get; set; } = "initial";
+
+        public Action? OnBodyRead { get; set; }
+
+        public int BodyReads { get; private set; }
+
+        public string Body
+        {
+            get
+            {
+                BodyReads++;
+                OnBodyRead?.Invoke();
+                return BodyValue;
+            }
+        }
+    }
+
+    private sealed partial class TrackedCommand : TrackedObservable, ICommand
+    {
+        public string Name { get; set; } = "Command";
+
+        public string Id => "test.command";
+
+        public IIconInfo Icon => null!;
+    }
+
+    private sealed partial class TrackedTree : TrackedObservable, ITreeContent
+    {
+        private TypedEventHandler<object, IItemsChangedEventArgs>? _itemsChanged;
+
+        public IContent? RootContent { get; set; }
+
+        public IContent[] Children { get; set; } = [];
+
+        public int ItemsSubscribers => _itemsChanged?.GetInvocationList().Length ?? 0;
+
+        public event TypedEventHandler<object, IItemsChangedEventArgs> ItemsChanged
+        {
+            add => _itemsChanged += value;
+            remove => _itemsChanged -= value;
+        }
+
+        public IContent[] GetChildren() => Children;
+
+        public void RaiseItemsChanged() => _itemsChanged?.Invoke(this, new ItemsChangedEventArgs());
+
+        public Action CaptureItemsChanged()
+        {
+            var handlers = _itemsChanged;
+            return () => handlers?.Invoke(this, new ItemsChangedEventArgs());
+        }
+    }
+
+    private sealed partial class TrackedListItem : ListItem
+    {
+        public int DetailsReads { get; private set; }
+
+        public bool FailTextToSuggest { get; set; }
+
+        public override string TextToSuggest
+        {
+            get => FailTextToSuggest ? throw new InvalidOperationException("broken suggestion") : base.TextToSuggest;
+            set => base.TextToSuggest = value;
+        }
+
+        public override IDetails? Details
+        {
+            get
+            {
+                DetailsReads++;
+                return base.Details;
+            }
+
+            set => base.Details = value;
+        }
+    }
+
+    private sealed class DetailsRecipient
+    {
+        public DetailsViewModel? Details { get; set; }
+    }
+
+    private sealed partial class TestListPage : ListPage
+    {
+        public override IListItem[] GetItems() => [];
+    }
+
+    private sealed partial class TestHost : AppExtensionHost
+    {
+        public override string? GetExtensionDisplayName() => "Details lifecycle tests";
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/DetailsLifecycleTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/DetailsLifecycleTests.cs
@@ -142,6 +142,281 @@ public sealed partial class DetailsLifecycleTests
     }
 
     [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public async Task AsyncSelections_SharePendingInitializationResult(bool failInitialization)
+    {
+        using var entered = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        var details = new TrackedDetails { OnBodyRead = () => Block(entered, release) };
+        var item = new TrackedListItem
+        {
+            Details = details,
+            TextToSuggest = "completed suggestion",
+            FailTextToSuggest = failInitialization,
+        };
+        var vm = CreateItem(item);
+        var first = Task.Run(vm.SafeSlowInitAsync);
+        Task<bool>? second = null;
+        Task<bool>? third = null;
+        try
+        {
+            Assert.IsTrue(entered.Wait(TimeSpan.FromSeconds(5)));
+            second = vm.SafeSlowInitAsync();
+            third = vm.SafeSlowInitAsync();
+
+            Assert.IsFalse(second.IsCompleted);
+            Assert.IsFalse(third.IsCompleted);
+            item.Title = "changed while initializing";
+            Assert.AreEqual(1, item.DetailsReads);
+        }
+        finally
+        {
+            release.Set();
+            await first.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+
+        Assert.IsNotNull(second);
+        Assert.IsNotNull(third);
+        Assert.AreEqual(!failInitialization, await first);
+        Assert.AreEqual(!failInitialization, await second.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.AreEqual(!failInitialization, await third.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.AreEqual(failInitialization, vm.IsInErrorState);
+        Assert.AreEqual(1, details.Adds);
+        if (!failInitialization)
+        {
+            Assert.AreEqual("completed suggestion", vm.TextToSuggest);
+        }
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public async Task AsyncSelection_QueuedBehindInitializationCompletesOrCleansUp(bool cleanup)
+    {
+        using var entered = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        var item = new TrackedListItem
+        {
+            OnSectionRead = () => Block(entered, release),
+            TextToSuggest = "queued suggestion",
+        };
+        var vm = CreateItem(item);
+        var initialization = Task.Run(vm.SafeInitializeProperties);
+        Task<bool>? selection = null;
+        try
+        {
+            Assert.IsTrue(entered.Wait(TimeSpan.FromSeconds(5)));
+            selection = vm.SafeSlowInitAsync();
+            Assert.IsFalse(selection.IsCompleted);
+            if (cleanup)
+            {
+                vm.SafeCleanup();
+                Assert.IsFalse(await selection.WaitAsync(TimeSpan.FromSeconds(5)));
+            }
+        }
+        finally
+        {
+            release.Set();
+            await initialization.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+
+        Assert.IsNotNull(selection);
+        Assert.AreEqual(!cleanup, await selection.WaitAsync(TimeSpan.FromSeconds(5)));
+        if (!cleanup)
+        {
+            Assert.AreEqual("queued suggestion", vm.TextToSuggest);
+        }
+    }
+
+    [TestMethod]
+    public async Task Reselection_PublishesCompletedSuggestionAfterOriginalSelectionIsCanceled()
+    {
+        using var entered = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        var details = new TrackedDetails { OnBodyRead = () => Block(entered, release) };
+        var vm = CreateItem(new TrackedListItem { Details = details, TextToSuggest = "completed suggestion" });
+        var page = new ListViewModel(new TestListPage(), _context.Scheduler, new TestHost(), CommandProviderContext.Empty, DefaultContextMenuFactory.Instance);
+        var recipient = new SuggestionRecipient();
+        WeakReferenceMessenger.Default.Register<SuggestionRecipient, UpdateSuggestionMessage>(recipient, static (r, message) => r.Suggestions.Add(message.TextToSuggest));
+        Task? first = null;
+        Task? latest = null;
+        try
+        {
+            first = page.SetSelectedItemAsync(vm);
+            Assert.IsTrue(entered.Wait(TimeSpan.FromSeconds(5)));
+            page.UpdateSelectedItemCommand.Execute(null);
+            latest = page.SetSelectedItemAsync(vm);
+
+            release.Set();
+            await Task.WhenAll(first, latest).WaitAsync(TimeSpan.FromSeconds(5));
+            _context.Scheduler.RunAll();
+
+            CollectionAssert.AreEqual(new[] { string.Empty, "completed suggestion" }, recipient.Suggestions);
+            Assert.AreEqual("completed suggestion", page.TextToSuggest);
+            Assert.AreEqual(1, details.Adds);
+        }
+        finally
+        {
+            release.Set();
+            await Task.WhenAll(first ?? Task.CompletedTask, latest ?? Task.CompletedTask).WaitAsync(TimeSpan.FromSeconds(5));
+            WeakReferenceMessenger.Default.UnregisterAll(recipient);
+            page.SafeCleanup();
+            page.Dispose();
+        }
+    }
+
+    [TestMethod]
+    public async Task SelectionCanceledBeforeUiPublication_DoesNotRestoreObsoleteSuggestion()
+    {
+        var vm = CreateItem(new TrackedListItem { TextToSuggest = "obsolete suggestion" });
+        var page = new ListViewModel(new TestListPage(), _context.Scheduler, new TestHost(), CommandProviderContext.Empty, DefaultContextMenuFactory.Instance);
+        var recipient = new SuggestionRecipient();
+        WeakReferenceMessenger.Default.Register<SuggestionRecipient, UpdateSuggestionMessage>(recipient, static (r, message) => r.Suggestions.Add(message.TextToSuggest));
+        try
+        {
+            await page.SetSelectedItemAsync(vm).WaitAsync(TimeSpan.FromSeconds(5));
+            page.UpdateSelectedItemCommand.Execute(null);
+            _context.Scheduler.RunAll();
+
+            CollectionAssert.AreEqual(new[] { string.Empty }, recipient.Suggestions);
+            Assert.AreEqual(string.Empty, page.TextToSuggest);
+        }
+        finally
+        {
+            WeakReferenceMessenger.Default.UnregisterAll(recipient);
+            page.SafeCleanup();
+            page.Dispose();
+        }
+    }
+
+    [TestMethod]
+    public async Task QueuedDetailsNotificationFailure_DoesNotFailItemInitialization()
+    {
+        using var entered = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        var command = new TrackedCommand();
+        var failure = new InvalidOperationException("notification failed");
+        var broken = new TrackedDetails { OnBodyRead = () => throw failure };
+        var item = new TrackedListItem
+        {
+            Command = command,
+            Title = "healthy item",
+            OnSectionRead = () => Block(entered, release),
+        };
+        var vm = CreateItem(item);
+        var initialization = Task.Run(vm.SafeInitializeProperties);
+        try
+        {
+            Assert.IsTrue(entered.Wait(TimeSpan.FromSeconds(5)));
+            item.Details = broken;
+            item.Title = "updated title";
+        }
+        finally
+        {
+            release.Set();
+            await initialization.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+
+        Assert.IsTrue(await initialization);
+        Assert.IsFalse(vm.IsInErrorState);
+        Assert.AreSame(command, vm.Command.Model.Unsafe);
+        Assert.AreEqual("updated title", vm.Title);
+        Assert.HasCount(1, _context.Errors);
+        Assert.AreSame(failure, _context.Errors[0]);
+        Assert.AreEqual(0, broken.Subscribers);
+
+        var healthyDetails = new TrackedDetails();
+        item.Details = healthyDetails;
+        healthyDetails.BodyValue = "live details";
+        healthyDetails.Raise(nameof(IDetails.Body));
+        Assert.AreEqual("live details", vm.Details?.Body);
+    }
+
+    [TestMethod]
+    public void QueuedDetailsBodyFailure_DoesNotFailSelectionOrDetachHealthyContent()
+    {
+        var failure = new InvalidOperationException("body notification failed");
+        var markdown = new TrackedMarkdown();
+        var details = new TrackedDetails { Content = [markdown] };
+        details.OnBodyRead = () =>
+        {
+            details.OnBodyRead = () => throw failure;
+            details.Raise(nameof(IDetails.Body));
+        };
+        var vm = CreateItem(new TrackedListItem { Details = details });
+
+        Assert.IsTrue(vm.SafeSlowInit());
+
+        Assert.IsFalse(vm.IsInErrorState);
+        Assert.AreEqual(1, details.Subscribers);
+        Assert.AreEqual(1, markdown.Subscribers);
+        Assert.HasCount(1, _context.Errors);
+        Assert.AreSame(failure, _context.Errors[0]);
+        details.OnBodyRead = null;
+        details.BodyValue = "recovered";
+        details.Raise(nameof(IDetails.Body));
+        Assert.AreEqual("recovered", vm.Details?.Body);
+    }
+
+    [TestMethod]
+    public void QueuedMarkdownFailure_DoesNotFailSelectionOrDetachContent()
+    {
+        var failure = new InvalidOperationException("markdown notification failed");
+        var markdown = new TrackedMarkdown();
+        markdown.OnBodyRead = () =>
+        {
+            markdown.OnBodyRead = () => throw failure;
+            markdown.Raise(nameof(IMarkdownContent.Body));
+        };
+        var vm = CreateItem(new TrackedListItem { Details = new TrackedDetails { Content = [markdown] } });
+
+        Assert.IsTrue(vm.SafeSlowInit());
+        _context.Scheduler.RunAll();
+
+        Assert.IsFalse(vm.IsInErrorState);
+        Assert.AreEqual(1, markdown.Subscribers);
+        Assert.HasCount(1, _context.Errors);
+        Assert.AreSame(failure, _context.Errors[0]);
+        markdown.OnBodyRead = null;
+        markdown.BodyValue = "recovered";
+        markdown.Raise(nameof(IMarkdownContent.Body));
+        Assert.IsInstanceOfType<ContentMarkdownViewModel>(vm.Details?.Content.Single(), out var content);
+        Assert.AreEqual("recovered", content.Body);
+    }
+
+    [TestMethod]
+    public void QueuedTreeItemsFailure_DoesNotFailSelectionOrDetachChildren()
+    {
+        var failure = new InvalidOperationException("tree notification failed");
+        var markdown = new TrackedMarkdown();
+        var tree = new TrackedTree { Children = [markdown] };
+        tree.OnChildrenRead = () =>
+        {
+            tree.OnChildrenRead = () => throw failure;
+            tree.RaiseItemsChanged();
+        };
+        var vm = CreateItem(new TrackedListItem { Details = new TrackedDetails { Content = [tree] } });
+
+        Assert.IsTrue(vm.SafeSlowInit());
+        _context.Scheduler.RunAll();
+
+        Assert.IsFalse(vm.IsInErrorState);
+        Assert.AreEqual(1, tree.Subscribers);
+        Assert.AreEqual(1, tree.ItemsSubscribers);
+        Assert.AreEqual(1, markdown.Subscribers);
+        Assert.HasCount(1, _context.Errors);
+        Assert.AreSame(failure, _context.Errors[0]);
+        tree.OnChildrenRead = null;
+        tree.Children = [];
+        tree.RaiseItemsChanged();
+        _context.Scheduler.RunAll();
+        Assert.IsInstanceOfType<ContentTreeViewModel>(vm.Details?.Content.Single(), out var content);
+        Assert.IsEmpty(content.Children);
+        Assert.AreEqual(0, markdown.Subscribers);
+    }
+
+    [TestMethod]
     public void Selection_NonObservableDetailsRefreshWithoutLeakingPreviousContent()
     {
         var first = new TrackedMarkdown();
@@ -616,7 +891,13 @@ public sealed partial class DetailsLifecycleTests
             remove => _itemsChanged -= value;
         }
 
-        public IContent[] GetChildren() => Children;
+        public Action? OnChildrenRead { get; set; }
+
+        public IContent[] GetChildren()
+        {
+            OnChildrenRead?.Invoke();
+            return Children;
+        }
 
         public void RaiseItemsChanged() => _itemsChanged?.Invoke(this, new ItemsChangedEventArgs());
 
@@ -632,6 +913,19 @@ public sealed partial class DetailsLifecycleTests
         public int DetailsReads { get; private set; }
 
         public bool FailTextToSuggest { get; set; }
+
+        public Action? OnSectionRead { get; set; }
+
+        public override string Section
+        {
+            get
+            {
+                OnSectionRead?.Invoke();
+                return base.Section;
+            }
+
+            set => base.Section = value;
+        }
 
         public override string TextToSuggest
         {
@@ -654,6 +948,11 @@ public sealed partial class DetailsLifecycleTests
     private sealed class DetailsRecipient
     {
         public DetailsViewModel? Details { get; set; }
+    }
+
+    private sealed class SuggestionRecipient
+    {
+        public List<string> Suggestions { get; } = [];
     }
 
     private sealed partial class TestListPage : ListPage


### PR DESCRIPTION
Command Palette now reuses a result’s details when it can, instead of rebuilding them every time you select it and leaving old copies listening for updates. It also cleans up replaced details, keeps live updates working, and fixes cases where switching results quickly could lose your search suggestion or a failed details update could mark a healthy result as broken.
