### PR TITLE
[PTRun][UnitConverter] Use invariant casing for degree unit tokens

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter.UnitTest/InputInterpreterTests.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter.UnitTest/InputInterpreterTests.cs
@@ -77,6 +77,27 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter.UnitTest
             CollectionAssert.AreEqual(expectedResult, input);
         }
 
+        [TestMethod]
+        public void PrefixesDegreesWithTurkishCulture()
+        {
+            CultureInfo originalCulture = CultureInfo.CurrentCulture;
+
+            try
+            {
+                CultureInfo.CurrentCulture = new CultureInfo("tr-TR");
+                string[] input = new string[] { "5", "CELSIUS", "in", "FAHRENHEIT" };
+                string[] expectedResult = new string[] { "5", "DegreeCelsius", "in", "DegreeFahrenheit" };
+
+                InputInterpreter.DegreePrefixer(ref input);
+
+                CollectionAssert.AreEqual(expectedResult, input);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+            }
+        }
+
         [DataTestMethod]
         [DataRow(new string[] { "7", "cm/sqs", "in", "m/s^2" }, new string[] { "7", "cm/s²", "in", "m/s^2" })]
         [DataRow(new string[] { "7", "sqft", "in", "sqcm" }, new string[] { "7", "ft²", "in", "cm²" })]

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/InputInterpreter.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/InputInterpreter.cs
@@ -119,7 +119,7 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
         /// </summary>
         public static void DegreePrefixer(ref string[] split)
         {
-            switch (split[1].ToLower(CultureInfo.CurrentCulture))
+            switch (split[1].ToLowerInvariant())
             {
                 case "celsius":
                     split[1] = "DegreeCelsius";
@@ -141,7 +141,7 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
                     break;
             }
 
-            switch (split[3].ToLower(CultureInfo.CurrentCulture))
+            switch (split[3].ToLowerInvariant())
             {
                 case "celsius":
                     split[3] = "DegreeCelsius";


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->

## Summary of the Pull Request

Fixes culture-sensitive parsing of `CELSIUS` and `FAHRENHEIT` in the PowerToys Run Unit Converter.

`DegreePrefixer()` was using `ToLower(CultureInfo.CurrentCulture)` for fixed English unit tokens. In `tr-TR`, uppercase `I` is lowercased to the dotless `ı`, causing inputs such as `CELSIUS` and `FAHRENHEIT` to miss their expected branches.

The implementation now uses `ToLowerInvariant()` for both unit tokens.

## PR Checklist

- [x] Closes:  https://github.com/microsoft/PowerToys/issues/50413
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places

## Detailed Description of the Pull Request / Additional comments

Updated `DegreePrefixer()` so internal English unit tokens are normalized independently of the user's current culture.

Added `PrefixesDegreesWithTurkishCulture`, which sets `CultureInfo.CurrentCulture` to `tr-TR` and verifies that:

- `CELSIUS` becomes `DegreeCelsius`
- `FAHRENHEIT` becomes `DegreeFahrenheit`

The test restores the original culture in a `finally` block.

## Validation Steps Performed

- `git diff --check` passed.
- Verified that Turkish casing produces `celsıus` and `fahrenheıt`.
- Added a regression test for `tr-TR`.
- The PowerToys unit test project could not be executed in this macOS environment because the required Windows/.NET Visual Studio build environment is unavailable.