### PR TITLE
[UITests][EnvVar] Add UI tests

### DIFF
--- a/.github/skills/ui-tests-migration/references/ci-stability.md
+++ b/.github/skills/ui-tests-migration/references/ci-stability.md
@@ -84,6 +84,22 @@ the clipboard is empty. Both adapt to a slow agent for free.
 > Corollary: **fail with the signal in the message.** `Assert.Fail("overlay never appeared after N
 > attempts")` tells you *which* signal missed on CI; `Assert.IsTrue(x)` tells you nothing.
 
+Avoid stacking fixed pacing on top of an authoritative wait. `Element.Invoke` and `Click` default
+to a 200ms post-action sleep. When the next step already waits for the transition, opt out locally:
+
+```csharp
+save.Invoke(msPostAction: 0);
+Assert.IsTrue(save.WaitForGone(10_000), "The saved dialog did not close.");
+```
+
+Do not remove shared defaults or stability samples globally. A control that already exists can
+still be awaiting list re-realization or an animation, so merely finding it is not always readiness.
+Also distinguish polling **intervals** from timeout **ceilings**: a two-match stable wait with a
+200ms interval pays at least 200ms, but a 10s timeout does not impose a 10s sleep. Every CLI-backed
+lookup, action, property read, or inspection starts another `winapp.exe`; repeated subtree
+inspections and re-resolution add real work even when explicit sleeps are zero. `TextBox.SetText`
+does not add a post-action sleep in the managed wrapper.
+
 ### Observed once is not necessarily stable
 
 Explorer selection, foreground, window bounds, and renderer state can briefly match and then regress

--- a/.github/skills/ui-tests-migration/references/project-setup.md
+++ b/.github/skills/ui-tests-migration/references/project-setup.md
@@ -156,6 +156,18 @@ the defect especially visible, but ordinary `Element.Click()`, `MouseClick()`, `
 coordinate-based `MouseHelper` calls need the same physical coordinate space. Some older reference
 projects omit the manifest; do not copy that omission into new or migrated projects.
 
+**Size secondary windows explicitly.** `UITestBase` maximizes its own Settings/scope window by
+default, but an editor discovered with `WindowsFinder.WaitForWindowByApp` does not inherit that
+behavior. For an editor whose geometry is not the behavior under test, call
+`WindowHelper.MaximizeWindow(new IntPtr(editor.WindowHandle))` after discovery, just as Settings
+does. Windows then uses that window's monitor work area and DPI instead of a hand-sized rectangle.
+
+Keep the DPI manifest even when maximizing. With a DPI-aware test host, `WindowSize.Large` is a
+fixed **1920x1080 physical-pixel** preset (clamped to 90% of the primary display), not a 1920x1080
+DIP request; its logical size therefore changes with scaling. Use a preset only when the scenario
+needs a specific size, and account for the target monitor/DPI rather than assuming the preset is
+DPI-scaled. Passing `WindowSize.UnSpecified` to `SetWindowSize` is a no-op, not a maximize request.
+
 ## 4c. (Visual tests only) embed platform baselines
 
 Add baseline PNGs as embedded resources and use `VisualAssert.AreEqual`:

--- a/PowerToys.slnx
+++ b/PowerToys.slnx
@@ -435,6 +435,10 @@
     <Project Path="src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesUILib.csproj" />
   </Folder>
   <Folder Name="/modules/EnvironmentVariables/Tests/">
+    <Project Path="src/modules/EnvironmentVariables/EnvironmentVariables.UITests/EnvironmentVariables.UITests.csproj">
+      <Platform Solution="*|ARM64" Project="ARM64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
     <Project Path="src/modules/EnvironmentVariables/EnvironmentVariablesUILib.Tests/EnvironmentVariablesUILib.UnitTests.csproj">
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />

--- a/doc/devdocs/development/ui-tests.md
+++ b/doc/devdocs/development/ui-tests.md
@@ -23,6 +23,9 @@ module suite on both supported Windows versions.
 Module-specific constraints are documented with the module; for example, see the
 [PowerRename UI-test notes](../modules/powerrename.md#ui-tests) for command-line selection, Boost
 engine lifetime, and signed shell-extension requirements.
+Read the [Environment Variables safety notes](../modules/environmentvariables.md#ui-tests) before
+running that suite: it temporarily replaces the real User PATH and must run only in a disposable VM,
+not on a working machine.
 
 ## Before running tests
 

--- a/doc/devdocs/modules/environmentvariables.md
+++ b/doc/devdocs/modules/environmentvariables.md
@@ -68,16 +68,26 @@ EnvironmentVariableUILib            # Abstracted UI methods and implementations
 
 - The module reads and writes variables directly to the registry instead of using the Environment API
 - This direct registry access approach is used because the Environment API automatically expands variables and has a timeout for notifications
-- When a profile variable has the same name as an existing User variable, a backup is created with the naming pattern: `VARIABLE_NAME_powertoys_PROFILE_NAME`
+- When a profile variable has the same name as an existing User variable, a backup is created with the naming pattern: `VARIABLE_NAME_PowerToys_PROFILE_NAME`
 
 ## UI tests
 
+**Do not run this suite on a working machine.** Use a disposable VM: the PATH scenario temporarily
+replaces the current user's PATH with `path1;path2;path3`. Stopping the test host, a timeout, or a
+machine reset can leave that PATH in place until recovery runs.
+
 `src\modules\EnvironmentVariables\EnvironmentVariables.UITests` uses `UITestAutomation.Next`
-and winappcli. Run it on an isolated interactive desktop: the suite edits the current user's
-environment, including User PATH. Test variables and profiles have unique names; cleanup restores
+and winappcli. Test variables and profiles have unique names; cleanup restores
 the original unexpanded values, registry value kinds, and profile/settings files. TMP and System
 PATH are not modified. Registry reads independently verify the persistent Windows environment
 shown by the OS editor, while UIA assertions verify the module's Applied variables list.
+
+Before modifying state, the fixture persists original variables and profile/module/global settings
+in `%LOCALAPPDATA%\Microsoft\PowerToys\EnvironmentVariables\ui-tests-state.json`. A subsequent suite
+invocation restores an interrupted run before taking a new snapshot. Cleanup attempts all restores
+even if stopping the editor or one restore fails, reports failures, and retains the recovery journal
+until restoration succeeds. Do not delete the journal to bypass recovery or attach it to a public
+issue: it contains the original user state.
 
 Coverage of [the UI-test checklist](https://github.com/microsoft/PowerToys/issues/40680):
 
@@ -99,3 +109,7 @@ Build with `tools\build\build.cmd -Path src\modules\EnvironmentVariables\Environ
 Run the resulting `EnvironmentVariables.UITests.exe` with `--report-trx`; the category is
 `EnvironmentVariables`. Use the `ui-tests-local-vm` workflow for full Windows 10 and Windows 11
 default/constrained runs, then select `[EnvironmentVariables.UITests]` in UI Test Automation CI.
+
+`TestState` intentionally owns this module's profile reconciliation and environment restoration.
+Use `SettingsConfigHelper.PreserveFile` or `PreserveModuleSettings` for ordinary in-process file
+snapshots; extracting a shared crash-recovery fixture is a separate framework change.

--- a/doc/devdocs/modules/environmentvariables.md
+++ b/doc/devdocs/modules/environmentvariables.md
@@ -69,3 +69,33 @@ EnvironmentVariableUILib            # Abstracted UI methods and implementations
 - The module reads and writes variables directly to the registry instead of using the Environment API
 - This direct registry access approach is used because the Environment API automatically expands variables and has a timeout for notifications
 - When a profile variable has the same name as an existing User variable, a backup is created with the naming pattern: `VARIABLE_NAME_powertoys_PROFILE_NAME`
+
+## UI tests
+
+`src\modules\EnvironmentVariables\EnvironmentVariables.UITests` uses `UITestAutomation.Next`
+and winappcli. Run it on an isolated interactive desktop: the suite edits the current user's
+environment, including User PATH. Test variables and profiles have unique names; cleanup restores
+the original unexpanded values, registry value kinds, and profile/settings files. TMP and System
+PATH are not modified. Registry reads independently verify the persistent Windows environment
+shown by the OS editor, while UIA assertions verify the module's Applied variables list.
+
+Coverage of [the UI-test checklist](https://github.com/microsoft/PowerToys/issues/40680):
+
+| Checklist items | Automated scenario |
+| --- | --- |
+| 2 | Non-elevated launch, enabled User Add button, disabled System Add and edit controls |
+| 3-5 (User) | Create, edit, and remove a User variable; verify registry and Applied variables |
+| 6-10, 20 | Create an empty profile, edit it, create an enabled two-variable profile, switch/unapply profiles, and delete both from UI and `profiles.json` |
+| 11-13 | Override a dedicated existing User variable, verify its backup, and restore it on unapply |
+| 14-16 | Verify combined PATH and separate profile PATH entries; move, insert, and delete entries |
+| 17-19 | Apply profile PATH, reopen the editor with the profile still enabled, then delete it and verify restoration |
+
+Item 1 and the System-variable repetition of items 3-5 remain **manual-only**. The local VM
+workflow requires a true standard-user test host; the current harness cannot approve credential
+prompts on the UAC secure desktop or automate an elevated editor across that boundary. The suite
+does not weaken UAC, store credentials, or report these scenarios as passing/skipped automated tests.
+
+Build with `tools\build\build.cmd -Path src\modules\EnvironmentVariables\EnvironmentVariables.UITests -Platform x64 -Configuration Debug`.
+Run the resulting `EnvironmentVariables.UITests.exe` with `--report-trx`; the category is
+`EnvironmentVariables`. Use the `ui-tests-local-vm` workflow for full Windows 10 and Windows 11
+default/constrained runs, then select `[EnvironmentVariables.UITests]` in UI Test Automation CI.

--- a/src/common/UITestAutomation.Next.UnitTests/EnvironmentVariablesTestStateTests.cs
+++ b/src/common/UITestAutomation.Next.UnitTests/EnvironmentVariablesTestStateTests.cs
@@ -1,0 +1,627 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+using System.Text.Json.Nodes;
+using Microsoft.EnvironmentVariables.UITests;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Win32;
+using VariableSnapshot = Microsoft.EnvironmentVariables.UITests.TestState.UserVariableSnapshot;
+
+namespace Microsoft.PowerToys.UITestAutomationNext.UnitTests;
+
+[TestClass]
+public sealed class EnvironmentVariablesTestStateTests
+{
+    private static readonly string[] PathVariableNames = ["Path", "Created"];
+    private static readonly string[] OrderedVariableNames = ["First", "Second", "Third"];
+    private static readonly string[] FileKeys = ["profiles", "moduleSettings", "globalSettings"];
+
+    [TestMethod]
+    public void ResetRestoresEveryVariableEvenWhenEditorStopFails()
+    {
+        using var fixture = new StateFixture();
+        var original = new VariableSnapshot(@"%USERPROFILE%\bin;;%OTHER%", RegistryValueKind.ExpandString);
+        fixture.Variables["Path"] = original;
+        var state = fixture.CreateState();
+        state.TrackUserVariable("Path");
+        state.TrackUserVariable("Created");
+        fixture.Variables["Path"] = new("changed", RegistryValueKind.String);
+        fixture.Variables["Created"] = new("created", RegistryValueKind.String);
+        fixture.FailStop = true;
+
+        var failure = Assert.ThrowsExactly<AggregateException>(state.Reset);
+
+        Assert.HasCount(1, failure.InnerExceptions);
+        CollectionAssert.AreEqual(PathVariableNames, fixture.RestoreAttempts);
+        Assert.AreEqual(original, fixture.Variables["Path"]);
+        Assert.IsFalse(fixture.Variables.ContainsKey("Created"));
+        Assert.AreEqual("[]", File.ReadAllText(fixture.ProfilesPath));
+        Assert.IsTrue(File.Exists(fixture.JournalPath));
+
+        fixture.FailStop = false;
+        state.Dispose();
+        Assert.IsFalse(File.Exists(fixture.JournalPath));
+    }
+
+    [TestMethod]
+    public void ResetAggregatesVariableFailuresAndRetriesWithoutSkippingLaterEntries()
+    {
+        using var fixture = new StateFixture();
+        var state = fixture.CreateState();
+        foreach (string name in OrderedVariableNames)
+        {
+            fixture.Variables[name] = new("original", RegistryValueKind.String);
+            state.TrackUserVariable(name);
+            fixture.Variables[name] = new("changed", RegistryValueKind.String);
+        }
+
+        byte[] journal = File.ReadAllBytes(fixture.JournalPath);
+        fixture.FailedVariables.UnionWith(["First", "Third"]);
+
+        var failure = Assert.ThrowsExactly<AggregateException>(state.Reset);
+
+        Assert.HasCount(2, failure.InnerExceptions);
+        CollectionAssert.AreEqual(OrderedVariableNames, fixture.RestoreAttempts);
+        Assert.AreEqual("original", fixture.Variables["Second"].Value);
+        Assert.AreEqual("changed", fixture.Variables["First"].Value);
+        CollectionAssert.AreEqual(journal, File.ReadAllBytes(fixture.JournalPath));
+
+        fixture.FailedVariables.Clear();
+        fixture.RestoreAttempts.Clear();
+        state.Reset();
+        CollectionAssert.AreEqual(OrderedVariableNames, fixture.RestoreAttempts);
+        Assert.IsTrue(fixture.Variables.Values.All(snapshot => snapshot.Value == "original"));
+        state.Dispose();
+        Assert.IsFalse(File.Exists(fixture.JournalPath));
+    }
+
+    [TestMethod]
+    public void DisposeAggregatesStopVariableAndFileFailuresAndRestoresRemainingState()
+    {
+        using var fixture = new StateFixture();
+        var state = fixture.CreateState();
+        state.TrackUserVariable("First");
+        state.TrackUserVariable("Second");
+        fixture.Variables["First"] = new("created", RegistryValueKind.String);
+        fixture.Variables["Second"] = new("created", RegistryValueKind.String);
+        fixture.FailedVariables.Add("First");
+        fixture.FailStop = true;
+        fixture.MutateFiles();
+
+        using (var lockedFile = new FileStream(fixture.ProfilesPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+        {
+            var failure = Assert.ThrowsExactly<AggregateException>(state.Dispose);
+
+            Assert.HasCount(3, failure.InnerExceptions);
+            Assert.IsFalse(fixture.Variables.ContainsKey("Second"));
+            fixture.AssertOriginalFile("moduleSettings");
+            fixture.AssertOriginalFile("globalSettings");
+            Assert.IsTrue(File.Exists(fixture.JournalPath));
+        }
+
+        fixture.FailStop = false;
+        fixture.FailedVariables.Clear();
+        state.Dispose();
+        fixture.AssertOriginalFiles();
+        Assert.IsEmpty(fixture.Variables);
+        Assert.IsFalse(File.Exists(fixture.JournalPath));
+    }
+
+    [TestMethod]
+    [DataRow("profiles")]
+    [DataRow("moduleSettings")]
+    public void DisposeContinuesAfterFileRestorationFailure(string failedFile)
+    {
+        using var fixture = new StateFixture();
+        var state = fixture.CreateState();
+        fixture.MutateFiles();
+        byte[] journal = File.ReadAllBytes(fixture.JournalPath);
+
+        using (var lockedFile = new FileStream(fixture.FilePaths[failedFile], FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+        {
+            var failure = Assert.ThrowsExactly<AggregateException>(state.Dispose);
+
+            Assert.HasCount(1, failure.InnerExceptions);
+            foreach (string key in fixture.FilePaths.Keys.Where(key => key != failedFile))
+            {
+                fixture.AssertOriginalFile(key);
+            }
+
+            CollectionAssert.AreEqual(journal, File.ReadAllBytes(fixture.JournalPath));
+        }
+
+        state.Dispose();
+        fixture.AssertOriginalFiles();
+        Assert.IsFalse(File.Exists(fixture.JournalPath));
+    }
+
+    [TestMethod]
+    public void DisposeRestoresOriginalBytesAndIsIdempotentAfterRemovingJournal()
+    {
+        using var fixture = new StateFixture();
+        var state = fixture.CreateState();
+        var journal = fixture.ReadJournal();
+        Assert.AreEqual(1, journal["version"]!.GetValue<int>());
+        CollectionAssert.AreEquivalent(
+            FileKeys,
+            journal["files"]!.AsObject().Select(property => property.Key).ToArray());
+        Assert.IsEmpty(journal["userVariables"]!.AsObject());
+        foreach (var (key, original) in fixture.OriginalFiles)
+        {
+            CollectionAssert.AreEqual(original, Convert.FromBase64String(journal["files"]![key]!.GetValue<string>()));
+        }
+
+        fixture.MutateFiles();
+        state.Dispose();
+
+        fixture.AssertOriginalFiles();
+        Assert.IsFalse(File.Exists(fixture.JournalPath));
+        Assert.IsFalse(File.Exists(fixture.JournalPath + ".new"));
+        int stops = fixture.StopAttempts;
+        state.Dispose();
+        Assert.AreEqual(stops, fixture.StopAttempts);
+    }
+
+    [TestMethod]
+    public void DisposeDeletesFilesThatDidNotExistBeforeTheScope()
+    {
+        using var fixture = new StateFixture();
+        foreach (string path in fixture.FilePaths.Values)
+        {
+            File.Delete(path);
+        }
+
+        var state = fixture.CreateState();
+        Assert.IsTrue(fixture.ReadJournal()["files"]!.AsObject().All(property => property.Value is null));
+        state.Reset();
+        fixture.MutateFiles();
+
+        state.Dispose();
+
+        Assert.IsTrue(fixture.FilePaths.Values.All(path => !File.Exists(path)));
+        Assert.IsFalse(File.Exists(fixture.JournalPath));
+    }
+
+    [TestMethod]
+    public void NewScopeRecoversAbortedRegistryAndFilesBeforeTakingItsBaseline()
+    {
+        using var fixture = new StateFixture();
+        var originalPath = new VariableSnapshot(@"%USERPROFILE%\bin;%UNEXPANDED%", RegistryValueKind.ExpandString);
+        var originalEmpty = new VariableSnapshot(string.Empty, RegistryValueKind.String);
+        fixture.Variables["Path"] = originalPath;
+        fixture.Variables["Empty"] = originalEmpty;
+        var abandoned = fixture.CreateState();
+        abandoned.TrackUserVariable("Path");
+        abandoned.TrackUserVariable("Empty");
+        abandoned.TrackUserVariable("Created");
+        fixture.Variables["Path"] = new("changed", RegistryValueKind.String);
+        fixture.Variables["Empty"] = new("changed", RegistryValueKind.ExpandString);
+        fixture.Variables["Created"] = new("created", RegistryValueKind.String);
+        fixture.MutateFiles();
+
+        // No Dispose: simulate losing the test host after mutations, including run_elevated=false.
+        var recovered = fixture.CreateState();
+
+        Assert.AreEqual(originalPath, fixture.Variables["Path"]);
+        Assert.AreEqual(originalEmpty, fixture.Variables["Empty"]);
+        Assert.IsFalse(fixture.Variables.ContainsKey("Created"));
+        fixture.AssertOriginalFiles();
+        Assert.IsTrue(JsonNode.Parse(File.ReadAllBytes(fixture.GlobalSettingsPath))!["run_elevated"]!.GetValue<bool>());
+        Assert.IsEmpty(fixture.ReadJournal()["userVariables"]!.AsObject());
+
+        recovered.TrackUserVariable("Path");
+        fixture.Variables["Path"] = new("changed again", RegistryValueKind.String);
+        fixture.MutateFiles();
+        recovered.Dispose();
+        Assert.AreEqual(originalPath, fixture.Variables["Path"]);
+        fixture.AssertOriginalFiles();
+        Assert.IsFalse(File.Exists(fixture.JournalPath));
+    }
+
+    [TestMethod]
+    public void AbortedRecoveryPreservesAnOriginallyMissingGlobalSettingsFile()
+    {
+        using var fixture = new StateFixture();
+        File.Delete(fixture.GlobalSettingsPath);
+        _ = fixture.CreateState();
+        fixture.MutateFiles();
+
+        var recovered = fixture.CreateState();
+
+        Assert.IsFalse(File.Exists(fixture.GlobalSettingsPath));
+        Assert.IsNull(fixture.ReadJournal()["files"]!["globalSettings"]);
+        File.WriteAllText(fixture.GlobalSettingsPath, """{"run_elevated":false}""");
+        recovered.Dispose();
+        Assert.IsFalse(File.Exists(fixture.GlobalSettingsPath));
+        Assert.IsFalse(File.Exists(fixture.JournalPath));
+    }
+
+    [TestMethod]
+    public void FailedRecoveryKeepsTheOriginalJournalAndContinuesRestoringAllState()
+    {
+        using var fixture = new StateFixture();
+        var abandoned = fixture.CreateState();
+        abandoned.TrackUserVariable("First");
+        abandoned.TrackUserVariable("Second");
+        fixture.Variables["First"] = new("created", RegistryValueKind.String);
+        fixture.Variables["Second"] = new("created", RegistryValueKind.String);
+        fixture.MutateFiles();
+        byte[] journal = File.ReadAllBytes(fixture.JournalPath);
+        fixture.FailStop = true;
+        fixture.FailedVariables.Add("First");
+
+        using (var lockedFile = new FileStream(fixture.ProfilesPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+        {
+            var failure = Assert.ThrowsExactly<AggregateException>(() => fixture.CreateState());
+
+            Assert.HasCount(3, failure.InnerExceptions);
+            Assert.IsFalse(fixture.Variables.ContainsKey("Second"));
+            fixture.AssertOriginalFile("moduleSettings");
+            fixture.AssertOriginalFile("globalSettings");
+            CollectionAssert.AreEqual(journal, File.ReadAllBytes(fixture.JournalPath));
+        }
+
+        fixture.FailStop = false;
+        fixture.FailedVariables.Clear();
+        var recovered = fixture.CreateState();
+        Assert.IsEmpty(fixture.Variables);
+        fixture.AssertOriginalFiles();
+        recovered.Dispose();
+        Assert.IsFalse(File.Exists(fixture.JournalPath));
+    }
+
+    [TestMethod]
+    public void SuccessfulResetRetainsSnapshotsForRecoveryOfSubsequentWrites()
+    {
+        using var fixture = new StateFixture();
+        var original = new VariableSnapshot(@"%USERPROFILE%\bin", RegistryValueKind.ExpandString);
+        fixture.Variables["Path"] = original;
+        var abandoned = fixture.CreateState();
+        abandoned.TrackUserVariable("Path");
+        fixture.Variables["Path"] = new("changed", RegistryValueKind.String);
+        abandoned.Reset();
+        Assert.AreEqual(original, fixture.Variables["Path"]);
+        Assert.IsNotNull(fixture.ReadJournal()["userVariables"]!["Path"]);
+        fixture.Variables["Path"] = new("late write", RegistryValueKind.String);
+
+        using var recovered = fixture.CreateState();
+
+        Assert.AreEqual(original, fixture.Variables["Path"]);
+        fixture.AssertOriginalFiles();
+    }
+
+    [TestMethod]
+    [DataRow("malformed")]
+    [DataRow("unsupportedVersion")]
+    [DataRow("missingVersion")]
+    [DataRow("unknownFile")]
+    [DataRow("missingFile")]
+    [DataRow("invalidFileBytes")]
+    [DataRow("nullFiles")]
+    [DataRow("nullVariable")]
+    [DataRow("unsupportedKind")]
+    [DataRow("missingValue")]
+    [DataRow("missingKind")]
+    [DataRow("duplicateName")]
+    [DataRow("invalidName")]
+    [DataRow("unknownProperty")]
+    [DataRow("numericValue")]
+    [DataRow("duplicateProperty")]
+    public void InvalidJournalFailsBeforeAnyRestorationOrReplacement(string corruption)
+    {
+        using var fixture = new StateFixture();
+        fixture.Variables["Path"] = new("private original", RegistryValueKind.ExpandString);
+        var abandoned = fixture.CreateState();
+        abandoned.TrackUserVariable("Path");
+        fixture.Variables["Path"] = new("test mutation", RegistryValueKind.String);
+        fixture.MutateFiles();
+        var journal = fixture.ReadJournal();
+        string unrelatedFile = Path.Combine(fixture.RootPath, "unrelated.json");
+        File.WriteAllText(unrelatedFile, "must remain untouched");
+
+        switch (corruption)
+        {
+            case "unsupportedVersion": journal["version"] = 2; break;
+            case "missingVersion": journal.Remove("version"); break;
+            case "unknownFile": journal["files"]![unrelatedFile] = Convert.ToBase64String([1, 2, 3]); break;
+            case "missingFile": journal["files"]!.AsObject().Remove("profiles"); break;
+            case "invalidFileBytes": journal["files"]!["profiles"] = "not base64"; break;
+            case "nullFiles": journal["files"] = null; break;
+            case "nullVariable": journal["userVariables"]!["Path"] = null; break;
+            case "unsupportedKind": journal["userVariables"]!["Path"]!["kind"] = (int)RegistryValueKind.MultiString; break;
+            case "missingValue": journal["userVariables"]!["Path"]!.AsObject().Remove("value"); break;
+            case "missingKind": journal["userVariables"]!["Path"]!.AsObject().Remove("kind"); break;
+            case "duplicateName": journal["userVariables"]!["PATH"] = journal["userVariables"]!["Path"]!.DeepClone(); break;
+            case "invalidName": journal["userVariables"]!["bad=name"] = journal["userVariables"]!["Path"]!.DeepClone(); break;
+            case "unknownProperty": journal["unexpected"] = true; break;
+            case "numericValue": journal["userVariables"]!["Path"]!["value"] = 42; break;
+        }
+
+        string contents = corruption switch
+        {
+            "malformed" => "{",
+            "duplicateProperty" => journal.ToJsonString().Replace("\"version\":1", "\"version\":1,\"version\":1", StringComparison.Ordinal),
+            _ => journal.ToJsonString(),
+        };
+        File.WriteAllText(fixture.JournalPath, contents);
+        byte[] corruptJournal = File.ReadAllBytes(fixture.JournalPath);
+        int stops = fixture.StopAttempts;
+
+        var failure = Assert.ThrowsExactly<InvalidDataException>(() => fixture.CreateState());
+
+        Assert.IsFalse(failure.ToString().Contains("private original", StringComparison.Ordinal));
+        Assert.AreEqual(stops, fixture.StopAttempts);
+        Assert.IsEmpty(fixture.RestoreAttempts);
+        Assert.AreEqual("test mutation", fixture.Variables["Path"].Value);
+        Assert.AreEqual("""{"run_elevated":false}""", File.ReadAllText(fixture.GlobalSettingsPath));
+        Assert.AreEqual("must remain untouched", File.ReadAllText(unrelatedFile));
+        CollectionAssert.AreEqual(corruptJournal, File.ReadAllBytes(fixture.JournalPath));
+    }
+
+    [TestMethod]
+    [DataRow(RegistryValueKind.Binary)]
+    [DataRow(RegistryValueKind.DWord)]
+    [DataRow(RegistryValueKind.QWord)]
+    [DataRow(RegistryValueKind.MultiString)]
+    [DataRow(RegistryValueKind.Unknown)]
+    [DataRow(RegistryValueKind.None)]
+    public void TrackRejectsUnsupportedRegistryKindsWithoutSavingALossySnapshot(RegistryValueKind kind)
+    {
+        using var fixture = new StateFixture();
+        using var state = fixture.CreateState();
+        fixture.Variables["Unsupported"] = new("not a raw registry string", kind);
+        byte[] journal = File.ReadAllBytes(fixture.JournalPath);
+
+        Assert.ThrowsExactly<NotSupportedException>(() => state.TrackUserVariable("Unsupported"));
+
+        CollectionAssert.AreEqual(journal, File.ReadAllBytes(fixture.JournalPath));
+        fixture.Variables["Unsupported"] = new("supported", RegistryValueKind.String);
+        state.TrackUserVariable("Unsupported");
+        Assert.AreEqual(2, fixture.ReadAttempts);
+        Assert.AreEqual("supported", fixture.ReadJournal()["userVariables"]!["Unsupported"]!["value"]!.GetValue<string>());
+    }
+
+    [TestMethod]
+    [DataRow(RegistryValueKind.String, "")]
+    [DataRow(RegistryValueKind.String, @"%TEMP%\literal")]
+    [DataRow(RegistryValueKind.ExpandString, @"%USERPROFILE%\bin;;%OTHER%")]
+    public void TrackPersistsRawValuesAndKindsOnlyOnceIgnoringNameCase(RegistryValueKind kind, string value)
+    {
+        using var fixture = new StateFixture();
+        var original = new VariableSnapshot(value, kind);
+        fixture.Variables["Path"] = original;
+        var state = fixture.CreateState();
+
+        state.TrackUserVariable("Path");
+        fixture.Variables["Path"] = new("changed", RegistryValueKind.String);
+        state.TrackUserVariable("PATH");
+
+        var snapshot = fixture.ReadJournal()["userVariables"]!["Path"]!;
+        Assert.AreEqual(value, snapshot["value"]!.GetValue<string>());
+        Assert.AreEqual((int)kind, snapshot["kind"]!.GetValue<int>());
+        Assert.AreEqual(1, fixture.ReadAttempts);
+        state.Dispose();
+        Assert.AreEqual(original, fixture.Variables["Path"]);
+    }
+
+    [TestMethod]
+    public void TrackDoesNotAcceptAnUnpersistedSnapshotWhenJournalReplacementFails()
+    {
+        using var fixture = new StateFixture();
+        using var state = fixture.CreateState();
+        fixture.Variables["Path"] = new("first read", RegistryValueKind.String);
+        byte[] originalJournal = File.ReadAllBytes(fixture.JournalPath);
+
+        using (var lockedJournal = new FileStream(fixture.JournalPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+        {
+            Assert.ThrowsExactly<IOException>(() => state.TrackUserVariable("Path"));
+        }
+
+        CollectionAssert.AreEqual(originalJournal, File.ReadAllBytes(fixture.JournalPath));
+        Assert.IsFalse(File.Exists(fixture.JournalPath + ".new"));
+        fixture.Variables["Path"] = new("retry baseline", RegistryValueKind.String);
+        state.TrackUserVariable("Path");
+        Assert.AreEqual(2, fixture.ReadAttempts);
+        Assert.AreEqual("retry baseline", fixture.ReadJournal()["userVariables"]!["Path"]!["value"]!.GetValue<string>());
+    }
+
+    [TestMethod]
+    public void InitialSnapshotPersistenceFailureDoesNotChangeOriginalFiles()
+    {
+        using var fixture = new StateFixture();
+        using (var lockedPending = new FileStream(fixture.JournalPath + ".new", FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None))
+        {
+            var failure = Assert.ThrowsExactly<AggregateException>(() => fixture.CreateState());
+
+            Assert.HasCount(2, failure.InnerExceptions);
+            fixture.AssertOriginalFiles();
+            Assert.IsFalse(File.Exists(fixture.JournalPath));
+        }
+
+        using var state = fixture.CreateState();
+        Assert.IsTrue(File.Exists(fixture.JournalPath));
+        Assert.IsFalse(File.Exists(fixture.JournalPath + ".new"));
+    }
+
+    [TestMethod]
+    public void ResetStillRestoresVariablesWhenClearingProfilesFails()
+    {
+        using var fixture = new StateFixture();
+        var state = fixture.CreateState();
+        state.TrackUserVariable("Created");
+        fixture.Variables["Created"] = new("created", RegistryValueKind.String);
+
+        using (var lockedProfiles = new FileStream(fixture.ProfilesPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+        {
+            var failure = Assert.ThrowsExactly<AggregateException>(state.Reset);
+
+            Assert.HasCount(1, failure.InnerExceptions);
+            Assert.IsFalse(fixture.Variables.ContainsKey("Created"));
+            Assert.IsTrue(File.Exists(fixture.JournalPath));
+        }
+
+        state.Dispose();
+        Assert.IsFalse(File.Exists(fixture.JournalPath));
+    }
+
+    [TestMethod]
+    [DataRow("")]
+    [DataRow(".new")]
+    public void DisposeKeepsTheJournalWhenJournalRemovalFails(string suffix)
+    {
+        using var fixture = new StateFixture();
+        var state = fixture.CreateState();
+        fixture.MutateFiles();
+        if (suffix.Length > 0)
+        {
+            File.WriteAllText(fixture.JournalPath + suffix, "interrupted pending write");
+        }
+
+        using (var lockedJournal = new FileStream(fixture.JournalPath + suffix, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+        {
+            var failure = Assert.ThrowsExactly<AggregateException>(state.Dispose);
+
+            Assert.HasCount(1, failure.InnerExceptions);
+            fixture.AssertOriginalFiles();
+            Assert.IsTrue(File.Exists(fixture.JournalPath));
+        }
+
+        state.Dispose();
+        Assert.IsFalse(File.Exists(fixture.JournalPath));
+        Assert.IsFalse(File.Exists(fixture.JournalPath + ".new"));
+    }
+
+    private sealed class StateFixture : IDisposable
+    {
+        internal StateFixture()
+        {
+            RootPath = Path.Combine(Path.GetTempPath(), $"EnvironmentVariablesTestStateTests-{Guid.NewGuid():N}");
+            ModuleDirectory = Path.Combine(RootPath, "EnvironmentVariables");
+            GlobalSettingsPath = Path.Combine(RootPath, "settings.json");
+            Directory.CreateDirectory(ModuleDirectory);
+            FilePaths = new()
+            {
+                ["profiles"] = Path.Combine(ModuleDirectory, "profiles.json"),
+                ["moduleSettings"] = Path.Combine(ModuleDirectory, "settings.json"),
+                ["globalSettings"] = GlobalSettingsPath,
+            };
+            OriginalFiles = new()
+            {
+                ["profiles"] = [0xEF, 0xBB, 0xBF, 0x5B, 0x5D],
+                ["moduleSettings"] = Encoding.UTF8.GetBytes("""{"properties":{"launch_as_admin":true}}"""),
+                ["globalSettings"] = Encoding.UTF8.GetBytes("""{"run_elevated":true,"unrelated":"preserved"}"""),
+            };
+            foreach (var (key, original) in OriginalFiles)
+            {
+                File.WriteAllBytes(FilePaths[key], original);
+            }
+        }
+
+        internal string RootPath { get; }
+
+        internal string ModuleDirectory { get; }
+
+        internal string GlobalSettingsPath { get; }
+
+        internal string ProfilesPath => FilePaths["profiles"];
+
+        internal string JournalPath => Path.Combine(ModuleDirectory, TestState.JournalFileName);
+
+        internal Dictionary<string, string> FilePaths { get; }
+
+        internal Dictionary<string, byte[]> OriginalFiles { get; }
+
+        internal Dictionary<string, VariableSnapshot> Variables { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+        internal HashSet<string> FailedVariables { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+        internal List<string> RestoreAttempts { get; } = [];
+
+        internal bool FailStop { get; set; }
+
+        internal int StopAttempts { get; private set; }
+
+        internal int ReadAttempts { get; private set; }
+
+        public void Dispose()
+        {
+            for (int attempt = 0; ; attempt++)
+            {
+                try
+                {
+                    Directory.Delete(RootPath, recursive: true);
+                    return;
+                }
+                catch (IOException error) when (attempt < 9 && (error.HResult & 0xFFFF) is 32 or 33)
+                {
+                    // Filesystem scanners can briefly retain a just-written fixture file.
+                    Thread.Sleep(100);
+                }
+            }
+        }
+
+        internal TestState CreateState()
+        {
+            return new(
+                ModuleDirectory,
+                GlobalSettingsPath,
+                () =>
+                {
+                    StopAttempts++;
+                    if (FailStop)
+                    {
+                        throw new InvalidOperationException("Simulated editor stop failure.");
+                    }
+                },
+                name =>
+                {
+                    ReadAttempts++;
+                    return Variables.GetValueOrDefault(name) ?? new(null, RegistryValueKind.String);
+                },
+                (name, snapshot) =>
+                {
+                    RestoreAttempts.Add(name);
+                    if (FailedVariables.Contains(name))
+                    {
+                        throw new IOException("Simulated registry write failure.");
+                    }
+
+                    if (snapshot.Value is null)
+                    {
+                        Variables.Remove(name);
+                    }
+                    else
+                    {
+                        Variables[name] = snapshot;
+                    }
+                });
+        }
+
+        internal JsonObject ReadJournal()
+        {
+            return JsonNode.Parse(File.ReadAllBytes(JournalPath))!.AsObject();
+        }
+
+        internal void MutateFiles()
+        {
+            File.WriteAllText(ProfilesPath, "[\"changed profiles\"]");
+            File.WriteAllText(FilePaths["moduleSettings"], """{"launch_as_admin":false}""");
+            File.WriteAllText(GlobalSettingsPath, """{"run_elevated":false}""");
+        }
+
+        internal void AssertOriginalFile(string key)
+        {
+            CollectionAssert.AreEqual(OriginalFiles[key], File.ReadAllBytes(FilePaths[key]), key);
+        }
+
+        internal void AssertOriginalFiles()
+        {
+            foreach (string key in FilePaths.Keys)
+            {
+                AssertOriginalFile(key);
+            }
+        }
+    }
+}

--- a/src/common/UITestAutomation.Next.UnitTests/SessionTests.cs
+++ b/src/common/UITestAutomation.Next.UnitTests/SessionTests.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+using Microsoft.PowerToys.UITest.Next;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.PowerToys.UITestAutomationNext.UnitTests;
+
+[TestClass]
+public sealed class SessionTests
+{
+    [TestMethod]
+    public void SlugInspectionReturnsOnlySelectedRootIncludingUnnamedElements()
+    {
+        using var document = JsonDocument.Parse("""
+            {"windows":[{"elements":[{
+              "selector":"grp-1234","type":"Group","className":"SettingsCard",
+              "x":-10,"y":20,"width":300,"height":40,
+              "children":[{"selector":"lbl-value-2345","type":"Text","name":"value"}]
+            }]}]}
+            """);
+
+        var matches = Session.ParseSearchResult(document.RootElement, fromInspection: true);
+
+        Assert.HasCount(1, matches);
+        Assert.AreEqual(new Session.SearchHit("grp-1234", string.Empty, "Group", "SettingsCard", -10, 20, 300, 40), matches[0]);
+    }
+
+    [TestMethod]
+    public void TextSearchPreservesAllMatchesAndMetadata()
+    {
+        using var document = JsonDocument.Parse("""
+            {"matches":[
+              {"selector":"btn-one-1234","name":"One","type":"Button","className":"Button","x":1,"y":2,"width":3,"height":4},
+              {"selector":"btn-two-5678","name":"Two","type":"Button","className":"ToggleSwitch"}
+            ]}
+            """);
+
+        var matches = Session.ParseSearchResult(document.RootElement, fromInspection: false);
+
+        Assert.HasCount(2, matches);
+        Assert.AreEqual(new Session.SearchHit("btn-one-1234", "One", "Button", "Button", 1, 2, 3, 4), matches[0]);
+        Assert.AreEqual(new Session.SearchHit("btn-two-5678", "Two", "Button", "ToggleSwitch", 0, 0, 0, 0), matches[1]);
+    }
+
+    [TestMethod]
+    [DataRow("""{"windows":[]}""", true)]
+    [DataRow("""{"windows":[{}]}""", true)]
+    [DataRow("""{"matches":[]}""", false)]
+    public void EmptyResultsRemainEmpty(string json, bool fromInspection)
+    {
+        using var document = JsonDocument.Parse(json);
+
+        Assert.HasCount(0, Session.ParseSearchResult(document.RootElement, fromInspection));
+    }
+}

--- a/src/common/UITestAutomation.Next.UnitTests/SessionTests.cs
+++ b/src/common/UITestAutomation.Next.UnitTests/SessionTests.cs
@@ -46,6 +46,35 @@ public sealed class SessionTests
     }
 
     [TestMethod]
+    public void InspectionAcceptsKnownMatchesEnvelope()
+    {
+        using var document = JsonDocument.Parse("""
+            {"matches":[{"selector":"btn-one-1234","name":"One","type":"Button","className":"Button","width":32,"height":24}]}
+            """);
+
+        var matches = Session.ParseSearchResult(document.RootElement, fromInspection: true);
+
+        Assert.HasCount(1, matches);
+        Assert.AreEqual(new Session.SearchHit("btn-one-1234", "One", "Button", "Button", 0, 0, 32, 24), matches[0]);
+    }
+
+    [TestMethod]
+    public void InspectionPrefersSelectedRootsOverSearchMatches()
+    {
+        using var document = JsonDocument.Parse("""
+            {
+              "windows":[{"elements":[{"selector":"grp-selected-1234","type":"Group"}]}],
+              "matches":[{"selector":"btn-unrelated-5678","type":"Button"}]
+            }
+            """);
+
+        var matches = Session.ParseSearchResult(document.RootElement, fromInspection: true);
+
+        Assert.HasCount(1, matches);
+        Assert.AreEqual("grp-selected-1234", matches[0].Selector);
+    }
+
+    [TestMethod]
     [DataRow("""{"windows":[]}""", true)]
     [DataRow("""{"windows":[{}]}""", true)]
     [DataRow("""{"matches":[]}""", false)]

--- a/src/common/UITestAutomation.Next.UnitTests/SessionTests.cs
+++ b/src/common/UITestAutomation.Next.UnitTests/SessionTests.cs
@@ -29,6 +29,22 @@ public sealed class SessionTests
     }
 
     [TestMethod]
+    public void SlugInspectionPreservesEmptyBoundsForOffscreenElements()
+    {
+        using var document = JsonDocument.Parse("""
+            {"windows":[{"elements":[{
+              "selector":"grp-offscreen-1234","type":"Group","className":"SettingsCard",
+              "isOffscreen":true,"x":0,"y":0,"width":0,"height":0
+            }]}]}
+            """);
+
+        var matches = Session.ParseSearchResult(document.RootElement, fromInspection: true);
+
+        Assert.HasCount(1, matches);
+        Assert.AreEqual(new Session.SearchHit("grp-offscreen-1234", string.Empty, "Group", "SettingsCard", 0, 0, 0, 0), matches[0]);
+    }
+
+    [TestMethod]
     public void TextSearchPreservesAllMatchesAndMetadata()
     {
         using var document = JsonDocument.Parse("""

--- a/src/common/UITestAutomation.Next.UnitTests/UITestAutomation.Next.UnitTests.csproj
+++ b/src/common/UITestAutomation.Next.UnitTests/UITestAutomation.Next.UnitTests.csproj
@@ -21,5 +21,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\UITestAutomation.Next\UITestAutomation.Next.csproj" />
+    <Compile Include="..\..\modules\EnvironmentVariables\EnvironmentVariables.UITests\TestState.cs" Link="EnvironmentVariables\TestState.cs" />
   </ItemGroup>
 </Project>

--- a/src/common/UITestAutomation.Next/Session.cs
+++ b/src/common/UITestAutomation.Next/Session.cs
@@ -469,7 +469,7 @@ public sealed class Session
                 .Where(window => window.TryGetProperty("elements", out var elements) && elements.ValueKind == JsonValueKind.Array)
                 .SelectMany(window => window.GetProperty("elements").EnumerateArray());
         }
-        else if (!fromInspection && root.TryGetProperty("matches", out var array) && array.ValueKind == JsonValueKind.Array)
+        else if (root.TryGetProperty("matches", out var array) && array.ValueKind == JsonValueKind.Array)
         {
             matches = array.EnumerateArray();
         }

--- a/src/common/UITestAutomation.Next/Session.cs
+++ b/src/common/UITestAutomation.Next/Session.cs
@@ -446,24 +446,45 @@ public sealed class Session
 
     private List<SearchHit> ExecuteSearch(By by)
     {
+        if (by.Selector == By.Kind.Slug)
+        {
+            // search matches Name/AutomationId text, not semantic slugs. inspect resolves a slug
+            // directly, including unnamed containers and repeated controls in a scoped subtree.
+            var inspected = WinappCli.InvokeJson("ui", "inspect", by.Value, TargetFlag, TargetValue, "--json", "-d", "1");
+            return ParseSearchResult(inspected, fromInspection: true);
+        }
+
         // winappcli accepts the selector text directly as the first positional argument.
         var root = WinappCli.InvokeJson("ui", "search", by.Value, TargetFlag, TargetValue, "--json");
+        return ParseSearchResult(root, fromInspection: false);
+    }
 
+    internal static List<SearchHit> ParseSearchResult(JsonElement root, bool fromInspection)
+    {
         var result = new List<SearchHit>();
-        if (root.TryGetProperty("matches", out var arr) && arr.ValueKind == JsonValueKind.Array)
+        IEnumerable<JsonElement> matches = [];
+        if (fromInspection && root.TryGetProperty("windows", out var windows) && windows.ValueKind == JsonValueKind.Array)
         {
-            foreach (var m in arr.EnumerateArray())
-            {
-                result.Add(new SearchHit(
-                    Selector: m.TryGetProperty("selector", out var s) ? (s.GetString() ?? string.Empty) : string.Empty,
-                    Name: m.TryGetProperty("name", out var n) ? (n.GetString() ?? string.Empty) : string.Empty,
-                    ControlType: m.TryGetProperty("type", out var t) ? (t.GetString() ?? string.Empty) : string.Empty,
-                    ClassName: m.TryGetProperty("className", out var c) ? (c.GetString() ?? string.Empty) : string.Empty,
-                    X: ReadInt(m, "x"),
-                    Y: ReadInt(m, "y"),
-                    Width: ReadInt(m, "width"),
-                    Height: ReadInt(m, "height")));
-            }
+            matches = windows.EnumerateArray()
+                .Where(window => window.TryGetProperty("elements", out var elements) && elements.ValueKind == JsonValueKind.Array)
+                .SelectMany(window => window.GetProperty("elements").EnumerateArray());
+        }
+        else if (!fromInspection && root.TryGetProperty("matches", out var array) && array.ValueKind == JsonValueKind.Array)
+        {
+            matches = array.EnumerateArray();
+        }
+
+        foreach (var m in matches)
+        {
+            result.Add(new SearchHit(
+                Selector: m.TryGetProperty("selector", out var s) ? (s.GetString() ?? string.Empty) : string.Empty,
+                Name: m.TryGetProperty("name", out var n) ? (n.GetString() ?? string.Empty) : string.Empty,
+                ControlType: m.TryGetProperty("type", out var t) ? (t.GetString() ?? string.Empty) : string.Empty,
+                ClassName: m.TryGetProperty("className", out var c) ? (c.GetString() ?? string.Empty) : string.Empty,
+                X: ReadInt(m, "x"),
+                Y: ReadInt(m, "y"),
+                Width: ReadInt(m, "width"),
+                Height: ReadInt(m, "height")));
         }
 
         return result;
@@ -472,5 +493,5 @@ public sealed class Session
             el.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.Number ? v.GetInt32() : 0;
     }
 
-    private sealed record SearchHit(string Selector, string Name, string ControlType, string ClassName, int X, int Y, int Width, int Height);
+    internal sealed record SearchHit(string Selector, string Name, string ControlType, string ClassName, int X, int Y, int Width, int Height);
 }

--- a/src/common/UITestAutomation.Next/WindowHelper.cs
+++ b/src/common/UITestAutomation.Next/WindowHelper.cs
@@ -87,6 +87,10 @@ public static class WindowHelper
     private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
 
     [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool IsZoomed(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
     private static extern int GetSystemMetrics(int nIndex);
 
     [DllImport("user32.dll")]
@@ -153,6 +157,9 @@ public static class WindowHelper
     /// can't hide controls such as the Settings NavigationView pane.
     /// </summary>
     public static void MaximizeWindow(IntPtr hWnd) => ShowWindow(hWnd, SW_MAXIMIZE);
+
+    /// <summary>Read the native maximized state without relying on a window's UIA provider or DPI.</summary>
+    public static bool IsWindowMaximized(IntPtr hWnd) => IsZoomed(hWnd);
 
     /// <summary>
     /// Restore a window from maximized/minimized. Needed before positioning a window that a test will

--- a/src/modules/EnvironmentVariables/EnvironmentVariables.UITests/EditorUi.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariables.UITests/EditorUi.cs
@@ -1,0 +1,300 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+using Microsoft.PowerToys.UITest.Next;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.EnvironmentVariables.UITests;
+
+internal sealed class EditorUi(Session session, TestContext context)
+{
+    internal Session Session { get; } = session;
+
+    internal void Step(string text) => context.WriteLine($"[{DateTime.UtcNow:HH:mm:ss.fff}] {text}");
+
+    internal static IEnumerable<JsonElement> Nodes(JsonElement root)
+    {
+        if (root.ValueKind == JsonValueKind.Object)
+        {
+            if (root.TryGetProperty("type", out _))
+            {
+                yield return root;
+            }
+
+            foreach (var property in root.EnumerateObject())
+            {
+                foreach (var child in Nodes(property.Value))
+                {
+                    yield return child;
+                }
+            }
+        }
+        else if (root.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in root.EnumerateArray())
+            {
+                foreach (var child in Nodes(item))
+                {
+                    yield return child;
+                }
+            }
+        }
+    }
+
+    internal static string Property(JsonElement node, string name) =>
+        node.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String ? value.GetString()! : string.Empty;
+
+    internal JsonElement Inspect(Element parent) =>
+        WinappCli.InvokeJson("ui", "inspect", parent.Selector, Session.TargetFlag, Session.TargetValue, "--json", "-d", "30");
+
+    internal T Child<T>(Element parent, string className, string? name = null, string? automationId = null)
+        where T : Element, new()
+    {
+        // Element.Find currently searches the whole session; inspect the actual subtree to avoid
+        // confusing User, System, profile, and Applied rows that share the same variable name.
+        var tree = Inspect(parent);
+        var matches = Nodes(tree).Where(node =>
+            Property(node, "className") == className &&
+            (name is null || Property(node, "name") == name) &&
+            (automationId is null || Property(node, "automationId") == automationId)).ToArray();
+        Assert.HasCount(1, matches, $"Expected one {className} '{name ?? automationId}' below {parent.Selector}. Tree: {tree}");
+        return Resolve<T>(matches[0]);
+    }
+
+    private T Resolve<T>(JsonElement node)
+        where T : Element, new()
+    {
+        string selector = Property(node, "selector");
+        Assert.IsFalse(string.IsNullOrEmpty(selector), $"UIA node has no selector: {node}");
+        return Session.Find<T>(By.Slug(selector));
+    }
+
+    internal void PathEntryMenu(int index, string action)
+    {
+        Step($"{action} PATH list entry {index}");
+        var buttons = Session.FindAll<Button>(By.AccessibilityId("PathEntryOptionsButton")).ToArray();
+        Assert.IsTrue(index >= 0 && index < buttons.Length, $"PATH entry {index} was not found among {buttons.Length} entries.");
+        buttons[index].Invoke();
+        Menu(action);
+    }
+
+    internal void SetPathEntry(int index, string value)
+    {
+        Step($"Setting PATH list entry {index} to {value}");
+        var entries = Nodes(Session.Inspect(depth: 30)).Where(node =>
+            Property(node, "className") == "TextBox" && Property(node, "automationId") == string.Empty).ToArray();
+        Assert.IsTrue(index >= 0 && index < entries.Length, $"PATH entry {index} was not found.");
+        Resolve<TextBox>(entries[index]).SetText(value);
+        Session.Find<TextBox>(By.AccessibilityId("EditVariableDialogNameTxtBox")).Focus();
+    }
+
+    internal void AssertPathEditor(string expected)
+    {
+        Assert.IsTrue(
+            Session.Find<TextBox>(By.AccessibilityId("EditVariableDialogValueTxtBox")).WaitForValue(expected, timeoutMS: 10_000),
+            $"PATH list editing did not produce '{expected}'.");
+    }
+
+    internal void AssertPathList(string profile, params string[] expected)
+    {
+        var card = VariableCard(Expand(profile), "PATH");
+        var text = Nodes(Inspect(card)).Where(node => Property(node, "type") == "Text")
+            .Select(node => Property(node, "name")).Where(name => name != "PATH").ToArray();
+        CollectionAssert.AreEqual(expected, text, "PATH must be displayed as separate ordered entries, not a semicolon-delimited value.");
+    }
+
+    internal Element Expander(string name)
+    {
+        var matches = Session.FindAll<Element>(By.Name(name), 10_000)
+            .Where(element => element.ClassName == "SettingsExpander" && element.Name == name).ToArray();
+        Assert.HasCount(1, matches, $"Expected the '{name}' variables expander.");
+        return matches[0];
+    }
+
+    internal Element Expand(string name)
+    {
+        var expander = Expander(name);
+        var header = Child<Element>(expander, "Microsoft.UI.Xaml.Controls.Expander", name);
+        if (header.GetProperty("ExpandCollapseState") != "Expanded")
+        {
+            Step($"Expanding {name}");
+            header.Invoke();
+            Assert.IsTrue(header.WaitForProperty("ExpandCollapseState", "Expanded", 10_000), $"'{name}' did not expand.");
+        }
+
+        return Expander(name);
+    }
+
+    internal Element VariableCard(Element parent, string name)
+    {
+        var tree = Inspect(parent);
+        var matches = Nodes(tree).Where(node => Property(node, "className") == "SettingsCard" &&
+            Nodes(node).Any(child => Property(child, "type") == "Text" && Property(child, "name") == name)).ToArray();
+        Assert.HasCount(1, matches, $"Expected one variable card for {name}. Tree: {tree}");
+        return Resolve<Element>(matches[0]);
+    }
+
+    internal void SaveDialog()
+    {
+        var save = Session.Find<Button>(By.AccessibilityId("PrimaryButton"));
+        Assert.IsTrue(save.IsEnabled, "The dialog Save button should be enabled.");
+        Step("Saving dialog");
+        save.Invoke();
+        Assert.IsTrue(save.WaitForGone(10_000), "The saved dialog did not close.");
+    }
+
+    internal void AddUserVariable(string name, string value)
+    {
+        Step($"Adding User variable {name}");
+        Session.Find<Button>(By.AccessibilityId("AddDefaultVariableUserBtn")).Invoke();
+        Session.Find<TextBox>(By.Name("Name")).SetText(name);
+        Session.Find<TextBox>(By.Name("Value")).SetText(value);
+        SaveDialog();
+        AssertUserVariable(name, value);
+        AssertAppliedVariable(name, value);
+    }
+
+    internal void VariableMenu(string set, string name, string action)
+    {
+        Step($"{action} variable {name} in {set}");
+        var expander = Expand(set);
+        var card = VariableCard(expander, name);
+        Child<Button>(card, "Button", automationId: "VariableOptionsButton").Invoke();
+        Menu(action);
+    }
+
+    internal void Menu(string name) =>
+        Session.FindAll<Element>(By.Name(name)).Single(element => element.ControlType == "MenuItem" && element.Name == name).Invoke();
+
+    internal void ConfirmRemoval()
+    {
+        Step("Confirming removal");
+        var yes = Session.Find<Button>(By.AccessibilityId("PrimaryButton"));
+        Assert.AreEqual("Yes", yes.Name);
+        yes.Invoke();
+        Assert.IsTrue(yes.WaitForGone(10_000), "The removal confirmation did not close.");
+    }
+
+    internal void CreateProfile(string name, bool enabled, params (string Name, string Value)[] variables)
+    {
+        Step($"Creating profile {name}");
+        Session.Find<TextBlock>(By.Name("New profile")).Invoke();
+        FillProfile(name, enabled, variables);
+    }
+
+    internal void EditProfile(string name, params (string Name, string Value)[] variables)
+    {
+        ProfileMenu(name, "Edit");
+        FillProfile(name, false, variables);
+    }
+
+    internal void ProfileMenu(string name, string action)
+    {
+        Step($"{action} profile {name}");
+        Child<Button>(Expander(name), "Button", automationId: "ProfileOptionsButton").Invoke();
+        Menu(action);
+    }
+
+    private void FillProfile(string name, bool enabled, (string Name, string Value)[] variables)
+    {
+        Session.Find<TextBox>(By.Name("Name")).SetText(name);
+        foreach (var variable in variables)
+        {
+            Step($"Adding {variable.Name} to profile {name}");
+            Session.Find<TextBlock>(By.Name("Add variable")).Invoke();
+            Session.Find<TextBox>(By.AccessibilityId("AddNewVariableName")).SetText(variable.Name);
+            Session.Find<TextBox>(By.AccessibilityId("AddNewVariableValue")).SetText(variable.Value);
+            var add = Session.Find<Button>(By.AccessibilityId("ConfirmAddVariableBtn"));
+            Assert.IsTrue(add.IsEnabled, $"Could not add {variable.Name} to {name}.");
+            add.Invoke();
+            Assert.IsTrue(add.WaitForGone(10_000), "The Add variable flyout did not close.");
+        }
+
+        var toggle = Session.Find<ToggleSwitch>(By.Name("Enabled"));
+        SetToggle(toggle, enabled);
+        SaveDialog();
+        AssertProfile(name, enabled, variables);
+    }
+
+    internal void SetProfileEnabled(string name, bool enabled)
+    {
+        Step($"Setting profile {name} enabled={enabled}");
+        SetToggle(Child<ToggleSwitch>(Expander(name), "ToggleSwitch"), enabled);
+        AssertProfile(name, enabled);
+    }
+
+    internal static void SetToggle(ToggleSwitch toggle, bool enabled)
+    {
+        if (toggle.IsOn != enabled)
+        {
+            toggle.Invoke();
+        }
+
+        Assert.IsTrue(toggle.WaitForProperty("ToggleState", enabled ? "On" : "Off", 10_000), "The toggle state did not update.");
+    }
+
+    internal void RemoveProfile(string name)
+    {
+        ProfileMenu(name, "Remove");
+        ConfirmRemoval();
+        Wait(
+            () => !ReadProfiles().EnumerateArray().Any(profile => profile.GetProperty("Name").GetString() == name),
+            $"Profile {name} was not removed from profiles.json.");
+        Assert.IsFalse(Session.FindAll<Element>(By.Name(name), 0).Any(element => element.ClassName == "SettingsExpander"), $"Profile {name} remains in the UI.");
+    }
+
+    internal void AssertProfile(string name, bool enabled, params (string Name, string Value)[] variables)
+    {
+        Wait(
+            () => ReadProfiles().EnumerateArray().Any(profile =>
+                profile.GetProperty("Name").GetString() == name &&
+                profile.GetProperty("IsEnabled").GetBoolean() == enabled &&
+                variables.All(variable => profile.GetProperty("Variables").EnumerateArray().Any(entry =>
+                    entry.GetProperty("Name").GetString() == variable.Name &&
+                    entry.GetProperty("Values").GetString() == variable.Value))),
+            $"Profile {name}, enabled={enabled}, was not persisted with the expected variables.");
+    }
+
+    internal static JsonElement ReadProfiles()
+    {
+        using var document = JsonDocument.Parse(File.ReadAllText(TestState.ProfilesPath));
+        return document.RootElement.Clone();
+    }
+
+    internal static void AssertUserVariable(string name, string? value) =>
+        Wait(() => TestState.ReadUserVariable(name) == value, $"User registry value {name} did not become '{value ?? "<absent>"}'.");
+
+    internal void AssertAppliedVariable(string name, string? value)
+    {
+        Step($"Checking Applied variables: {name}={value ?? "<absent>"}");
+        Wait(
+            () =>
+            {
+                var panel = Session.Find<Element>(By.AccessibilityId("AppliedVariablesScrollViewer"));
+                string[] text = Nodes(Inspect(panel)).Where(node => Property(node, "type") == "Text")
+                    .Select(node => Property(node, "name")).ToArray();
+                if (value is null)
+                {
+                    return !text.Contains(name, StringComparer.OrdinalIgnoreCase);
+                }
+
+                return Enumerable.Range(0, Math.Max(0, text.Length - 1)).Any(index =>
+                    text[index].Equals(name, StringComparison.OrdinalIgnoreCase) && text[index + 1] == value);
+            },
+            $"Applied variables did not show {name}={value ?? "<absent>"}.");
+    }
+
+    internal static void Wait(Func<bool> condition, string failure)
+    {
+        var result = WaitHelper.WaitForStable(
+            condition,
+            match => match,
+            timeoutMS: 20_000,
+            requiredConsecutiveMatches: 2,
+            pollIntervalMS: 200,
+            shouldRetryException: exception => exception is IOException or JsonException);
+        Assert.IsTrue(result.Succeeded, $"{failure} Last transient error: {result.LastException}");
+    }
+}

--- a/src/modules/EnvironmentVariables/EnvironmentVariables.UITests/EditorUi.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariables.UITests/EditorUi.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
 using System.Text.Json;
 using Microsoft.PowerToys.UITest.Next;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -46,21 +47,49 @@ internal sealed class EditorUi(Session session, TestContext context)
     internal static string Property(JsonElement node, string name) =>
         node.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String ? value.GetString()! : string.Empty;
 
-    internal JsonElement Inspect(Element parent) =>
-        WinappCli.InvokeJson("ui", "inspect", parent.Selector, Session.TargetFlag, Session.TargetValue, "--json", "-d", "30");
+    internal JsonElement Inspect(Element parent, int depth = 8) =>
+        WinappCli.InvokeJson("ui", "inspect", parent.Selector, Session.TargetFlag, Session.TargetValue, "--json", "-d", depth.ToString(CultureInfo.InvariantCulture));
 
     internal T Child<T>(Element parent, string className, string? name = null, string? automationId = null)
         where T : Element, new()
     {
         // Element.Find currently searches the whole session; inspect the actual subtree to avoid
         // confusing User, System, profile, and Applied rows that share the same variable name.
-        var tree = Inspect(parent);
-        var matches = Nodes(tree).Where(node =>
+        var match = WaitForDescendant(parent, node =>
             Property(node, "className") == className &&
             (name is null || Property(node, "name") == name) &&
-            (automationId is null || Property(node, "automationId") == automationId)).ToArray();
-        Assert.HasCount(1, matches, $"Expected one {className} '{name ?? automationId}' below {parent.Selector}. Tree: {tree}");
-        return Resolve<T>(matches[0]);
+            (automationId is null || Property(node, "automationId") == automationId),
+            $"{className} '{name ?? automationId}'");
+        return Resolve<T>(match);
+    }
+
+    private JsonElement WaitForDescendant(Element parent, Func<JsonElement, bool> predicate, string description)
+    {
+        JsonElement tree = default;
+        var result = WaitHelper.WaitForStable(
+            () =>
+            {
+                tree = Inspect(parent);
+                return Nodes(tree).Where(predicate).ToArray();
+            },
+            matches => matches?.Length == 1,
+            timeoutMS: 15_000,
+            requiredConsecutiveMatches: 2,
+            pollIntervalMS: 200,
+            shouldRetryException: exception => exception is AssertFailedException &&
+                exception.Message.Contains("stale_element", StringComparison.OrdinalIgnoreCase));
+        if (!result.Succeeded)
+        {
+            string preview = tree.ValueKind == JsonValueKind.Undefined ? "<unavailable>" : tree.GetRawText();
+            if (preview.Length > 2_000)
+            {
+                preview = preview[..2_000] + "... (truncated)";
+            }
+
+            Assert.Fail($"Expected one {description} below {parent.Selector}; last count: {result.LastObservation?.Length}. Tree: {preview}");
+        }
+
+        return result.LastObservation![0];
     }
 
     private T Resolve<T>(JsonElement node)
@@ -77,16 +106,17 @@ internal sealed class EditorUi(Session session, TestContext context)
         var buttons = Session.FindAll<Button>(By.AccessibilityId("PathEntryOptionsButton")).ToArray();
         Assert.IsTrue(index >= 0 && index < buttons.Length, $"PATH entry {index} was not found among {buttons.Length} entries.");
         buttons[index].Invoke();
-        Menu(action);
+        Menu($"{action}PathEntryMenuItem");
     }
 
     internal void SetPathEntry(int index, string value)
     {
         Step($"Setting PATH list entry {index} to {value}");
-        var entries = Nodes(Session.Inspect(depth: 30)).Where(node =>
-            Property(node, "className") == "TextBox" && Property(node, "automationId") == string.Empty).ToArray();
+        var entries = Session.FindAll<TextBox>(By.AccessibilityId("VariableListEntryValueTextBox")).ToArray();
         Assert.IsTrue(index >= 0 && index < entries.Length, $"PATH entry {index} was not found.");
-        Resolve<TextBox>(entries[index]).SetText(value);
+        Assert.IsFalse(string.IsNullOrWhiteSpace(entries[index].Name), "List-entry editors must expose an accessible name.");
+        entries[index].SetText(value);
+        // The product commits list-entry edits in EditVariableValuesListTextBox_LostFocus.
         Session.Find<TextBox>(By.AccessibilityId("EditVariableDialogNameTxtBox")).Focus();
     }
 
@@ -113,27 +143,35 @@ internal sealed class EditorUi(Session session, TestContext context)
         return matches[0];
     }
 
-    internal Element Expand(string name)
+    internal Element Expand(string name) => Expand(Expander(name));
+
+    internal Element ExpandDefaultSet(EnvironmentVariableTarget target) =>
+        Expand(Session.Find<Element>(By.AccessibilityId(target switch
+        {
+            EnvironmentVariableTarget.User => "UserVariablesExpander",
+            EnvironmentVariableTarget.Machine => "SystemVariablesExpander",
+            _ => throw new ArgumentOutOfRangeException(nameof(target)),
+        })));
+
+    private Element Expand(Element expander)
     {
-        var expander = Expander(name);
-        var header = Child<Element>(expander, "Microsoft.UI.Xaml.Controls.Expander", name);
+        var header = Child<Element>(expander, "Microsoft.UI.Xaml.Controls.Expander");
         if (header.GetProperty("ExpandCollapseState") != "Expanded")
         {
-            Step($"Expanding {name}");
+            Step($"Expanding {expander.Name}");
             header.Invoke();
-            Assert.IsTrue(header.WaitForProperty("ExpandCollapseState", "Expanded", 10_000), $"'{name}' did not expand.");
+            Assert.IsTrue(header.WaitForProperty("ExpandCollapseState", "Expanded", 10_000), $"'{expander.Name}' did not expand.");
         }
 
-        return Expander(name);
+        return expander;
     }
 
     internal Element VariableCard(Element parent, string name)
     {
-        var tree = Inspect(parent);
-        var matches = Nodes(tree).Where(node => Property(node, "className") == "SettingsCard" &&
-            Nodes(node).Any(child => Property(child, "type") == "Text" && Property(child, "name") == name)).ToArray();
-        Assert.HasCount(1, matches, $"Expected one variable card for {name}. Tree: {tree}");
-        return Resolve<Element>(matches[0]);
+        var match = WaitForDescendant(parent, node => Property(node, "className") == "SettingsCard" &&
+            Nodes(node).Any(child => Property(child, "type") == "Text" && Property(child, "name") == name),
+            $"variable card for {name}");
+        return Resolve<Element>(match);
     }
 
     internal void SaveDialog()
@@ -145,46 +183,48 @@ internal sealed class EditorUi(Session session, TestContext context)
         Assert.IsTrue(save.WaitForGone(10_000), "The saved dialog did not close.");
     }
 
-    internal void AddUserVariable(string name, string value)
+    internal void AddUserVariableAndVerify(string name, string value)
     {
         Step($"Adding User variable {name}");
         Session.Find<Button>(By.AccessibilityId("AddDefaultVariableUserBtn")).Invoke();
-        Session.Find<TextBox>(By.Name("Name")).SetText(name);
-        Session.Find<TextBox>(By.Name("Value")).SetText(value);
+        Session.Find<TextBox>(By.AccessibilityId("DefaultVariableNameTextBox")).SetText(name);
+        Session.Find<TextBox>(By.AccessibilityId("DefaultVariableValueTextBox")).SetText(value);
         SaveDialog();
         AssertUserVariable(name, value);
         AssertAppliedVariable(name, value);
     }
 
-    internal void VariableMenu(string set, string name, string action)
+    internal void VariableMenu(string profile, string name, string action) => VariableMenu(Expand(profile), name, action);
+
+    internal void VariableMenu(EnvironmentVariableTarget target, string name, string action) => VariableMenu(ExpandDefaultSet(target), name, action);
+
+    private void VariableMenu(Element expander, string name, string action)
     {
-        Step($"{action} variable {name} in {set}");
-        var expander = Expand(set);
+        Step($"{action} variable {name} in {expander.Name}");
         var card = VariableCard(expander, name);
         Child<Button>(card, "Button", automationId: "VariableOptionsButton").Invoke();
-        Menu(action);
+        Menu($"{action}VariableMenuItem");
     }
 
-    internal void Menu(string name) =>
-        Session.FindAll<Element>(By.Name(name)).Single(element => element.ControlType == "MenuItem" && element.Name == name).Invoke();
+    private void Menu(string automationId) => Session.Find<Element>(By.AccessibilityId(automationId)).Invoke();
 
     internal void ConfirmRemoval()
     {
         Step("Confirming removal");
         var yes = Session.Find<Button>(By.AccessibilityId("PrimaryButton"));
-        Assert.AreEqual("Yes", yes.Name);
+        Assert.IsTrue(yes.IsEnabled, "The removal confirmation must be enabled.");
         yes.Invoke();
         Assert.IsTrue(yes.WaitForGone(10_000), "The removal confirmation did not close.");
     }
 
-    internal void CreateProfile(string name, bool enabled, params (string Name, string Value)[] variables)
+    internal void CreateProfileAndVerify(string name, bool enabled, params (string Name, string Value)[] variables)
     {
         Step($"Creating profile {name}");
-        Session.Find<TextBlock>(By.Name("New profile")).Invoke();
+        Session.Find<Button>(By.AccessibilityId("NewProfileButton")).Invoke();
         FillProfile(name, enabled, variables);
     }
 
-    internal void EditProfile(string name, params (string Name, string Value)[] variables)
+    internal void EditProfileAndVerify(string name, params (string Name, string Value)[] variables)
     {
         ProfileMenu(name, "Edit");
         FillProfile(name, false, variables);
@@ -193,17 +233,19 @@ internal sealed class EditorUi(Session session, TestContext context)
     internal void ProfileMenu(string name, string action)
     {
         Step($"{action} profile {name}");
-        Child<Button>(Expander(name), "Button", automationId: "ProfileOptionsButton").Invoke();
-        Menu(action);
+        var options = Child<Button>(Expander(name), "Button", automationId: "ProfileOptionsButton");
+        Assert.IsFalse(string.IsNullOrWhiteSpace(options.Name), "Profile options must expose an accessible name.");
+        options.Invoke();
+        Menu($"{action}ProfileMenuItem");
     }
 
     private void FillProfile(string name, bool enabled, (string Name, string Value)[] variables)
     {
-        Session.Find<TextBox>(By.Name("Name")).SetText(name);
+        Session.Find<TextBox>(By.AccessibilityId("ProfileNameTextBox")).SetText(name);
         foreach (var variable in variables)
         {
             Step($"Adding {variable.Name} to profile {name}");
-            Session.Find<TextBlock>(By.Name("Add variable")).Invoke();
+            Session.Find<Button>(By.AccessibilityId("AddProfileVariableButton")).Invoke();
             Session.Find<TextBox>(By.AccessibilityId("AddNewVariableName")).SetText(variable.Name);
             Session.Find<TextBox>(By.AccessibilityId("AddNewVariableValue")).SetText(variable.Value);
             var add = Session.Find<Button>(By.AccessibilityId("ConfirmAddVariableBtn"));
@@ -212,13 +254,13 @@ internal sealed class EditorUi(Session session, TestContext context)
             Assert.IsTrue(add.WaitForGone(10_000), "The Add variable flyout did not close.");
         }
 
-        var toggle = Session.Find<ToggleSwitch>(By.Name("Enabled"));
+        var toggle = Session.Find<ToggleSwitch>(By.AccessibilityId("ProfileEnabledToggle"));
         SetToggle(toggle, enabled);
         SaveDialog();
         AssertProfile(name, enabled, variables);
     }
 
-    internal void SetProfileEnabled(string name, bool enabled)
+    internal void SetProfileEnabledAndVerify(string name, bool enabled)
     {
         Step($"Setting profile {name} enabled={enabled}");
         SetToggle(Child<ToggleSwitch>(Expander(name), "ToggleSwitch"), enabled);
@@ -235,7 +277,7 @@ internal sealed class EditorUi(Session session, TestContext context)
         Assert.IsTrue(toggle.WaitForProperty("ToggleState", enabled ? "On" : "Off", 10_000), "The toggle state did not update.");
     }
 
-    internal void RemoveProfile(string name)
+    internal void RemoveProfileAndVerify(string name)
     {
         ProfileMenu(name, "Remove");
         ConfirmRemoval();
@@ -269,17 +311,19 @@ internal sealed class EditorUi(Session session, TestContext context)
     internal void AssertAppliedVariable(string name, string? value)
     {
         Step($"Checking Applied variables: {name}={value ?? "<absent>"}");
+        var panel = Session.Find<Element>(By.AccessibilityId("AppliedVariablesScrollViewer"));
         Wait(
             () =>
             {
-                var panel = Session.Find<Element>(By.AccessibilityId("AppliedVariablesScrollViewer"));
-                string[] text = Nodes(Inspect(panel)).Where(node => Property(node, "type") == "Text")
+                string[] text = Nodes(Inspect(panel, depth: 6)).Where(node => Property(node, "type") == "Text")
                     .Select(node => Property(node, "name")).ToArray();
                 if (value is null)
                 {
                     return !text.Contains(name, StringComparer.OrdinalIgnoreCase);
                 }
 
+                // The Applied-variable template exposes name/value TextBlocks in row order.
+                // Windows variable names ignore casing; values must retain their exact text.
                 return Enumerable.Range(0, Math.Max(0, text.Length - 1)).Any(index =>
                     text[index].Equals(name, StringComparison.OrdinalIgnoreCase) && text[index + 1] == value);
             },

--- a/src/modules/EnvironmentVariables/EnvironmentVariables.UITests/EditorUi.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariables.UITests/EditorUi.cs
@@ -105,7 +105,7 @@ internal sealed class EditorUi(Session session, TestContext context)
         Step($"{action} PATH list entry {index}");
         var buttons = Session.FindAll<Button>(By.AccessibilityId("PathEntryOptionsButton")).ToArray();
         Assert.IsTrue(index >= 0 && index < buttons.Length, $"PATH entry {index} was not found among {buttons.Length} entries.");
-        buttons[index].Invoke();
+        buttons[index].Invoke(msPostAction: 0);
         Menu($"{action}PathEntryMenuItem");
     }
 
@@ -159,7 +159,7 @@ internal sealed class EditorUi(Session session, TestContext context)
         if (header.GetProperty("ExpandCollapseState") != "Expanded")
         {
             Step($"Expanding {expander.Name}");
-            header.Invoke();
+            header.Invoke(msPostAction: 0);
             Assert.IsTrue(header.WaitForProperty("ExpandCollapseState", "Expanded", 10_000), $"'{expander.Name}' did not expand.");
         }
 
@@ -179,14 +179,14 @@ internal sealed class EditorUi(Session session, TestContext context)
         var save = Session.Find<Button>(By.AccessibilityId("PrimaryButton"));
         Assert.IsTrue(save.IsEnabled, "The dialog Save button should be enabled.");
         Step("Saving dialog");
-        save.Invoke();
+        save.Invoke(msPostAction: 0);
         Assert.IsTrue(save.WaitForGone(10_000), "The saved dialog did not close.");
     }
 
     internal void AddUserVariableAndVerify(string name, string value)
     {
         Step($"Adding User variable {name}");
-        Session.Find<Button>(By.AccessibilityId("AddDefaultVariableUserBtn")).Invoke();
+        Session.Find<Button>(By.AccessibilityId("AddDefaultVariableUserBtn")).Invoke(msPostAction: 0);
         Session.Find<TextBox>(By.AccessibilityId("DefaultVariableNameTextBox")).SetText(name);
         Session.Find<TextBox>(By.AccessibilityId("DefaultVariableValueTextBox")).SetText(value);
         SaveDialog();
@@ -202,10 +202,11 @@ internal sealed class EditorUi(Session session, TestContext context)
     {
         Step($"{action} variable {name} in {expander.Name}");
         var card = VariableCard(expander, name);
-        Child<Button>(card, "Button", automationId: "VariableOptionsButton").Invoke();
+        Child<Button>(card, "Button", automationId: "VariableOptionsButton").Invoke(msPostAction: 0);
         Menu($"{action}VariableMenuItem");
     }
 
+    // List-edit menu actions can re-realize controls that already exist, so retain their transition grace.
     private void Menu(string automationId) => Session.Find<Element>(By.AccessibilityId(automationId)).Invoke();
 
     internal void ConfirmRemoval()
@@ -213,14 +214,14 @@ internal sealed class EditorUi(Session session, TestContext context)
         Step("Confirming removal");
         var yes = Session.Find<Button>(By.AccessibilityId("PrimaryButton"));
         Assert.IsTrue(yes.IsEnabled, "The removal confirmation must be enabled.");
-        yes.Invoke();
+        yes.Invoke(msPostAction: 0);
         Assert.IsTrue(yes.WaitForGone(10_000), "The removal confirmation did not close.");
     }
 
     internal void CreateProfileAndVerify(string name, bool enabled, params (string Name, string Value)[] variables)
     {
         Step($"Creating profile {name}");
-        Session.Find<Button>(By.AccessibilityId("NewProfileButton")).Invoke();
+        Session.Find<Button>(By.AccessibilityId("NewProfileButton")).Invoke(msPostAction: 0);
         FillProfile(name, enabled, variables);
     }
 
@@ -235,7 +236,7 @@ internal sealed class EditorUi(Session session, TestContext context)
         Step($"{action} profile {name}");
         var options = Child<Button>(Expander(name), "Button", automationId: "ProfileOptionsButton");
         Assert.IsFalse(string.IsNullOrWhiteSpace(options.Name), "Profile options must expose an accessible name.");
-        options.Invoke();
+        options.Invoke(msPostAction: 0);
         Menu($"{action}ProfileMenuItem");
     }
 
@@ -245,12 +246,12 @@ internal sealed class EditorUi(Session session, TestContext context)
         foreach (var variable in variables)
         {
             Step($"Adding {variable.Name} to profile {name}");
-            Session.Find<Button>(By.AccessibilityId("AddProfileVariableButton")).Invoke();
+            Session.Find<Button>(By.AccessibilityId("AddProfileVariableButton")).Invoke(msPostAction: 0);
             Session.Find<TextBox>(By.AccessibilityId("AddNewVariableName")).SetText(variable.Name);
             Session.Find<TextBox>(By.AccessibilityId("AddNewVariableValue")).SetText(variable.Value);
             var add = Session.Find<Button>(By.AccessibilityId("ConfirmAddVariableBtn"));
             Assert.IsTrue(add.IsEnabled, $"Could not add {variable.Name} to {name}.");
-            add.Invoke();
+            add.Invoke(msPostAction: 0);
             Assert.IsTrue(add.WaitForGone(10_000), "The Add variable flyout did not close.");
         }
 
@@ -271,7 +272,7 @@ internal sealed class EditorUi(Session session, TestContext context)
     {
         if (toggle.IsOn != enabled)
         {
-            toggle.Invoke();
+            toggle.Invoke(msPostAction: 0);
         }
 
         Assert.IsTrue(toggle.WaitForProperty("ToggleState", enabled ? "On" : "Off", 10_000), "The toggle state did not update.");

--- a/src/modules/EnvironmentVariables/EnvironmentVariables.UITests/EnvironmentVariables.UITests.csproj
+++ b/src/modules/EnvironmentVariables/EnvironmentVariables.UITests/EnvironmentVariables.UITests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(RepoRoot)src\Common.Dotnet.CsWinRT.props" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <RootNamespace>Microsoft.EnvironmentVariables.UITests</RootNamespace>
+    <AssemblyName>EnvironmentVariables.UITests</AssemblyName>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <RunVSTest>false</RunVSTest>
+    <OutputPath>$(RepoRoot)$(Platform)\$(Configuration)\tests\EnvironmentVariables.UITests\</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest" />
+    <ProjectReference Include="..\..\..\common\UITestAutomation.Next\UITestAutomation.Next.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/modules/EnvironmentVariables/EnvironmentVariables.UITests/EnvironmentVariablesTests.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariables.UITests/EnvironmentVariablesTests.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using Microsoft.PowerToys.UITest.Next;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -12,6 +13,7 @@ namespace Microsoft.EnvironmentVariables.UITests;
 public sealed class EnvironmentVariablesTests : UITestBase
 {
     private static TestState state = null!;
+    private static bool ownsPreparedScope;
     private EditorUi editor = null!;
     private string prefix = string.Empty;
 
@@ -28,7 +30,76 @@ public sealed class EnvironmentVariablesTests : UITestBase
     }
 
     [ClassCleanup(ClassCleanupBehavior.EndOfClass)]
-    public static void RestoreState() => state?.Dispose();
+    public static void RestoreState()
+    {
+        try
+        {
+            StopPreparedScope();
+        }
+        finally
+        {
+            state?.Dispose();
+        }
+    }
+
+    protected override void PrepareTestState()
+    {
+        // CI agents can launch the test host elevated. Use the Runner's supported opt-out before
+        // attaching Settings, rather than attempting to invoke its disabled administrator switch.
+        TestState.ConfigureNonElevatedRunner();
+        ownsPreparedScope = true;
+        StartRunner("--dont-elevate");
+        var ready = WaitHelper.WaitForStable(
+            () =>
+            {
+                var processes = Process.GetProcessesByName("PowerToys");
+                try
+                {
+                    return processes.Length == 1 && ElevationHelper.IsProcessElevated(processes[0].Id) == false;
+                }
+                finally
+                {
+                    foreach (var process in processes)
+                    {
+                        process.Dispose();
+                    }
+                }
+            },
+            match => match,
+            timeoutMS: 60_000,
+            requiredConsecutiveMatches: 3,
+            pollIntervalMS: 200);
+        Assert.IsTrue(ready.Succeeded, "The Runner did not establish a non-elevated instance.");
+
+        StartRunner("--open-settings");
+        var settings = WindowsFinder.WaitForWindowByApp("PowerToys.Settings", window => window.Width > 400 && window.Height > 300, timeoutMS: 90_000);
+        Assert.IsNotNull(settings, "The non-elevated Runner did not open Settings.");
+        Assert.IsFalse(settings.IsElevated, "Settings must be non-elevated so the administrator launch option is editable.");
+    }
+
+    private void StartRunner(string arguments)
+    {
+        string executable = SessionHelper.GetExecutablePath(PowerToysModule.Runner);
+        TestContext.WriteLine($"[{DateTime.UtcNow:HH:mm:ss.fff}] Starting Runner {arguments}");
+        using var process = Process.Start(new ProcessStartInfo(executable, arguments)
+        {
+            WorkingDirectory = Path.GetDirectoryName(executable),
+            UseShellExecute = true,
+        });
+        Assert.IsNotNull(process, "The Runner launch did not return a process.");
+    }
+
+    private static void StopPreparedScope()
+    {
+        if (!ownsPreparedScope)
+        {
+            return;
+        }
+
+        Assert.IsTrue(WindowControl.TryKillProcessTreeByNameAndWait("PowerToys.Settings", 10_000), "Could not close the test-owned Settings process.");
+        Assert.IsTrue(WindowControl.TryKillProcessTreeByNameAndWait("PowerToys", 10_000), "Could not close the test-owned Runner process.");
+        ownsPreparedScope = false;
+    }
 
     [TestInitialize]
     public void OpenEditor()
@@ -53,7 +124,14 @@ public sealed class EnvironmentVariablesTests : UITestBase
         }
         finally
         {
-            state.Reset();
+            try
+            {
+                state.Reset();
+            }
+            finally
+            {
+                StopPreparedScope();
+            }
         }
     }
 
@@ -215,10 +293,12 @@ public sealed class EnvironmentVariablesTests : UITestBase
         var settings = new EditorUi(Session, TestContext);
         var adminCard = Session.Find<Element>(By.AccessibilityId("EnvironmentVariablesToggleLaunchAdministrator"));
         EditorUi.SetToggle(settings.Child<ToggleSwitch>(adminCard, "ToggleSwitch"), false);
+        var launchCard = Session.Find<Element>(By.AccessibilityId("EnvironmentVariablesLaunchButtonControl"));
+        launchCard.Focus();
         Assert.IsTrue(
             WindowControl.WaitForForeground(new IntPtr(Session.WindowHandle), timeoutMS: 10_000),
             $"Settings must own foreground before clicking its launch card: {WindowControl.GetForegroundWindowInfo()}");
-        Session.Find<Element>(By.AccessibilityId("EnvironmentVariablesLaunchButtonControl")).Click();
+        launchCard.Click();
         var window = WindowsFinder.WaitForWindowByApp(TestState.ProcessName, candidate => candidate.Width > 400 && candidate.Height > 300, timeoutMS: 30_000);
         Assert.IsNotNull(window, "Environment Variables did not launch from Settings.");
         WindowHelper.SetWindowSize(new IntPtr(window.WindowHandle), WindowSize.Large);

--- a/src/modules/EnvironmentVariables/EnvironmentVariables.UITests/EnvironmentVariablesTests.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariables.UITests/EnvironmentVariablesTests.cs
@@ -2,7 +2,9 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Text.Json;
 using Microsoft.PowerToys.UITest.Next;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -10,6 +12,7 @@ namespace Microsoft.EnvironmentVariables.UITests;
 
 [TestClass]
 [TestCategory("EnvironmentVariables")]
+[DoNotParallelize]
 public sealed class EnvironmentVariablesTests : UITestBase
 {
     private static TestState state = null!;
@@ -34,6 +37,7 @@ public sealed class EnvironmentVariablesTests : UITestBase
     {
         try
         {
+            // Initialization can fail before per-test cleanup runs; retain the owned-scope safety net.
             StopPreparedScope();
         }
         finally
@@ -46,6 +50,7 @@ public sealed class EnvironmentVariablesTests : UITestBase
     {
         // CI agents can launch the test host elevated. Use the Runner's supported opt-out before
         // attaching Settings, rather than attempting to invoke its disabled administrator switch.
+        // TestState journals the original global settings before this baseline is changed.
         TestState.ConfigureNonElevatedRunner();
         ownsPreparedScope = true;
         StartRunner("--dont-elevate");
@@ -117,9 +122,7 @@ public sealed class EnvironmentVariablesTests : UITestBase
             await CaptureFailureArtifactsBeforeCleanupAsync();
             if (TestContext.CurrentTestOutcome != UnitTestOutcome.Passed && editor is not null)
             {
-                string path = Path.Combine(TestContext.TestRunResultsDirectory!, $"{TestContext.TestName}-editor.json");
-                File.WriteAllText(path, editor.Session.Inspect(depth: 30).GetRawText());
-                TestContext.AddResultFile(path);
+                TryCaptureEditorTree();
             }
         }
         finally
@@ -135,28 +138,56 @@ public sealed class EnvironmentVariablesTests : UITestBase
         }
     }
 
+    private void TryCaptureEditorTree()
+    {
+        try
+        {
+            string? directory = TestContext.TestRunResultsDirectory;
+            if (string.IsNullOrWhiteSpace(directory))
+            {
+                TestContext.WriteLine("The test results directory is unavailable; using temporary storage for the editor diagnostic.");
+                directory = Path.GetTempPath();
+            }
+
+            Directory.CreateDirectory(directory);
+            string path = Path.Combine(directory, $"{TestContext.TestName}-{Guid.NewGuid():N}-editor.json");
+            File.WriteAllText(path, editor.Session.Inspect(depth: 30).GetRawText());
+            TestContext.AddResultFile(path);
+        }
+        catch (Exception error) when (error is AssertFailedException or IOException or UnauthorizedAccessException or TimeoutException or Win32Exception or InvalidOperationException or ArgumentException or JsonException)
+        {
+            TestContext.WriteLine($"Could not capture the editor UIA diagnostic: {error.Message}");
+        }
+    }
+
     [TestMethod]
     public void StandardUserCannotEditSystemVariables()
     {
         Assert.IsFalse(editor.Session.IsElevated, "Launch as administrator OFF must launch a non-elevated editor.");
         Assert.IsTrue(editor.Session.Find<Button>(By.AccessibilityId("AddDefaultVariableUserBtn")).IsEnabled);
         Assert.IsFalse(editor.Session.Find<Button>(By.AccessibilityId("AddDefaultVariableSystemBtn")).IsEnabled);
-        var system = editor.Expand("System");
+        var system = editor.ExpandDefaultSet(EnvironmentVariableTarget.Machine);
         var path = editor.VariableCard(system, "Path");
-        Assert.IsFalse(editor.Child<Button>(path, "Button", automationId: "VariableOptionsButton").IsEnabled, "System variables must be read-only.");
+        var liveBounds = editor.Session.Find<Element>(By.Slug(path.Selector));
+        Assert.IsTrue(
+            liveBounds.Width > 0 && liveBounds.Height > 0,
+            $"Live winapp ui inspect must preserve slug bounds for {path.Selector}; got {liveBounds.Width}x{liveBounds.Height}.");
+        var options = editor.Child<Button>(path, "Button", automationId: "VariableOptionsButton");
+        Assert.IsFalse(options.IsEnabled, "System variables must be read-only.");
+        Assert.IsFalse(string.IsNullOrWhiteSpace(options.Name), "Variable options must expose an accessible name.");
     }
 
     [TestMethod]
     public void UserVariableCrudUpdatesAppliedVariables()
     {
         string name = Track("User");
-        editor.AddUserVariable(name, "original");
-        editor.VariableMenu("User", name, "Edit");
+        editor.AddUserVariableAndVerify(name, "original");
+        editor.VariableMenu(EnvironmentVariableTarget.User, name, "Edit");
         editor.Session.Find<TextBox>(By.AccessibilityId("EditVariableDialogValueTxtBox")).SetText("edited");
         editor.SaveDialog();
         EditorUi.AssertUserVariable(name, "edited");
         editor.AssertAppliedVariable(name, "edited");
-        editor.VariableMenu("User", name, "Remove");
+        editor.VariableMenu(EnvironmentVariableTarget.User, name, "Remove");
         editor.ConfirmRemoval();
         EditorUi.AssertUserVariable(name, null);
         editor.AssertAppliedVariable(name, null);
@@ -171,16 +202,16 @@ public sealed class EnvironmentVariablesTests : UITestBase
         string two = Track("Two");
         string three = Track("Three");
 
-        editor.CreateProfile(first, false);
+        editor.CreateProfileAndVerify(first, false);
         Assert.AreEqual(0, EditorUi.ReadProfiles().EnumerateArray().Single().GetProperty("Variables").GetArrayLength(), "The first profile should initially be empty.");
-        editor.EditProfile(first, (one, "first"));
-        editor.CreateProfile(second, true, (two, "second"), (three, "third"));
+        editor.EditProfileAndVerify(first, (one, "first"));
+        editor.CreateProfileAndVerify(second, true, (two, "second"), (three, "third"));
         EditorUi.AssertUserVariable(two, "second");
         EditorUi.AssertUserVariable(three, "third");
         editor.AssertAppliedVariable(two, "second");
         editor.AssertAppliedVariable(three, "third");
 
-        editor.SetProfileEnabled(first, true);
+        editor.SetProfileEnabledAndVerify(first, true);
         editor.AssertProfile(second, false);
         Assert.IsFalse(editor.Child<ToggleSwitch>(editor.Expander(second), "ToggleSwitch").IsOn, "Applying a profile must turn off the previously active profile's switch.");
         EditorUi.AssertUserVariable(one, "first");
@@ -190,11 +221,11 @@ public sealed class EnvironmentVariablesTests : UITestBase
         editor.AssertAppliedVariable(two, null);
         editor.AssertAppliedVariable(three, null);
 
-        editor.SetProfileEnabled(first, false);
+        editor.SetProfileEnabledAndVerify(first, false);
         EditorUi.AssertUserVariable(one, null);
         editor.AssertAppliedVariable(one, null);
-        editor.RemoveProfile(first);
-        editor.RemoveProfile(second);
+        editor.RemoveProfileAndVerify(first);
+        editor.RemoveProfileAndVerify(second);
         Assert.AreEqual(0, EditorUi.ReadProfiles().GetArrayLength(), "Both profiles must be gone from profiles.json.");
     }
 
@@ -205,41 +236,41 @@ public sealed class EnvironmentVariablesTests : UITestBase
         string profile = prefix + "_OverrideProfile";
         string backup = name + "_PowerToys_" + profile;
         state.TrackUserVariable(backup);
-        editor.AddUserVariable(name, "original");
-        editor.CreateProfile(profile, false, (name, "overridden"));
-        editor.SetProfileEnabled(profile, true);
+        editor.AddUserVariableAndVerify(name, "original");
+        editor.CreateProfileAndVerify(profile, false, (name, "overridden"));
+        editor.SetProfileEnabledAndVerify(profile, true);
         EditorUi.AssertUserVariable(name, "overridden");
         EditorUi.AssertUserVariable(backup, "original");
         editor.AssertAppliedVariable(name, "overridden");
         editor.AssertAppliedVariable(backup, "original");
-        editor.SetProfileEnabled(profile, false);
+        editor.SetProfileEnabledAndVerify(profile, false);
         EditorUi.AssertUserVariable(name, "original");
         EditorUi.AssertUserVariable(backup, null);
         editor.AssertAppliedVariable(name, "original");
         editor.AssertAppliedVariable(backup, null);
-        editor.RemoveProfile(profile);
+        editor.RemoveProfileAndVerify(profile);
     }
 
     [TestMethod]
     public void PathEntriesCanBeReorderedInsertedAndDeleted()
     {
         string profile = prefix + "_PathEditor";
-        editor.CreateProfile(profile, false, ("PATH", "path1;path2;path3"));
+        editor.CreateProfileAndVerify(profile, false, ("PATH", "path1;path2;path3"));
         editor.AssertPathList(profile, "path1", "path2", "path3");
         editor.VariableMenu(profile, "PATH", "Edit");
 
-        editor.PathEntryMenu(1, "Move up");
+        editor.PathEntryMenu(1, "MoveUp");
         editor.AssertPathEditor("path2;path1;path3");
-        editor.PathEntryMenu(0, "Move down");
+        editor.PathEntryMenu(0, "MoveDown");
         editor.AssertPathEditor("path1;path2;path3");
-        editor.PathEntryMenu(0, "Move up");
+        editor.PathEntryMenu(0, "MoveUp");
         editor.AssertPathEditor("path1;path2;path3");
-        editor.PathEntryMenu(2, "Move down");
+        editor.PathEntryMenu(2, "MoveDown");
         editor.AssertPathEditor("path1;path2;path3");
-        editor.PathEntryMenu(1, "Insert Before");
+        editor.PathEntryMenu(1, "InsertBefore");
         editor.SetPathEntry(1, "before");
         editor.AssertPathEditor("path1;before;path2;path3");
-        editor.PathEntryMenu(2, "Insert After");
+        editor.PathEntryMenu(2, "InsertAfter");
         editor.SetPathEntry(3, "after");
         editor.AssertPathEditor("path1;before;path2;after;path3");
         editor.PathEntryMenu(0, "Delete");
@@ -247,7 +278,7 @@ public sealed class EnvironmentVariablesTests : UITestBase
         editor.SaveDialog();
         editor.AssertProfile(profile, false, ("PATH", "before;path2;after;path3"));
         editor.AssertPathList(profile, "before", "path2", "after", "path3");
-        editor.RemoveProfile(profile);
+        editor.RemoveProfileAndVerify(profile);
     }
 
     [TestMethod]
@@ -260,7 +291,7 @@ public sealed class EnvironmentVariablesTests : UITestBase
         string? original = TestState.ReadUserVariable("Path");
         string system = Environment.ExpandEnvironmentVariables(TestState.ReadSystemVariable("Path")!);
         editor.AssertAppliedVariable("Path", system + (original is null ? string.Empty : ";" + Environment.ExpandEnvironmentVariables(original)));
-        editor.CreateProfile(profile, true, ("PATH", "path1;path2;path3"));
+        editor.CreateProfileAndVerify(profile, true, ("PATH", "path1;path2;path3"));
         EditorUi.AssertUserVariable("Path", "path1;path2;path3");
         EditorUi.AssertUserVariable(backup, original);
         editor.AssertAppliedVariable("Path", system + ";path1;path2;path3");
@@ -274,7 +305,7 @@ public sealed class EnvironmentVariablesTests : UITestBase
         EditorUi.AssertUserVariable("Path", "path1;path2;path3");
         editor.AssertAppliedVariable("Path", system + ";path1;path2;path3");
 
-        editor.RemoveProfile(profile);
+        editor.RemoveProfileAndVerify(profile);
         EditorUi.AssertUserVariable("Path", original);
         EditorUi.AssertUserVariable(backup, null);
         editor.AssertAppliedVariable("Path", system + (original is null ? string.Empty : ";" + Environment.ExpandEnvironmentVariables(original)));

--- a/src/modules/EnvironmentVariables/EnvironmentVariables.UITests/EnvironmentVariablesTests.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariables.UITests/EnvironmentVariablesTests.cs
@@ -1,0 +1,236 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.PowerToys.UITest.Next;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.EnvironmentVariables.UITests;
+
+[TestClass]
+[TestCategory("EnvironmentVariables")]
+public sealed class EnvironmentVariablesTests : UITestBase
+{
+    private static TestState state = null!;
+    private EditorUi editor = null!;
+    private string prefix = string.Empty;
+
+    public EnvironmentVariablesTests()
+        : base(PowerToysModule.PowerToysSettings, enableModules: ["EnvironmentVariables"])
+    {
+    }
+
+    [ClassInitialize]
+    public static void InitializeState(TestContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        state = new TestState();
+    }
+
+    [ClassCleanup(ClassCleanupBehavior.EndOfClass)]
+    public static void RestoreState() => state?.Dispose();
+
+    [TestInitialize]
+    public void OpenEditor()
+    {
+        state.Reset();
+        prefix = $"PTUITest_{Guid.NewGuid():N}";
+        LaunchEditor();
+    }
+
+    [TestCleanup]
+    public async Task RestoreTestState()
+    {
+        try
+        {
+            await CaptureFailureArtifactsBeforeCleanupAsync();
+            if (TestContext.CurrentTestOutcome != UnitTestOutcome.Passed && editor is not null)
+            {
+                string path = Path.Combine(TestContext.TestRunResultsDirectory!, $"{TestContext.TestName}-editor.json");
+                File.WriteAllText(path, editor.Session.Inspect(depth: 30).GetRawText());
+                TestContext.AddResultFile(path);
+            }
+        }
+        finally
+        {
+            state.Reset();
+        }
+    }
+
+    [TestMethod]
+    public void StandardUserCannotEditSystemVariables()
+    {
+        Assert.IsFalse(editor.Session.IsElevated, "Launch as administrator OFF must launch a non-elevated editor.");
+        Assert.IsTrue(editor.Session.Find<Button>(By.AccessibilityId("AddDefaultVariableUserBtn")).IsEnabled);
+        Assert.IsFalse(editor.Session.Find<Button>(By.AccessibilityId("AddDefaultVariableSystemBtn")).IsEnabled);
+        var system = editor.Expand("System");
+        var path = editor.VariableCard(system, "Path");
+        Assert.IsFalse(editor.Child<Button>(path, "Button", automationId: "VariableOptionsButton").IsEnabled, "System variables must be read-only.");
+    }
+
+    [TestMethod]
+    public void UserVariableCrudUpdatesAppliedVariables()
+    {
+        string name = Track("User");
+        editor.AddUserVariable(name, "original");
+        editor.VariableMenu("User", name, "Edit");
+        editor.Session.Find<TextBox>(By.AccessibilityId("EditVariableDialogValueTxtBox")).SetText("edited");
+        editor.SaveDialog();
+        EditorUi.AssertUserVariable(name, "edited");
+        editor.AssertAppliedVariable(name, "edited");
+        editor.VariableMenu("User", name, "Remove");
+        editor.ConfirmRemoval();
+        EditorUi.AssertUserVariable(name, null);
+        editor.AssertAppliedVariable(name, null);
+    }
+
+    [TestMethod]
+    public void ProfilesCanBeCreatedEditedSwitchedAndRemoved()
+    {
+        string first = prefix + "_Profile1";
+        string second = prefix + "_Profile2";
+        string one = Track("One");
+        string two = Track("Two");
+        string three = Track("Three");
+
+        editor.CreateProfile(first, false);
+        Assert.AreEqual(0, EditorUi.ReadProfiles().EnumerateArray().Single().GetProperty("Variables").GetArrayLength(), "The first profile should initially be empty.");
+        editor.EditProfile(first, (one, "first"));
+        editor.CreateProfile(second, true, (two, "second"), (three, "third"));
+        EditorUi.AssertUserVariable(two, "second");
+        EditorUi.AssertUserVariable(three, "third");
+        editor.AssertAppliedVariable(two, "second");
+        editor.AssertAppliedVariable(three, "third");
+
+        editor.SetProfileEnabled(first, true);
+        editor.AssertProfile(second, false);
+        Assert.IsFalse(editor.Child<ToggleSwitch>(editor.Expander(second), "ToggleSwitch").IsOn, "Applying a profile must turn off the previously active profile's switch.");
+        EditorUi.AssertUserVariable(one, "first");
+        EditorUi.AssertUserVariable(two, null);
+        EditorUi.AssertUserVariable(three, null);
+        editor.AssertAppliedVariable(one, "first");
+        editor.AssertAppliedVariable(two, null);
+        editor.AssertAppliedVariable(three, null);
+
+        editor.SetProfileEnabled(first, false);
+        EditorUi.AssertUserVariable(one, null);
+        editor.AssertAppliedVariable(one, null);
+        editor.RemoveProfile(first);
+        editor.RemoveProfile(second);
+        Assert.AreEqual(0, EditorUi.ReadProfiles().GetArrayLength(), "Both profiles must be gone from profiles.json.");
+    }
+
+    [TestMethod]
+    public void ExistingVariableOverrideCreatesAndRestoresBackup()
+    {
+        string name = Track("Override");
+        string profile = prefix + "_OverrideProfile";
+        string backup = name + "_PowerToys_" + profile;
+        state.TrackUserVariable(backup);
+        editor.AddUserVariable(name, "original");
+        editor.CreateProfile(profile, false, (name, "overridden"));
+        editor.SetProfileEnabled(profile, true);
+        EditorUi.AssertUserVariable(name, "overridden");
+        EditorUi.AssertUserVariable(backup, "original");
+        editor.AssertAppliedVariable(name, "overridden");
+        editor.AssertAppliedVariable(backup, "original");
+        editor.SetProfileEnabled(profile, false);
+        EditorUi.AssertUserVariable(name, "original");
+        EditorUi.AssertUserVariable(backup, null);
+        editor.AssertAppliedVariable(name, "original");
+        editor.AssertAppliedVariable(backup, null);
+        editor.RemoveProfile(profile);
+    }
+
+    [TestMethod]
+    public void PathEntriesCanBeReorderedInsertedAndDeleted()
+    {
+        string profile = prefix + "_PathEditor";
+        editor.CreateProfile(profile, false, ("PATH", "path1;path2;path3"));
+        editor.AssertPathList(profile, "path1", "path2", "path3");
+        editor.VariableMenu(profile, "PATH", "Edit");
+
+        editor.PathEntryMenu(1, "Move up");
+        editor.AssertPathEditor("path2;path1;path3");
+        editor.PathEntryMenu(0, "Move down");
+        editor.AssertPathEditor("path1;path2;path3");
+        editor.PathEntryMenu(0, "Move up");
+        editor.AssertPathEditor("path1;path2;path3");
+        editor.PathEntryMenu(2, "Move down");
+        editor.AssertPathEditor("path1;path2;path3");
+        editor.PathEntryMenu(1, "Insert Before");
+        editor.SetPathEntry(1, "before");
+        editor.AssertPathEditor("path1;before;path2;path3");
+        editor.PathEntryMenu(2, "Insert After");
+        editor.SetPathEntry(3, "after");
+        editor.AssertPathEditor("path1;before;path2;after;path3");
+        editor.PathEntryMenu(0, "Delete");
+        editor.AssertPathEditor("before;path2;after;path3");
+        editor.SaveDialog();
+        editor.AssertProfile(profile, false, ("PATH", "before;path2;after;path3"));
+        editor.AssertPathList(profile, "before", "path2", "after", "path3");
+        editor.RemoveProfile(profile);
+    }
+
+    [TestMethod]
+    public void AppliedPathSurvivesReopenAndDeletingProfileRestoresUserPath()
+    {
+        string profile = prefix + "_PathProfile";
+        string backup = "PATH_PowerToys_" + profile;
+        state.TrackUserVariable("Path");
+        state.TrackUserVariable(backup);
+        string? original = TestState.ReadUserVariable("Path");
+        string system = Environment.ExpandEnvironmentVariables(TestState.ReadSystemVariable("Path")!);
+        editor.AssertAppliedVariable("Path", system + (original is null ? string.Empty : ";" + Environment.ExpandEnvironmentVariables(original)));
+        editor.CreateProfile(profile, true, ("PATH", "path1;path2;path3"));
+        EditorUi.AssertUserVariable("Path", "path1;path2;path3");
+        EditorUi.AssertUserVariable(backup, original);
+        editor.AssertAppliedVariable("Path", system + ";path1;path2;path3");
+
+        editor.Step("Closing and reopening the editor to read persisted profile state");
+        WindowControl.TryCloseByApp(TestState.ProcessName);
+        EditorUi.Wait(() => !WindowsFinder.ListByApp(TestState.ProcessName).Any(), "The editor window did not close.");
+        LaunchEditor();
+        editor.AssertProfile(profile, true, ("PATH", "path1;path2;path3"));
+        Assert.IsTrue(editor.Child<ToggleSwitch>(editor.Expander(profile), "ToggleSwitch").IsOn);
+        EditorUi.AssertUserVariable("Path", "path1;path2;path3");
+        editor.AssertAppliedVariable("Path", system + ";path1;path2;path3");
+
+        editor.RemoveProfile(profile);
+        EditorUi.AssertUserVariable("Path", original);
+        EditorUi.AssertUserVariable(backup, null);
+        editor.AssertAppliedVariable("Path", system + (original is null ? string.Empty : ";" + Environment.ExpandEnvironmentVariables(original)));
+        editor.AssertAppliedVariable(backup, null);
+    }
+
+    private void LaunchEditor()
+    {
+        TestContext.WriteLine($"[{DateTime.UtcNow:HH:mm:ss.fff}] Launching Environment Variables from Settings with administrator mode OFF.");
+        if (!Session.Has(By.AccessibilityId("EnvironmentVariablesNavItem"), 500))
+        {
+            Session.Find<NavigationViewItem>(By.AccessibilityId("AdvancedNavItem")).Click();
+        }
+
+        Session.Find<NavigationViewItem>(By.AccessibilityId("EnvironmentVariablesNavItem")).Click();
+        var settings = new EditorUi(Session, TestContext);
+        var adminCard = Session.Find<Element>(By.AccessibilityId("EnvironmentVariablesToggleLaunchAdministrator"));
+        EditorUi.SetToggle(settings.Child<ToggleSwitch>(adminCard, "ToggleSwitch"), false);
+        Assert.IsTrue(
+            WindowControl.WaitForForeground(new IntPtr(Session.WindowHandle), timeoutMS: 10_000),
+            $"Settings must own foreground before clicking its launch card: {WindowControl.GetForegroundWindowInfo()}");
+        Session.Find<Element>(By.AccessibilityId("EnvironmentVariablesLaunchButtonControl")).Click();
+        var window = WindowsFinder.WaitForWindowByApp(TestState.ProcessName, candidate => candidate.Width > 400 && candidate.Height > 300, timeoutMS: 30_000);
+        Assert.IsNotNull(window, "Environment Variables did not launch from Settings.");
+        WindowHelper.SetWindowSize(new IntPtr(window.WindowHandle), WindowSize.Large);
+        editor = new EditorUi(window, TestContext);
+        Assert.IsTrue(window.WaitForElement(By.AccessibilityId("AddDefaultVariableUserBtn"), 15_000), "The editor did not become ready.");
+    }
+
+    private string Track(string suffix)
+    {
+        string name = prefix + "_" + suffix;
+        state.TrackUserVariable(name);
+        Assert.IsNull(TestState.ReadUserVariable(name), "The unique fixture name must not replace an existing variable.");
+        return name;
+    }
+}

--- a/src/modules/EnvironmentVariables/EnvironmentVariables.UITests/EnvironmentVariablesTests.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariables.UITests/EnvironmentVariablesTests.cs
@@ -163,6 +163,9 @@ public sealed class EnvironmentVariablesTests : UITestBase
     [TestMethod]
     public void StandardUserCannotEditSystemVariables()
     {
+        Assert.IsTrue(
+            WindowHelper.IsWindowMaximized(new IntPtr(editor.Session.WindowHandle)),
+            "The editor must be maximized, matching the Settings window's default state.");
         Assert.IsFalse(editor.Session.IsElevated, "Launch as administrator OFF must launch a non-elevated editor.");
         Assert.IsTrue(editor.Session.Find<Button>(By.AccessibilityId("AddDefaultVariableUserBtn")).IsEnabled);
         Assert.IsFalse(editor.Session.Find<Button>(By.AccessibilityId("AddDefaultVariableSystemBtn")).IsEnabled);
@@ -317,10 +320,10 @@ public sealed class EnvironmentVariablesTests : UITestBase
         TestContext.WriteLine($"[{DateTime.UtcNow:HH:mm:ss.fff}] Launching Environment Variables from Settings with administrator mode OFF.");
         if (!Session.Has(By.AccessibilityId("EnvironmentVariablesNavItem"), 500))
         {
-            Session.Find<NavigationViewItem>(By.AccessibilityId("AdvancedNavItem")).Click();
+            Session.Find<NavigationViewItem>(By.AccessibilityId("AdvancedNavItem")).Click(msPostAction: 0);
         }
 
-        Session.Find<NavigationViewItem>(By.AccessibilityId("EnvironmentVariablesNavItem")).Click();
+        Session.Find<NavigationViewItem>(By.AccessibilityId("EnvironmentVariablesNavItem")).Click(msPostAction: 0);
         var settings = new EditorUi(Session, TestContext);
         var adminCard = Session.Find<Element>(By.AccessibilityId("EnvironmentVariablesToggleLaunchAdministrator"));
         EditorUi.SetToggle(settings.Child<ToggleSwitch>(adminCard, "ToggleSwitch"), false);
@@ -329,10 +332,10 @@ public sealed class EnvironmentVariablesTests : UITestBase
         Assert.IsTrue(
             WindowControl.WaitForForeground(new IntPtr(Session.WindowHandle), timeoutMS: 10_000),
             $"Settings must own foreground before clicking its launch card: {WindowControl.GetForegroundWindowInfo()}");
-        launchCard.Click();
+        launchCard.Click(msPostAction: 0);
         var window = WindowsFinder.WaitForWindowByApp(TestState.ProcessName, candidate => candidate.Width > 400 && candidate.Height > 300, timeoutMS: 30_000);
         Assert.IsNotNull(window, "Environment Variables did not launch from Settings.");
-        WindowHelper.SetWindowSize(new IntPtr(window.WindowHandle), WindowSize.Large);
+        WindowHelper.MaximizeWindow(new IntPtr(window.WindowHandle));
         editor = new EditorUi(window, TestContext);
         Assert.IsTrue(window.WaitForElement(By.AccessibilityId("AddDefaultVariableUserBtn"), 15_000), "The editor did not become ready.");
     }

--- a/src/modules/EnvironmentVariables/EnvironmentVariables.UITests/EnvironmentVariablesTests.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariables.UITests/EnvironmentVariablesTests.cs
@@ -169,12 +169,19 @@ public sealed class EnvironmentVariablesTests : UITestBase
         Assert.IsFalse(editor.Session.IsElevated, "Launch as administrator OFF must launch a non-elevated editor.");
         Assert.IsTrue(editor.Session.Find<Button>(By.AccessibilityId("AddDefaultVariableUserBtn")).IsEnabled);
         Assert.IsFalse(editor.Session.Find<Button>(By.AccessibilityId("AddDefaultVariableSystemBtn")).IsEnabled);
-        var system = editor.ExpandDefaultSet(EnvironmentVariableTarget.Machine);
-        var path = editor.VariableCard(system, "Path");
-        var liveBounds = editor.Session.Find<Element>(By.Slug(path.Selector));
+
+        // Off-screen variable rows can legitimately have empty bounds. Exercise the CLI geometry
+        // contract on the visible window, independently of list length, scroll position, or DPI.
+        var root = editor.Session.Inspect(depth: 1).GetProperty("windows")[0].GetProperty("elements")[0];
+        var rootSelector = EditorUi.Property(root, "selector");
+        var liveBounds = editor.Session.Find<Window>(By.Slug(rootSelector));
         Assert.IsTrue(
             liveBounds.Width > 0 && liveBounds.Height > 0,
-            $"Live winapp ui inspect must preserve slug bounds for {path.Selector}; got {liveBounds.Width}x{liveBounds.Height}.");
+            $"Live winapp ui inspect must preserve visible window bounds for {rootSelector}; got {liveBounds.Width}x{liveBounds.Height}.");
+
+        var system = editor.ExpandDefaultSet(EnvironmentVariableTarget.Machine);
+        var path = editor.VariableCard(system, "Path");
+        editor.Step($"Checking System PATH editability independently of row geometry ({path.Width}x{path.Height}).");
         var options = editor.Child<Button>(path, "Button", automationId: "VariableOptionsButton");
         Assert.IsFalse(options.IsEnabled, "System variables must be read-only.");
         Assert.IsFalse(string.IsNullOrWhiteSpace(options.Name), "Variable options must expose an accessible name.");

--- a/src/modules/EnvironmentVariables/EnvironmentVariables.UITests/TestState.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariables.UITests/TestState.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.PowerToys.UITest.Next;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Win32;
+
+namespace Microsoft.EnvironmentVariables.UITests;
+
+internal sealed class TestState : IDisposable
+{
+    internal const string ProcessName = "PowerToys.EnvironmentVariables";
+
+    internal static readonly string ModuleDirectory = Path.Combine(SettingsConfigHelper.PowerToysSettingsRoot, "EnvironmentVariables");
+    internal static readonly string ProfilesPath = Path.Combine(ModuleDirectory, "profiles.json");
+
+    private readonly Dictionary<string, (object? Value, RegistryValueKind Kind)> userVariables = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, byte[]?> files = new();
+
+    internal TestState()
+    {
+        StopEditor();
+        Directory.CreateDirectory(ModuleDirectory);
+        foreach (string name in new[] { "profiles.json", "settings.json" })
+        {
+            string path = Path.Combine(ModuleDirectory, name);
+            files.Add(path, File.Exists(path) ? File.ReadAllBytes(path) : null);
+        }
+    }
+
+    internal static string? ReadUserVariable(string name)
+    {
+        using var key = Registry.CurrentUser.OpenSubKey("Environment");
+        return key?.GetValue(name, null, RegistryValueOptions.DoNotExpandEnvironmentNames) as string;
+    }
+
+    internal static string? ReadSystemVariable(string name)
+    {
+        using var key = Registry.LocalMachine.OpenSubKey(@"SYSTEM\CurrentControlSet\Control\Session Manager\Environment");
+        return key?.GetValue(name, null, RegistryValueOptions.DoNotExpandEnvironmentNames) as string;
+    }
+
+    internal static void StopEditor()
+    {
+        Assert.IsTrue(
+            WindowControl.TryKillProcessTreeByNameAndWait(ProcessName, timeoutMS: 10_000),
+            "Environment Variables must exit before restoring its files and registry values.");
+    }
+
+    internal void TrackUserVariable(string name)
+    {
+        if (userVariables.ContainsKey(name))
+        {
+            return;
+        }
+
+        using var key = Registry.CurrentUser.OpenSubKey("Environment");
+        object? value = key?.GetValue(name, null, RegistryValueOptions.DoNotExpandEnvironmentNames);
+        userVariables.Add(name, (value, value is null ? RegistryValueKind.String : key!.GetValueKind(name)));
+    }
+
+    internal void Reset()
+    {
+        StopEditor();
+        using var key = Registry.CurrentUser.CreateSubKey("Environment", writable: true);
+        foreach (var (name, original) in userVariables)
+        {
+            if (original.Value is null)
+            {
+                Environment.SetEnvironmentVariable(name, null, EnvironmentVariableTarget.User);
+            }
+            else
+            {
+                // Notify Explorer through the OS API, then preserve the original registry kind
+                // as well as the unexpanded text (notably REG_EXPAND_SZ User PATH values).
+                Environment.SetEnvironmentVariable(name, original.Value.ToString(), EnvironmentVariableTarget.User);
+                key.SetValue(name, original.Value, original.Kind);
+            }
+        }
+
+        userVariables.Clear();
+        File.WriteAllText(ProfilesPath, "[]");
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Reset();
+        }
+        finally
+        {
+            foreach (var (path, original) in files)
+            {
+                if (original is null)
+                {
+                    File.Delete(path);
+                }
+                else
+                {
+                    File.WriteAllBytes(path, original);
+                }
+            }
+        }
+    }
+}

--- a/src/modules/EnvironmentVariables/EnvironmentVariables.UITests/TestState.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariables.UITests/TestState.cs
@@ -2,7 +2,9 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 using Microsoft.PowerToys.UITest.Next;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Win32;
@@ -12,25 +14,81 @@ namespace Microsoft.EnvironmentVariables.UITests;
 internal sealed class TestState : IDisposable
 {
     internal const string ProcessName = "PowerToys.EnvironmentVariables";
+    internal const string JournalFileName = "ui-tests-state.json";
+
+    private const int JournalVersion = 1;
+    private const string ProfilesKey = "profiles";
+    private const string ModuleSettingsKey = "moduleSettings";
+    private const string GlobalSettingsKey = "globalSettings";
 
     internal static readonly string ModuleDirectory = Path.Combine(SettingsConfigHelper.PowerToysSettingsRoot, "EnvironmentVariables");
     internal static readonly string ProfilesPath = Path.Combine(ModuleDirectory, "profiles.json");
     private static readonly string GlobalSettingsPath = Path.Combine(SettingsConfigHelper.PowerToysSettingsRoot, "settings.json");
 
-    private readonly Dictionary<string, (object? Value, RegistryValueKind Kind)> userVariables = new(StringComparer.OrdinalIgnoreCase);
-    private readonly Dictionary<string, byte[]?> files = new();
+    private static readonly JsonSerializerOptions JournalOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+        RespectRequiredConstructorParameters = true,
+        AllowDuplicateProperties = false,
+    };
+
+    private readonly Dictionary<string, UserVariableSnapshot> userVariables = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, byte[]?> files = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, string> filePaths;
+    private readonly string journalPath;
+    private readonly Action stopEditor;
+    private readonly Func<string, UserVariableSnapshot> readUserVariable;
+    private readonly Action<string, UserVariableSnapshot> restoreUserVariable;
+    private bool disposed;
 
     internal TestState()
+        : this(ModuleDirectory, GlobalSettingsPath, StopEditor, ReadUserVariableSnapshot, RestoreUserVariable)
     {
-        StopEditor();
-        Directory.CreateDirectory(ModuleDirectory);
-        foreach (string name in new[] { "profiles.json", "settings.json" })
+    }
+
+    internal TestState(
+        string moduleDirectory,
+        string globalSettingsPath,
+        Action stopEditor,
+        Func<string, UserVariableSnapshot> readUserVariable,
+        Action<string, UserVariableSnapshot> restoreUserVariable)
+    {
+        ArgumentNullException.ThrowIfNull(stopEditor);
+        ArgumentNullException.ThrowIfNull(readUserVariable);
+        ArgumentNullException.ThrowIfNull(restoreUserVariable);
+
+        this.stopEditor = stopEditor;
+        this.readUserVariable = readUserVariable;
+        this.restoreUserVariable = restoreUserVariable;
+        filePaths = new(StringComparer.Ordinal)
         {
-            string path = Path.Combine(ModuleDirectory, name);
-            files.Add(path, File.Exists(path) ? File.ReadAllBytes(path) : null);
+            [ProfilesKey] = Path.Combine(moduleDirectory, "profiles.json"),
+            [ModuleSettingsKey] = Path.Combine(moduleDirectory, "settings.json"),
+            [GlobalSettingsKey] = globalSettingsPath,
+        };
+        journalPath = Path.Combine(moduleDirectory, JournalFileName);
+        Directory.CreateDirectory(moduleDirectory);
+
+        byte[]? previousJournal = ReadFileSnapshot(journalPath);
+        if (previousJournal is not null)
+        {
+            LoadJournal(previousJournal);
+            RestoreClassState();
+            userVariables.Clear();
+            files.Clear();
+        }
+        else
+        {
+            stopEditor();
         }
 
-        files.Add(GlobalSettingsPath, File.Exists(GlobalSettingsPath) ? File.ReadAllBytes(GlobalSettingsPath) : null);
+        foreach (var (key, path) in filePaths)
+        {
+            files.Add(key, ReadFileSnapshot(path));
+        }
+
+        SaveJournal(userVariables);
     }
 
     internal static void ConfigureNonElevatedRunner()
@@ -56,63 +114,260 @@ internal sealed class TestState : IDisposable
     {
         Assert.IsTrue(
             WindowControl.TryKillProcessTreeByNameAndWait(ProcessName, timeoutMS: 10_000),
-            "Environment Variables must exit before restoring its files and registry values.");
+            "Environment Variables did not exit; state restoration will still be attempted.");
     }
 
     internal void TrackUserVariable(string name)
     {
+        ObjectDisposedException.ThrowIf(disposed, this);
+        if (!IsValidVariableName(name))
+        {
+            throw new ArgumentException("A valid environment variable name is required.", nameof(name));
+        }
+
         if (userVariables.ContainsKey(name))
         {
             return;
         }
 
-        using var key = Registry.CurrentUser.OpenSubKey("Environment");
-        object? value = key?.GetValue(name, null, RegistryValueOptions.DoNotExpandEnvironmentNames);
-        userVariables.Add(name, (value, value is null ? RegistryValueKind.String : key!.GetValueKind(name)));
+        UserVariableSnapshot original = readUserVariable(name);
+        if (!IsSupportedSnapshot(original))
+        {
+            throw new NotSupportedException("Only string and expandable-string environment variables can be preserved.");
+        }
+
+        var updatedVariables = new Dictionary<string, UserVariableSnapshot>(userVariables, StringComparer.OrdinalIgnoreCase)
+        {
+            [name] = original,
+        };
+
+        // Do not permit mutation until the original raw value is durably recoverable.
+        SaveJournal(updatedVariables);
+        userVariables.Add(name, original);
     }
 
     internal void Reset()
     {
-        StopEditor();
-        using var key = Registry.CurrentUser.CreateSubKey("Environment", writable: true);
-        foreach (var (name, original) in userVariables)
-        {
-            if (original.Value is null)
-            {
-                Environment.SetEnvironmentVariable(name, null, EnvironmentVariableTarget.User);
-            }
-            else
-            {
-                // Notify Explorer through the OS API, then preserve the original registry kind
-                // as well as the unexpanded text (notably REG_EXPAND_SZ User PATH values).
-                Environment.SetEnvironmentVariable(name, original.Value.ToString(), EnvironmentVariableTarget.User);
-                key.SetValue(name, original.Value, original.Kind);
-            }
-        }
-
-        userVariables.Clear();
-        File.WriteAllText(ProfilesPath, "[]");
+        ObjectDisposedException.ThrowIf(disposed, this);
+        var failures = new List<Exception>();
+        RestoreVariables(failures);
+        AttemptRestore(() => File.WriteAllText(filePaths[ProfilesKey], "[]"), "reset profiles", failures);
+        ThrowRestorationFailures(failures);
     }
 
     public void Dispose()
     {
+        if (disposed)
+        {
+            return;
+        }
+
+        RestoreClassState();
+        disposed = true;
+    }
+
+    private static byte[]? ReadFileSnapshot(string path)
+    {
         try
         {
-            Reset();
+            return File.ReadAllBytes(path);
         }
-        finally
+        catch (FileNotFoundException)
         {
-            foreach (var (path, original) in files)
+            return null;
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return null;
+        }
+    }
+
+    private static bool IsValidVariableName(string name)
+    {
+        return !string.IsNullOrEmpty(name) && !name.Contains('=') && !name.Contains('\0');
+    }
+
+    private static bool IsSupportedSnapshot(UserVariableSnapshot? snapshot)
+    {
+        return snapshot is not null && snapshot.Kind is RegistryValueKind.String or RegistryValueKind.ExpandString;
+    }
+
+    private static UserVariableSnapshot ReadUserVariableSnapshot(string name)
+    {
+        using var key = Registry.CurrentUser.OpenSubKey("Environment");
+        if (key is null || !key.GetValueNames().Contains(name, StringComparer.OrdinalIgnoreCase))
+        {
+            return new(null, RegistryValueKind.String);
+        }
+
+        object? value = key.GetValue(name, null, RegistryValueOptions.DoNotExpandEnvironmentNames);
+        var snapshot = new UserVariableSnapshot(value as string, key.GetValueKind(name));
+        if (value is not string || !IsSupportedSnapshot(snapshot))
+        {
+            throw new NotSupportedException("Only string and expandable-string environment variables can be preserved.");
+        }
+
+        return snapshot;
+    }
+
+    private static void RestoreUserVariable(string name, UserVariableSnapshot original)
+    {
+        var failures = new List<Exception>();
+        AttemptRestore(
+            () => Environment.SetEnvironmentVariable(name, original.Value, EnvironmentVariableTarget.User),
+            "notify the user environment change",
+            failures);
+        AttemptRestore(
+            () =>
             {
-                if (original is null)
+                // Preserve raw text and kind even if the notifying OS API failed or converted the value.
+                using var key = Registry.CurrentUser.CreateSubKey("Environment", writable: true);
+                if (original.Value is null)
                 {
-                    File.Delete(path);
+                    key.DeleteValue(name, throwOnMissingValue: false);
                 }
                 else
                 {
-                    File.WriteAllBytes(path, original);
+                    key.SetValue(name, original.Value, original.Kind);
                 }
-            }
+            },
+            "restore the raw user registry value",
+            failures);
+        ThrowRestorationFailures(failures);
+    }
+
+    private static void AttemptRestore(Action action, string operation, List<Exception> failures)
+    {
+        try
+        {
+            action();
+        }
+        catch (Exception exception)
+        {
+            failures.Add(new InvalidOperationException($"Failed to {operation}.", exception));
         }
     }
+
+    private static void ThrowRestorationFailures(List<Exception> failures)
+    {
+        if (failures.Count > 0)
+        {
+            throw new AggregateException("Environment Variables test state restoration failed; the journal is retained for retry.", failures);
+        }
+    }
+
+    private void RestoreVariables(List<Exception> failures)
+    {
+        AttemptRestore(stopEditor, "stop the Environment Variables editor", failures);
+        foreach (var (name, original) in userVariables)
+        {
+            AttemptRestore(() => restoreUserVariable(name, original), $"restore user variable '{name}'", failures);
+        }
+
+        // Retain even successfully restored entries until class cleanup, since an editor that
+        // failed to stop can write them again before a retry or a subsequent suite run.
+    }
+
+    private void RestoreClassState()
+    {
+        var failures = new List<Exception>();
+        RestoreVariables(failures);
+        foreach (var (key, path) in filePaths)
+        {
+            AttemptRestore(
+                () =>
+                {
+                    byte[]? original = files[key];
+                    if (original is null)
+                    {
+                        File.Delete(path);
+                    }
+                    else
+                    {
+                        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+                        File.WriteAllBytes(path, original);
+                    }
+                },
+                $"restore {key}",
+                failures);
+        }
+
+        ThrowRestorationFailures(failures);
+        AttemptRestore(() => File.Delete(journalPath + ".new"), "remove the pending recovery journal", failures);
+        ThrowRestorationFailures(failures);
+        AttemptRestore(() => File.Delete(journalPath), "remove the recovery journal", failures);
+        ThrowRestorationFailures(failures);
+    }
+
+    private void LoadJournal(byte[] contents)
+    {
+        Journal? journal;
+        try
+        {
+            journal = JsonSerializer.Deserialize<Journal>(contents, JournalOptions);
+        }
+        catch (JsonException exception)
+        {
+            throw new InvalidDataException("The Environment Variables recovery journal is corrupt or unsupported; it has not been replaced.", exception);
+        }
+
+        if (journal is null || journal.Version != JournalVersion || journal.Files is null || journal.UserVariables is null ||
+            journal.Files.Count != filePaths.Count || journal.Files.Keys.Any(key => !filePaths.ContainsKey(key)))
+        {
+            throw new InvalidDataException("The Environment Variables recovery journal has an unsupported version or file snapshot set; it has not been replaced.");
+        }
+
+        foreach (var (name, snapshot) in journal.UserVariables)
+        {
+            if (!IsValidVariableName(name) || !IsSupportedSnapshot(snapshot) || !userVariables.TryAdd(name, snapshot))
+            {
+                throw new InvalidDataException("The Environment Variables recovery journal contains an invalid or unsupported variable snapshot; it has not been replaced.");
+            }
+        }
+
+        foreach (var (key, original) in journal.Files)
+        {
+            files.Add(key, original);
+        }
+    }
+
+    private void SaveJournal(Dictionary<string, UserVariableSnapshot> variables)
+    {
+        string pendingPath = journalPath + ".new";
+        try
+        {
+            using (var stream = new FileStream(pendingPath, FileMode.Create, FileAccess.Write, FileShare.None, 4096, FileOptions.WriteThrough))
+            {
+                JsonSerializer.Serialize(stream, new Journal(JournalVersion, files, variables), JournalOptions);
+                stream.Flush(flushToDisk: true);
+            }
+
+            if (File.Exists(journalPath))
+            {
+                File.Replace(pendingPath, journalPath, destinationBackupFileName: null);
+            }
+            else
+            {
+                File.Move(pendingPath, journalPath);
+            }
+        }
+        catch (Exception exception)
+        {
+            var failures = new List<Exception> { exception };
+            AttemptRestore(() => File.Delete(pendingPath), "remove the incomplete recovery journal", failures);
+            if (failures.Count > 1)
+            {
+                throw new AggregateException("Could not persist the Environment Variables recovery journal.", failures);
+            }
+
+            throw;
+        }
+    }
+
+    internal sealed record UserVariableSnapshot(string? Value, RegistryValueKind Kind);
+
+    private sealed record Journal(
+        int Version,
+        Dictionary<string, byte[]?> Files,
+        Dictionary<string, UserVariableSnapshot> UserVariables);
 }

--- a/src/modules/EnvironmentVariables/EnvironmentVariables.UITests/TestState.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariables.UITests/TestState.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Text.Json.Nodes;
 using Microsoft.PowerToys.UITest.Next;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Win32;
@@ -14,6 +15,7 @@ internal sealed class TestState : IDisposable
 
     internal static readonly string ModuleDirectory = Path.Combine(SettingsConfigHelper.PowerToysSettingsRoot, "EnvironmentVariables");
     internal static readonly string ProfilesPath = Path.Combine(ModuleDirectory, "profiles.json");
+    private static readonly string GlobalSettingsPath = Path.Combine(SettingsConfigHelper.PowerToysSettingsRoot, "settings.json");
 
     private readonly Dictionary<string, (object? Value, RegistryValueKind Kind)> userVariables = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, byte[]?> files = new();
@@ -27,6 +29,15 @@ internal sealed class TestState : IDisposable
             string path = Path.Combine(ModuleDirectory, name);
             files.Add(path, File.Exists(path) ? File.ReadAllBytes(path) : null);
         }
+
+        files.Add(GlobalSettingsPath, File.Exists(GlobalSettingsPath) ? File.ReadAllBytes(GlobalSettingsPath) : null);
+    }
+
+    internal static void ConfigureNonElevatedRunner()
+    {
+        var settings = JsonNode.Parse(File.ReadAllText(GlobalSettingsPath))!.AsObject();
+        settings["run_elevated"] = false;
+        File.WriteAllText(GlobalSettingsPath, settings.ToJsonString());
     }
 
     internal static string? ReadUserVariable(string name)

--- a/src/modules/EnvironmentVariables/EnvironmentVariables.UITests/app.manifest
+++ b/src/modules/EnvironmentVariables/EnvironmentVariables.UITests/app.manifest
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="EnvironmentVariables.UITests.app" />
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml
@@ -73,6 +73,7 @@
                         </StackPanel>
                     </tkcontrols:SettingsCard.Description>
                     <Button
+                        AutomationProperties.AutomationId="VariableOptionsButton"
                         Content="{ui:FontIcon Glyph=&#xE712;}"
                         IsEnabled="{x:Bind IsEditable}"
                         Style="{StaticResource SubtleButtonStyle}">
@@ -212,7 +213,10 @@
                                             x:Uid="ToggleSwitch"
                                             IsOn="{x:Bind IsEnabled, Mode=TwoWay}"
                                             Style="{StaticResource RightAlignedCompactToggleSwitchStyle}" />
-                                        <Button Content="{ui:FontIcon Glyph=&#xE712;}" Style="{StaticResource SubtleButtonStyle}">
+                                        <Button
+                                            AutomationProperties.AutomationId="ProfileOptionsButton"
+                                            Content="{ui:FontIcon Glyph=&#xE712;}"
+                                            Style="{StaticResource SubtleButtonStyle}">
                                             <Button.Flyout>
                                                 <MenuFlyout>
                                                     <MenuFlyoutItem
@@ -486,6 +490,7 @@
                                         x:Uid="More_Options_Button"
                                         Grid.Column="1"
                                         VerticalAlignment="Center"
+                                        AutomationProperties.AutomationId="PathEntryOptionsButton"
                                         Content="&#xE712;"
                                         FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                         Style="{StaticResource SubtleButtonStyle}">

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml
@@ -73,6 +73,7 @@
                         </StackPanel>
                     </tkcontrols:SettingsCard.Description>
                     <Button
+                        x:Uid="More_Options_Button"
                         AutomationProperties.AutomationId="VariableOptionsButton"
                         Content="{ui:FontIcon Glyph=&#xE712;}"
                         IsEnabled="{x:Bind IsEditable}"
@@ -81,12 +82,14 @@
                             <MenuFlyout>
                                 <MenuFlyoutItem
                                     x:Uid="EditItem"
+                                    AutomationProperties.AutomationId="EditVariableMenuItem"
                                     Click="EditVariable_Click"
                                     CommandParameter="{x:Bind (models:Variable)}"
                                     Icon="{ui:FontIcon Glyph=&#xE70F;}" />
                                 <MenuFlyoutSeparator />
                                 <MenuFlyoutItem
                                     x:Uid="RemoveItem"
+                                    AutomationProperties.AutomationId="RemoveVariableMenuItem"
                                     Click="Delete_Variable_Click"
                                     CommandParameter="{x:Bind (models:Variable)}"
                                     Icon="{ui:FontIcon Glyph=&#xE74D;}" />
@@ -130,7 +133,7 @@
 
         <!--  buttons  -->
         <StackPanel Orientation="Horizontal">
-            <Button Command="{x:Bind NewProfileCommand}">
+            <Button AutomationProperties.AutomationId="NewProfileButton" Command="{x:Bind NewProfileCommand}">
                 <StackPanel Orientation="Horizontal" Spacing="8">
                     <FontIcon
                         x:Name="Icon"
@@ -214,6 +217,7 @@
                                             IsOn="{x:Bind IsEnabled, Mode=TwoWay}"
                                             Style="{StaticResource RightAlignedCompactToggleSwitchStyle}" />
                                         <Button
+                                            x:Uid="More_Options_Button"
                                             AutomationProperties.AutomationId="ProfileOptionsButton"
                                             Content="{ui:FontIcon Glyph=&#xE712;}"
                                             Style="{StaticResource SubtleButtonStyle}">
@@ -221,12 +225,14 @@
                                                 <MenuFlyout>
                                                     <MenuFlyoutItem
                                                         x:Uid="EditItem"
+                                                        AutomationProperties.AutomationId="EditProfileMenuItem"
                                                         Click="EditProfileBtn_Click"
                                                         CommandParameter="{x:Bind (models:ProfileVariablesSet)}"
                                                         Icon="{ui:FontIcon Glyph=&#xE70F;}" />
                                                     <MenuFlyoutSeparator />
                                                     <MenuFlyoutItem
                                                         x:Uid="RemoveItem"
+                                                        AutomationProperties.AutomationId="RemoveProfileMenuItem"
                                                         Click="RemoveProfileBtn_Click"
                                                         CommandParameter="{x:Bind (models:ProfileVariablesSet)}"
                                                         Icon="{ui:FontIcon Glyph=&#xE74D;}" />
@@ -260,6 +266,7 @@
 
                     <tkcontrols:SettingsExpander
                         Margin="0,4,0,0"
+                        AutomationProperties.AutomationId="UserVariablesExpander"
                         Header="{x:Bind ViewModel.UserDefaultSet.Name}"
                         HeaderIcon="{ui:FontIcon Glyph=&#xE77B;}">
                         <tkcontrols:SettingsExpander.ItemsHeader>
@@ -284,7 +291,10 @@
                         </StackPanel>
                     </tkcontrols:SettingsExpander>
 
-                    <tkcontrols:SettingsExpander Header="{x:Bind ViewModel.SystemDefaultSet.Name}" HeaderIcon="{ui:FontIcon Glyph=&#xE977;}">
+                    <tkcontrols:SettingsExpander
+                        AutomationProperties.AutomationId="SystemVariablesExpander"
+                        Header="{x:Bind ViewModel.SystemDefaultSet.Name}"
+                        HeaderIcon="{ui:FontIcon Glyph=&#xE977;}">
                         <tkcontrols:SettingsExpander.ItemsHeader>
                             <ItemsRepeater
                                 ItemTemplate="{StaticResource VariableTemplate}"
@@ -420,6 +430,7 @@
                 Spacing="16">
                 <TextBox
                     x:Uid="AddNewVariableName"
+                    AutomationProperties.AutomationId="DefaultVariableNameTextBox"
                     IsSpellCheckEnabled="False"
                     Text="{Binding Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                     TextChanged="AddDefaultVariableNameTxtBox_TextChanged" />
@@ -427,6 +438,7 @@
                     x:Uid="AddNewVariableValue"
                     MaxHeight="240"
                     AcceptsReturn="False"
+                    AutomationProperties.AutomationId="DefaultVariableValueTextBox"
                     IsSpellCheckEnabled="False"
                     ScrollViewer.IsVerticalRailEnabled="True"
                     ScrollViewer.VerticalScrollBarVisibility="Auto"
@@ -482,6 +494,8 @@
                                         <ColumnDefinition Width="40" />
                                     </Grid.ColumnDefinitions>
                                     <TextBox
+                                        x:Uid="VariableListEntryValue"
+                                        AutomationProperties.AutomationId="VariableListEntryValueTextBox"
                                         Background="Transparent"
                                         BorderBrush="Transparent"
                                         LostFocus="EditVariableValuesListTextBox_LostFocus"
@@ -498,24 +512,29 @@
                                             <MenuFlyout>
                                                 <MenuFlyoutItem
                                                     x:Uid="MoveUp"
+                                                    AutomationProperties.AutomationId="MoveUpPathEntryMenuItem"
                                                     Click="ReorderButtonUp_Click"
                                                     Icon="{ui:FontIcon Glyph=&#xE74A;}" />
                                                 <MenuFlyoutItem
                                                     x:Uid="MoveDown"
+                                                    AutomationProperties.AutomationId="MoveDownPathEntryMenuItem"
                                                     Click="ReorderButtonDown_Click"
                                                     Icon="{ui:FontIcon Glyph=&#xE74B;}" />
                                                 <MenuFlyoutSeparator />
                                                 <MenuFlyoutItem
                                                     x:Uid="RemoveListItem"
+                                                    AutomationProperties.AutomationId="DeletePathEntryMenuItem"
                                                     Click="RemoveListVariableButton_Click"
                                                     Icon="{ui:FontIcon Glyph=&#xE74D;}" />
                                                 <MenuFlyoutSeparator />
                                                 <MenuFlyoutItem
                                                     x:Uid="InsertListEntryBefore"
+                                                    AutomationProperties.AutomationId="InsertBeforePathEntryMenuItem"
                                                     Click="InsertListEntryBeforeButton_Click"
                                                     Icon="{ui:FontIcon Glyph=&#xECC8;}" />
                                                 <MenuFlyoutItem
                                                     x:Uid="InsertListEntryAfter"
+                                                    AutomationProperties.AutomationId="InsertAfterPathEntryMenuItem"
                                                     Click="InsertListEntryAfterButton_Click"
                                                     Icon="{ui:FontIcon Glyph=&#xECC8;}" />
                                             </MenuFlyout>
@@ -556,6 +575,7 @@
                             x:Uid="NewProfileNameTxtBox"
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Center"
+                            AutomationProperties.AutomationId="ProfileNameTextBox"
                             IsSpellCheckEnabled="False"
                             Text="{Binding Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         <ToggleSwitch
@@ -564,6 +584,7 @@
                             MinWidth="0"
                             Margin="0,0,0,0"
                             VerticalAlignment="Center"
+                            AutomationProperties.AutomationId="ProfileEnabledToggle"
                             IsOn="{Binding IsEnabled, Mode=TwoWay}"
                             OffContent=""
                             OnContent="" />
@@ -624,7 +645,7 @@
 
                     </Grid>
 
-                    <Button>
+                    <Button AutomationProperties.AutomationId="AddProfileVariableButton">
                         <StackPanel Orientation="Horizontal" Spacing="8">
                             <FontIcon
                                 x:Name="AddVariableIcon"

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Strings/en-us/Resources.resw
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Strings/en-us/Resources.resw
@@ -250,6 +250,14 @@
   <data name="More_Options_ButtonTooltip.Text" xml:space="preserve">
     <value>More options</value>
   </data>
+  <data name="More_Options_Button.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>More options</value>
+    <comment>Accessible name for a variable or profile options button.</comment>
+  </data>
+  <data name="VariableListEntryValue.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>List entry value</value>
+    <comment>Accessible name for an editable entry in a list-valued environment variable, such as PATH.</comment>
+  </data>
   <data name="MoveDown.Text" xml:space="preserve">
     <value>Move down</value>
   </data>


### PR DESCRIPTION
## Summary of the Pull Request

Add a greenfield `EnvironmentVariables.UITests` suite using `UITestAutomation.Next` and winappcli, based on the checklist in #40680.

The six end-to-end scenarios cover non-elevated launch restrictions, User-variable CRUD, profile creation and switching, override backups, PATH list editing, and persistence across editor restarts. Assertions check both the UI and the persisted Windows environment.

Related to #40680. Elevated launch and System-variable CRUD remain explicitly documented manual-only scenarios, so this PR does not claim complete automation of that issue.

## PR Checklist

- [ ] **Communication:** I've discussed this with core contributors already.
- [x] **Tests:** Added/updated and all automated scenarios pass.
- [x] **Localization:** New accessibility labels use localized resources; selectors use stable AutomationIds.
- [x] **Dev docs:** Updated `doc\devdocs\modules\environmentvariables.md` with coverage, execution guidance, and manual-only limitations.
- [x] **New binaries:** Registered the test project in `PowerToys.slnx`, with x64/ARM64 mappings and the output layout used by existing UI-test discovery.

N/A: end-user documentation changes and product installer/signing entries. No product binaries or new third-party dependencies are added.

## Detailed Description of the Pull Request / Additional comments

### Coverage

| Checklist items | Scenario |
| --- | --- |
| 2 | Launch without elevation; verify User controls are enabled and System controls are read-only. |
| 3-5, User variables | Add, edit, and remove a variable; verify registry values and the Applied variables list. |
| 6-10, 20 | Create and edit profiles, apply a two-variable profile, switch the active profile, unapply it, and delete both profiles from the UI and `profiles.json`. |
| 11-13 | Override a dedicated existing User variable; verify the backup and restoration when the profile is unapplied. |
| 14-16 | Verify combined PATH and separate profile entries; exercise move up/down, insert before/after, and delete. |
| 17-19 | Apply profile PATH, reopen the editor with the profile still enabled, then delete the profile and verify restoration. |

### Implementation

- `src\modules\EnvironmentVariables\EnvironmentVariables.UITests` uses unique fixture names, bounded readiness checks, scoped UI-tree inspection, and a PerMonitorV2 manifest. Cleanup restores original unexpanded values, registry value kinds, and profile/module/global settings, and captures failure evidence before closing test-owned processes. TMP and System PATH are not modified.
- Original state is journaled before mutations in `ui-tests-state.json`. Cleanup attempts all restorations even after a stop/write failure, retains the journal on failure, and recovers an interrupted run before taking a fresh baseline. Added 41 isolated recovery/cleanup regression cases using a fake registry and temporary files.
- The suite prepares the Runner through its supported `--dont-elevate` path so Settings remains non-elevated even when CI launches the test host elevated. It focuses the launch card and verifies foreground ownership before physical input.
- `src\common\UITestAutomation.Next\Session.cs` resolves `By.Slug` through `winapp ui inspect` rather than text search, allowing unnamed containers and repeated controls to be addressed reliably. Seven parser regression cases cover metadata and supported envelope shapes; the live UI scenario also requires non-zero bounds from a real semantic-slug lookup.
- `EnvironmentVariablesMainPage.xaml` exposes stable AutomationIds for dialog fields, actions, default-variable expanders, menus, and list-entry editors. Localized accessible names cover list-entry editors and options buttons. The suite no longer selects translated captions such as Name, Value, Edit, or Yes.
- Scoped lookups wait for consecutive unique matches, inspection depths and inline diagnostic output are bounded, and optional diagnostic failures do not replace the original test failure.

**Do not run this suite on a working machine.** It temporarily replaces User PATH; use a disposable VM and retain the recovery journal if a run is interrupted.

**Manual-only boundary:** checklist item 1 and the System-variable repetition of items 3-5 require elevated interaction across UAC's secure desktop. These are not represented as passing or skipped automated tests; no credential handling or UAC bypass is introduced.

## Validation Steps Performed

For the review follow-up, built the affected product/test projects and the ARM64 Release test executable. Ran the combined unit regression filter and the complete six-test suite in separate Windows 10 and Windows 11 VMs with default resources (4 vCPU / 8 GB).

| Validation | Result |
| --- | --- |
| Shared session-parser unit tests | 7/7 passed |
| State-journal and cleanup unit tests | 41/41 passed |
| Windows 10 local VM, default profile | 6/6 passed |
| Windows 11 local VM, default profile | 6/6 passed |
| Final focused live slug/selector run | 2/2 passed |

Confirmed that no test-owned environment variables or recovery journals remained after successful cleanup. Local builds contain English resources; no non-English runtime validation is claimed.

**Earlier baseline (`c773426a5e`, before review follow-up):** all six scenarios passed on both local default and constrained profiles, and scoped UI Test Automation CI passed **36/36** across Windows 10 x64, Windows 11 x64, and ARM64, each with machine-wide and per-user installations. CI has not been rerun for the review follow-up; the current results above are local validation.
