### PR TITLE
CmdPal: Stop reloading clipboard entries that haven't changed

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
@@ -984,8 +984,8 @@ public partial class ListViewModel : PageViewModel, IDisposable
             LoadExtendedAttributes(haveProperties.GetProperties().AsReadOnly());
         }
 
-        FetchItems(keepSelection: true, ensureSelectionVisible: true);
         model.ItemsChanged += Model_ItemsChanged;
+        FetchItems(keepSelection: true, ensureSelectionVisible: true);
     }
 
     private static IGridPropertiesViewModel? LoadGridPropertiesViewModel(IGridProperties? gridProperties)

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests/ClipboardHistoryCacheTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests/ClipboardHistoryCacheTests.cs
@@ -1,0 +1,207 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests;
+
+[TestClass]
+public sealed class ClipboardHistoryCacheTests
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public async Task RefreshAsync_RequestsDuringRead_CoalescesAndPublishesLatestOnly(bool obsoleteReadFails)
+    {
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var reads = 0;
+        var publications = 0;
+        var current = Mock.Of<IListItem>();
+        using var source = new TestClipboardHistorySource
+        {
+            Read = async _ =>
+            {
+                if (Interlocked.Increment(ref reads) == 1)
+                {
+                    started.SetResult();
+                    await release.Task;
+                    if (obsoleteReadFails)
+                    {
+                        throw new InvalidOperationException("Obsolete history read failed.");
+                    }
+
+                    return [Entry("stale", Mock.Of<IListItem>())];
+                }
+
+                return [Entry("current", current)];
+            },
+        };
+        await using var cache = new ClipboardHistoryCache(source, new ClipboardHistoryWorker(), () => publications++);
+        var refresh = cache.RefreshAsync();
+        try
+        {
+            await started.Task.WaitAsync(Timeout);
+            for (var i = 0; i < 20; i++)
+            {
+                Assert.AreSame(refresh, cache.RefreshAsync());
+            }
+        }
+        finally
+        {
+            release.TrySetResult();
+        }
+
+        await refresh.WaitAsync(Timeout);
+
+        Assert.AreEqual(2, reads);
+        Assert.AreEqual(1, publications);
+        Assert.HasCount(1, cache.Items);
+        Assert.AreSame(current, cache.Items[0]);
+    }
+
+    [TestMethod]
+    public async Task Clear_DuringRead_ImmediatelyDropsSnapshotAndRejectsStaleResult()
+    {
+        var first = Mock.Of<IListItem>();
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var source = new TestClipboardHistorySource
+        {
+            Read = _ => Task.FromResult<IReadOnlyList<ClipboardHistoryEntry>>([Entry("a", first)]),
+        };
+        await using var cache = new ClipboardHistoryCache(source, new ClipboardHistoryWorker(), () => { });
+        await cache.RefreshAsync().WaitAsync(Timeout);
+        source.Read = async _ =>
+        {
+            started.TrySetResult();
+            await release.Task;
+            return [Entry("a", first)];
+        };
+
+        var refresh = cache.RefreshAsync();
+        try
+        {
+            await started.Task.WaitAsync(Timeout);
+            cache.Clear();
+            Assert.IsEmpty(cache.Items);
+            source.Read = _ => Task.FromResult<IReadOnlyList<ClipboardHistoryEntry>>([]);
+            Assert.AreSame(refresh, cache.RefreshAsync());
+        }
+        finally
+        {
+            release.TrySetResult();
+        }
+
+        await refresh.WaitAsync(Timeout);
+        Assert.IsEmpty(cache.Items);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_Failure_ClearsStaleItemsAndCanRetry()
+    {
+        using var source = new TestClipboardHistorySource
+        {
+            Read = _ => Task.FromResult<IReadOnlyList<ClipboardHistoryEntry>>([Entry("a", Mock.Of<IListItem>())]),
+        };
+        await using var cache = new ClipboardHistoryCache(source, new ClipboardHistoryWorker(), () => { });
+        await cache.RefreshAsync().WaitAsync(Timeout);
+        source.Read = _ => Task.FromException<IReadOnlyList<ClipboardHistoryEntry>>(new InvalidOperationException("History unavailable."));
+
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => cache.RefreshAsync().WaitAsync(Timeout));
+        Assert.IsEmpty(cache.Items);
+        Assert.IsFalse(cache.IsRefreshing);
+
+        var replacement = Mock.Of<IListItem>();
+        source.Read = _ => Task.FromResult<IReadOnlyList<ClipboardHistoryEntry>>([Entry("b", replacement)]);
+        await cache.RefreshAsync().WaitAsync(Timeout);
+        Assert.AreSame(replacement, cache.Items[0]);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_DispatchFailure_DoesNotLeaveRefreshStuck()
+    {
+        using var source = new TestClipboardHistorySource();
+        await using var cache = new ClipboardHistoryCache(source, new RejectingWorker(), () => { });
+
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => cache.RefreshAsync());
+
+        Assert.IsFalse(cache.IsRefreshing);
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => cache.RefreshAsync());
+        Assert.IsFalse(cache.IsRefreshing);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_DisabledThenEnabled_ReloadsContentRatherThanKeepingOldEntries()
+    {
+        var loads = 0;
+        var entry = new ClipboardHistoryEntry("a", _ =>
+        {
+            loads++;
+            return Task.FromResult(Mock.Of<IListItem>());
+        });
+        using var source = new TestClipboardHistorySource
+        {
+            Read = _ => Task.FromResult<IReadOnlyList<ClipboardHistoryEntry>>([entry]),
+        };
+        await using var cache = new ClipboardHistoryCache(source, new ClipboardHistoryWorker(), () => { });
+        await cache.RefreshAsync().WaitAsync(Timeout);
+        var original = cache.Items[0];
+
+        source.Read = _ => Task.FromResult<IReadOnlyList<ClipboardHistoryEntry>>([]);
+        await cache.RefreshAsync().WaitAsync(Timeout);
+        Assert.IsEmpty(cache.Items);
+
+        source.Read = _ => Task.FromResult<IReadOnlyList<ClipboardHistoryEntry>>([entry]);
+        await cache.RefreshAsync().WaitAsync(Timeout);
+        Assert.AreEqual(2, loads);
+        Assert.AreNotSame(original, cache.Items[0]);
+    }
+
+    [TestMethod]
+    public async Task DisposeAsync_DuringRead_CancelsAndPreventsPublication()
+    {
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var blocked = new TaskCompletionSource<IReadOnlyList<ClipboardHistoryEntry>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var publications = 0;
+        using var source = new TestClipboardHistorySource
+        {
+            Read = token =>
+            {
+                started.SetResult();
+                return blocked.Task.WaitAsync(token);
+            },
+        };
+        var worker = new ClipboardHistoryWorker();
+        await using var cache = new ClipboardHistoryCache(source, worker, () => publications++);
+        var refresh = cache.RefreshAsync();
+        await started.Task.WaitAsync(Timeout);
+
+        await cache.DisposeAsync().AsTask().WaitAsync(Timeout);
+        await refresh.WaitAsync(Timeout);
+        await cache.RefreshAsync();
+
+        Assert.AreEqual(0, publications);
+        Assert.IsEmpty(cache.Items);
+        Assert.ThrowsExactly<ObjectDisposedException>(() => worker.RunAsync(() => Task.CompletedTask));
+    }
+
+    private static ClipboardHistoryEntry Entry(string id, IListItem item) => new(id, _ => Task.FromResult(item));
+
+    private sealed class RejectingWorker : IClipboardHistoryWorker
+    {
+        public Task RunAsync(Func<Task> action) => Task.FromException(new InvalidOperationException("Dispatcher unavailable."));
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests/ClipboardHistoryListPageTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests/ClipboardHistoryListPageTests.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
+using Microsoft.CmdPal.Ext.ClipboardHistory.Pages;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests;
+
+[TestClass]
+public sealed class ClipboardHistoryListPageTests
+{
+    [TestMethod]
+    public async Task GetItems_RepeatedFetches_ReusesSnapshotWithOneSettingsSubscriber()
+    {
+        var settings = new TestSettings();
+        var reads = 0;
+        var item = Mock.Of<IListItem>();
+        using var source = new TestClipboardHistorySource
+        {
+            Read = _ =>
+            {
+                reads++;
+                return Task.FromResult<IReadOnlyList<ClipboardHistoryEntry>>([new("a", _ => Task.FromResult(item))]);
+            },
+        };
+        await using var page = new ClipboardHistoryListPage(settings, source, new ClipboardHistoryWorker());
+        var published = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        page.ItemsChanged += (_, _) => published.TrySetResult();
+
+        page.GetItems();
+        await published.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        for (var i = 0; i < 20; i++)
+        {
+            Assert.AreSame(item, page.GetItems()[0]);
+        }
+
+        Assert.AreEqual(1, reads);
+        Assert.AreEqual(1, settings.Subscribers);
+        Assert.AreEqual(1, source.HistorySubscribers);
+        Assert.AreEqual(1, source.EnabledSubscribers);
+
+        settings.RaiseChanged();
+        Assert.AreEqual(1, reads);
+        Assert.AreSame(item, page.GetItems()[0]);
+
+        await page.DisposeAsync();
+        Assert.AreEqual(0, settings.Subscribers);
+        Assert.AreEqual(0, source.HistorySubscribers);
+        Assert.AreEqual(0, source.EnabledSubscribers);
+        Assert.IsTrue(source.IsDisposed);
+        Assert.IsEmpty(page.GetItems());
+    }
+
+    [TestMethod]
+    public async Task DisposeAsync_UnopenedPage_DetachesSettingsAndHistoryEvents()
+    {
+        var settings = new TestSettings();
+        using var source = new TestClipboardHistorySource();
+        var worker = new ClipboardHistoryWorker();
+        await using var page = new ClipboardHistoryListPage(settings, source, worker);
+        var notifications = 0;
+        page.ItemsChanged += (_, _) => notifications++;
+
+        await page.DisposeAsync();
+        settings.RaiseChanged();
+        source.RaiseHistoryChanged();
+        source.RaiseHistoryEnabledChanged();
+
+        Assert.AreEqual(0, notifications);
+        Assert.AreEqual(0, settings.Subscribers);
+        Assert.AreEqual(0, source.HistorySubscribers);
+        Assert.AreEqual(0, source.EnabledSubscribers);
+        Assert.IsTrue(source.IsDisposed);
+        Assert.ThrowsExactly<ObjectDisposedException>(() => worker.RunAsync(() => Task.CompletedTask));
+    }
+
+    private sealed class TestSettings : IClipboardHistorySettings
+    {
+        private EventHandler _changed;
+
+        public event EventHandler Changed
+        {
+            add => _changed += value;
+            remove => _changed -= value;
+        }
+
+        public int Subscribers => _changed?.GetInvocationList().Length ?? 0;
+
+        public bool KeepAfterPaste => false;
+
+        public bool DeleteFromHistoryRequiresConfirmation => true;
+
+        public PrimaryAction PrimaryAction => PrimaryAction.Default;
+
+        public void RaiseChanged() => _changed?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests/ClipboardHistoryListPageTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests/ClipboardHistoryListPageTests.cs
@@ -4,18 +4,165 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
+using ManagedCommon;
 using Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
+using Microsoft.CmdPal.Ext.ClipboardHistory.Helpers.Analyzers;
+using Microsoft.CmdPal.Ext.ClipboardHistory.Models;
 using Microsoft.CmdPal.Ext.ClipboardHistory.Pages;
+using Microsoft.CmdPal.Ext.ClipboardHistory.Properties;
 using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.Graphics.Imaging;
+using Windows.Storage.Streams;
 
 namespace Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests;
 
 [TestClass]
 public sealed class ClipboardHistoryListPageTests
 {
+    [TestMethod]
+    public async Task GetItems_FileChanged_RefreshesDetailsWithoutReloadingClipboardContent()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(path, "before");
+            File.SetLastWriteTime(path, new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Local));
+            var settings = new TestSettings();
+            var data = CreateTextData(path);
+            var item = new ClipboardListItem(new ClipboardItem { Content = path, Settings = settings, Item = null }, settings, data);
+            var loads = 0;
+            using var source = new TestClipboardHistorySource
+            {
+                Read = _ => Task.FromResult<IReadOnlyList<ClipboardHistoryEntry>>(
+                    [new("file", _ =>
+                    {
+                        loads++;
+                        return Task.FromResult<IListItem>(item);
+                    })]),
+            };
+            await using var page = new ClipboardHistoryListPage(settings, source, new ClipboardHistoryWorker());
+            await LoadPageAsync(page);
+            var original = page.GetItems()[0];
+            var originalDetails = original.Details;
+            var originalCommand = original.Command;
+            Assert.AreEqual(SizeFormatter.FormatSize(6), GetDetail(originalDetails, Resources.metadata_file_system_size_key));
+            var originalModified = GetDetail(originalDetails, Resources.metadata_file_system_modified_key);
+            var detailsNotifications = 0;
+            item.PropChanged += (_, args) => detailsNotifications += args.PropertyName == nameof(item.Details) ? 1 : 0;
+
+            File.WriteAllText(path, new string('x', 8192));
+            var modified = new DateTime(2025, 2, 2, 13, 0, 0, DateTimeKind.Local);
+            File.SetLastWriteTime(path, modified);
+            var reopened = page.GetItems()[0];
+            var updatedDetails = reopened.Details;
+
+            Assert.AreSame(original, reopened);
+            Assert.AreSame(originalCommand, reopened.Command);
+            Assert.AreSame(data, item.DataPackageView);
+            Assert.AreEqual(path, await data.GetTextAsync());
+            Assert.AreEqual(1, loads);
+            Assert.AreEqual(1, detailsNotifications);
+            Assert.AreNotSame(originalDetails, updatedDetails);
+            Assert.AreEqual(SizeFormatter.FormatSize(8192), GetDetail(updatedDetails, Resources.metadata_file_system_size_key));
+            Assert.AreEqual(modified.ToString(CultureInfo.CurrentCulture), GetDetail(updatedDetails, Resources.metadata_file_system_modified_key));
+            Assert.AreNotEqual(originalModified, GetDetail(updatedDetails, Resources.metadata_file_system_modified_key));
+            Assert.AreEqual(SizeFormatter.FormatSize(6), GetDetail(originalDetails, Resources.metadata_file_system_size_key));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [TestMethod]
+    public async Task GetItems_FileRemovedAndRecreated_RefreshesActionsAndMetadata()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(path, "before");
+            var settings = new TestSettings();
+            var item = new ClipboardListItem(new ClipboardItem { Content = path, Settings = settings, Item = null }, settings, CreateTextData(path));
+            using var source = new TestClipboardHistorySource
+            {
+                Read = _ => Task.FromResult<IReadOnlyList<ClipboardHistoryEntry>>([new("file", _ => Task.FromResult<IListItem>(item))]),
+            };
+            await using var page = new ClipboardHistoryListPage(settings, source, new ClipboardHistoryWorker());
+            await LoadPageAsync(page);
+            var initial = page.GetItems()[0];
+            var originalCommand = initial.Command;
+            Assert.IsTrue(HasShowInFolderCommand(initial));
+            Assert.IsTrue(initial.Details.Metadata.Any(detail => detail.Key == Resources.metadata_file_system_size_key));
+
+            File.Delete(path);
+            var removed = page.GetItems()[0];
+            Assert.AreSame(initial, removed);
+            Assert.AreSame(originalCommand, removed.Command);
+            Assert.IsFalse(HasShowInFolderCommand(removed));
+            Assert.IsFalse(removed.Details.Metadata.Any(detail => detail.Key == Resources.metadata_file_system_size_key));
+
+            File.WriteAllText(path, "recreated");
+            var recreated = page.GetItems()[0];
+            Assert.AreSame(initial, recreated);
+            Assert.AreSame(originalCommand, recreated.Command);
+            Assert.IsTrue(HasShowInFolderCommand(recreated));
+            Assert.AreEqual(SizeFormatter.FormatSize(9), GetDetail(recreated.Details, Resources.metadata_file_system_size_key));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public async Task GetItems_UnchangedTextOrImage_PreservesDetailsAndCommands(bool image)
+    {
+        var settings = new TestSettings();
+        using var imageStream = new InMemoryRandomAccessStream();
+        if (image)
+        {
+            var encoder = await BitmapEncoder.CreateAsync(BitmapEncoder.PngEncoderId, imageStream);
+            encoder.SetPixelData(BitmapPixelFormat.Bgra8, BitmapAlphaMode.Straight, 1, 1, 96, 96, [0, 0, 0, 255]);
+            await encoder.FlushAsync();
+        }
+
+        var item = new ClipboardListItem(
+            new ClipboardItem
+            {
+                Content = image ? null : "unchanged clipboard text",
+                ImageData = image ? RandomAccessStreamReference.CreateFromStream(imageStream) : null,
+                Settings = settings,
+                Item = null,
+            },
+            settings,
+            CreateTextData("unchanged clipboard text"));
+        using var source = new TestClipboardHistorySource
+        {
+            Read = _ => Task.FromResult<IReadOnlyList<ClipboardHistoryEntry>>([new("item", _ => Task.FromResult<IListItem>(item))]),
+        };
+        await using var page = new ClipboardHistoryListPage(settings, source, new ClipboardHistoryWorker());
+        await LoadPageAsync(page);
+        var first = page.GetItems()[0];
+        var details = first.Details;
+        var commands = first.MoreCommands;
+
+        var reopened = page.GetItems()[0];
+
+        Assert.AreSame(first, reopened);
+        Assert.AreSame(details, reopened.Details);
+        Assert.AreSame(commands, reopened.MoreCommands);
+    }
+
     [TestMethod]
     public async Task GetItems_RepeatedFetches_ReusesSnapshotWithOneSettingsSubscriber()
     {
@@ -79,6 +226,39 @@ public sealed class ClipboardHistoryListPageTests
         Assert.AreEqual(0, source.EnabledSubscribers);
         Assert.IsTrue(source.IsDisposed);
         Assert.ThrowsExactly<ObjectDisposedException>(() => worker.RunAsync(() => Task.CompletedTask));
+    }
+
+    private static DataPackageView CreateTextData(string text)
+    {
+        var data = new DataPackage();
+        data.SetText(text);
+        return data.GetView();
+    }
+
+    private static string GetDetail(IDetails details, string key)
+    {
+        var element = details.Metadata.Single(detail => detail.Key == key);
+        Assert.IsInstanceOfType<DetailsLink>(element.Data, out var link);
+        return link.Text;
+    }
+
+    private static bool HasShowInFolderCommand(IListItem item) =>
+        item.MoreCommands.OfType<ICommandContextItem>().Any(context => context.Command is ShowFileInFolderCommand);
+
+    private static async Task LoadPageAsync(ClipboardHistoryListPage page)
+    {
+        var published = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        void OnItemsChanged(object sender, IItemsChangedEventArgs args) => published.TrySetResult();
+        page.ItemsChanged += OnItemsChanged;
+        try
+        {
+            page.GetItems();
+            await published.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        }
+        finally
+        {
+            page.ItemsChanged -= OnItemsChanged;
+        }
     }
 
     private sealed class TestSettings : IClipboardHistorySettings

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests/ClipboardHistorySnapshotTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests/ClipboardHistorySnapshotTests.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests;
+
+[TestClass]
+public sealed class ClipboardHistorySnapshotTests
+{
+    [TestMethod]
+    public async Task RefreshAsync_UnchangedEntries_ReusesItemsWithoutLoadingContent()
+    {
+        var loads = 0;
+        var entry = new ClipboardHistoryEntry("text", _ =>
+        {
+            loads++;
+            return Task.FromResult(Mock.Of<IListItem>());
+        });
+
+        var first = await ClipboardHistorySnapshot.Empty.RefreshAsync([entry], CancellationToken.None);
+        var second = await first.RefreshAsync([entry], CancellationToken.None);
+
+        Assert.AreEqual(1, loads);
+        Assert.AreSame(first.Items[0], second.Items[0]);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_AddRemoveReorder_KeepsOnlyCurrentHistoryInOrder()
+    {
+        var loads = 0;
+        ClipboardHistoryEntry Entry(string id) => new(id, _ =>
+        {
+            loads++;
+            return Task.FromResult(Mock.Of<IListItem>());
+        });
+
+        var first = await ClipboardHistorySnapshot.Empty.RefreshAsync([Entry("a"), Entry("b")], CancellationToken.None);
+        var second = await first.RefreshAsync([Entry("b"), Entry("c"), Entry("a")], CancellationToken.None);
+        Assert.AreSame(first.Items[1], second.Items[0]);
+        Assert.AreSame(first.Items[0], second.Items[2]);
+        Assert.AreEqual(3, loads);
+
+        var third = await second.RefreshAsync([Entry("c")], CancellationToken.None);
+        Assert.HasCount(1, third.Items);
+        Assert.AreSame(second.Items[1], third.Items[0]);
+
+        var fourth = await third.RefreshAsync([Entry("a"), Entry("c")], CancellationToken.None);
+        Assert.AreEqual(4, loads);
+        Assert.AreNotSame(first.Items[0], fourth.Items[0]);
+        Assert.AreSame(third.Items[0], fourth.Items[1]);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_RemovedItem_DoesNotDisposeContentHeldByACommand()
+    {
+        var item = new Mock<IListItem>();
+        var disposable = item.As<IDisposable>();
+        var first = await ClipboardHistorySnapshot.Empty.RefreshAsync(
+            [new ClipboardHistoryEntry("image", _ => Task.FromResult(item.Object))],
+            CancellationToken.None);
+
+        var empty = await first.RefreshAsync([], CancellationToken.None);
+
+        Assert.IsEmpty(empty.Items);
+        Assert.AreSame(item.Object, first.Items[0]);
+        disposable.Verify(value => value.Dispose(), Times.Never());
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_Canceled_DoesNotReadContent()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var loads = 0;
+        var entry = new ClipboardHistoryEntry("a", _ =>
+        {
+            loads++;
+            return Task.FromResult(Mock.Of<IListItem>());
+        });
+
+        await Assert.ThrowsExactlyAsync<OperationCanceledException>(() =>
+            ClipboardHistorySnapshot.Empty.RefreshAsync([entry], cancellation.Token));
+
+        Assert.AreEqual(0, loads);
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests/ClipboardHistoryWorkerTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests/ClipboardHistoryWorkerTests.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Storage.Streams;
+using Windows.System;
+
+namespace Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests;
+
+[TestClass]
+public sealed class ClipboardHistoryWorkerTests
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+
+    [TestMethod]
+    public async Task RunAsync_AcrossManagedAndWinRtAwaits_ReusesPumpedStaThread()
+    {
+        await using var worker = new ClipboardHistoryWorker();
+        var threadId = 0;
+        await worker.RunAsync(async () =>
+        {
+            threadId = Environment.CurrentManagedThreadId;
+            Assert.AreEqual(ApartmentState.STA, Thread.CurrentThread.GetApartmentState());
+            Assert.IsNotNull(DispatcherQueue.GetForCurrentThread());
+            await Task.Yield();
+            Assert.AreEqual(threadId, Environment.CurrentManagedThreadId);
+            using var stream = new InMemoryRandomAccessStream();
+            using var writer = new DataWriter(stream);
+            writer.WriteString("clipboard");
+            await writer.StoreAsync();
+            Assert.AreEqual(threadId, Environment.CurrentManagedThreadId);
+            Assert.AreEqual(ApartmentState.STA, Thread.CurrentThread.GetApartmentState());
+        }).WaitAsync(Timeout);
+
+        await worker.RunAsync(() =>
+        {
+            Assert.AreEqual(threadId, Environment.CurrentManagedThreadId);
+            return Task.CompletedTask;
+        }).WaitAsync(Timeout);
+    }
+
+    [TestMethod]
+    public async Task DisposeAsync_PendingContinuation_DrainsBeforeStoppingQueue()
+    {
+        await using var worker = new ClipboardHistoryWorker();
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        DispatcherQueue queue = null;
+        var resumed = false;
+        var work = worker.RunAsync(async () =>
+        {
+            queue = DispatcherQueue.GetForCurrentThread();
+            started.SetResult();
+            await release.Task;
+            resumed = true;
+        });
+
+        await started.Task.WaitAsync(Timeout);
+        var shutdown = worker.DisposeAsync().AsTask();
+        try
+        {
+            Assert.IsFalse(shutdown.IsCompleted);
+            Assert.ThrowsExactly<ObjectDisposedException>(() => worker.RunAsync(() => Task.CompletedTask));
+        }
+        finally
+        {
+            release.TrySetResult();
+        }
+
+        await work.WaitAsync(Timeout);
+        await shutdown.WaitAsync(Timeout);
+        Assert.IsTrue(resumed);
+        Assert.IsFalse(queue.TryEnqueue(() => { }));
+        await worker.DisposeAsync();
+    }
+
+    [TestMethod]
+    public async Task RunAsync_Fault_PropagatesAndLeavesWorkerUsable()
+    {
+        await using var worker = new ClipboardHistoryWorker();
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => worker.RunAsync(
+            () => throw new InvalidOperationException("Expected failure.")).WaitAsync(Timeout));
+
+        var ran = false;
+        await worker.RunAsync(() =>
+        {
+            ran = true;
+            return Task.CompletedTask;
+        }).WaitAsync(Timeout);
+
+        Assert.IsTrue(ran);
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests/ClipboardHistoryWorkerTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests/ClipboardHistoryWorkerTests.cs
@@ -27,8 +27,10 @@ public sealed class ClipboardHistoryWorkerTests
             threadId = Environment.CurrentManagedThreadId;
             Assert.AreEqual(ApartmentState.STA, Thread.CurrentThread.GetApartmentState());
             Assert.IsNotNull(DispatcherQueue.GetForCurrentThread());
+            Assert.IsNotNull(SynchronizationContext.Current);
             await Task.Yield();
             Assert.AreEqual(threadId, Environment.CurrentManagedThreadId);
+            Assert.IsNotNull(SynchronizationContext.Current);
             using var stream = new InMemoryRandomAccessStream();
             using var writer = new DataWriter(stream);
             writer.WriteString("clipboard");
@@ -77,6 +79,30 @@ public sealed class ClipboardHistoryWorkerTests
         Assert.IsTrue(resumed);
         Assert.IsFalse(queue.TryEnqueue(() => { }));
         await worker.DisposeAsync();
+    }
+
+    [TestMethod]
+    public async Task SynchronizationContext_Copy_PostsToWorkerAndRejectsAfterShutdown()
+    {
+        await using var worker = new ClipboardHistoryWorker();
+        SynchronizationContext context = null;
+        var threadId = 0;
+        await worker.RunAsync(() =>
+        {
+            threadId = Environment.CurrentManagedThreadId;
+            context = SynchronizationContext.Current.CreateCopy();
+            return Task.CompletedTask;
+        }).WaitAsync(Timeout);
+        var posted = new TaskCompletionSource<(int ThreadId, ApartmentState Apartment, SynchronizationContext Context)>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        context.Post(_ => posted.SetResult((Environment.CurrentManagedThreadId, Thread.CurrentThread.GetApartmentState(), SynchronizationContext.Current)), null);
+        var result = await posted.Task.WaitAsync(Timeout);
+
+        Assert.AreEqual(threadId, result.ThreadId);
+        Assert.AreEqual(ApartmentState.STA, result.Apartment);
+        Assert.AreSame(context, result.Context);
+        await worker.DisposeAsync();
+        Assert.ThrowsExactly<InvalidOperationException>(() => context.Post(_ => { }, null));
     }
 
     [TestMethod]

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests/TestClipboardHistorySource.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests/TestClipboardHistorySource.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
+
+namespace Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests;
+
+internal sealed partial class TestClipboardHistorySource : IClipboardHistorySource
+{
+    private EventHandler _historyChanged;
+    private EventHandler _historyEnabledChanged;
+
+    public event EventHandler HistoryChanged
+    {
+        add => _historyChanged += value;
+        remove => _historyChanged -= value;
+    }
+
+    public event EventHandler HistoryEnabledChanged
+    {
+        add => _historyEnabledChanged += value;
+        remove => _historyEnabledChanged -= value;
+    }
+
+    public Func<CancellationToken, Task<IReadOnlyList<ClipboardHistoryEntry>>> Read { get; set; } = _ => Task.FromResult<IReadOnlyList<ClipboardHistoryEntry>>([]);
+
+    public int HistorySubscribers => _historyChanged?.GetInvocationList().Length ?? 0;
+
+    public int EnabledSubscribers => _historyEnabledChanged?.GetInvocationList().Length ?? 0;
+
+    public bool IsDisposed { get; private set; }
+
+    public Task<IReadOnlyList<ClipboardHistoryEntry>> ReadAsync(CancellationToken cancellationToken) => Read(cancellationToken);
+
+    public void RaiseHistoryChanged() => _historyChanged?.Invoke(this, EventArgs.Empty);
+
+    public void RaiseHistoryEnabledChanged() => _historyEnabledChanged?.Invoke(this, EventArgs.Empty);
+
+    public void Dispose() => IsDisposed = true;
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ListViewModelTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ListViewModelTests.cs
@@ -76,8 +76,73 @@ public partial class ListViewModelTests
         public void TriggerItemsChanged(int totalItems) => RaiseItemsChanged(totalItems);
     }
 
+    private sealed partial class FirstFetchNotificationPage(bool publishOnBackgroundThread) : ListPage
+    {
+        private readonly IListItem[] _readyItems = [new ListItem(new NoOpCommand() { Name = "Loaded item" })];
+        private int _getItemsCallCount;
+
+        public int GetItemsCallCount => Volatile.Read(ref _getItemsCallCount);
+
+        public override IListItem[] GetItems()
+        {
+            if (Interlocked.Increment(ref _getItemsCallCount) == 1)
+            {
+                if (publishOnBackgroundThread)
+                {
+                    Task.Run(() => RaiseItemsChanged(1)).GetAwaiter().GetResult();
+                }
+                else
+                {
+                    RaiseItemsChanged(1);
+                }
+
+                return [];
+            }
+
+            return _readyItems;
+        }
+    }
+
     private static ListViewModel CreateViewModel(IListPage page) =>
         new(page, TaskScheduler.Default, new TestAppExtensionHost(), CommandProviderContext.Empty, DefaultContextMenuFactory.Instance);
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public async Task InitializeProperties_ItemsPublishedDuringFirstFetch_DisplaysLoadedItems(bool publishOnBackgroundThread)
+    {
+        var page = new FirstFetchNotificationPage(publishOnBackgroundThread)
+        {
+            Id = "first.fetch.page",
+            Name = "First Fetch Page",
+        };
+        var viewModel = CreateViewModel(page);
+        var itemsLoaded = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        void OnItemsUpdated(ListViewModel sender, ItemsUpdatedEventArgs args)
+        {
+            if (sender.FilteredItems.Count == 1 && sender.FilteredItems[0].Name == "Loaded item")
+            {
+                itemsLoaded.TrySetResult(true);
+            }
+        }
+
+        viewModel.ItemsUpdated += OnItemsUpdated;
+        try
+        {
+            viewModel.InitializeProperties();
+            await itemsLoaded.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            Assert.HasCount(1, viewModel.FilteredItems);
+            Assert.AreEqual("Loaded item", viewModel.FilteredItems[0].Name);
+            Assert.AreEqual(2, page.GetItemsCallCount);
+        }
+        finally
+        {
+            viewModel.ItemsUpdated -= OnItemsUpdated;
+            viewModel.SafeCleanup();
+            viewModel.Dispose();
+        }
+    }
 
     [TestMethod]
     public async Task RecursiveItemsChangedDuringGetItems_IsDeferredUntilGetItemsReturns()

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/ClipboardHistoryCommandsProvider.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/ClipboardHistoryCommandsProvider.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
 using Microsoft.CmdPal.Ext.ClipboardHistory.Pages;
 using Microsoft.CommandPalette.Extensions;
@@ -13,11 +14,12 @@ public partial class ClipboardHistoryCommandsProvider : CommandProvider
 {
     private readonly ListItem _clipboardHistoryListItem;
     private readonly SettingsManager _settingsManager = new();
+    private readonly ClipboardHistoryListPage _page;
 
     public ClipboardHistoryCommandsProvider()
     {
-        var page = new ClipboardHistoryListPage(_settingsManager);
-        _clipboardHistoryListItem = new ListItem(page)
+        _page = new ClipboardHistoryListPage(_settingsManager);
+        _clipboardHistoryListItem = new ListItem(_page)
         {
             Title = Properties.Resources.list_item_title,
             Icon = Icons.ClipboardListIcon,
@@ -35,5 +37,12 @@ public partial class ClipboardHistoryCommandsProvider : CommandProvider
     public override IListItem[] TopLevelCommands()
     {
         return [_clipboardHistoryListItem];
+    }
+
+    public override void Dispose()
+    {
+        _page.Dispose();
+        GC.SuppressFinalize(this);
+        base.Dispose();
     }
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/ClipboardHistoryCache.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/ClipboardHistoryCache.cs
@@ -1,0 +1,227 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
+
+internal sealed class ClipboardHistoryCache(IClipboardHistorySource source, IClipboardHistoryWorker worker, Action changed) : IAsyncDisposable
+{
+    private readonly Lock _gate = new();
+    private readonly CancellationTokenSource _shutdown = new();
+    private ClipboardHistorySnapshot _snapshot = ClipboardHistorySnapshot.Empty;
+    private Task _refresh = Task.CompletedTask;
+    private Task? _dispose;
+    private CancellationTokenSource? _loadCancellation;
+    private long _version;
+    private bool _refreshing;
+    private bool _disposed;
+
+    public bool IsRefreshing
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _refreshing;
+            }
+        }
+    }
+
+    public IListItem[] Items
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _snapshot.Items;
+            }
+        }
+    }
+
+    public Task RefreshAsync()
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                return Task.CompletedTask;
+            }
+
+            _version++;
+            if (_refreshing)
+            {
+                _loadCancellation?.Cancel();
+            }
+            else
+            {
+                _refreshing = true;
+                var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                _refresh = completion.Task;
+                _ = RunWorkerAsync(completion);
+            }
+
+            return _refresh;
+        }
+    }
+
+    private async Task RunWorkerAsync(TaskCompletionSource completion)
+    {
+        try
+        {
+            await worker.RunAsync(RefreshCoreAsync).ConfigureAwait(false);
+            completion.SetResult();
+        }
+        catch (Exception ex)
+        {
+            lock (_gate)
+            {
+                if (ReferenceEquals(_refresh, completion.Task))
+                {
+                    _refreshing = false;
+                }
+            }
+
+            completion.SetException(ex);
+        }
+    }
+
+    public void Clear()
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _version++;
+            _snapshot = ClipboardHistorySnapshot.Empty;
+            _loadCancellation?.Cancel();
+        }
+
+        changed();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        lock (_gate)
+        {
+            if (_dispose is null)
+            {
+                _disposed = true;
+                _snapshot = ClipboardHistorySnapshot.Empty;
+                _refreshing = false;
+                _shutdown.Cancel();
+                _dispose = DisposeCoreAsync();
+            }
+
+            return new ValueTask(_dispose);
+        }
+    }
+
+    private async Task RefreshCoreAsync()
+    {
+        while (true)
+        {
+            long version;
+            ClipboardHistorySnapshot previous;
+            CancellationTokenSource cancellation;
+            lock (_gate)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                version = _version;
+                previous = _snapshot;
+                cancellation = CancellationTokenSource.CreateLinkedTokenSource(_shutdown.Token);
+                _loadCancellation = cancellation;
+            }
+
+            ClipboardHistorySnapshot next;
+            try
+            {
+                var entries = await source.ReadAsync(cancellation.Token);
+                next = await previous.RefreshAsync(entries, cancellation.Token);
+            }
+            catch (Exception ex)
+            {
+                bool hadItems;
+                lock (_gate)
+                {
+                    if (_disposed || version != _version)
+                    {
+                        if (ex is not OperationCanceledException)
+                        {
+                            ExtensionHost.LogMessage(ex.ToString());
+                        }
+
+                        if (_disposed)
+                        {
+                            return;
+                        }
+
+                        continue;
+                    }
+
+                    hadItems = _snapshot.Items.Length > 0;
+                    _snapshot = ClipboardHistorySnapshot.Empty;
+                    _refreshing = false;
+                }
+
+                if (hadItems)
+                {
+                    changed();
+                }
+
+                throw;
+            }
+            finally
+            {
+                lock (_gate)
+                {
+                    _loadCancellation = null;
+                    cancellation.Dispose();
+                }
+            }
+
+            lock (_gate)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                if (version != _version)
+                {
+                    continue;
+                }
+
+                _snapshot = next;
+                _refreshing = false;
+            }
+
+            changed();
+            return;
+        }
+    }
+
+    private async Task DisposeCoreAsync()
+    {
+        try
+        {
+            await worker.DisposeAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            _shutdown.Dispose();
+        }
+    }
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/ClipboardHistorySnapshot.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/ClipboardHistorySnapshot.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CommandPalette.Extensions;
+
+namespace Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
+
+internal sealed class ClipboardHistorySnapshot
+{
+    private readonly Dictionary<string, IListItem> _itemsById;
+
+    public static ClipboardHistorySnapshot Empty { get; } = new([], []);
+
+    public IListItem[] Items { get; }
+
+    private ClipboardHistorySnapshot(Dictionary<string, IListItem> itemsById, IListItem[] items)
+    {
+        _itemsById = itemsById;
+        Items = items;
+    }
+
+    public async Task<ClipboardHistorySnapshot> RefreshAsync(IReadOnlyList<ClipboardHistoryEntry> entries, CancellationToken cancellationToken)
+    {
+        Dictionary<string, IListItem> itemsById = new(entries.Count, StringComparer.Ordinal);
+        var items = new IListItem[entries.Count];
+        for (var i = 0; i < entries.Count; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var entry = entries[i];
+            if (!_itemsById.TryGetValue(entry.Id, out var item))
+            {
+                item = await entry.LoadAsync(cancellationToken);
+            }
+
+            itemsById.Add(entry.Id, item);
+            items[i] = item;
+        }
+
+        return new ClipboardHistorySnapshot(itemsById, items);
+    }
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/ClipboardHistorySource.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/ClipboardHistorySource.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CmdPal.Ext.ClipboardHistory.Models;
+using Microsoft.CommandPalette.Extensions;
+using Windows.ApplicationModel.DataTransfer;
+
+namespace Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
+
+internal sealed partial class ClipboardHistorySource : IClipboardHistorySource
+{
+    private readonly IClipboardHistorySettings _settings;
+    private readonly Lock _gate = new();
+    private bool _subscribed;
+    private bool _disposed;
+
+    public event EventHandler? HistoryChanged;
+
+    public event EventHandler? HistoryEnabledChanged;
+
+    public ClipboardHistorySource(IClipboardHistorySettings settings)
+    {
+        _settings = settings;
+    }
+
+    public async Task<IReadOnlyList<ClipboardHistoryEntry>> ReadAsync(CancellationToken cancellationToken)
+    {
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (!_subscribed)
+            {
+                Clipboard.HistoryChanged += OnHistoryChanged;
+                try
+                {
+                    Clipboard.HistoryEnabledChanged += OnHistoryEnabledChanged;
+                }
+                catch
+                {
+                    Clipboard.HistoryChanged -= OnHistoryChanged;
+                    throw;
+                }
+
+                _subscribed = true;
+            }
+        }
+
+        if (!Clipboard.IsHistoryEnabled())
+        {
+            return [];
+        }
+
+        var history = await Clipboard.GetHistoryItemsAsync().AsTask(cancellationToken);
+        if (history.Status != ClipboardHistoryItemsResultStatus.Success)
+        {
+            throw new InvalidOperationException($"Clipboard history returned {history.Status}.");
+        }
+
+        List<ClipboardHistoryEntry> entries = [];
+        foreach (var item in history.Items)
+        {
+            if (item.Content.Contains(StandardDataFormats.Text) || item.Content.Contains(StandardDataFormats.Bitmap))
+            {
+                entries.Add(new ClipboardHistoryEntry(item.Id, token => LoadItemAsync(item, token)));
+            }
+        }
+
+        return entries;
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            _disposed = true;
+            if (_subscribed)
+            {
+                Clipboard.HistoryChanged -= OnHistoryChanged;
+                Clipboard.HistoryEnabledChanged -= OnHistoryEnabledChanged;
+                _subscribed = false;
+            }
+        }
+    }
+
+    private async Task<IListItem> LoadItemAsync(ClipboardHistoryItem item, CancellationToken cancellationToken)
+    {
+        var text = item.Content.Contains(StandardDataFormats.Text)
+            ? await item.Content.GetTextAsync().AsTask(cancellationToken)
+            : null;
+        var image = item.Content.Contains(StandardDataFormats.Bitmap)
+            ? await item.Content.GetBitmapAsync().AsTask(cancellationToken)
+            : null;
+
+        return new ClipboardListItem(new ClipboardItem { Settings = _settings, Content = text, ImageData = image, Item = item }, _settings);
+    }
+
+    private void OnHistoryChanged(object? sender, ClipboardHistoryChangedEventArgs args) => HistoryChanged?.Invoke(this, EventArgs.Empty);
+
+    private void OnHistoryEnabledChanged(object? sender, object args) => HistoryEnabledChanged?.Invoke(this, EventArgs.Empty);
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/ClipboardHistoryWorker.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/ClipboardHistoryWorker.cs
@@ -1,0 +1,159 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Windows.System;
+using WinRT;
+
+namespace Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
+
+internal sealed partial class ClipboardHistoryWorker : IClipboardHistoryWorker
+{
+    private readonly Lock _gate = new();
+    private readonly TaskCompletionSource _drained = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private DispatcherQueueController? _controller;
+    private int _pending;
+    private Task? _shutdown;
+
+    private static DispatcherQueueController CreateController()
+    {
+        // Clipboard awaits need both an STA apartment and a running message pump.
+        var options = new DispatcherQueueOptions
+        {
+            Size = Marshal.SizeOf<DispatcherQueueOptions>(),
+            ThreadType = DispatcherQueueThreadType.Dedicated,
+            ApartmentType = DispatcherQueueApartmentType.Sta,
+        };
+        Marshal.ThrowExceptionForHR(CreateDispatcherQueueController(options, out var controller));
+        try
+        {
+            return MarshalInterface<DispatcherQueueController>.FromAbi(controller);
+        }
+        finally
+        {
+            Marshal.Release(controller);
+        }
+    }
+
+    public Task RunAsync(Func<Task> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        DispatcherQueue queue;
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_shutdown is not null, this);
+            _controller ??= CreateController();
+            queue = _controller.DispatcherQueue;
+            _pending++;
+        }
+
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        try
+        {
+            if (!queue.TryEnqueue(async () =>
+            {
+                SynchronizationContext.SetSynchronizationContext(new QueueSynchronizationContext(queue));
+                try
+                {
+                    await action();
+                    completion.SetResult();
+                }
+                catch (Exception ex)
+                {
+                    completion.SetException(ex);
+                }
+                finally
+                {
+                    CompleteWork();
+                }
+            }))
+            {
+                throw new InvalidOperationException("The clipboard dispatcher rejected work.");
+            }
+        }
+        catch (Exception ex)
+        {
+            completion.SetException(ex);
+            CompleteWork();
+        }
+
+        return completion.Task;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        lock (_gate)
+        {
+            if (_pending == 0)
+            {
+                _drained.TrySetResult();
+            }
+
+            _shutdown ??= ShutdownAsync();
+            return new ValueTask(_shutdown);
+        }
+    }
+
+    private void CompleteWork()
+    {
+        lock (_gate)
+        {
+            _pending--;
+            if (_pending == 0 && _shutdown is not null)
+            {
+                _drained.TrySetResult();
+            }
+        }
+    }
+
+    private async Task ShutdownAsync()
+    {
+        await _drained.Task.ConfigureAwait(false);
+        if (_controller is not null)
+        {
+            await _controller.ShutdownQueueAsync().AsTask().ConfigureAwait(false);
+        }
+    }
+
+    [DllImport("CoreMessaging.dll")]
+    private static extern int CreateDispatcherQueueController(DispatcherQueueOptions options, out IntPtr controller);
+
+    private enum DispatcherQueueThreadType
+    {
+        Dedicated = 1,
+    }
+
+    private enum DispatcherQueueApartmentType
+    {
+        Sta = 2,
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct DispatcherQueueOptions
+    {
+        public int Size;
+        public DispatcherQueueThreadType ThreadType;
+        public DispatcherQueueApartmentType ApartmentType;
+    }
+
+    private sealed class QueueSynchronizationContext(DispatcherQueue queue) : SynchronizationContext
+    {
+        public override SynchronizationContext CreateCopy() => new QueueSynchronizationContext(queue);
+
+        public override void Post(SendOrPostCallback callback, object? state)
+        {
+            if (!queue.TryEnqueue(() =>
+            {
+                SetSynchronizationContext(this);
+                callback(state);
+            }))
+            {
+                throw new InvalidOperationException("The clipboard dispatcher rejected a continuation.");
+            }
+        }
+    }
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/ClipboardHistoryWorker.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/ClipboardHistoryWorker.cs
@@ -7,7 +7,8 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Windows.System;
-using WinRT;
+using Windows.Win32;
+using Windows.Win32.System.WinRT;
 
 namespace Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
 
@@ -21,22 +22,15 @@ internal sealed partial class ClipboardHistoryWorker : IClipboardHistoryWorker
 
     private static DispatcherQueueController CreateController()
     {
-        // Clipboard awaits need both an STA apartment and a running message pump.
+        // Use the OS dispatcher so clipboard reads don't depend on WinUI activation.
         var options = new DispatcherQueueOptions
         {
-            Size = Marshal.SizeOf<DispatcherQueueOptions>(),
-            ThreadType = DispatcherQueueThreadType.Dedicated,
-            ApartmentType = DispatcherQueueApartmentType.Sta,
+            dwSize = (uint)Marshal.SizeOf<DispatcherQueueOptions>(),
+            threadType = DISPATCHERQUEUE_THREAD_TYPE.DQTYPE_THREAD_DEDICATED,
+            apartmentType = DISPATCHERQUEUE_THREAD_APARTMENTTYPE.DQTAT_COM_STA,
         };
-        Marshal.ThrowExceptionForHR(CreateDispatcherQueueController(options, out var controller));
-        try
-        {
-            return MarshalInterface<DispatcherQueueController>.FromAbi(controller);
-        }
-        finally
-        {
-            Marshal.Release(controller);
-        }
+        PInvoke.CreateDispatcherQueueController(options, out DispatcherQueueController controller).ThrowOnFailure();
+        return controller;
     }
 
     public Task RunAsync(Func<Task> action)
@@ -117,27 +111,6 @@ internal sealed partial class ClipboardHistoryWorker : IClipboardHistoryWorker
         {
             await _controller.ShutdownQueueAsync().AsTask().ConfigureAwait(false);
         }
-    }
-
-    [DllImport("CoreMessaging.dll")]
-    private static extern int CreateDispatcherQueueController(DispatcherQueueOptions options, out IntPtr controller);
-
-    private enum DispatcherQueueThreadType
-    {
-        Dedicated = 1,
-    }
-
-    private enum DispatcherQueueApartmentType
-    {
-        Sta = 2,
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    private struct DispatcherQueueOptions
-    {
-        public int Size;
-        public DispatcherQueueThreadType ThreadType;
-        public DispatcherQueueApartmentType ApartmentType;
     }
 
     private sealed class QueueSynchronizationContext(DispatcherQueue queue) : SynchronizationContext

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/IClipboardHistorySettings.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/IClipboardHistorySettings.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
+
+internal interface IClipboardHistorySettings : ISettingOptions
+{
+    event EventHandler? Changed;
+
+    PrimaryAction PrimaryAction { get; }
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/IClipboardHistorySource.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/IClipboardHistorySource.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CommandPalette.Extensions;
+
+namespace Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
+
+internal interface IClipboardHistorySource : IDisposable
+{
+    event EventHandler? HistoryChanged;
+
+    event EventHandler? HistoryEnabledChanged;
+
+    Task<IReadOnlyList<ClipboardHistoryEntry>> ReadAsync(CancellationToken cancellationToken);
+}
+
+internal sealed record ClipboardHistoryEntry(string Id, Func<CancellationToken, Task<IListItem>> LoadAsync);

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/IClipboardHistoryWorker.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/IClipboardHistoryWorker.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
+
+internal interface IClipboardHistoryWorker : IAsyncDisposable
+{
+    Task RunAsync(Func<Task> action);
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/SettingsManager.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/SettingsManager.cs
@@ -9,7 +9,7 @@ using Microsoft.CommandPalette.Extensions.Toolkit;
 
 namespace Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
 
-internal sealed class SettingsManager : JsonSettingsManager, ISettingOptions
+internal sealed class SettingsManager : JsonSettingsManager, IClipboardHistorySettings
 {
     private const string Namespace = "clipboardHistory";
 
@@ -43,6 +43,8 @@ internal sealed class SettingsManager : JsonSettingsManager, ISettingOptions
 
     public PrimaryAction PrimaryAction => Enum.TryParse<PrimaryAction>(_primaryAction.Value, out var action) ? action : PrimaryAction.Default;
 
+    public event EventHandler? Changed;
+
     private static string SettingsJsonPath()
     {
         var directory = Utilities.BaseSettingsPath("Microsoft.CmdPal");
@@ -61,6 +63,12 @@ internal sealed class SettingsManager : JsonSettingsManager, ISettingOptions
 
         LoadSettings();
 
-        Settings.SettingsChanged += (_, _) => SaveSettings();
+        Settings.SettingsChanged += OnSettingsChanged;
+    }
+
+    private void OnSettingsChanged(object sender, Settings settings)
+    {
+        SaveSettings();
+        Changed?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Microsoft.CmdPal.Ext.ClipboardHistory.csproj
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Microsoft.CmdPal.Ext.ClipboardHistory.csproj
@@ -8,6 +8,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <Nullable>enable</Nullable>
+    <CsWin32RunAsBuildTask>true</CsWin32RunAsBuildTask>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\common\ManagedCommon\ManagedCommon.csproj" />
@@ -15,7 +16,16 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" />
+    <PackageReference Include="Microsoft.Windows.CsWin32">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <!-- WASDK, WebView2, CmdPal Toolkit references now included via Common.ExtDependencies.props -->
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="NativeMethods.txt" />
+    <AdditionalFiles Include="NativeMethods.json" />
   </ItemGroup>
 
   <!-- String resources -->

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/NativeMethods.json
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/NativeMethods.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://aka.ms/CsWin32.schema.json",
+  "comInterop": {
+    "useComSourceGenerators": true
+  }
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/NativeMethods.txt
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/NativeMethods.txt
@@ -1,0 +1,1 @@
+CreateDispatcherQueueController

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Pages/ClipboardHistoryListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Pages/ClipboardHistoryListPage.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
@@ -12,32 +10,72 @@ using Microsoft.CmdPal.Ext.ClipboardHistory.Models;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using Microsoft.Win32;
-using Windows.ApplicationModel.DataTransfer;
 
 namespace Microsoft.CmdPal.Ext.ClipboardHistory.Pages;
 
-internal sealed partial class ClipboardHistoryListPage : ListPage
+internal sealed partial class ClipboardHistoryListPage : ListPage, IDisposable, IAsyncDisposable
 {
-    private readonly SettingsManager _settingsManager;
-    private readonly ObservableCollection<ClipboardItem> clipboardHistory;
-    private readonly string _defaultIconPath;
+    private readonly Lock _gate = new();
+    private readonly IClipboardHistorySettings _settingsManager;
+    private readonly IClipboardHistorySource _source;
+    private readonly ClipboardHistoryCache _cache;
+    private Task? _observedRefresh;
+    private bool _started;
+    private bool _refreshFailed;
+    private bool _disposed;
 
     public ClipboardHistoryListPage(SettingsManager settingsManager)
+        : this(settingsManager, new ClipboardHistorySource(settingsManager), new ClipboardHistoryWorker())
+    {
+    }
+
+    internal ClipboardHistoryListPage(IClipboardHistorySettings settingsManager, IClipboardHistorySource source, IClipboardHistoryWorker worker)
     {
         ArgumentNullException.ThrowIfNull(settingsManager);
 
         _settingsManager = settingsManager;
-        clipboardHistory = [];
-        _defaultIconPath = string.Empty;
+        _source = source;
+        _cache = new ClipboardHistoryCache(source, worker, OnSnapshotChanged);
         Icon = Icons.ClipboardListIcon;
         Name = Properties.Resources.clipboard_history_page_name;
         Id = "com.microsoft.cmdpal.clipboardHistory";
         ShowDetails = true;
 
-        Clipboard.HistoryChanged += TrackClipboardHistoryChanged_EventHandler;
+        _source.HistoryChanged += OnHistoryChanged;
+        _source.HistoryEnabledChanged += OnHistoryEnabledChanged;
+        _settingsManager.Changed += OnSettingsChanged;
     }
 
-    private void TrackClipboardHistoryChanged_EventHandler(object? sender, ClipboardHistoryChangedEventArgs? e) => RaiseItemsChanged(0);
+    private void OnHistoryChanged(object? sender, EventArgs args) => Refresh();
+
+    private void OnHistoryEnabledChanged(object? sender, EventArgs args)
+    {
+        _cache.Clear();
+        Refresh();
+    }
+
+    private void OnSettingsChanged(object? sender, EventArgs args) => OnSnapshotChanged();
+
+    private void OnSnapshotChanged()
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            foreach (var item in _cache.Items)
+            {
+                if (item is ClipboardListItem clipboardItem)
+                {
+                    clipboardItem.RefreshCommands();
+                }
+            }
+
+            RaiseItemsChanged(_cache.Items.Length);
+        }
+    }
 
     private bool IsClipboardHistoryEnabled()
     {
@@ -67,93 +105,115 @@ internal sealed partial class ClipboardHistoryListPage : ListPage
         }
     }
 
-    private async Task LoadClipboardHistoryAsync()
+    private async void Refresh()
     {
+        Task? refresh = null;
         try
         {
-            List<ClipboardItem> items = [];
-
-            if (!Clipboard.IsHistoryEnabled())
+            lock (_gate)
             {
-                return;
-            }
-
-            var historyItems = await Clipboard.GetHistoryItemsAsync();
-            if (historyItems.Status != ClipboardHistoryItemsResultStatus.Success)
-            {
-                return;
-            }
-
-            foreach (var item in historyItems.Items)
-            {
-                if (item.Content.Contains(StandardDataFormats.Text))
+                if (!_started || _disposed)
                 {
-                    var text = await item.Content.GetTextAsync();
-                    items.Add(new ClipboardItem { Settings = _settingsManager, Content = text, Item = item });
-                }
-                else if (item.Content.Contains(StandardDataFormats.Bitmap))
-                {
-                    items.Add(new ClipboardItem { Settings = _settingsManager, Item = item });
-                }
-            }
-
-            clipboardHistory.Clear();
-
-            foreach (var item in items)
-            {
-                if (item.Item.Content.Contains(StandardDataFormats.Bitmap))
-                {
-                    var imageReceived = await item.Item.Content.GetBitmapAsync();
-
-                    if (imageReceived is not null)
-                    {
-                        item.ImageData = imageReceived;
-                    }
+                    return;
                 }
 
-                clipboardHistory.Add(item);
+                var pending = _cache.RefreshAsync();
+                if (ReferenceEquals(pending, _observedRefresh))
+                {
+                    return;
+                }
+
+                refresh = pending;
+                _observedRefresh = refresh;
+                _refreshFailed = false;
+                IsLoading = true;
             }
+
+            await refresh.ConfigureAwait(false);
         }
         catch (Exception ex)
         {
-            // TODO GH #108 We need to figure out some logging
-            // Logger.LogError("Loading clipboard history failed", ex);
+            lock (_gate)
+            {
+                if (!_disposed && (refresh is null || ReferenceEquals(refresh, _observedRefresh)))
+                {
+                    _refreshFailed = true;
+                }
+            }
+
             ExtensionHost.ShowStatus(new StatusMessage() { Message = Properties.Resources.clipboard_failed_to_load, State = MessageState.Error }, StatusContext.Page);
             ExtensionHost.LogMessage(ex.ToString());
         }
-    }
-
-    private void LoadClipboardHistoryInSTA()
-    {
-        // https://github.com/microsoft/windows-rs/issues/317
-        // Clipboard API needs to be called in STA or it
-        // hangs.
-        var thread = new Thread(() =>
+        finally
         {
-            var t = LoadClipboardHistoryAsync();
-            t.ConfigureAwait(false);
-            t.Wait();
-        });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
-    }
-
-    private ListItem[] GetClipboardHistoryListItems()
-    {
-        LoadClipboardHistoryInSTA();
-        List<ListItem> listItems = [];
-        for (var i = 0; i < clipboardHistory.Count; i++)
-        {
-            var item = clipboardHistory[i];
-            if (item is not null)
+            lock (_gate)
             {
-                listItems.Add(new ClipboardListItem(item, _settingsManager));
+                if (!_disposed && refresh is not null && ReferenceEquals(refresh, _observedRefresh))
+                {
+                    IsLoading = _cache.IsRefreshing;
+                }
+            }
+        }
+    }
+
+    public override IListItem[] GetItems()
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                return [];
+            }
+
+            if (!_started || _refreshFailed)
+            {
+                _started = true;
+                Refresh();
+            }
+
+            return _cache.Items;
+        }
+    }
+
+    public void Dispose() => _ = DisposeWorkerAsync();
+
+    public async ValueTask DisposeAsync()
+    {
+        var disposeSource = false;
+        lock (_gate)
+        {
+            if (!_disposed)
+            {
+                _disposed = true;
+                _source.HistoryChanged -= OnHistoryChanged;
+                _source.HistoryEnabledChanged -= OnHistoryEnabledChanged;
+                _settingsManager.Changed -= OnSettingsChanged;
+                disposeSource = true;
             }
         }
 
-        return listItems.ToArray();
+        try
+        {
+            if (disposeSource)
+            {
+                _source.Dispose();
+            }
+        }
+        finally
+        {
+            await _cache.DisposeAsync().ConfigureAwait(false);
+        }
     }
 
-    public override IListItem[] GetItems() => GetClipboardHistoryListItems();
+    private async Task DisposeWorkerAsync()
+    {
+        try
+        {
+            await DisposeAsync();
+        }
+        catch (Exception ex)
+        {
+            ExtensionHost.LogMessage(ex.ToString());
+        }
+    }
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Pages/ClipboardHistoryListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Pages/ClipboardHistoryListPage.cs
@@ -171,7 +171,16 @@ internal sealed partial class ClipboardHistoryListPage : ListPage, IDisposable, 
                 Refresh();
             }
 
-            return _cache.Items;
+            var items = _cache.Items;
+            foreach (var item in items)
+            {
+                if (item is ClipboardListItem clipboardItem)
+                {
+                    clipboardItem.RefreshFileSystemMetadata();
+                }
+            }
+
+            return items;
         }
     }
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Pages/ClipboardListItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Pages/ClipboardListItem.cs
@@ -27,13 +27,14 @@ internal sealed partial class ClipboardListItem : ListItem
         new TextMetadataProvider(),
     ];
 
-    private readonly SettingsManager _settingsManager;
+    private readonly IClipboardHistorySettings _settingsManager;
     private readonly ClipboardItem _item;
 
     private readonly CommandContextItem _deleteContextMenuItem;
     private readonly CommandContextItem? _pasteCommand;
     private readonly CommandContextItem? _copyCommand;
     private readonly Lazy<Details> _lazyDetails;
+    private PrimaryAction? _primaryAction;
 
     public override IDetails? Details
     {
@@ -43,11 +44,10 @@ internal sealed partial class ClipboardListItem : ListItem
         }
     }
 
-    public ClipboardListItem(ClipboardItem item, SettingsManager settingsManager)
+    public ClipboardListItem(ClipboardItem item, IClipboardHistorySettings settingsManager)
     {
         _item = item;
         _settingsManager = settingsManager;
-        _settingsManager.Settings.SettingsChanged += SettingsOnSettingsChanged;
 
         _lazyDetails = new(() => CreateDetails());
 
@@ -95,20 +95,21 @@ internal sealed partial class ClipboardListItem : ListItem
         RefreshCommands();
     }
 
-    private void SettingsOnSettingsChanged(object sender, Settings args)
+    internal void RefreshCommands()
     {
-        RefreshCommands();
-    }
+        var primaryAction = _settingsManager.PrimaryAction;
+        if (_primaryAction == primaryAction)
+        {
+            return;
+        }
 
-    private void RefreshCommands()
-    {
         if (_item is { IsText: false, IsImage: false })
         {
             MoreCommands = [_deleteContextMenuItem];
             Icon = _settingsManager.PrimaryAction == PrimaryAction.Paste ? Icons.Clipboard : Icons.Copy;
         }
 
-        switch (_settingsManager.PrimaryAction)
+        switch (primaryAction)
         {
             case PrimaryAction.Paste:
                 Command = _pasteCommand?.Command;
@@ -149,6 +150,8 @@ internal sealed partial class ClipboardListItem : ListItem
 
                 break;
         }
+
+        _primaryAction = primaryAction;
     }
 
     private IContextItem[] BuildMoreCommands(CommandContextItem? firstCommand)

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Pages/ClipboardListItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Pages/ClipboardListItem.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
 using Microsoft.CmdPal.Common.Commands;
 using Microsoft.CmdPal.Ext.ClipboardHistory.Commands;
 using Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
@@ -19,10 +20,12 @@ namespace Microsoft.CmdPal.Ext.ClipboardHistory.Models;
 
 internal sealed partial class ClipboardListItem : ListItem
 {
+    private static readonly TextFileSystemMetadataProvider FileSystemMetadataProvider = new();
+
     private static readonly IClipboardMetadataProvider[] MetadataProviders =
     [
         new ImageMetadataProvider(),
-        new TextFileSystemMetadataProvider(),
+        FileSystemMetadataProvider,
         new WebLinkMetadataProvider(),
         new TextMetadataProvider(),
     ];
@@ -33,23 +36,30 @@ internal sealed partial class ClipboardListItem : ListItem
     private readonly CommandContextItem _deleteContextMenuItem;
     private readonly CommandContextItem? _pasteCommand;
     private readonly CommandContextItem? _copyCommand;
-    private readonly Lazy<Details> _lazyDetails;
+    private readonly bool _hasFileSystemMetadata;
+    private Lazy<Details> _lazyDetails;
     private PrimaryAction? _primaryAction;
 
     public override IDetails? Details
     {
-        get => _lazyDetails.Value;
+        get => Volatile.Read(ref _lazyDetails).Value;
         set
         {
         }
     }
 
     public ClipboardListItem(ClipboardItem item, IClipboardHistorySettings settingsManager)
+        : this(item, settingsManager, item.Item.Content)
+    {
+    }
+
+    internal ClipboardListItem(ClipboardItem item, IClipboardHistorySettings settingsManager, DataPackageView dataPackageView)
     {
         _item = item;
         _settingsManager = settingsManager;
 
         _lazyDetails = new(() => CreateDetails());
+        _hasFileSystemMetadata = FileSystemMetadataProvider.CanHandle(item);
 
         var deleteConfirmationCommand = new ConfirmableCommand
         {
@@ -64,7 +74,7 @@ internal sealed partial class ClipboardListItem : ListItem
             RequestedShortcut = KeyChords.DeleteEntry,
         };
 
-        DataPackageView = _item.Item.Content;
+        DataPackageView = dataPackageView;
 
         if (item.IsImage)
         {
@@ -95,10 +105,26 @@ internal sealed partial class ClipboardListItem : ListItem
         RefreshCommands();
     }
 
-    internal void RefreshCommands()
+    internal void RefreshFileSystemMetadata()
+    {
+        if (!_hasFileSystemMetadata)
+        {
+            return;
+        }
+
+        // The clipboard text is unchanged, but its file may have changed since the last fetch.
+        var previousDetails = Interlocked.Exchange(ref _lazyDetails, new(CreateDetails));
+        RefreshCommands(force: true);
+        if (previousDetails.IsValueCreated)
+        {
+            OnPropertyChanged(nameof(Details));
+        }
+    }
+
+    internal void RefreshCommands(bool force = false)
     {
         var primaryAction = _settingsManager.PrimaryAction;
-        if (_primaryAction == primaryAction)
+        if (!force && _primaryAction == primaryAction)
         {
             return;
         }


### PR DESCRIPTION
CmdPal was rebuilding the entire clipboard history on every refresh and hanging onto old copies in memory. This reuses entries that haven’t changed, loads updates in the background, and lets those old copies go while keeping file details current.