### PR TITLE
CmdPal: Prevent duplicate shortcut handling

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/LocalKeyboardListener.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/LocalKeyboardListener.cs
@@ -114,7 +114,7 @@ internal sealed partial class LocalKeyboardListener : IDisposable
     {
         try
         {
-            if (nCode >= 0 && IsKeyDownHook(lParam))
+            if (nCode == PInvoke.HC_ACTION && IsKeyDownHook(lParam))
             {
                 InvokeKeyDown((VirtualKey)wParam.Value);
             }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/NativeMethods.txt
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/NativeMethods.txt
@@ -57,6 +57,7 @@ INFINITE
 CWMO_FLAGS
 
 GetCurrentThreadId
+HC_ACTION
 SetWindowsHookEx
 UnhookWindowsHookEx
 CallNextHookEx


### PR DESCRIPTION
## Summary of the Pull Request

Only process `HC_ACTION` keyboard notifications, preventing `HC_NOREMOVE` peeks from triggering actions twice.


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #50426
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

