### PR TITLE
[PowerDisplay] Add JSON Lines output to the CLI

### DIFF
--- a/src/modules/powerdisplay/PowerDisplay.Cli.UnitTests/IpcDispatchTests.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Cli.UnitTests/IpcDispatchTests.cs
@@ -4,12 +4,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PowerDisplay.Cli.Commands;
 using PowerDisplay.Cli.Ipc;
+using PowerDisplay.Cli.Output;
 using PowerDisplay.Contracts;
 
 namespace PowerDisplay.Cli.UnitTests;
@@ -94,6 +96,40 @@ public class IpcDispatchTests
         // An error envelope (isError=true) routes through the error renderer (stderr) only and must
         // never leak to the success path (stdout).
         Assert.AreEqual(0, output.StdoutLines.Count, "error envelope must not render via the success path");
+    }
+
+    [TestMethod]
+    public async Task ApplyProfile_MessageIdOnlyError_JsonOutputWritesLocalizedStderrAndExits7()
+    {
+        var errorResponse = new CliErrorResult
+        {
+            Command = CliCommandNames.ApplyProfile,
+            Error = new CliError
+            {
+                Code = CliErrorCodes.ArgumentError,
+                MessageId = CliMessageIds.ProfileNotFound,
+                Value = "42",
+            },
+        };
+        var responseJson = SerializeError(errorResponse);
+        var stdout = new StringWriter();
+        var stderr = new StringWriter();
+        var output = new JsonCliOutput(stdout, stderr);
+        var dispatcher = new IpcDispatcher(
+            (_, _, _) => Task.FromResult<string?>(responseJson),
+            output,
+            AnyTimeout);
+
+        var exit = await dispatcher.SendApplyProfileAsync(
+            CliRequestBuilder.BuildApplyProfile(42),
+            CancellationToken.None);
+
+        Assert.AreEqual(CliExitCodes.ArgumentError, exit);
+        Assert.AreEqual(string.Empty, stdout.ToString());
+        var rendered = JsonSerializer.Deserialize(stderr.ToString(), ContractsJsonContext.Default.CliErrorResult);
+        Assert.IsNotNull(rendered);
+        Assert.AreEqual("no profile with id 42", rendered.Error.Message);
+        Assert.AreEqual("run 'PowerToys.PowerDisplay.Cli.exe profiles' to see available profiles", rendered.Error.Hint);
     }
 
     // ── apply-profile always exits 0 (best-effort) ───────────────────────────

--- a/src/modules/powerdisplay/PowerDisplay.Cli.UnitTests/JsonCliOutputTests.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Cli.UnitTests/JsonCliOutputTests.cs
@@ -1,0 +1,206 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PowerDisplay.Cli.Output;
+using PowerDisplay.Contracts;
+
+namespace PowerDisplay.Cli.UnitTests;
+
+/// <summary>
+/// Tests the JSON Lines renderer's stream routing and source-generated serialization for every
+/// result envelope accepted by <see cref="ICliOutput"/>.
+/// </summary>
+[TestClass]
+public class JsonCliOutputTests
+{
+    [TestMethod]
+    public void SuccessWriters_EmitOneCompactJsonObjectPerLineToStdout()
+    {
+        var stdout = new StringWriter();
+        var stderr = new StringWriter();
+        var output = new JsonCliOutput(stdout, stderr);
+
+        output.WriteListResult(new CliListResult
+        {
+            Monitors = new List<CliMonitorRef>
+            {
+                new() { Number = 1, Id = "MON-1", Name = "Display", Method = "DDC/CI" },
+            },
+        });
+        output.WriteSetResult(new CliSetResult
+        {
+            Monitor = new CliMonitorRef { Number = 1, Id = "MON-1", Name = "Display", Method = "DDC/CI" },
+            Setting = "brightness",
+            BeforeDisplay = "40%",
+            AfterDisplay = "50%",
+        });
+        output.WriteGetResult(new CliGetResult
+        {
+            Monitors = new List<CliGetMonitorEntry>
+            {
+                new()
+                {
+                    Monitor = new CliMonitorRef { Number = 1, Id = "MON-1", Name = "Display", Method = "DDC/CI" },
+                    Settings = new List<CliSettingValue>
+                    {
+                        new() { Setting = "brightness", Display = "50%", Supported = true },
+                    },
+                },
+            },
+        });
+        output.WriteCapabilitiesResult(new CliCapabilitiesResult
+        {
+            Monitor = new CliMonitorRef { Number = 1, Id = "MON-1", Name = "Display" },
+            CommunicationMethod = "DDC/CI",
+            VcpCodes = new List<CliVcpCodeInfo>
+            {
+                new() { Code = "0x10", Name = "brightness", Continuous = true },
+            },
+        });
+        output.WriteProfileListResult(new CliProfileListResult
+        {
+            Profiles = new List<CliProfileInfo>
+            {
+                new() { Id = 4, Name = "Work", MonitorCount = 1, LastModified = "2026-08-28T00:00:00Z" },
+            },
+        });
+        output.WriteApplyProfileResult(new CliApplyProfileResult { ProfileId = 4, Profile = "Work" });
+
+        Assert.AreEqual(string.Empty, stderr.ToString());
+        var lines = Lines(stdout.ToString());
+        CollectionAssert.AreEqual(
+            new[]
+            {
+                CliCommandNames.List,
+                CliCommandNames.Set,
+                CliCommandNames.Get,
+                CliCommandNames.Capabilities,
+                CliCommandNames.Profiles,
+                CliCommandNames.ApplyProfile,
+            },
+            lines.Select(CommandFromJson).ToArray());
+
+        Assert.AreEqual(6, lines.Count);
+        Assert.IsTrue(lines.All(line => line.StartsWith('{') && line.EndsWith('}')));
+        Assert.IsTrue(lines.All(line => !line.Contains('\r') && !line.Contains('\n')));
+    }
+
+    [TestMethod]
+    public void WriteProfileListResult_SpecialNameRoundTripsOnOnePhysicalLine()
+    {
+        const string ProfileName = "Office | Focus \"quoted\"\n\u7b2c\u4e8c\u884c";
+        var stdout = new StringWriter();
+        var output = new JsonCliOutput(stdout, new StringWriter());
+
+        output.WriteProfileListResult(new CliProfileListResult
+        {
+            Profiles = new List<CliProfileInfo>
+            {
+                new() { Id = 7, Name = ProfileName, MonitorCount = 2 },
+            },
+        });
+
+        var lines = Lines(stdout.ToString());
+        Assert.AreEqual(1, lines.Count, "an embedded newline must be JSON-escaped");
+        var roundTripped = JsonSerializer.Deserialize(
+            lines[0],
+            ContractsJsonContext.Default.CliProfileListResult);
+        Assert.IsNotNull(roundTripped);
+        Assert.AreEqual(ProfileName, roundTripped.Profiles.Single().Name);
+    }
+
+    [TestMethod]
+    public void WriteError_EmitsJsonOnlyToStderr()
+    {
+        var stdout = new StringWriter();
+        var stderr = new StringWriter();
+        var output = new JsonCliOutput(stdout, stderr);
+
+        output.WriteError(new CliErrorResult
+        {
+            Command = CliCommandNames.ApplyProfile,
+            Error = new CliError
+            {
+                Code = CliErrorCodes.ArgumentError,
+                Message = "Profile not found.",
+                Hint = "Run profiles first.",
+            },
+        });
+
+        Assert.AreEqual(string.Empty, stdout.ToString());
+        var lines = Lines(stderr.ToString());
+        Assert.AreEqual(1, lines.Count);
+        var error = JsonSerializer.Deserialize(lines[0], ContractsJsonContext.Default.CliErrorResult);
+        Assert.IsNotNull(error);
+        Assert.IsTrue(error.IsError);
+        Assert.AreEqual(CliErrorCodes.ArgumentError, error.Error.Code);
+        Assert.AreEqual("Run profiles first.", error.Error.Hint);
+    }
+
+    [TestMethod]
+    public void WriteError_ProfileNotFoundMessageId_LocalizesCopyAndPreservesStructuredFields()
+    {
+        var stdout = new StringWriter();
+        var stderr = new StringWriter();
+        var output = new JsonCliOutput(stdout, stderr);
+        var source = new CliErrorResult
+        {
+            Command = CliCommandNames.ApplyProfile,
+            Error = new CliError
+            {
+                Code = CliErrorCodes.ArgumentError,
+                MessageId = CliMessageIds.ProfileNotFound,
+                Value = "404",
+                Detail = "profile store lookup completed",
+            },
+        };
+
+        output.WriteError(source);
+
+        Assert.AreEqual(string.Empty, stdout.ToString());
+        Assert.AreEqual(string.Empty, source.Error.Message, "the source envelope must not be mutated");
+        Assert.IsNull(source.Error.Hint, "the source envelope must not be mutated");
+
+        var lines = Lines(stderr.ToString());
+        Assert.AreEqual(1, lines.Count);
+        var error = JsonSerializer.Deserialize(lines[0], ContractsJsonContext.Default.CliErrorResult);
+        Assert.IsNotNull(error);
+        Assert.AreEqual(CliErrorCodes.ArgumentError, error.Error.Code);
+        Assert.AreEqual(CliMessageIds.ProfileNotFound, error.Error.MessageId);
+        Assert.AreEqual("404", error.Error.Value);
+        Assert.AreEqual("profile store lookup completed", error.Error.Detail);
+        Assert.AreEqual("no profile with id 404", error.Error.Message);
+        Assert.AreEqual("run 'PowerToys.PowerDisplay.Cli.exe profiles' to see available profiles", error.Error.Hint);
+    }
+
+    [TestMethod]
+    public void WriteWarning_IsSilent()
+    {
+        var stdout = new StringWriter();
+        var stderr = new StringWriter();
+        var output = new JsonCliOutput(stdout, stderr);
+
+        output.WriteWarning("monitor number ignored");
+
+        Assert.AreEqual(string.Empty, stdout.ToString());
+        Assert.AreEqual(string.Empty, stderr.ToString());
+    }
+
+    private static List<string> Lines(string text)
+        => text.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(line => line.TrimEnd('\r'))
+            .ToList();
+
+    private static string CommandFromJson(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.GetProperty("command").GetString() ?? string.Empty;
+    }
+}

--- a/src/modules/powerdisplay/PowerDisplay.Cli.UnitTests/ProgramTokenTests.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Cli.UnitTests/ProgramTokenTests.cs
@@ -4,10 +4,12 @@
 
 using System.CommandLine;
 using System.CommandLine.Parsing;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PowerDisplay.Cli;
 using PowerDisplay.Cli.Commands;
 using PowerDisplay.Cli.Options;
+using PowerDisplay.Cli.Output;
 using PowerDisplay.Contracts;
 
 namespace PowerDisplay.Cli.UnitTests;
@@ -137,6 +139,62 @@ public class ProgramTokenTests
         Assert.AreEqual(0, parsed.Errors.Count, "--quiet must not consume the profile id");
         Assert.AreEqual(1, parsed.GetValueForArgument(CliOptions.ProfileId));
         Assert.IsTrue(parsed.GetValueForOption(CliOptions.Quiet), "a bare --quiet resolves to true");
+    }
+
+    [DataTestMethod]
+    [DataRow("--json", "apply-profile", "17")]
+    [DataRow("apply-profile", "--json", "17")]
+    [DataRow("apply-profile", "17", "--json")]
+    public void Json_IsGlobalAndDoesNotSwallowApplyProfileId(string first, string second, string third)
+    {
+        var parsed = Parse(first, second, third);
+
+        Assert.AreEqual(0, parsed.Errors.Count);
+        Assert.IsTrue(parsed.GetValueForOption(CliOptions.Json));
+        Assert.AreEqual(17, parsed.GetValueForArgument(CliOptions.ProfileId));
+        Assert.AreEqual(ArgumentArity.Zero, CliOptions.Json.Arity);
+    }
+
+    [DataTestMethod]
+    [DataRow("--json", "profiles")]
+    [DataRow("profiles", "--json")]
+    public void Json_ParsesBeforeOrAfterProfilesCommand(string first, string second)
+    {
+        var parsed = Parse(first, second);
+
+        Assert.AreEqual(0, parsed.Errors.Count);
+        Assert.IsTrue(parsed.GetValueForOption(CliOptions.Json));
+    }
+
+    [TestMethod]
+    public void Json_ParseError_SelectsJsonErrorRenderer()
+    {
+        var parsed = Parse("--json", "apply-profile", "not-an-id");
+        Assert.IsTrue(parsed.Errors.Count > 0);
+
+        var stdout = new System.IO.StringWriter();
+        var stderr = new System.IO.StringWriter();
+        var output = Program.CreateOutput(parsed, stdout, stderr);
+        Assert.IsInstanceOfType<JsonCliOutput>(output);
+
+        output.WriteError(Program.BuildParseErrorResult(
+            parsed.CommandResult.Command.Name,
+            parsed.Errors.Select(error => error.Message)));
+
+        Assert.AreEqual(string.Empty, stdout.ToString());
+        var error = System.Text.Json.JsonSerializer.Deserialize(
+            stderr.ToString(),
+            ContractsJsonContext.Default.CliErrorResult);
+        Assert.IsNotNull(error);
+        Assert.AreEqual(CliErrorCodes.ArgumentError, error.Error.Code);
+    }
+
+    [TestMethod]
+    public void NoJson_SelectsExistingTextRenderer()
+    {
+        var output = Program.CreateOutput(Parse("profiles"), new System.IO.StringWriter(), new System.IO.StringWriter());
+
+        Assert.IsInstanceOfType<TextCliOutput>(output);
     }
 
     [TestMethod]

--- a/src/modules/powerdisplay/PowerDisplay.Cli/Commands/PowerDisplayRootCommand.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Cli/Commands/PowerDisplayRootCommand.cs
@@ -21,6 +21,7 @@ public sealed partial class PowerDisplayRootCommand : RootCommand
         : base("PowerToys PowerDisplay - control monitor settings from the command line.")
     {
         AddGlobalOption(CliOptions.Quiet);
+        AddGlobalOption(CliOptions.Json);
 
         AddCommand(BuildList());
         AddCommand(BuildCapabilities());

--- a/src/modules/powerdisplay/PowerDisplay.Cli/Options/CliOptions.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Cli/Options/CliOptions.cs
@@ -143,6 +143,15 @@ public static class CliOptions
         Arity = ArgumentArity.Zero,
     };
 
+    // A pure presence flag so it can appear immediately before a subcommand argument without
+    // consuming that argument (for example, `apply-profile --json 3`).
+    public static readonly Option<bool> Json = new(
+        ["--json"],
+        "Write compact JSON Lines output for scripting and automation.")
+    {
+        Arity = ArgumentArity.Zero,
+    };
+
     // Arity is Zero (a pure presence flag), not ZeroOrOne: same greedy-swallow reasoning as --quiet
     // and the up/down setting flags. A bare --confirm-power-off resolves to true.
     public static readonly Option<bool> ConfirmPowerOff = new(

--- a/src/modules/powerdisplay/PowerDisplay.Cli/Output/ICliOutput.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Cli/Output/ICliOutput.cs
@@ -7,10 +7,9 @@ using PowerDisplay.Contracts;
 namespace PowerDisplay.Cli.Output;
 
 /// <summary>
-/// Abstraction over CLI output rendering (today only <see cref="TextCliOutput"/>; the seam also
-/// lets tests capture output). Each command builds the typed result record and hands it to one of
-/// these methods. Errors are routed through <see cref="WriteError"/> regardless of which command
-/// produced them.
+/// Abstraction over human-readable and JSON Lines CLI output rendering. Each command builds the
+/// typed result record and hands it to one of these methods. Errors are routed through
+/// <see cref="WriteError"/> regardless of which command produced them.
 /// </summary>
 public interface ICliOutput
 {

--- a/src/modules/powerdisplay/PowerDisplay.Cli/Output/JsonCliOutput.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Cli/Output/JsonCliOutput.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Text.Json;
+using PowerDisplay.Contracts;
+
+namespace PowerDisplay.Cli.Output;
+
+/// <summary>
+/// Machine-readable JSON Lines output. Each result is one compact JSON object; successful results
+/// go to stdout and errors go to stderr. Errors retain their stable structured fields while also
+/// materializing the CLI-localized message and hint. Warnings are omitted so both streams remain
+/// JSON-only.
+/// </summary>
+public sealed class JsonCliOutput : ICliOutput
+{
+    private readonly TextWriter _stdout;
+    private readonly TextWriter _stderr;
+
+    public JsonCliOutput()
+        : this(Console.Out, Console.Error)
+    {
+    }
+
+    public JsonCliOutput(TextWriter stdout, TextWriter stderr)
+    {
+        _stdout = stdout;
+        _stderr = stderr;
+    }
+
+    public void WriteListResult(CliListResult result)
+        => _stdout.WriteLine(JsonSerializer.Serialize(result, ContractsJsonContext.Default.CliListResult));
+
+    public void WriteSetResult(CliSetResult result)
+        => _stdout.WriteLine(JsonSerializer.Serialize(result, ContractsJsonContext.Default.CliSetResult));
+
+    public void WriteGetResult(CliGetResult result)
+        => _stdout.WriteLine(JsonSerializer.Serialize(result, ContractsJsonContext.Default.CliGetResult));
+
+    public void WriteCapabilitiesResult(CliCapabilitiesResult result)
+        => _stdout.WriteLine(JsonSerializer.Serialize(result, ContractsJsonContext.Default.CliCapabilitiesResult));
+
+    public void WriteProfileListResult(CliProfileListResult result)
+        => _stdout.WriteLine(JsonSerializer.Serialize(result, ContractsJsonContext.Default.CliProfileListResult));
+
+    public void WriteApplyProfileResult(CliApplyProfileResult result)
+        => _stdout.WriteLine(JsonSerializer.Serialize(result, ContractsJsonContext.Default.CliApplyProfileResult));
+
+    public void WriteError(CliErrorResult result)
+    {
+        var source = result.Error;
+        var (message, hint) = CliErrorLocalizer.Localize(source);
+
+        // IPC errors normally carry only MessageId plus structured data. Serialize a localized copy
+        // so JSON consumers receive displayable prose without losing stable fields or mutating the
+        // app-produced envelope that may still be observed by the dispatcher/caller.
+        var localized = new CliErrorResult
+        {
+            IsError = result.IsError,
+            Version = result.Version,
+            Command = result.Command,
+            Monitor = result.Monitor,
+            Error = new CliError
+            {
+                Code = source.Code,
+                MessageId = source.MessageId,
+                Message = message,
+                Setting = source.Setting,
+                Value = source.Value,
+                ExpectedRange = source.ExpectedRange,
+                Supported = source.Supported,
+                Detail = source.Detail,
+                Hint = hint,
+            },
+        };
+
+        _stderr.WriteLine(JsonSerializer.Serialize(localized, ContractsJsonContext.Default.CliErrorResult));
+    }
+
+    public void WriteWarning(string message)
+    {
+    }
+}

--- a/src/modules/powerdisplay/PowerDisplay.Cli/Program.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Cli/Program.cs
@@ -116,14 +116,16 @@ public static class Program
             return await root.InvokeAsync(VersionArgs);
         }
 
-        var quiet = parseResult.GetValueForOption(CliOptions.Quiet);
-        ICliOutput output = new TextCliOutput(quiet);
+        // Select the renderer before handling parse errors so `--json` callers receive the same
+        // machine-readable error envelope as IPC and validation failures. Help/version returned
+        // above and remain owned by System.CommandLine's human-readable renderers.
+        ICliOutput output = CreateOutput(parseResult, Console.Out, Console.Error);
 
         if (parseResult.Errors.Count > 0)
         {
             // System.CommandLine can report several parse errors for one bad invocation; collapse
             // them into a single envelope so consumers always receive exactly one parseable
-            // object (text output) instead of N concatenated ones.
+            // JSON object (or one text error) instead of N concatenated errors.
             output.WriteError(BuildParseErrorResult(
                 CommandLabelFor(parseResult),
                 parseResult.Errors.Select(e => e.Message)));
@@ -504,6 +506,14 @@ public static class Program
         var combined = string.Join("; ", messages.Where(m => !string.IsNullOrWhiteSpace(m)));
         return ArgumentError(command, combined.Length == 0 ? Resources.Error_InvalidArguments : combined);
     }
+
+    // Centralizes renderer selection so parse-error behavior can be tested without redirecting the
+    // process-global Console writers. JSON mode intentionally ignores --quiet because it never emits
+    // warnings; text mode preserves the existing quiet behavior.
+    internal static ICliOutput CreateOutput(ParseResult parseResult, TextWriter stdout, TextWriter stderr)
+        => parseResult.GetValueForOption(CliOptions.Json)
+            ? new JsonCliOutput(stdout, stderr)
+            : new TextCliOutput(stdout, stderr, parseResult.GetValueForOption(CliOptions.Quiet));
 
     // Single ARGUMENT_ERROR envelope shape, shared by the syntactic-validation sites in
     // DispatchAsync and by BuildParseErrorResult. Setting/Hint default to null (omitted from JSON).


### PR DESCRIPTION
## Summary of the Pull Request

Add a global `--json` flag to PowerDisplay CLI for scripting and automation. Commands emit compact JSON Lines results to stdout and structured errors to stderr, including parse errors and localized IPC errors. Text output remains the default.

## PR Stack

1. **This PR — CLI:** `main` ← `codex/powerdisplay-cli-json`
2. **#50432 — Command Palette:** `codex/powerdisplay-cli-json` ← `codex/cmdpal-powerdisplay-profiles`

Review and merge this PR first. After it is squash-merged, rebase the CmdPal-only commit onto the updated `main` and retarget #50432 to `main` before merging the second PR.

## PR Checklist

- Related issue: none linked.
- [ ] **Communication:** Discussed with core contributors.
- [ ] **Tests:** Added/updated and all pass. Historical results and exclusions are recorded below; tests were not rerun for the split.
- [x] **Localization:** Structured errors reuse existing CLI-localized messages and hints.
- [ ] **Dev docs:** Added/updated.
- **New binaries:** None added.
- [ ] **Documentation updated:** Follow-up documentation for the new CLI flag.

## Detailed Description of the Pull Request / Additional comments

- `src/modules/powerdisplay/PowerDisplay.Cli/Options/CliOptions.cs` and `Commands/PowerDisplayRootCommand.cs` register `--json` as a global presence flag.
- `src/modules/powerdisplay/PowerDisplay.Cli/Output/JsonCliOutput.cs` serializes all six existing result types with the source-generated v1.0 contracts and preserves structured error fields while localizing a copy of the error.
- `src/modules/powerdisplay/PowerDisplay.Cli/Program.cs` selects the renderer before handling parse errors; help and version output keep their existing behavior.
- `src/modules/powerdisplay/PowerDisplay.Cli.UnitTests/` covers serialization, stdout/stderr routing, localized errors, flag placement, and renderer selection.

The eight changed files are independent of Command Palette. Existing contracts and project references are sufficient; this PR adds no dependency or IPC schema change.

## Validation Steps Performed

- Split verification: this PR contains exactly the eight CLI and CLI-test files from original #50432 at `0936fecded49935870bf8016f5260b27b635959f`, with identical file contents.
- `git diff --check` passed. The two-PR stack reconstructs the original repository tree exactly.
- Builds/tests were not rerun for this history-only split; no source code was changed by the split.
- Historical validation reported in the original PR: Release/x64 build of `PowerDisplay.Cli.UnitTests` through `tools/build/build.ps1` passed with exit code 0; VSTest passed **108/108**, excluding `CliPipeClientTests`.
- That real-pipe class was excluded after two failures in a prior full run (116/118 passed) attributed to the installed PowerDisplay occupying the same pipe name. Those tests remain unvalidated in isolation.

