### PR TITLE
[Power Display] Allow disabling individual monitor options

### DIFF
--- a/src/modules/powerdisplay/PowerDisplay.Lib.UnitTests/DdcCiControllerVcpValueBlockTests.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib.UnitTests/DdcCiControllerVcpValueBlockTests.cs
@@ -1,0 +1,269 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PowerDisplay.Common.Drivers.DDC;
+using PowerDisplay.Common.Models;
+using PowerDisplay.Common.Services;
+using PowerDisplay.Models;
+using static PowerDisplay.UnitTests.DdcFakes;
+
+namespace PowerDisplay.UnitTests;
+
+/// <summary>
+/// Exercises the shared write boundary with an injected writer. The nonzero handles used here
+/// are test tokens; every read and write is injected, so these tests never access a monitor.
+/// </summary>
+[TestClass]
+public sealed class DdcCiControllerVcpValueBlockTests
+{
+    private const string AffectedMonitorId = @"\\?\DISPLAY#SAM105C#5&ABC&0&UID1";
+    private const string OtherMonitorId = @"\\?\DISPLAY#AOCB326#5&ABC&0&UID2";
+
+    [TestMethod]
+    public async Task HardwareRule_HardOffNeverReachesWriterEvenWhenUserAllowsIt()
+    {
+        var writer = new RecordingVcpWriter();
+        using var controller = NewController(writer, (_, _, _) => false);
+
+        var result = await controller.SetPowerStateAsync(NewMonitor(AffectedMonitorId), 0x05);
+
+        Assert.IsFalse(result.IsSuccess);
+        StringAssert.Contains(result.ErrorMessage!, "disabled");
+        Assert.AreEqual(0, writer.Writes.Count);
+    }
+
+    [TestMethod]
+    [DataRow(AffectedMonitorId, 0xD6, 0x01)]
+    [DataRow(AffectedMonitorId, 0xD6, 0x04)]
+    [DataRow(AffectedMonitorId, 0x14, 0x05)]
+    [DataRow(AffectedMonitorId, 0x60, 0x05)]
+    [DataRow(MonitorId, 0xD6, 0x05)]
+    public async Task HardwareRule_LeavesOtherStatesCodesAndMonitorsWritable(string monitorId, int code, int value)
+    {
+        var writer = new RecordingVcpWriter();
+        using var controller = NewController(writer);
+        var monitor = NewMonitor(monitorId);
+
+        var result = await WriteAsync(controller, monitor, code, value);
+
+        Assert.IsTrue(result.IsSuccess, result.ErrorMessage);
+        Assert.AreEqual(1, writer.Writes.Count);
+        Assert.AreEqual((monitor.Handle, (byte)code, (uint)value), writer.Writes[0]);
+    }
+
+    [TestMethod]
+    [DataRow(0x10)]
+    [DataRow(0x12)]
+    [DataRow(0x62)]
+    [DataRow(0x14)]
+    [DataRow(0x60)]
+    [DataRow(0xD6)]
+    public async Task UserRule_CoversEveryVcpWriteEntryPoint(int code)
+    {
+        var writer = new RecordingVcpWriter();
+        using var controller = NewController(
+            writer,
+            (id, vcpCode, value) => id == MonitorId && vcpCode == code && value == 30);
+
+        var result = await WriteAsync(controller, NewMonitor(), code, 30);
+
+        Assert.IsFalse(result.IsSuccess);
+        StringAssert.Contains(result.ErrorMessage!, "disabled");
+        Assert.AreEqual(0, writer.Writes.Count);
+    }
+
+    [TestMethod]
+    [DataRow(OtherMonitorId, 0x14, 0x05)]
+    [DataRow(MonitorId, 0x60, 0x05)]
+    [DataRow(MonitorId, 0x14, 0x06)]
+    public async Task UserRule_DoesNotBlockADifferentMonitorCodeOrValue(string monitorId, int code, int value)
+    {
+        var writer = new RecordingVcpWriter();
+        using var controller = NewController(
+            writer,
+            (id, vcpCode, rawValue) => id == MonitorId && vcpCode == 0x14 && rawValue == 0x05);
+
+        var result = await WriteAsync(controller, NewMonitor(monitorId), code, value);
+
+        Assert.IsTrue(result.IsSuccess, result.ErrorMessage);
+        Assert.AreEqual(1, writer.Writes.Count);
+        Assert.AreEqual((byte)code, writer.Writes[0].Code);
+        Assert.AreEqual((uint)value, writer.Writes[0].Value);
+    }
+
+    [TestMethod]
+    public async Task UserRule_ConsultsTheLatestSnapshotForEveryWrite()
+    {
+        using var manager = new MonitorManager(new RecordingKnownGoodStore());
+        var writer = new RecordingVcpWriter();
+        using var controller = NewController(writer, manager.IsVcpValueBlocked);
+        var monitor = NewMonitor();
+
+        var initiallyAllowed = await controller.SetPowerStateAsync(monitor, 0x05);
+        manager.SetDisabledVcpValues(new Dictionary<string, List<VcpValueBlock>>
+        {
+            [MonitorId] = new() { new() { VcpCode = 0xD6, Values = new() { 0x05 } } },
+        });
+        var disabled = await controller.SetPowerStateAsync(monitor, 0x05);
+        var wake = await controller.SetPowerStateAsync(monitor, 0x01);
+        manager.SetDisabledVcpValues(Array.Empty<KeyValuePair<string, List<VcpValueBlock>>>());
+        var allowedAgain = await controller.SetPowerStateAsync(monitor, 0x05);
+
+        Assert.IsTrue(initiallyAllowed.IsSuccess, initiallyAllowed.ErrorMessage);
+        Assert.IsFalse(disabled.IsSuccess);
+        StringAssert.Contains(disabled.ErrorMessage!, "disabled");
+        Assert.IsTrue(wake.IsSuccess, wake.ErrorMessage);
+        Assert.IsTrue(allowedAgain.IsSuccess, allowedAgain.ErrorMessage);
+        CollectionAssert.AreEqual(
+            new[]
+            {
+                (monitor.Handle, (byte)0xD6, 0x05U),
+                (monitor.Handle, (byte)0xD6, 0x01U),
+                (monitor.Handle, (byte)0xD6, 0x05U),
+            },
+            writer.Writes);
+    }
+
+    [TestMethod]
+    [DataRow(0x10, 50, 40, 60, 30)]
+    [DataRow(0x12, 80, 25, 50, 40)]
+    [DataRow(0x62, 200, 10, 20, 40)]
+    public async Task ContinuousWrites_CheckTheScaledRawValue(
+        int code,
+        int maximum,
+        int blockedPercentage,
+        int allowedPercentage,
+        int allowedRawValue)
+    {
+        var writer = new RecordingVcpWriter();
+        var checkedValues = new List<int>();
+        using var controller = NewController(writer, (id, vcpCode, value) =>
+        {
+            Assert.AreEqual(MonitorId, id);
+            Assert.AreEqual((byte)code, vcpCode);
+            checkedValues.Add(value);
+            return value == 20;
+        });
+        var monitor = NewMonitor();
+        monitor.BrightnessVcpMax = maximum;
+        monitor.ContrastVcpMax = maximum;
+        monitor.VolumeVcpMax = maximum;
+
+        var disabled = await WriteAsync(controller, monitor, code, blockedPercentage);
+        var allowed = await WriteAsync(controller, monitor, code, allowedPercentage);
+
+        Assert.IsFalse(disabled.IsSuccess);
+        StringAssert.Contains(disabled.ErrorMessage!, "disabled");
+        Assert.IsTrue(allowed.IsSuccess, allowed.ErrorMessage);
+        CollectionAssert.AreEqual(new[] { 20, allowedRawValue }, checkedValues);
+        Assert.AreEqual(1, writer.Writes.Count);
+        Assert.AreEqual((monitor.Handle, (byte)code, (uint)allowedRawValue), writer.Writes[0]);
+    }
+
+    [TestMethod]
+    public async Task WriteRestriction_IsCheckedBeforeHandleValidation()
+    {
+        var writer = new RecordingVcpWriter();
+        var blockWrite = true;
+        using var controller = NewController(writer, (_, _, _) => blockWrite);
+        var monitor = NewMonitor();
+        monitor.Handle = IntPtr.Zero;
+
+        var disabled = await controller.SetPowerStateAsync(monitor, 0x05);
+        blockWrite = false;
+        var invalidHandle = await controller.SetPowerStateAsync(monitor, 0x05);
+
+        Assert.IsFalse(disabled.IsSuccess);
+        StringAssert.Contains(disabled.ErrorMessage!, "disabled");
+        Assert.IsFalse(invalidHandle.IsSuccess);
+        Assert.AreEqual("Invalid monitor handle", invalidHandle.ErrorMessage);
+        Assert.AreEqual(0, writer.Writes.Count);
+    }
+
+    [TestMethod]
+    [DataRow(0x10)]
+    [DataRow(0x12)]
+    [DataRow(0x62)]
+    [DataRow(0x14)]
+    [DataRow(0x60)]
+    [DataRow(0xD6)]
+    public async Task Reads_DoNotConsultWriteRestrictions(int code)
+    {
+        var writer = new RecordingVcpWriter();
+        var reader = new RecordingVcpReader(VcpReadAttempt.Success(5, 100));
+        var restrictionCalls = 0;
+        using var controller = NewController(
+            writer,
+            (_, _, _) =>
+            {
+                restrictionCalls++;
+                return true;
+            },
+            reader);
+
+        var value = await ReadAsync(controller, NewMonitor(AffectedMonitorId), code);
+
+        Assert.IsTrue(value.IsValid);
+        Assert.AreEqual(5, value.Current);
+        Assert.AreEqual(0, restrictionCalls);
+        CollectionAssert.AreEqual(new[] { (byte)code }, reader.Codes);
+        Assert.AreEqual(0, writer.Writes.Count);
+    }
+
+    private static DdcCiController NewController(
+        RecordingVcpWriter writer,
+        Func<string, byte, int, bool>? isBlocked = null,
+        IVcpFeatureReader? reader = null) =>
+        new(
+            new RecordingKnownGoodStore(),
+            reader ?? new RecordingVcpReader(),
+            isVcpValueBlocked: isBlocked,
+            writeVcpFeature: writer.Write);
+
+    private static Monitor NewMonitor(string id = MonitorId) => new()
+    {
+        Id = id,
+        Handle = new IntPtr(123),
+        BrightnessVcpMax = 100,
+        ContrastVcpMax = 100,
+        VolumeVcpMax = 100,
+    };
+
+    private static Task<MonitorOperationResult> WriteAsync(DdcCiController controller, Monitor monitor, int code, int value) => code switch
+    {
+        0x10 => controller.SetBrightnessAsync(monitor, value),
+        0x12 => controller.SetContrastAsync(monitor, value),
+        0x62 => controller.SetVolumeAsync(monitor, value),
+        0x14 => controller.SetColorTemperatureAsync(monitor, value),
+        0x60 => controller.SetInputSourceAsync(monitor, value),
+        0xD6 => controller.SetPowerStateAsync(monitor, value),
+        _ => throw new ArgumentOutOfRangeException(nameof(code)),
+    };
+
+    private static Task<VcpFeatureValue> ReadAsync(DdcCiController controller, Monitor monitor, int code) => code switch
+    {
+        0x10 => controller.GetBrightnessAsync(monitor),
+        0x12 => controller.GetContrastAsync(monitor),
+        0x62 => controller.GetVolumeAsync(monitor),
+        0x14 => controller.GetColorTemperatureAsync(monitor),
+        0x60 => controller.GetInputSourceAsync(monitor),
+        0xD6 => controller.GetPowerStateAsync(monitor),
+        _ => throw new ArgumentOutOfRangeException(nameof(code)),
+    };
+
+    private sealed class RecordingVcpWriter
+    {
+        public List<(IntPtr Handle, byte Code, uint Value)> Writes { get; } = new();
+
+        public bool Write(IntPtr handle, byte code, uint value)
+        {
+            Writes.Add((handle, code, value));
+            return true;
+        }
+    }
+}

--- a/src/modules/powerdisplay/PowerDisplay.Lib.UnitTests/MonitorManagerVcpValueBlockTests.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib.UnitTests/MonitorManagerVcpValueBlockTests.cs
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PowerDisplay.Common.Services;
+using PowerDisplay.Models;
+using static PowerDisplay.UnitTests.DdcFakes;
+
+namespace PowerDisplay.UnitTests;
+
+/// <summary>
+/// Covers replacement and isolation of the settings snapshot consulted by DDC writes.
+/// Managers are never asked to discover monitors or perform hardware operations.
+/// </summary>
+[TestClass]
+public sealed class MonitorManagerVcpValueBlockTests
+{
+    private const string AffectedMonitorId = @"\\?\DISPLAY#SAM105C#5&ABC&0&UID1";
+    private const string OtherMonitorId = @"\\?\DISPLAY#AOCB326#5&ABC&0&UID2";
+
+    [TestMethod]
+    public void UserRules_MatchMonitorIdsIgnoringCaseButKeepInstancesAndCodesSeparate()
+    {
+        using var manager = new MonitorManager(new RecordingKnownGoodStore());
+        manager.SetDisabledVcpValues(new Dictionary<string, List<VcpValueBlock>>
+        {
+            [MonitorId] = new() { new() { VcpCode = 0xD6, Values = new() { 0x05 } } },
+            [OtherMonitorId] = new() { new() { VcpCode = 0x60, Values = new() { 0x1234 } } },
+        });
+
+        Assert.IsTrue(manager.IsVcpValueBlocked(MonitorId.ToLowerInvariant(), 0xD6, 0x05));
+        Assert.IsFalse(manager.IsVcpValueBlocked(OtherMonitorId, 0xD6, 0x05));
+        Assert.IsFalse(manager.IsVcpValueBlocked(MonitorId, 0x14, 0x05));
+        Assert.IsFalse(manager.IsVcpValueBlocked(MonitorId, 0xD6, 0x01));
+        Assert.IsTrue(manager.IsVcpValueBlocked(OtherMonitorId.ToLowerInvariant(), 0x60, 0x1234));
+        Assert.IsFalse(manager.IsVcpValueBlocked(OtherMonitorId, 0x60, 0x34));
+        Assert.IsFalse(manager.IsVcpValueBlocked(MonitorId, 0x60, 0x1234));
+    }
+
+    [TestMethod]
+    public void SetDisabledVcpValues_DeepCopiesEveryMutableLevel()
+    {
+        using var manager = new MonitorManager(new RecordingKnownGoodStore());
+        var values = new List<int> { 0x05 };
+        var block = new VcpValueBlock { VcpCode = 0xD6, Values = values };
+        var blocks = new List<VcpValueBlock> { block };
+        var entries = new Dictionary<string, List<VcpValueBlock>> { [MonitorId] = blocks };
+
+        manager.SetDisabledVcpValues(entries);
+
+        block.VcpCode = 0x60;
+        values.Clear();
+        values.Add(0x04);
+        blocks.Clear();
+        blocks.Add(new VcpValueBlock { VcpCode = 0x12, Values = new() { 30 } });
+        entries.Clear();
+
+        Assert.IsTrue(manager.IsVcpValueBlocked(MonitorId, 0xD6, 0x05));
+        Assert.IsFalse(manager.IsVcpValueBlocked(MonitorId, 0xD6, 0x04));
+        Assert.IsFalse(manager.IsVcpValueBlocked(MonitorId, 0x60, 0x05));
+        Assert.IsFalse(manager.IsVcpValueBlocked(MonitorId, 0x60, 0x04));
+        Assert.IsFalse(manager.IsVcpValueBlocked(MonitorId, 0x12, 30));
+    }
+
+    [TestMethod]
+    public void SetDisabledVcpValues_ReplacesAndClearsThePreviousSnapshot()
+    {
+        using var manager = new MonitorManager(new RecordingKnownGoodStore());
+        manager.SetDisabledVcpValues(new Dictionary<string, List<VcpValueBlock>>
+        {
+            [MonitorId] = new() { new() { VcpCode = 0xD6, Values = new() { 0x05 } } },
+        });
+        Assert.IsTrue(manager.IsVcpValueBlocked(MonitorId, 0xD6, 0x05));
+
+        manager.SetDisabledVcpValues(new Dictionary<string, List<VcpValueBlock>>
+        {
+            [OtherMonitorId] = new() { new() { VcpCode = 0x60, Values = new() { 0x11 } } },
+        });
+        Assert.IsFalse(manager.IsVcpValueBlocked(MonitorId, 0xD6, 0x05));
+        Assert.IsTrue(manager.IsVcpValueBlocked(OtherMonitorId, 0x60, 0x11));
+
+        manager.SetDisabledVcpValues(Array.Empty<KeyValuePair<string, List<VcpValueBlock>>>());
+        Assert.IsFalse(manager.IsVcpValueBlocked(MonitorId, 0xD6, 0x05));
+        Assert.IsFalse(manager.IsVcpValueBlocked(OtherMonitorId, 0x60, 0x11));
+    }
+
+    [TestMethod]
+    public void HardwareRules_CannotBeOverriddenByEmptyOrReplacedUserSettings()
+    {
+        using var manager = new MonitorManager(new RecordingKnownGoodStore());
+        Assert.IsTrue(manager.IsVcpValueBlocked(AffectedMonitorId, 0xD6, 0x05));
+
+        manager.SetDisabledVcpValues(new Dictionary<string, List<VcpValueBlock>>
+        {
+            [AffectedMonitorId.ToLowerInvariant()] = new() { new() { VcpCode = 0xD6, Values = new() { 0x04 } } },
+        });
+        Assert.IsTrue(manager.IsVcpValueBlocked(AffectedMonitorId, 0xD6, 0x04));
+        Assert.IsTrue(manager.IsVcpValueBlocked(AffectedMonitorId, 0xD6, 0x05));
+        Assert.IsFalse(manager.IsVcpValueBlocked(AffectedMonitorId, 0xD6, 0x01));
+
+        manager.SetDisabledVcpValues(new Dictionary<string, List<VcpValueBlock>> { [AffectedMonitorId] = new() });
+        Assert.IsFalse(manager.IsVcpValueBlocked(AffectedMonitorId, 0xD6, 0x04));
+        Assert.IsTrue(manager.IsVcpValueBlocked(AffectedMonitorId, 0xD6, 0x05));
+
+        manager.SetDisabledVcpValues(Array.Empty<KeyValuePair<string, List<VcpValueBlock>>>());
+        Assert.IsTrue(manager.IsVcpValueBlocked(AffectedMonitorId, 0xD6, 0x05));
+        Assert.IsFalse(manager.IsVcpValueBlocked(MonitorId, 0xD6, 0x05));
+        Assert.IsFalse(manager.IsVcpValueBlocked(AffectedMonitorId, 0x14, 0x05));
+    }
+
+    [TestMethod]
+    public void SetDisabledVcpValues_IgnoresEmptyIdsAndNullRules()
+    {
+        using var manager = new MonitorManager(new RecordingKnownGoodStore());
+        manager.SetDisabledVcpValues(new List<KeyValuePair<string, List<VcpValueBlock>>>
+        {
+            new(null!, new() { new() { VcpCode = 0xD6, Values = new() { 0x05 } } }),
+            new(string.Empty, new() { new() { VcpCode = 0xD6, Values = new() { 0x05 } } }),
+            new(MonitorId, null!),
+            new(OtherMonitorId, new() { null!, new() { VcpCode = 0xD6, Values = null! } }),
+        });
+
+        Assert.IsFalse(manager.IsVcpValueBlocked(string.Empty, 0xD6, 0x05));
+        Assert.IsFalse(manager.IsVcpValueBlocked(MonitorId, 0xD6, 0x05));
+        Assert.IsFalse(manager.IsVcpValueBlocked(OtherMonitorId, 0xD6, 0x05));
+        Assert.IsTrue(manager.IsVcpValueBlocked(AffectedMonitorId, 0xD6, 0x05));
+    }
+}

--- a/src/modules/powerdisplay/PowerDisplay.Lib.UnitTests/VcpValueRestrictionsTests.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib.UnitTests/VcpValueRestrictionsTests.cs
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PowerDisplay.Models;
+
+namespace PowerDisplay.UnitTests;
+
+[TestClass]
+public class VcpValueRestrictionsTests
+{
+    private const string AffectedMonitor = @"\\?\DISPLAY#SAM105C#5&abc&0&UID111";
+    private const string OtherMonitor = @"\\?\DISPLAY#DELD1A8#5&abc&0&UID222";
+
+    [TestMethod]
+    [DataRow(@"\\?\DISPLAY#SAM105C#5&abc&0&UID111")]
+    [DataRow(@"\\?\display#sam105c#5&xyz&0&uid222")]
+    [DataRow(@"\\?\DISPLAY#SAM105C#5&xyz&0&UID333#{guid}")]
+    public void HardwareRule_MatchesModelRegardlessOfCaseOrInstance(string monitorId)
+    {
+        Assert.IsTrue(VcpValueRestrictions.IsBlockedByHardware(monitorId, 0xD6, 0x05));
+        StringAssert.Contains(
+            VcpValueRestrictions.GetHardwareBlockReason(monitorId, 0xD6, 0x05)!,
+            "https://github.com/microsoft/PowerToys/issues/50449");
+    }
+
+    [TestMethod]
+    public void HardwareRule_OnlyBlocksTheSpecifiedModelCodeAndValue()
+    {
+        Assert.IsTrue(VcpValueRestrictions.IsBlockedByHardware(AffectedMonitor, 0xD6, 0x05));
+        Assert.IsFalse(VcpValueRestrictions.IsBlockedByHardware(OtherMonitor, 0xD6, 0x05));
+        Assert.IsFalse(VcpValueRestrictions.IsBlockedByHardware(AffectedMonitor, 0xD6, 0x01));
+        Assert.IsFalse(VcpValueRestrictions.IsBlockedByHardware(AffectedMonitor, 0xD6, 0x04));
+        Assert.IsFalse(VcpValueRestrictions.IsBlockedByHardware(AffectedMonitor, 0x14, 0x05));
+        Assert.IsFalse(VcpValueRestrictions.IsBlockedByHardware(AffectedMonitor, 0xD6, 0x105));
+        Assert.IsNull(VcpValueRestrictions.GetHardwareBlockReason(AffectedMonitor, 0xD6, 0x04));
+    }
+
+    [TestMethod]
+    [DataRow(null)]
+    [DataRow("")]
+    [DataRow("SAM105C")]
+    [DataRow(@"\\?\DISPLAY#SAM105C")]
+    [DataRow(@"\\?\DISPLAY##instance")]
+    public void HardwareRule_UnrecognizedMonitorIdDoesNotMatch(string? monitorId)
+    {
+        Assert.IsFalse(VcpValueRestrictions.IsBlockedByHardware(monitorId!, 0xD6, 0x05));
+        Assert.IsNull(VcpValueRestrictions.GetHardwareBlockReason(monitorId!, 0xD6, 0x05));
+    }
+
+    [TestMethod]
+    public void UserRules_SupportMultipleCodesAndValuesWithoutTruncatingToAByte()
+    {
+        var userBlocks = new List<VcpValueBlock>
+        {
+            new() { VcpCode = 0x60, Values = new List<int> { 0x11, 0x12 } },
+            new() { VcpCode = 0xE0, Values = new List<int> { 0x1234 } },
+        };
+
+        Assert.IsTrue(VcpValueRestrictions.IsBlocked(OtherMonitor, 0x60, 0x11, userBlocks));
+        Assert.IsTrue(VcpValueRestrictions.IsBlocked(OtherMonitor, 0x60, 0x12, userBlocks));
+        Assert.IsTrue(VcpValueRestrictions.IsBlocked(OtherMonitor, 0xE0, 0x1234, userBlocks));
+        Assert.IsFalse(VcpValueRestrictions.IsBlocked(OtherMonitor, 0x60, 0x0F, userBlocks));
+        Assert.IsFalse(VcpValueRestrictions.IsBlocked(OtherMonitor, 0xE0, 0x34, userBlocks));
+        Assert.IsFalse(VcpValueRestrictions.IsBlocked(OtherMonitor, 0xE1, 0x1234, userBlocks));
+    }
+
+    [TestMethod]
+    public void CombinedRules_AreAUnionAndUserRulesCannotOverrideHardwareRules()
+    {
+        var userBlocks = new List<VcpValueBlock>
+        {
+            new() { VcpCode = 0xD6, Values = new List<int> { 0x04 } },
+        };
+
+        Assert.IsTrue(VcpValueRestrictions.IsBlocked(AffectedMonitor, 0xD6, 0x04, userBlocks));
+        Assert.IsTrue(VcpValueRestrictions.IsBlocked(AffectedMonitor, 0xD6, 0x05, userBlocks));
+        Assert.IsFalse(VcpValueRestrictions.IsBlocked(AffectedMonitor, 0xD6, 0x01, userBlocks));
+        Assert.IsFalse(VcpValueRestrictions.IsBlockedByHardware(AffectedMonitor, 0xD6, 0x04));
+
+        userBlocks.Clear();
+
+        Assert.IsTrue(VcpValueRestrictions.IsBlocked(AffectedMonitor, 0xD6, 0x05, userBlocks));
+        Assert.IsFalse(VcpValueRestrictions.IsBlocked(AffectedMonitor, 0xD6, 0x04, userBlocks));
+        Assert.IsTrue(VcpValueRestrictions.IsBlocked(AffectedMonitor, 0xD6, 0x05, null));
+    }
+
+    [TestMethod]
+    public void UserRules_NullListsEntriesAndValuesAreSafe()
+    {
+        var userBlocks = new List<VcpValueBlock>
+        {
+            null!,
+            new() { VcpCode = 0xD6, Values = null! },
+        };
+
+        Assert.IsFalse(VcpValueRestrictions.IsBlocked(OtherMonitor, 0xD6, 0x05, null));
+        Assert.IsFalse(VcpValueRestrictions.IsBlocked(OtherMonitor, 0xD6, 0x05, userBlocks));
+        Assert.IsTrue(VcpValueRestrictions.IsBlocked(AffectedMonitor, 0xD6, 0x05, userBlocks));
+    }
+}

--- a/src/modules/powerdisplay/PowerDisplay.Lib.UnitTests/VcpValueSettingsTests.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib.UnitTests/VcpValueSettingsTests.cs
@@ -1,0 +1,185 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PowerDisplay.Models;
+
+namespace PowerDisplay.UnitTests;
+
+[TestClass]
+public class VcpValueSettingsTests
+{
+    private static readonly int[] OriginalColorPresetValues = { 0x05, 0x08 };
+    private static readonly int[] UpdatedColorPresetValues = { 0x05, 0x06 };
+
+    [TestMethod]
+    public void Rule_SourceGeneratedJsonPersistsNumericCodeAndValues()
+    {
+        var rule = new VcpValueBlock { VcpCode = 0xE0, Values = new List<int> { 0x05, 0x1234 } };
+
+        var json = JsonSerializer.Serialize(rule, VcpValueSerializationContext.Default.VcpValueBlock);
+        using var document = JsonDocument.Parse(json);
+        var restored = JsonSerializer.Deserialize(json, VcpValueSerializationContext.Default.VcpValueBlock);
+
+        Assert.AreEqual(JsonValueKind.Number, document.RootElement.GetProperty("vcpCode").ValueKind);
+        Assert.AreEqual(224, document.RootElement.GetProperty("vcpCode").GetInt32());
+        Assert.AreEqual(JsonValueKind.Number, document.RootElement.GetProperty("values")[1].ValueKind);
+        Assert.AreEqual(4660, document.RootElement.GetProperty("values")[1].GetInt32());
+        Assert.IsNotNull(restored);
+        Assert.AreEqual(rule.VcpCode, restored.VcpCode);
+        CollectionAssert.AreEqual(rule.Values, restored.Values);
+    }
+
+    [TestMethod]
+    [DataRow("{}")]
+    [DataRow("{\"disabledVcpValues\":null}")]
+    public void Monitor_LegacyAndNullJsonDefaultToEmptyRules(string json)
+    {
+        var monitor = JsonSerializer.Deserialize(json, SettingsSerializationContext.Default.MonitorInfo);
+
+        Assert.IsNotNull(monitor);
+        Assert.IsNotNull(monitor.DisabledVcpValues);
+        Assert.AreEqual(0, monitor.DisabledVcpValues.Count);
+    }
+
+    [TestMethod]
+    public void Monitor_SourceGeneratedJsonRoundTripPreservesRules()
+    {
+        var original = new MonitorInfo
+        {
+            Id = @"\\?\DISPLAY#SAM105C#5&abc&0&UID111",
+            DisabledVcpValues = new List<VcpValueBlock>
+            {
+                new() { VcpCode = 0xD6, Values = new List<int> { 0x04, 0x05 } },
+                new() { VcpCode = 0x60, Values = new List<int> { 0x11 } },
+            },
+        };
+
+        var json = JsonSerializer.Serialize(original, SettingsSerializationContext.Default.MonitorInfo);
+        using var document = JsonDocument.Parse(json);
+        var rules = document.RootElement.GetProperty("disabledVcpValues");
+        var restored = JsonSerializer.Deserialize(json, SettingsSerializationContext.Default.MonitorInfo);
+
+        Assert.AreEqual(214, rules[0].GetProperty("vcpCode").GetInt32());
+        Assert.AreEqual(5, rules[0].GetProperty("values")[1].GetInt32());
+        Assert.IsNotNull(restored);
+        Assert.AreEqual(original.Id, restored.Id);
+        Assert.AreEqual(2, restored.DisabledVcpValues.Count);
+        Assert.AreEqual((byte)0xD6, restored.DisabledVcpValues[0].VcpCode);
+        CollectionAssert.AreEqual(original.DisabledVcpValues[0].Values, restored.DisabledVcpValues[0].Values);
+        Assert.AreEqual((byte)0x60, restored.DisabledVcpValues[1].VcpCode);
+    }
+
+    [TestMethod]
+    public void Rule_NullValuesJsonNormalizesToEmptyList()
+    {
+        const string json = "{\"vcpCode\":214,\"values\":null}";
+
+        var rule = JsonSerializer.Deserialize(json, VcpValueSerializationContext.Default.VcpValueBlock);
+
+        Assert.IsNotNull(rule);
+        Assert.IsNotNull(rule.Values);
+        Assert.AreEqual(0, rule.Values.Count);
+    }
+
+    [TestMethod]
+    public void Monitor_UpdateFromCopiesRestrictionsWithoutSharingMutableLists()
+    {
+        var source = new MonitorInfo
+        {
+            DisabledVcpValues = new List<VcpValueBlock>
+            {
+                new() { VcpCode = 0xD6, Values = new List<int> { 0x05 } },
+            },
+        };
+        var target = new MonitorInfo();
+        var notifications = new List<string?>();
+        target.PropertyChanged += (_, args) => notifications.Add(args.PropertyName);
+
+        target.UpdateFrom(source);
+
+        Assert.AreEqual(1, target.DisabledVcpValues.Count);
+        Assert.AreEqual((byte)0xD6, target.DisabledVcpValues[0].VcpCode);
+        Assert.AreEqual(0x05, target.DisabledVcpValues[0].Values.Single());
+        CollectionAssert.Contains(notifications, nameof(MonitorInfo.DisabledVcpValues));
+        Assert.AreNotSame(source.DisabledVcpValues, target.DisabledVcpValues);
+        Assert.AreNotSame(source.DisabledVcpValues[0].Values, target.DisabledVcpValues[0].Values);
+
+        source.DisabledVcpValues[0].Values.Clear();
+
+        Assert.AreEqual(0x05, target.DisabledVcpValues[0].Values.Single());
+    }
+
+    [TestMethod]
+    public void Monitor_ReplacingRulesInvalidatesColorPresetsAndDoesNotReinsertBlockedCurrentValue()
+    {
+        var monitor = CreateColorPresetMonitor();
+        var originalPresets = monitor.ColorPresetsForDisplay;
+
+        monitor.DisabledVcpValues = new List<VcpValueBlock>
+        {
+            new() { VcpCode = 0x14, Values = new List<int> { 0x05 } },
+        };
+
+        Assert.AreNotSame(originalPresets, monitor.ColorPresetsForDisplay);
+        Assert.AreEqual(0x08, monitor.ColorPresetsForDisplay.Single().VcpValue);
+        Assert.AreEqual(0x05, monitor.ColorTemperatureVcp, "Restrictions must not change the observed current value.");
+        Assert.AreEqual(2, monitor.VcpCodesFormatted[0].ValueList.Count, "Raw supported options remain available for the restriction editor.");
+
+        monitor.DisabledVcpValues = null!;
+
+        Assert.IsNotNull(monitor.DisabledVcpValues);
+        CollectionAssert.AreEqual(OriginalColorPresetValues, monitor.ColorPresetsForDisplay.Select(preset => preset.VcpValue).ToArray());
+    }
+
+    [TestMethod]
+    public void Monitor_SupportOptionsUpdateWhenValuesAndNamesChangeWithoutChangingCount()
+    {
+        var monitor = CreateColorPresetMonitor();
+        var originalPresets = monitor.ColorPresetsForDisplay;
+
+        monitor.VcpCodesFormatted = new List<VcpCodeDisplayInfo>
+        {
+            new()
+            {
+                Code = "0x14",
+                ValueList = new List<VcpValueInfo>
+                {
+                    new() { Value = "0x05", Name = "Custom warm" },
+                    new() { Value = "0x06", Name = "7500 K" },
+                },
+            },
+        };
+
+        Assert.AreNotSame(originalPresets, monitor.ColorPresetsForDisplay);
+        CollectionAssert.AreEqual(UpdatedColorPresetValues, monitor.ColorPresetsForDisplay.Select(preset => preset.VcpValue).ToArray());
+        Assert.AreEqual("Custom warm", monitor.VcpCodesFormatted[0].ValueList[0].Name);
+        Assert.AreEqual("Custom warm", monitor.ColorPresetsForDisplay[0].DisplayName);
+    }
+
+    private static MonitorInfo CreateColorPresetMonitor()
+    {
+        return new MonitorInfo
+        {
+            SupportsColorTemperature = true,
+            ColorTemperatureVcp = 0x05,
+            VcpCodesFormatted = new List<VcpCodeDisplayInfo>
+            {
+                new()
+                {
+                    Code = "0x14",
+                    ValueList = new List<VcpValueInfo>
+                    {
+                        new() { Value = "0x05", Name = "6500 K" },
+                        new() { Value = "0x08", Name = "9300 K" },
+                    },
+                },
+            },
+        };
+    }
+}

--- a/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/DDC/DdcCiController.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/DDC/DdcCiController.cs
@@ -39,6 +39,8 @@ namespace PowerDisplay.Common.Drivers.DDC
         private readonly VcpFeatureProbeService _probeService;
         private readonly ContinuousVcpInitializer _continuousInitializer;
         private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync;
+        private readonly Func<string, byte, int, bool>? _isVcpValueBlocked;
+        private readonly Func<IntPtr, byte, uint, bool> _writeVcpFeature;
 
         private bool _disposed;
 
@@ -54,9 +56,17 @@ namespace PowerDisplay.Common.Drivers.DDC
         /// silently loses the discovery cache that maximum compatibility mode depends on.
         /// </param>
         public DdcCiController(IKnownGoodVcpStore knownGoodStore)
+            : this(knownGoodStore, new NativeVcpFeatureReader())
+        {
+        }
+
+        internal DdcCiController(
+            IKnownGoodVcpStore knownGoodStore,
+            Func<string, byte, int, bool> isVcpValueBlocked)
             : this(
                 knownGoodStore,
-                new NativeVcpFeatureReader())
+                new NativeVcpFeatureReader(),
+                isVcpValueBlocked: isVcpValueBlocked)
         {
         }
 
@@ -66,14 +76,20 @@ namespace PowerDisplay.Common.Drivers.DDC
         /// Pacing delay for the capabilities retry loop and the VCP probe. Injected so tests can
         /// drive the discovery pipeline without waiting out the real inter-transaction intervals.
         /// </param>
+        /// <param name="isVcpValueBlocked">Optional user restriction lookup for raw VCP writes.</param>
+        /// <param name="writeVcpFeature">Optional native writer replacement for hardware-free tests.</param>
         internal DdcCiController(
             IKnownGoodVcpStore knownGoodStore,
             IVcpFeatureReader reader,
-            Func<TimeSpan, CancellationToken, Task>? delayAsync = null)
+            Func<TimeSpan, CancellationToken, Task>? delayAsync = null,
+            Func<string, byte, int, bool>? isVcpValueBlocked = null,
+            Func<IntPtr, byte, uint, bool>? writeVcpFeature = null)
         {
             _knownGoodStore = knownGoodStore;
             _vcpReader = reader;
             _delayAsync = delayAsync ?? Task.Delay;
+            _isVcpValueBlocked = isVcpValueBlocked;
+            _writeVcpFeature = writeVcpFeature ?? SetVCPFeature;
             _probeService = new VcpFeatureProbeService(_vcpReader, _delayAsync);
             _continuousInitializer = new ContinuousVcpInitializer(_vcpReader, _knownGoodStore);
             _discoveryHelper = new MonitorDiscoveryHelper();
@@ -904,6 +920,12 @@ namespace PowerDisplay.Common.Drivers.DDC
             return Task.Run(
                 () =>
                 {
+                    if (VcpValueRestrictions.IsBlockedByHardware(monitor.Id, vcpCode, value) ||
+                        _isVcpValueBlocked?.Invoke(monitor.Id, vcpCode, value) == true)
+                    {
+                        return MonitorOperationResult.Failure($"VCP 0x{vcpCode:X2} value 0x{value:X2} is disabled for this monitor");
+                    }
+
                     if (monitor.Handle == IntPtr.Zero)
                     {
                         return MonitorOperationResult.Failure("Invalid monitor handle");
@@ -911,7 +933,7 @@ namespace PowerDisplay.Common.Drivers.DDC
 
                     try
                     {
-                        if (SetVCPFeature(monitor.Handle, vcpCode, (uint)value))
+                        if (_writeVcpFeature(monitor.Handle, vcpCode, (uint)value))
                         {
                             RefreshKnownGoodAfterWrite(monitor, vcpCode, value);
                             return MonitorOperationResult.Success();

--- a/src/modules/powerdisplay/PowerDisplay.Lib/Models/MonitorIdentity.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Models/MonitorIdentity.cs
@@ -87,21 +87,7 @@ public static class MonitorIdentity
     /// <param name="monitorId">A Monitor.Id (no trailing <c>#{guid}</c>) or a raw DevicePath (with trailing <c>#{guid}</c>).</param>
     /// <returns>EdidId segment (e.g. <c>"DELD1A8"</c>), or empty string if the input is not a recognized form.</returns>
     public static string EdidIdFromMonitorId(string? monitorId)
-    {
-        if (string.IsNullOrEmpty(monitorId))
-        {
-            return string.Empty;
-        }
-
-        // Split: ["\\?\DISPLAY", "DELD1A8", "5&abc&0&UID12345"]
-        var parts = monitorId.Split('#');
-        if (parts.Length < 3 || string.IsNullOrEmpty(parts[1]))
-        {
-            return string.Empty;
-        }
-
-        return parts[1];
-    }
+        => PowerDisplay.Models.MonitorHardwareId.EdidIdFromMonitorId(monitorId);
 
     /// <summary>
     /// Return true if <paramref name="monitorId"/> matches the legacy

--- a/src/modules/powerdisplay/PowerDisplay.Lib/Services/MonitorManager.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Services/MonitorManager.cs
@@ -35,6 +35,9 @@ namespace PowerDisplay.Common.Services
         // Built-in entries are loaded automatically by the service constructor.
         private readonly MonitorBlacklistService _blacklistService = new();
 
+        private IReadOnlyDictionary<string, List<VcpValueBlock>> _disabledVcpValues =
+            new Dictionary<string, List<VcpValueBlock>>(MonitorIdComparer.Instance);
+
         // Controllers stored by type for O(1) lookup based on CommunicationMethod
         private DdcCiController? _ddcController;
         private WmiController? _wmiController;
@@ -58,7 +61,7 @@ namespace PowerDisplay.Common.Services
             try
             {
                 // DDC/CI controller (external monitors)
-                _ddcController = new DdcCiController(knownGoodStore);
+                _ddcController = new DdcCiController(knownGoodStore, IsVcpValueBlocked);
             }
             catch (Exception ex)
             {
@@ -88,6 +91,46 @@ namespace PowerDisplay.Common.Services
             {
                 _ddcController.MaxCompatibilityMode = enabled;
             }
+        }
+
+        /// <summary>
+        /// Replaces the user-disabled raw VCP values with a snapshot of the current settings.
+        /// The DDC writer consults this snapshot immediately before sending a command.
+        /// </summary>
+        public void SetDisabledVcpValues(IEnumerable<KeyValuePair<string, List<VcpValueBlock>>> entries)
+        {
+            ArgumentNullException.ThrowIfNull(entries);
+
+            var snapshot = new Dictionary<string, List<VcpValueBlock>>(MonitorIdComparer.Instance);
+            foreach (var entry in entries)
+            {
+                if (string.IsNullOrEmpty(entry.Key))
+                {
+                    continue;
+                }
+
+                snapshot[entry.Key] = entry.Value?
+                    .Where(block => block != null)
+                    .Select(block => new VcpValueBlock
+                    {
+                        VcpCode = block.VcpCode,
+                        Values = block.Values?.ToList() ?? new List<int>(),
+                    })
+                    .ToList() ?? new List<VcpValueBlock>();
+            }
+
+            Volatile.Write(ref _disabledVcpValues, snapshot);
+        }
+
+        /// <summary>
+        /// Reports whether a raw VCP value is disabled by the user or a hardware compatibility rule.
+        /// Does not change the monitor's advertised capabilities or perform hardware I/O.
+        /// </summary>
+        public bool IsVcpValueBlocked(string monitorId, byte vcpCode, int value)
+        {
+            var snapshot = Volatile.Read(ref _disabledVcpValues);
+            snapshot.TryGetValue(monitorId, out var userBlocks);
+            return VcpValueRestrictions.IsBlocked(monitorId, vcpCode, value, userBlocks);
         }
 
         /// <summary>

--- a/src/modules/powerdisplay/PowerDisplay.Models/BuiltInVcpValueBlacklist.json
+++ b/src/modules/powerdisplay/PowerDisplay.Models/BuiltInVcpValueBlacklist.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "entries": [
+    {
+      "edidId": "SAM105C",
+      "vcpCode": 214,
+      "values": [5],
+      "comments": "Off (Hard) can leave the monitor unresponsive. See https://github.com/microsoft/PowerToys/issues/50449"
+    }
+  ]
+}

--- a/src/modules/powerdisplay/PowerDisplay.Models/BuiltInVcpValueBlacklistFile.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Models/BuiltInVcpValueBlacklistFile.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace PowerDisplay.Models
+{
+    /// <summary>
+    /// Versioned JSON shape for the built-in restrictions on VCP values.
+    /// </summary>
+    public class BuiltInVcpValueBlacklistFile
+    {
+        [JsonPropertyName("version")]
+        public int Version { get; set; }
+
+        [JsonPropertyName("entries")]
+        public List<VcpValueBlacklistEntry> Entries { get; set; } = new();
+    }
+}

--- a/src/modules/powerdisplay/PowerDisplay.Models/MonitorHardwareId.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Models/MonitorHardwareId.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace PowerDisplay.Models
+{
+    /// <summary>
+    /// Extracts the model identifier shared by monitors of the same model without
+    /// retaining the per-instance part of a Windows monitor device path.
+    /// </summary>
+    public static class MonitorHardwareId
+    {
+        /// <summary>
+        /// Extracts the EDID PnP identifier from a canonical Monitor.Id or a raw
+        /// QueryDisplayConfig device path. Unrecognized forms return an empty string.
+        /// </summary>
+        public static string EdidIdFromMonitorId(string? monitorId)
+        {
+            if (string.IsNullOrEmpty(monitorId))
+            {
+                return string.Empty;
+            }
+
+            // Both forms place the EDID identifier between the first two '#' separators.
+            var parts = monitorId.Split('#');
+            if (parts.Length < 3 || string.IsNullOrEmpty(parts[1]))
+            {
+                return string.Empty;
+            }
+
+            return parts[1];
+        }
+    }
+}

--- a/src/modules/powerdisplay/PowerDisplay.Models/PowerDisplay.Models.csproj
+++ b/src/modules/powerdisplay/PowerDisplay.Models/PowerDisplay.Models.csproj
@@ -22,5 +22,6 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="BuiltInMonitorBlacklist.json" />
+    <EmbeddedResource Include="BuiltInVcpValueBlacklist.json" />
   </ItemGroup>
 </Project>

--- a/src/modules/powerdisplay/PowerDisplay.Models/VcpValueBlacklistEntry.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Models/VcpValueBlacklistEntry.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json.Serialization;
+
+namespace PowerDisplay.Models
+{
+    /// <summary>
+    /// Known problematic values for one VCP code on a monitor model. Unlike a whole
+    /// monitor blacklist entry, this restriction only prevents matching writes.
+    /// </summary>
+    public class VcpValueBlacklistEntry : VcpValueBlock
+    {
+        [JsonPropertyName("edidId")]
+        public string EdidId { get; set; } = string.Empty;
+
+        [JsonPropertyName("comments")]
+        public string Comments { get; set; } = string.Empty;
+    }
+}

--- a/src/modules/powerdisplay/PowerDisplay.Models/VcpValueBlock.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Models/VcpValueBlock.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace PowerDisplay.Models
+{
+    /// <summary>
+    /// Values that must not be written to one VCP code. Values are persisted as
+    /// numbers so display names and localization never affect the restriction.
+    /// </summary>
+    public class VcpValueBlock
+    {
+        private List<int> _values = new();
+
+        [JsonPropertyName("vcpCode")]
+        public byte VcpCode { get; set; }
+
+        [JsonPropertyName("values")]
+        public List<int> Values
+        {
+            get => _values;
+            set => _values = value ?? new List<int>();
+        }
+    }
+}

--- a/src/modules/powerdisplay/PowerDisplay.Models/VcpValueRestrictions.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Models/VcpValueRestrictions.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+
+namespace PowerDisplay.Models
+{
+    /// <summary>
+    /// Combines per-monitor user restrictions with the built-in hardware rules.
+    /// These rules apply to writes only; they do not change VCP reads or discovery.
+    /// </summary>
+    public static class VcpValueRestrictions
+    {
+        private const string ResourceName = "PowerDisplay.Models.BuiltInVcpValueBlacklist.json";
+
+        private static readonly Lazy<IReadOnlyList<VcpValueBlacklistEntry>> _hardwareBlocks = new(LoadHardwareBlocks);
+
+        public static bool IsBlocked(string monitorId, byte vcpCode, int value, IEnumerable<VcpValueBlock>? userBlocks)
+        {
+            return IsBlockedByHardware(monitorId, vcpCode, value)
+                || (userBlocks?.Any(block => block != null && block.VcpCode == vcpCode && block.Values.Contains(value)) ?? false);
+        }
+
+        public static bool IsBlockedByHardware(string monitorId, byte vcpCode, int value)
+        {
+            return FindHardwareBlock(monitorId, vcpCode, value) != null;
+        }
+
+        /// <summary>
+        /// Returns the built-in explanation for a matching restriction, or null when allowed.
+        /// Comments include the source issue and are displayed as shipped, like monitor blacklist comments.
+        /// </summary>
+        public static string? GetHardwareBlockReason(string monitorId, byte vcpCode, int value)
+        {
+            return FindHardwareBlock(monitorId, vcpCode, value)?.Comments;
+        }
+
+        private static VcpValueBlacklistEntry? FindHardwareBlock(string monitorId, byte vcpCode, int value)
+        {
+            var edidId = MonitorHardwareId.EdidIdFromMonitorId(monitorId);
+            if (string.IsNullOrEmpty(edidId))
+            {
+                return null;
+            }
+
+            return _hardwareBlocks.Value.FirstOrDefault(block =>
+                string.Equals(block.EdidId, edidId, StringComparison.OrdinalIgnoreCase)
+                && block.VcpCode == vcpCode
+                && block.Values.Contains(value));
+        }
+
+        private static IReadOnlyList<VcpValueBlacklistEntry> LoadHardwareBlocks()
+        {
+            // Follow the existing embedded monitor blacklist loader: load once, without
+            // introducing a logging or reflection-based serialization dependency in Models.
+            try
+            {
+                using var stream = typeof(VcpValueRestrictions).Assembly.GetManifestResourceStream(ResourceName);
+                if (stream == null)
+                {
+                    return Array.Empty<VcpValueBlacklistEntry>();
+                }
+
+                var file = JsonSerializer.Deserialize(stream, VcpValueSerializationContext.Default.BuiltInVcpValueBlacklistFile);
+                if (file?.Version != 1 || file.Entries == null)
+                {
+                    return Array.Empty<VcpValueBlacklistEntry>();
+                }
+
+                return file.Entries
+                    .Where(entry => entry != null && !string.IsNullOrWhiteSpace(entry.EdidId))
+                    .Select(entry => new VcpValueBlacklistEntry
+                    {
+                        EdidId = entry.EdidId.Trim().ToUpperInvariant(),
+                        VcpCode = entry.VcpCode,
+                        Values = entry.Values,
+                        Comments = entry.Comments ?? string.Empty,
+                    })
+                    .ToList();
+            }
+            catch
+            {
+                return Array.Empty<VcpValueBlacklistEntry>();
+            }
+        }
+    }
+}

--- a/src/modules/powerdisplay/PowerDisplay.Models/VcpValueSerializationContext.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Models/VcpValueSerializationContext.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace PowerDisplay.Models
+{
+    /// <summary>
+    /// Source-generated serialization for VCP value restrictions, including Native AOT.
+    /// </summary>
+    [JsonSourceGenerationOptions(
+        WriteIndented = false,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never)]
+    [JsonSerializable(typeof(VcpValueBlock))]
+    [JsonSerializable(typeof(List<VcpValueBlock>))]
+    [JsonSerializable(typeof(BuiltInVcpValueBlacklistFile))]
+    public partial class VcpValueSerializationContext : JsonSerializerContext
+    {
+    }
+}

--- a/src/modules/powerdisplay/PowerDisplay/ViewModels/MainViewModel.Monitors.cs
+++ b/src/modules/powerdisplay/PowerDisplay/ViewModels/MainViewModel.Monitors.cs
@@ -33,6 +33,8 @@ public partial class MainViewModel
             var settings = _settingsUtils.GetSettingsOrDefault<PowerDisplaySettings>(PowerDisplaySettings.ModuleName);
             _monitorManager.SetMaxCompatibilityMode(settings.Properties.MaxCompatibilityMode);
 
+            ApplyVcpValueRestrictions(settings);
+
             // Discover monitors
             var monitors = await _monitorManager.DiscoverMonitorsAsync(cancellationToken);
 
@@ -123,6 +125,8 @@ public partial class MainViewModel
             var settings = _settingsUtils.GetSettingsOrDefault<PowerDisplaySettings>(PowerDisplaySettings.ModuleName);
             _monitorManager.SetMaxCompatibilityMode(settings.Properties.MaxCompatibilityMode);
 
+            ApplyVcpValueRestrictions(settings);
+
             var monitors = await _monitorManager.DiscoverMonitorsAsync(_cancellationTokenSource.Token);
 
             _dispatcherQueue.TryEnqueue(() =>
@@ -156,6 +160,8 @@ public partial class MainViewModel
         // Load settings to check for hidden monitors
         var settings = _settingsUtils.GetSettingsOrDefault<PowerDisplaySettings>(PowerDisplaySettings.ModuleName);
         var hiddenMonitorIds = GetHiddenMonitorIds(settings);
+
+        ApplyVcpValueRestrictions(settings);
 
         foreach (var monitor in monitors)
         {

--- a/src/modules/powerdisplay/PowerDisplay/ViewModels/MainViewModel.Settings.cs
+++ b/src/modules/powerdisplay/PowerDisplay/ViewModels/MainViewModel.Settings.cs
@@ -166,6 +166,12 @@ public partial class MainViewModel
         }
     }
 
+    private void ApplyVcpValueRestrictions(PowerDisplaySettings settings)
+    {
+        _monitorManager.SetDisabledVcpValues(settings.Properties.Monitors.Select(monitor =>
+            new KeyValuePair<string, List<VcpValueBlock>>(monitor.Id, monitor.DisabledVcpValues)));
+    }
+
     /// <summary>
     /// Loads the saved profiles and returns the valid profile with the given id, or null (logging a
     /// warning under <paramref name="logPrefix"/>) when it is missing or invalid.
@@ -633,6 +639,11 @@ public partial class MainViewModel
         target.EnableRotation = source.EnableRotation;
         target.EnableColorTemperature = source.EnableColorTemperature;
         target.EnablePowerState = source.EnablePowerState;
+        target.DisabledVcpValues = source.DisabledVcpValues.Where(block => block != null).Select(block => new VcpValueBlock
+        {
+            VcpCode = block.VcpCode,
+            Values = block.Values.ToList(),
+        }).ToList();
     }
 
     /// <summary>

--- a/src/modules/powerdisplay/PowerDisplay/ViewModels/MonitorViewModel.cs
+++ b/src/modules/powerdisplay/PowerDisplay/ViewModels/MonitorViewModel.cs
@@ -134,6 +134,12 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
             return false;
         }
 
+        if (_monitorManager.IsVcpValueBlocked(Id, vcpCode, value))
+        {
+            Logger.LogWarning($"[{Id}] VCP 0x{vcpCode:X2} value 0x{value:X2} is disabled, skipping");
+            return false;
+        }
+
         return true;
     }
 
@@ -600,13 +606,15 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
             return;
         }
 
-        _availableColorPresets = colorTempInfo.SupportedValues.Select(value => new ColorTemperatureItem
-        {
-            VcpValue = value,
-            DisplayName = Common.Utils.VcpNames.GetValueName(0x14, value, _mainViewModel?.CustomVcpMappings, _monitor.Id) is string n ? $"{n} (0x{value:X2})" : $"0x{value:X2}",
-            IsSelected = value == _monitor.CurrentColorTemperature,
-            MonitorId = _monitor.Id,
-        }).ToList();
+        _availableColorPresets = colorTempInfo.SupportedValues
+            .Where(value => !_monitorManager.IsVcpValueBlocked(Id, 0x14, value))
+            .Select(value => new ColorTemperatureItem
+            {
+                VcpValue = value,
+                DisplayName = Common.Utils.VcpNames.GetValueName(0x14, value, _mainViewModel?.CustomVcpMappings, _monitor.Id) is string n ? $"{n} (0x{value:X2})" : $"0x{value:X2}",
+                IsSelected = value == _monitor.CurrentColorTemperature,
+                MonitorId = _monitor.Id,
+            }).ToList();
 
         OnPropertyChanged(nameof(AvailableColorPresets));
     }
@@ -659,13 +667,15 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
             return;
         }
 
-        _availableInputSources = supportedSources.Select(value => new InputSourceItem
-        {
-            Value = value,
-            Name = Common.Utils.VcpNames.GetValueName(0x60, value, _mainViewModel?.CustomVcpMappings, _monitor.Id) ?? $"Source 0x{value:X2}",
-            SelectionVisibility = value == _monitor.CurrentInputSource ? Visibility.Visible : Visibility.Collapsed,
-            MonitorId = _monitor.Id,
-        }).ToList();
+        _availableInputSources = supportedSources
+            .Where(value => !_monitorManager.IsVcpValueBlocked(Id, 0x60, value))
+            .Select(value => new InputSourceItem
+            {
+                Value = value,
+                Name = Common.Utils.VcpNames.GetValueName(0x60, value, _mainViewModel?.CustomVcpMappings, _monitor.Id) ?? $"Source 0x{value:X2}",
+                SelectionVisibility = value == _monitor.CurrentInputSource ? Visibility.Visible : Visibility.Collapsed,
+                MonitorId = _monitor.Id,
+            }).ToList();
 
         OnPropertyChanged(nameof(AvailableInputSources));
     }
@@ -685,6 +695,9 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
         OnPropertyChanged(nameof(CurrentInputSourceName));
         _availableInputSources = null;  // Force rebuild with new custom names
         OnPropertyChanged(nameof(AvailableInputSources));
+
+        _availablePowerStates = null;
+        OnPropertyChanged(nameof(AvailablePowerStates));
     }
 
     /// <summary>
@@ -776,13 +789,15 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
             return;
         }
 
-        _availablePowerStates = supportedStates.Select(value => new PowerStateItem
-        {
-            Value = value,
-            Name = Common.Utils.VcpNames.GetValueName(0xD6, value) ?? $"State 0x{value:X2}",
-            IsSelected = value == _monitor.CurrentPowerState,
-            MonitorId = _monitor.Id,
-        }).ToList();
+        _availablePowerStates = supportedStates
+            .Where(value => !_monitorManager.IsVcpValueBlocked(Id, 0xD6, value))
+            .Select(value => new PowerStateItem
+            {
+                Value = value,
+                Name = Common.Utils.VcpNames.GetValueName(0xD6, value) ?? $"State 0x{value:X2}",
+                IsSelected = value == _monitor.CurrentPowerState,
+                MonitorId = _monitor.Id,
+            }).ToList();
 
         OnPropertyChanged(nameof(AvailablePowerStates));
     }

--- a/src/settings-ui/Settings.UI.Library/MonitorInfo.cs
+++ b/src/settings-ui/Settings.UI.Library/MonitorInfo.cs
@@ -30,6 +30,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         private bool _enableRotation;
         private bool _enableColorTemperature;
         private bool _enablePowerState;
+        private List<VcpValueBlock> _disabledVcpValues = new();
         private System.DateTime? _lastSeenUtc;
         private string _capabilitiesRaw = string.Empty;
         private List<VcpCodeDisplayInfo> _vcpCodesFormatted = new List<VcpCodeDisplayInfo>();
@@ -51,7 +52,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         /// <summary>
         /// Invalidates the color preset cache and notifies property changes.
-        /// Call this when VcpCodesFormatted or SupportsColorTemperature changes.
+        /// Call this when capabilities, monitor identity, or VCP value restrictions change.
         /// </summary>
         private void InvalidateColorPresetCache()
         {
@@ -149,6 +150,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
                 {
                     _id = value;
                     OnPropertyChanged();
+                    InvalidateColorPresetCache();
                 }
             }
         }
@@ -329,6 +331,22 @@ namespace Microsoft.PowerToys.Settings.UI.Library
                     _enablePowerState = value;
                     OnPropertyChanged();
                 }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets values the user has disabled for this monitor. Replace the list
+        /// when editing restrictions so dependent controls receive property notifications.
+        /// </summary>
+        [JsonPropertyName("disabledVcpValues")]
+        public List<VcpValueBlock> DisabledVcpValues
+        {
+            get => _disabledVcpValues;
+            set
+            {
+                _disabledVcpValues = value ?? new List<VcpValueBlock>();
+                OnPropertyChanged();
+                InvalidateColorPresetCache();
             }
         }
 
@@ -588,7 +606,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
                     bool parsed = int.TryParse(cleanHex, System.Globalization.NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture, out int vcpValue);
                     return (VcpValue: parsed ? vcpValue : 0, Name: valueInfo.Name);
                 })
-                .Where(x => x.VcpValue > 0);
+                .Where(x => x.VcpValue > 0 && !VcpValueRestrictions.IsBlocked(Id, VcpCodeSelectColorPreset, x.VcpValue, DisabledVcpValues));
 
             // Compute presets inline (avoiding dependency on PowerDisplay.Lib's ColorTemperatureHelper)
             var presetList = colorTempValues
@@ -623,9 +641,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
                 // Check if current value is in the preset list
                 var currentValueInList = presets.Any(p => p.VcpValue == _colorTemperatureVcp);
 
-                if (currentValueInList)
+                if (currentValueInList || VcpValueRestrictions.IsBlocked(Id, VcpCodeSelectColorPreset, _colorTemperatureVcp, DisabledVcpValues))
                 {
-                    // Current value is in the list, return as-is
+                    // A blocked current value must not be reintroduced as a selectable custom preset.
                     _colorPresetsForDisplayCache = presets;
                 }
                 else
@@ -760,6 +778,10 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             EnableRotation = other.EnableRotation;
             EnableColorTemperature = other.EnableColorTemperature;
             EnablePowerState = other.EnablePowerState;
+            DisabledVcpValues = other.DisabledVcpValues
+                .Where(block => block != null)
+                .Select(block => new VcpValueBlock { VcpCode = block.VcpCode, Values = new List<int>(block.Values) })
+                .ToList();
             CapabilitiesRaw = other.CapabilitiesRaw;
             VcpCodesFormatted = other.VcpCodesFormatted;
             SupportsBrightness = other.SupportsBrightness;

--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/PowerDisplayVcpValuePersistenceTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/PowerDisplayVcpValuePersistenceTests.cs
@@ -1,0 +1,160 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.PowerToys.Settings.UI.UnitTests.BackwardsCompatibility;
+using Microsoft.PowerToys.Settings.UI.UnitTests.Mocks;
+using Microsoft.PowerToys.Settings.UI.ViewModels;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using PowerDisplay.Models;
+
+namespace ViewModelTests;
+
+[TestClass]
+public class PowerDisplayVcpValuePersistenceTests
+{
+    [TestMethod]
+    public void DisabledVcpValues_ChangesSaveAndSendOnceWhileRefreshingPresets()
+    {
+        var monitor = CreateMonitor();
+        var namedEvents = new List<string>();
+        var operationOrder = new List<string>();
+        using var viewModel = CreateViewModel(out _, out var settingsUtils, out var ipcMessages, monitor, namedEvents: namedEvents, operationOrder: operationOrder);
+        Assert.AreEqual(2, monitor.ColorPresetsForDisplay.Count);
+
+        monitor.DisabledVcpValues = new List<VcpValueBlock>
+        {
+            new() { VcpCode = 0x14, Values = new() { 0x05 } },
+        };
+
+        settingsUtils.Verify(
+            utils => utils.SaveSettings(It.IsAny<string>(), PowerDisplaySettings.ModuleName, SettingsUtils.DefaultFileName),
+            Times.Once);
+        Assert.AreEqual(1, ipcMessages.Count);
+        Assert.AreEqual(1, namedEvents.Count);
+        Assert.AreEqual("save,ipc,signal", string.Join(',', operationOrder));
+        var savedBlock = GetSavedSettings(settingsUtils).Properties.Monitors.Single().DisabledVcpValues.Single();
+        Assert.AreEqual((byte)0x14, savedBlock.VcpCode);
+        Assert.AreEqual(0x05, savedBlock.Values.Single());
+        Assert.AreEqual(0x08, monitor.ColorPresetsForDisplay.Single().VcpValue);
+    }
+
+    [TestMethod]
+    public void ReloadMonitors_ChangedRestrictionsDoNotSaveOrSend()
+    {
+        var monitor = CreateMonitor();
+        Action reloadMonitors = null;
+        var namedEvents = new List<string>();
+        using var viewModel = CreateViewModel(
+            out _,
+            out var settingsUtils,
+            out var ipcMessages,
+            monitor,
+            (_, callback) => reloadMonitors = callback,
+            namedEvents);
+        var updatedSettings = new PowerDisplaySettings();
+        var updatedMonitor = CreateMonitor();
+        updatedMonitor.EnableColorTemperature = true;
+        updatedMonitor.DisabledVcpValues = new List<VcpValueBlock>
+        {
+            new() { VcpCode = 0x14, Values = new() { 0x05 } },
+        };
+        updatedSettings.Properties.Monitors.Add(updatedMonitor);
+        settingsUtils.Setup(utils => utils.GetSettingsOrDefault<PowerDisplaySettings>(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(updatedSettings);
+
+        reloadMonitors();
+
+        Assert.AreSame(monitor, viewModel.Monitors.Single());
+        Assert.IsTrue(monitor.EnableColorTemperature);
+        Assert.AreEqual(0x05, monitor.DisabledVcpValues.Single().Values.Single());
+        settingsUtils.Verify(
+            utils => utils.SaveSettings(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
+            Times.Never);
+        Assert.AreEqual(0, ipcMessages.Count);
+        Assert.AreEqual(0, namedEvents.Count);
+    }
+
+    private static MonitorInfo CreateMonitor()
+    {
+        return new MonitorInfo
+        {
+            Id = @"\\?\DISPLAY#TEST001#1",
+            SupportsColorTemperature = true,
+            ColorTemperatureVcp = 0x05,
+            VcpCodesFormatted = new List<VcpCodeDisplayInfo>
+            {
+                new()
+                {
+                    Code = "0x14",
+                    ValueList = new()
+                    {
+                        new() { Value = "0x05", Name = "6500 K" },
+                        new() { Value = "0x08", Name = "9300 K" },
+                    },
+                },
+            },
+        };
+    }
+
+    private static PowerDisplaySettings GetSavedSettings(Mock<SettingsUtils> settingsUtils)
+    {
+        var save = settingsUtils.Invocations.Single(invocation => invocation.Method.Name == nameof(SettingsUtils.SaveSettings));
+        return JsonSerializer.Deserialize((string)save.Arguments[0], SettingsSerializationContext.Default.PowerDisplaySettings);
+    }
+
+    private static PowerDisplayViewModel CreateViewModel(
+        out PowerDisplaySettings settings,
+        out Mock<SettingsUtils> settingsUtils,
+        out List<string> ipcMessages,
+        MonitorInfo monitor = null,
+        Action<string, Action> waitForEventLoop = null,
+        List<string> namedEvents = null,
+        List<string> operationOrder = null)
+    {
+        var powerDisplaySettingsUtils =
+            ISettingsUtilsMocks.GetStubSettingsUtils<PowerDisplaySettings>();
+        var generalSettingsUtils =
+            ISettingsUtilsMocks.GetStubSettingsUtils<GeneralSettings>();
+
+        settings = powerDisplaySettingsUtils.Object.GetSettingsOrDefault<PowerDisplaySettings>(
+            PowerDisplaySettings.ModuleName);
+        if (monitor != null)
+        {
+            settings.Properties.Monitors.Add(monitor);
+        }
+
+        settingsUtils = powerDisplaySettingsUtils;
+        var messages = new List<string>();
+        ipcMessages = messages;
+        var events = namedEvents ?? new List<string>();
+        var operations = operationOrder ?? new List<string>();
+        powerDisplaySettingsUtils.Setup(utils => utils.SaveSettings(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Callback<string, string, string>((_, _, _) => operations.Add("save"));
+
+        return new PowerDisplayViewModel(
+            powerDisplaySettingsUtils.Object,
+            new BackCompatTestProperties.MockSettingsRepository<GeneralSettings>(
+                generalSettingsUtils.Object),
+            new BackCompatTestProperties.MockSettingsRepository<PowerDisplaySettings>(
+                powerDisplaySettingsUtils.Object),
+            message =>
+            {
+                messages.Add(message);
+                operations.Add("ipc");
+                return 0;
+            },
+            waitForEventLoop ?? ((_, _) => { }),
+            eventName =>
+            {
+                events.Add(eventName);
+                operations.Add("signal");
+            });
+    }
+}

--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/ProfileEditorVcpValueRestrictionTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/ProfileEditorVcpValueRestrictionTests.cs
@@ -1,0 +1,378 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.PowerToys.Settings.UI.ViewModels;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PowerDisplay.Models;
+
+namespace ViewModelTests
+{
+    [TestClass]
+    public class ProfileEditorVcpValueRestrictionTests
+    {
+        [TestMethod]
+        public void ColorTemperature_BlockedCurrentValueRequiresAnAllowedSelection()
+        {
+            var monitor = CreateMonitor();
+            monitor.DisabledVcpValues = CreateColorRestrictions(0x05);
+            using var viewModel = CreateViewModel(monitor);
+            var item = viewModel.Monitors.Single();
+            item.IsSelected = true;
+            item.IncludeColorTemperature = true;
+
+            Assert.AreEqual(0x08, item.ColorPresetsForDisplay.Single().VcpValue);
+            Assert.IsNull(item.ColorTemperature);
+            Assert.IsFalse(item.HasValidColorTemperature);
+            Assert.IsFalse(viewModel.CanSave);
+            Assert.IsNull(viewModel.CreateProfile().MonitorSettings.Single().ColorTemperatureVcp);
+
+            item.ColorTemperature = 0x08;
+
+            Assert.IsTrue(item.HasValidColorTemperature);
+            Assert.IsTrue(viewModel.CanSave);
+            Assert.AreEqual((int?)0x08, viewModel.CreateProfile().MonitorSettings.Single().ColorTemperatureVcp);
+        }
+
+        [TestMethod]
+        public void CanSave_InvalidIncludedColorTemperatureBlocksOtherSettingsUntilUnchecked()
+        {
+            var monitor = CreateMonitor();
+            monitor.DisabledVcpValues = CreateColorRestrictions(0x05);
+            using var viewModel = CreateViewModel(monitor);
+            var item = viewModel.Monitors.Single();
+            item.IsSelected = true;
+            item.IncludeBrightness = true;
+            item.IncludeColorTemperature = true;
+
+            Assert.IsFalse(viewModel.CanSave);
+            var settings = viewModel.CreateProfile().MonitorSettings.Single();
+            Assert.AreEqual((int?)monitor.CurrentBrightness, settings.Brightness);
+            Assert.IsNull(settings.ColorTemperatureVcp);
+
+            item.IncludeColorTemperature = false;
+
+            Assert.IsTrue(viewModel.CanSave);
+            Assert.IsNull(viewModel.CreateProfile().MonitorSettings.Single().ColorTemperatureVcp);
+        }
+
+        [TestMethod]
+        public void ColorTemperature_AllPresetsBlockedCannotBeIncluded()
+        {
+            var monitor = CreateMonitor();
+            monitor.DisabledVcpValues = CreateColorRestrictions(0x05, 0x08);
+            using var viewModel = CreateViewModel(monitor);
+            var item = viewModel.Monitors.Single();
+            item.IsSelected = true;
+            item.IncludeColorTemperature = true;
+
+            Assert.AreEqual(0, item.ColorPresetsForDisplay.Count);
+            Assert.IsNull(item.ColorTemperature);
+            Assert.IsFalse(item.HasValidColorTemperature);
+            Assert.IsFalse(viewModel.CanSave);
+            Assert.IsNull(viewModel.CreateProfile().MonitorSettings.Single().ColorTemperatureVcp);
+        }
+
+        [TestMethod]
+        public void ColorTemperature_PrefillingBlockedValuePreservesOriginalSetting()
+        {
+            const int savedValue = 0x05;
+            var monitor = CreateMonitor();
+            monitor.ColorTemperatureVcp = 0x08;
+            monitor.DisabledVcpValues = CreateColorRestrictions(0x05);
+            using var viewModel = CreateViewModel(monitor);
+            var item = viewModel.Monitors.Single();
+            Assert.AreEqual((int?)0x08, item.ColorTemperature);
+
+            viewModel.PreFillProfile(new PowerDisplayProfile(
+                "Existing profile",
+                new List<ProfileMonitorSetting> { new(monitor.Id, colorTemperatureVcp: savedValue) }));
+
+            Assert.IsNull(item.ColorTemperature);
+            Assert.IsTrue(item.IncludeColorTemperature);
+            Assert.IsTrue(item.HasPreservedSettings);
+            Assert.IsTrue(viewModel.CanSave);
+            Assert.AreEqual((int?)savedValue, viewModel.CreateProfile().MonitorSettings.Single().ColorTemperatureVcp);
+        }
+
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public void ColorPresets_UnchangedRestrictionsPreserveSelectionAndInclusion(bool includeColorTemperature)
+        {
+            var monitor = CreateMonitor();
+            using var viewModel = CreateViewModel(monitor);
+            var item = viewModel.Monitors.Single();
+            item.SuppressAutoSelection = true;
+            item.ColorTemperature = 0x08;
+            item.SuppressAutoSelection = false;
+            item.IncludeColorTemperature = includeColorTemperature;
+            var presetChanges = 0;
+            item.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName == nameof(MonitorSelectionItem.ColorPresetsForDisplay))
+                {
+                    presetChanges++;
+
+                    // Replacing ComboBox.ItemsSource can synchronously clear SelectedValue.
+                    item.ColorTemperature = null;
+                }
+            };
+
+            monitor.DisabledVcpValues = new List<VcpValueBlock>();
+
+            Assert.IsTrue(presetChanges > 0);
+            Assert.AreEqual((int?)0x08, item.ColorTemperature);
+            Assert.IsTrue(item.HasValidColorTemperature);
+            Assert.AreEqual(includeColorTemperature, item.IncludeColorTemperature);
+        }
+
+        [TestMethod]
+        public void ColorPresets_BlockingTheSelectedValueClearsSelectionAndNotifiesValidation()
+        {
+            var monitor = CreateMonitor();
+            using var viewModel = CreateViewModel(monitor);
+            var item = viewModel.Monitors.Single();
+            item.IsSelected = true;
+            item.ColorTemperature = 0x08;
+            Assert.IsTrue(viewModel.CanSave);
+            var canSaveChanged = false;
+            viewModel.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName == nameof(ProfileEditorViewModel.CanSave))
+                {
+                    canSaveChanged = true;
+                }
+            };
+
+            monitor.DisabledVcpValues = CreateColorRestrictions(0x08);
+
+            Assert.IsNull(item.ColorTemperature);
+            Assert.IsTrue(item.IncludeColorTemperature);
+            Assert.IsFalse(item.HasValidColorTemperature);
+            Assert.IsFalse(viewModel.CanSave);
+            Assert.IsTrue(canSaveChanged);
+            Assert.IsNull(viewModel.CreateProfile().MonitorSettings.Single().ColorTemperatureVcp);
+
+            viewModel.Dispose();
+            canSaveChanged = false;
+            var itemChanges = 0;
+            item.PropertyChanged += (_, _) => itemChanges++;
+            monitor.DisabledVcpValues = new List<VcpValueBlock>();
+
+            Assert.IsFalse(canSaveChanged);
+            Assert.AreEqual(0, itemChanges);
+        }
+
+        [TestMethod]
+        public void CanSave_BlockedOriginalColorTemperatureSurvivesSupportChanges()
+        {
+            var monitor = CreateMonitor();
+            monitor.DisabledVcpValues = CreateColorRestrictions(0x05, 0x08);
+            using var viewModel = CreateViewModel(monitor);
+            viewModel.PreFillProfile(new PowerDisplayProfile(
+                "Existing profile",
+                new List<ProfileMonitorSetting> { new(monitor.Id, brightness: 25, colorTemperatureVcp: 0x08) }));
+            Assert.IsTrue(viewModel.CanSave);
+            var canSaveChanges = 0;
+            viewModel.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName == nameof(ProfileEditorViewModel.CanSave))
+                {
+                    canSaveChanges++;
+                }
+            };
+
+            monitor.SupportsColorTemperature = false;
+
+            Assert.IsTrue(viewModel.CanSave);
+            Assert.IsTrue(canSaveChanges > 0);
+            canSaveChanges = 0;
+
+            monitor.SupportsColorTemperature = true;
+
+            Assert.IsTrue(viewModel.CanSave);
+            Assert.IsTrue(canSaveChanges > 0);
+            Assert.AreEqual((int?)0x08, viewModel.CreateProfile().MonitorSettings.Single().ColorTemperatureVcp);
+        }
+
+        [TestMethod]
+        public void CreateProfile_BlockedOriginalColorTemperatureIsPreservedUntilExplicitlyRemoved()
+        {
+            var monitor = CreateMonitor();
+            using var viewModel = CreateViewModel(monitor);
+            viewModel.PreFillProfile(new PowerDisplayProfile(
+                "Existing profile",
+                new List<ProfileMonitorSetting> { new(monitor.Id, brightness: 25, colorTemperatureVcp: 0x05) }));
+            var item = viewModel.Monitors.Single();
+
+            monitor.DisabledVcpValues = CreateColorRestrictions(0x05);
+
+            Assert.IsNull(item.ColorTemperature);
+            Assert.IsTrue(item.IncludeColorTemperature);
+            Assert.IsTrue(item.HasPreservedSettings);
+            Assert.IsTrue(viewModel.CanSave);
+            var savedSettings = viewModel.CreateProfile().MonitorSettings.Single();
+            Assert.AreEqual((int?)25, savedSettings.Brightness);
+            Assert.AreEqual((int?)0x05, savedSettings.ColorTemperatureVcp);
+
+            item.IncludeColorTemperature = false;
+
+            Assert.IsTrue(viewModel.CanSave);
+            Assert.IsFalse(item.HasPreservedSettings);
+            Assert.IsNull(viewModel.CreateProfile().MonitorSettings.Single().ColorTemperatureVcp);
+        }
+
+        [TestMethod]
+        public void CanSave_BlockingNewColorTemperatureDoesNotRestoreTheOriginalValue()
+        {
+            var monitor = CreateMonitor();
+            using var viewModel = CreateViewModel(monitor);
+            viewModel.PreFillProfile(new PowerDisplayProfile(
+                "Existing profile",
+                new List<ProfileMonitorSetting> { new(monitor.Id, brightness: 25, colorTemperatureVcp: 0x05) }));
+            var item = viewModel.Monitors.Single();
+            item.ColorTemperature = 0x08;
+            Assert.IsTrue(viewModel.CanSave);
+            Assert.AreEqual((int?)0x08, viewModel.CreateProfile().MonitorSettings.Single().ColorTemperatureVcp);
+
+            monitor.DisabledVcpValues = CreateColorRestrictions(0x08);
+
+            Assert.IsNull(item.ColorTemperature);
+            Assert.IsTrue(item.IncludeColorTemperature);
+            Assert.IsFalse(viewModel.CanSave);
+            Assert.IsNull(viewModel.CreateProfile().MonitorSettings.Single().ColorTemperatureVcp);
+
+            item.IncludeColorTemperature = false;
+
+            Assert.IsTrue(viewModel.CanSave);
+            Assert.IsNull(viewModel.CreateProfile().MonitorSettings.Single().ColorTemperatureVcp);
+        }
+
+        [TestMethod]
+        public void ColorTemperature_UnblockingOriginalValueRestoresSelectionAndClearsPreservationNotice()
+        {
+            var monitor = CreateMonitor();
+            using var viewModel = CreateViewModel(monitor);
+            viewModel.PreFillProfile(new PowerDisplayProfile(
+                "Existing profile",
+                new List<ProfileMonitorSetting> { new(monitor.Id, brightness: 25, colorTemperatureVcp: 0x05) }));
+            var item = viewModel.Monitors.Single();
+            Assert.IsFalse(viewModel.HasPreservedSettings);
+            var preservationChanges = 0;
+            viewModel.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName == nameof(ProfileEditorViewModel.HasPreservedSettings))
+                {
+                    preservationChanges++;
+                }
+            };
+            item.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName == nameof(MonitorSelectionItem.ColorPresetsForDisplay))
+                {
+                    // Match the synchronous selection clear when ComboBox.ItemsSource changes.
+                    item.ColorTemperature = null;
+                }
+            };
+
+            monitor.DisabledVcpValues = CreateColorRestrictions(0x05);
+
+            Assert.IsNull(item.ColorTemperature);
+            Assert.IsTrue(item.IncludeColorTemperature);
+            Assert.IsTrue(item.HasPreservedSettings);
+            Assert.IsTrue(viewModel.HasPreservedSettings);
+            Assert.IsTrue(preservationChanges > 0);
+            Assert.AreEqual((int?)0x05, viewModel.CreateProfile().MonitorSettings.Single().ColorTemperatureVcp);
+            preservationChanges = 0;
+
+            monitor.DisabledVcpValues = new List<VcpValueBlock>();
+
+            Assert.AreEqual((int?)0x05, item.ColorTemperature);
+            Assert.IsTrue(item.IncludeColorTemperature);
+            Assert.IsTrue(item.HasValidColorTemperature);
+            Assert.IsFalse(item.HasPreservedSettings);
+            Assert.IsFalse(viewModel.HasPreservedSettings);
+            Assert.IsTrue(preservationChanges > 0);
+            Assert.IsTrue(viewModel.CanSave);
+            Assert.AreEqual((int?)0x05, viewModel.CreateProfile().MonitorSettings.Single().ColorTemperatureVcp);
+        }
+
+        [TestMethod]
+        public void CanSave_ChoosingAnotherUnavailableValueDoesNotPreserveBlockedOriginalColorTemperature()
+        {
+            var monitor = CreateMonitor();
+            monitor.DisabledVcpValues = CreateColorRestrictions(0x05, 0x08);
+            using var viewModel = CreateViewModel(monitor);
+            viewModel.PreFillProfile(new PowerDisplayProfile(
+                "Existing profile",
+                new List<ProfileMonitorSetting> { new(monitor.Id, brightness: 25, colorTemperatureVcp: 0x05) }));
+            var item = viewModel.Monitors.Single();
+            Assert.IsNull(item.ColorTemperature);
+            Assert.IsTrue(viewModel.CanSave);
+            Assert.IsTrue(viewModel.HasPreservedSettings);
+            var validationChanges = 0;
+            viewModel.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName == nameof(ProfileEditorViewModel.CanSave))
+                {
+                    validationChanges++;
+                }
+            };
+
+            item.ColorTemperature = 0x0B;
+
+            Assert.IsNull(item.ColorTemperature);
+            Assert.IsTrue(item.IncludeColorTemperature);
+            Assert.IsFalse(viewModel.CanSave);
+            Assert.IsFalse(viewModel.HasPreservedSettings);
+            Assert.IsTrue(validationChanges > 0);
+            Assert.IsNull(viewModel.CreateProfile().MonitorSettings.Single().ColorTemperatureVcp);
+        }
+
+        private static ProfileEditorViewModel CreateViewModel(MonitorInfo monitor)
+        {
+            return new ProfileEditorViewModel(new ObservableCollection<MonitorInfo> { monitor }, "Profile");
+        }
+
+        private static MonitorInfo CreateMonitor()
+        {
+            return new MonitorInfo
+            {
+                Id = "DISPLAY#TEST001#1",
+                Name = "Monitor",
+                CurrentBrightness = 75,
+                ColorTemperatureVcp = 0x05,
+                SupportsColorTemperature = true,
+                VcpCodesFormatted = CreateColorCapabilities(),
+            };
+        }
+
+        private static List<VcpCodeDisplayInfo> CreateColorCapabilities(string secondPresetName = "9300 K")
+        {
+            return new()
+            {
+                new()
+                {
+                    Code = "0x14",
+                    Title = "Color preset (0x14)",
+                    HasValues = true,
+                    ValueList = new()
+                    {
+                        new() { Value = "0x05", Name = "6500 K" },
+                        new() { Value = "0x08", Name = secondPresetName },
+                    },
+                },
+            };
+        }
+
+        private static List<VcpValueBlock> CreateColorRestrictions(params int[] values)
+        {
+            return new() { new() { VcpCode = 0x14, Values = values.ToList() } };
+        }
+    }
+}

--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/VcpValueBlockEditorViewModelTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/VcpValueBlockEditorViewModelTests.cs
@@ -1,0 +1,178 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.PowerToys.Settings.UI.ViewModels;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PowerDisplay.Models;
+
+namespace ViewModelTests
+{
+    [TestClass]
+    public class VcpValueBlockEditorViewModelTests
+    {
+        [TestMethod]
+        public void Editor_UsesFormattedNamesAndSavesNumericCodeAndValue()
+        {
+            var monitor = CreateMonitor("DISPLAY#TEST001#1");
+            monitor.VcpCodesFormatted[0].Title = "Localized power mode (0xD6)";
+            monitor.VcpCodesFormatted[0].ValueList[1].Name = "My panel off option";
+            var editor = new VcpValueBlockEditorViewModel(monitor);
+
+            Assert.AreEqual("Localized power mode (0xD6)", editor.AvailableCodes.Single().Title);
+            var hardOff = editor.AvailableValues.Single(value => value.Value == 0x05);
+            Assert.AreEqual("My panel off option (0x05)", hardOff.DisplayName);
+
+            hardOff.IsDisabled = true;
+            var saved = editor.CreateValueBlocks().Single();
+
+            Assert.AreEqual((byte)0xD6, saved.VcpCode);
+            Assert.AreEqual(0x05, saved.Values.Single());
+        }
+
+        [TestMethod]
+        public void Editor_OnlyOffersThisMonitorsReportedDiscreteOptions()
+        {
+            var first = CreateMonitor("DISPLAY#TEST001#1");
+            first.DisabledVcpValues = new List<VcpValueBlock> { new() { VcpCode = 0xD6, Values = new() { 0x05 } } };
+            var second = CreateMonitor("DISPLAY#TEST001#2");
+            second.VcpCodesFormatted = new List<VcpCodeDisplayInfo>
+            {
+                new() { Code = "0x10", Title = "Brightness" },
+                new()
+                {
+                    Code = "0x60",
+                    Title = "Input source (0x60)",
+                    ValueList = new() { new() { Value = "0x11", Name = "HDMI-1" } },
+                },
+            };
+
+            var firstEditor = new VcpValueBlockEditorViewModel(first);
+            var secondEditor = new VcpValueBlockEditorViewModel(second);
+
+            Assert.IsTrue(firstEditor.AvailableValues.Single(value => value.Value == 0x05).IsDisabled);
+            Assert.AreEqual((byte)0x60, secondEditor.AvailableCodes.Single().Code);
+            Assert.AreEqual(0x11, secondEditor.AvailableValues.Single().Value);
+            Assert.IsFalse(secondEditor.AvailableValues.Single().IsDisabled);
+            Assert.AreEqual(0, secondEditor.CreateValueBlocks().Count);
+        }
+
+        [TestMethod]
+        public void Editor_CancelLeavesOriginalRulesUnchangedAndResultDoesNotAliasThem()
+        {
+            var monitor = CreateMonitor("DISPLAY#TEST001#1");
+            monitor.DisabledVcpValues = new List<VcpValueBlock> { new() { VcpCode = 0xD6, Values = new() { 0x05 } } };
+            var editor = new VcpValueBlockEditorViewModel(monitor);
+
+            editor.AvailableValues.Single(value => value.Value == 0x05).IsDisabled = false;
+            editor.AvailableValues.Single(value => value.Value == 0x01).IsDisabled = true;
+
+            Assert.AreEqual(0x05, monitor.DisabledVcpValues.Single().Values.Single());
+            var saved = editor.CreateValueBlocks();
+            saved.Single().Values.Clear();
+            Assert.AreEqual(0x05, monitor.DisabledVcpValues.Single().Values.Single());
+            Assert.AreEqual(0x01, editor.CreateValueBlocks().Single().Values.Single());
+        }
+
+        [TestMethod]
+        public void Editor_SavePreservesRulesMissingFromCurrentCapabilities()
+        {
+            var monitor = CreateMonitor("DISPLAY#TEST001#1");
+            monitor.DisabledVcpValues = new List<VcpValueBlock>
+            {
+                new() { VcpCode = 0xD6, Values = new() { 0x04, 0x05 } },
+                new() { VcpCode = 0x60, Values = new() { 0x11 } },
+            };
+            var editor = new VcpValueBlockEditorViewModel(monitor);
+            editor.AvailableValues.Single(value => value.Value == 0x05).IsDisabled = false;
+
+            var saved = editor.CreateValueBlocks();
+
+            Assert.AreEqual(0x04, saved.Single(block => block.VcpCode == 0xD6).Values.Single());
+            Assert.AreEqual(0x11, saved.Single(block => block.VcpCode == 0x60).Values.Single());
+        }
+
+        [TestMethod]
+        public void Editor_ChangingSelectedCodeRetainsEditsForAllCodes()
+        {
+            var monitor = CreateMonitor("DISPLAY#TEST001#1");
+            monitor.VcpCodesFormatted.Add(new VcpCodeDisplayInfo
+            {
+                Code = "0x60",
+                Title = "Input source (0x60)",
+                ValueList = new() { new() { Value = "0x11", Name = "HDMI-1" } },
+            });
+            var editor = new VcpValueBlockEditorViewModel(monitor);
+            editor.AvailableValues.Single(value => value.Value == 0x05).IsDisabled = true;
+
+            editor.SelectedCode = editor.AvailableCodes.Single(code => code.Code == 0x60);
+            editor.AvailableValues.Single().IsDisabled = true;
+            editor.SelectedCode = editor.AvailableCodes.Single(code => code.Code == 0xD6);
+
+            Assert.IsTrue(editor.AvailableValues.Single(value => value.Value == 0x05).IsDisabled);
+            var saved = editor.CreateValueBlocks();
+            Assert.AreEqual(0x05, saved.Single(block => block.VcpCode == 0xD6).Values.Single());
+            Assert.AreEqual(0x11, saved.Single(block => block.VcpCode == 0x60).Values.Single());
+        }
+
+        [TestMethod]
+        public void Editor_HardwareRestrictionIsCheckedLockedAndNotPersistedAsUserPreference()
+        {
+            var monitor = CreateMonitor("DISPLAY#SAM105C#1");
+            var editor = new VcpValueBlockEditorViewModel(monitor);
+            var hardOff = editor.AvailableValues.Single(value => value.Value == 0x05);
+
+            Assert.IsTrue(editor.HasHardwareBlocks);
+            Assert.IsTrue(hardOff.IsDisabled);
+            Assert.IsTrue(hardOff.IsHardwareBlocked);
+            Assert.IsFalse(string.IsNullOrWhiteSpace(hardOff.HardwareBlockReason));
+
+            hardOff.IsDisabled = false;
+
+            Assert.IsTrue(hardOff.IsDisabled);
+            Assert.AreEqual(0, editor.CreateValueBlocks().Count);
+        }
+
+        [TestMethod]
+        public void Editor_NoDiscreteCapabilitiesHasEmptyStateAndRetainsExistingRules()
+        {
+            var monitor = new MonitorInfo
+            {
+                Id = "DISPLAY#TEST001#1",
+                DisabledVcpValues = new() { new() { VcpCode = 0xD6, Values = new() { 0x05 } } },
+            };
+
+            var editor = new VcpValueBlockEditorViewModel(monitor);
+
+            Assert.IsFalse(editor.HasOptions);
+            Assert.IsNull(editor.SelectedCode);
+            Assert.AreEqual(0, editor.AvailableValues.Count);
+            Assert.AreEqual(0x05, editor.CreateValueBlocks().Single().Values.Single());
+        }
+
+        private static MonitorInfo CreateMonitor(string id)
+        {
+            return new MonitorInfo
+            {
+                Id = id,
+                Name = "Monitor",
+                VcpCodesFormatted = new()
+                {
+                    new()
+                    {
+                        Code = "0xD6",
+                        Title = "Power mode (0xD6)",
+                        ValueList = new()
+                        {
+                            new() { Value = "0x01", Name = "On" },
+                            new() { Value = "0x05", Name = "Off (Hard)" },
+                        },
+                    },
+                },
+            };
+        }
+    }
+}

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerDisplayPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerDisplayPage.xaml
@@ -285,6 +285,12 @@
                                                 <tkcontrols:SettingsCard ContentAlignment="Left">
                                                     <CheckBox x:Uid="PowerDisplay_Monitor_HideMonitor" IsChecked="{x:Bind IsHidden, Mode=TwoWay}" />
                                                 </tkcontrols:SettingsCard>
+                                                <tkcontrols:SettingsCard x:Uid="PowerDisplay_Monitor_DisabledOptions">
+                                                    <Button
+                                                        x:Uid="PowerDisplay_Monitor_DisabledOptions_EditButton"
+                                                        Click="EditDisabledOptions_Click"
+                                                        Tag="{x:Bind}" />
+                                                </tkcontrols:SettingsCard>
                                                 <tkcontrols:SettingsCard x:Uid="PowerDisplay_Monitor_Diagnostics">
                                                     <Button
                                                         x:Uid="PowerDisplay_Monitor_Diagnostics_CopyButton"

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerDisplayPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerDisplayPage.xaml.cs
@@ -52,6 +52,20 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             ViewModel.RefreshEnabledState();
         }
 
+        private async void EditDisabledOptions_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not Button button || button.Tag is not MonitorInfo monitor)
+            {
+                return;
+            }
+
+            var dialog = new VcpValueBlockEditorDialog(monitor) { XamlRoot = XamlRoot };
+            if (await dialog.ShowAsync() == ContentDialogResult.Primary && dialog.ResultBlocks != null)
+            {
+                monitor.DisabledVcpValues = dialog.ResultBlocks;
+            }
+        }
+
         private void CopyVcpCodes_Click(object sender, RoutedEventArgs e)
         {
             if (sender is Button button && button.Tag is MonitorInfo monitor)

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/VcpValueBlockEditorDialog.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/VcpValueBlockEditorDialog.xaml
@@ -1,0 +1,68 @@
+<ContentDialog
+    x:Class="Microsoft.PowerToys.Settings.UI.Views.VcpValueBlockEditorDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:viewmodels="using:Microsoft.PowerToys.Settings.UI.ViewModels"
+    DefaultButton="Primary"
+    IsPrimaryButtonEnabled="{x:Bind ViewModel.HasOptions}"
+    PrimaryButtonClick="ContentDialog_PrimaryButtonClick"
+    Style="{StaticResource DefaultContentDialogStyle}"
+    mc:Ignorable="d">
+
+    <StackPanel MinWidth="350" Spacing="16">
+        <TextBlock
+            FontWeight="SemiBold"
+            Text="{x:Bind ViewModel.MonitorName}"
+            TextWrapping="Wrap" />
+        <TextBlock
+            x:Uid="PowerDisplay_DisabledOptionsEditor_Description"
+            TextWrapping="Wrap"
+            Visibility="{x:Bind ViewModel.HasOptions, Converter={StaticResource BoolToVisibilityConverter}}" />
+        <TextBlock
+            x:Uid="PowerDisplay_DisabledOptionsEditor_Empty"
+            TextWrapping="Wrap"
+            Visibility="{x:Bind ViewModel.HasOptions, Converter={StaticResource ReverseBoolToVisibilityConverter}}" />
+        <ComboBox
+            x:Uid="PowerDisplay_DisabledOptionsEditor_VcpCode"
+            HorizontalAlignment="Stretch"
+            DisplayMemberPath="Title"
+            ItemsSource="{x:Bind ViewModel.AvailableCodes}"
+            SelectedItem="{x:Bind ViewModel.SelectedCode, Mode=TwoWay}"
+            Visibility="{x:Bind ViewModel.HasOptions, Converter={StaticResource BoolToVisibilityConverter}}" />
+        <InfoBar
+            x:Uid="PowerDisplay_DisabledOptionsEditor_Hardware"
+            IsClosable="False"
+            IsOpen="{x:Bind ViewModel.HasHardwareBlocks, Mode=OneWay}"
+            Severity="Informational" />
+        <ScrollViewer
+            MaxHeight="320"
+            HorizontalScrollBarVisibility="Disabled"
+            HorizontalScrollMode="Disabled"
+            VerticalScrollBarVisibility="Auto">
+            <ItemsControl ItemsSource="{x:Bind ViewModel.AvailableValues, Mode=OneWay}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate x:DataType="viewmodels:VcpValueBlockItem">
+                        <StackPanel Margin="0,0,0,8" Spacing="4">
+                            <CheckBox
+                                HorizontalAlignment="Stretch"
+                                HorizontalContentAlignment="Stretch"
+                                AutomationProperties.Name="{x:Bind DisplayName}"
+                                IsChecked="{x:Bind IsDisabled, Mode=TwoWay}"
+                                IsEnabled="{x:Bind IsHardwareBlocked, Converter={StaticResource BoolNegationConverter}}">
+                                <TextBlock Text="{x:Bind DisplayName}" TextWrapping="Wrap" />
+                            </CheckBox>
+                            <TextBlock
+                                Margin="32,0,0,0"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                Text="{x:Bind HardwareBlockReason}"
+                                TextWrapping="Wrap"
+                                Visibility="{x:Bind IsHardwareBlocked, Converter={StaticResource BoolToVisibilityConverter}}" />
+                        </StackPanel>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
+    </StackPanel>
+</ContentDialog>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/VcpValueBlockEditorDialog.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/VcpValueBlockEditorDialog.xaml.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Collections.Generic;
+using Microsoft.PowerToys.Settings.UI.Helpers;
+using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.PowerToys.Settings.UI.ViewModels;
+using Microsoft.UI.Xaml.Controls;
+using PowerDisplay.Models;
+
+namespace Microsoft.PowerToys.Settings.UI.Views
+{
+    public sealed partial class VcpValueBlockEditorDialog : ContentDialog
+    {
+        public VcpValueBlockEditorDialog(MonitorInfo monitor)
+        {
+            ViewModel = new VcpValueBlockEditorViewModel(monitor);
+            InitializeComponent();
+
+            var resourceLoader = ResourceLoaderInstance.ResourceLoader;
+            Title = resourceLoader.GetString("PowerDisplay_DisabledOptionsEditor_Title");
+            PrimaryButtonText = resourceLoader.GetString("PowerDisplay_Dialog_Save");
+            CloseButtonText = resourceLoader.GetString("PowerDisplay_Dialog_Cancel");
+        }
+
+        public VcpValueBlockEditorViewModel ViewModel { get; }
+
+        public List<VcpValueBlock>? ResultBlocks { get; private set; }
+
+        private void ContentDialog_PrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+        {
+            ResultBlocks = ViewModel.CreateValueBlocks();
+        }
+    }
+}

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -6105,7 +6105,7 @@ The break timer font matches the text font.</value>
     <value>Select what monitors and settings to include for this profile</value>
   </data>
   <data name="PowerDisplay_ProfileEditor_PreservedSettings.Message" xml:space="preserve">
-    <value>Saved settings for unavailable monitors or features are kept. Uncheck a setting to remove it. Applying the profile still respects monitor capabilities.</value>
+    <value>Saved settings for unavailable monitors or features are kept. Uncheck a setting to remove it. Applying the profile still respects monitor capabilities and disabled options.</value>
   </data>
   <data name="PowerDisplay_ProfileEditor_Brightness.Text" xml:space="preserve">
     <value>Brightness</value>
@@ -6166,6 +6166,33 @@ The break timer font matches the text font.</value>
   </data>
   <data name="PowerDisplay_Monitor_CapabilitiesWarning.Message" xml:space="preserve">
     <value>This monitor did not report DDC/CI capabilities. Advanced controls may be limited.</value>
+  </data>
+  <data name="PowerDisplay_Monitor_DisabledOptions.Header" xml:space="preserve">
+    <value>Disabled monitor options</value>
+  </data>
+  <data name="PowerDisplay_Monitor_DisabledOptions.Description" xml:space="preserve">
+    <value>Choose which supported options Power Display must not apply to this monitor</value>
+  </data>
+  <data name="PowerDisplay_Monitor_DisabledOptions_EditButton.Content" xml:space="preserve">
+    <value>Edit</value>
+  </data>
+  <data name="PowerDisplay_Monitor_DisabledOptions_EditButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Edit disabled monitor options</value>
+  </data>
+  <data name="PowerDisplay_DisabledOptionsEditor_Title" xml:space="preserve">
+    <value>Disabled monitor options</value>
+  </data>
+  <data name="PowerDisplay_DisabledOptionsEditor_Description.Text" xml:space="preserve">
+    <value>Select a monitor setting, then check the options to disable. Disabled options are hidden from controls and cannot be applied by Power Display.</value>
+  </data>
+  <data name="PowerDisplay_DisabledOptionsEditor_Empty.Text" xml:space="preserve">
+    <value>This monitor has not reported any supported options that can be disabled.</value>
+  </data>
+  <data name="PowerDisplay_DisabledOptionsEditor_VcpCode.Header" xml:space="preserve">
+    <value>Monitor setting</value>
+  </data>
+  <data name="PowerDisplay_DisabledOptionsEditor_Hardware.Message" xml:space="preserve">
+    <value>Some options are disabled automatically because they can cause problems with this monitor. These options cannot be enabled.</value>
   </data>
   <data name="PowerDisplay_Monitor_VcpCapabilities.Header" xml:space="preserve">
     <value>VCP capabilities</value>

--- a/src/settings-ui/Settings.UI/ViewModels/PowerDisplayViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/PowerDisplayViewModel.cs
@@ -608,6 +608,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 nameof(MonitorInfo.EnableRotation) or
                 nameof(MonitorInfo.EnableColorTemperature) or
                 nameof(MonitorInfo.EnablePowerState) or
+                nameof(MonitorInfo.DisabledVcpValues) or
                 nameof(MonitorInfo.IsHidden)))
             {
                 return;

--- a/src/settings-ui/Settings.UI/ViewModels/VcpCodeBlockItem.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/VcpCodeBlockItem.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.PowerToys.Settings.UI.ViewModels
+{
+    public class VcpCodeBlockItem
+    {
+        public VcpCodeBlockItem(byte code, string title, IReadOnlyList<VcpValueBlockItem> values)
+        {
+            Code = code;
+            Title = string.IsNullOrWhiteSpace(title) ? $"0x{code:X2}" : title;
+            Values = values;
+        }
+
+        public byte Code { get; }
+
+        public string Title { get; }
+
+        public IReadOnlyList<VcpValueBlockItem> Values { get; }
+    }
+}

--- a/src/settings-ui/Settings.UI/ViewModels/VcpValueBlockEditorViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/VcpValueBlockEditorViewModel.cs
@@ -1,0 +1,144 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using Microsoft.PowerToys.Settings.UI.Library;
+using PowerDisplay.Models;
+
+namespace Microsoft.PowerToys.Settings.UI.ViewModels
+{
+    /// <summary>
+    /// Edits a snapshot of one monitor's disabled options without changing its settings until saved.
+    /// </summary>
+    public class VcpValueBlockEditorViewModel : INotifyPropertyChanged
+    {
+        private readonly Dictionary<byte, HashSet<int>> _originalBlocks;
+        private VcpCodeBlockItem? _selectedCode;
+
+        public VcpValueBlockEditorViewModel(MonitorInfo monitor)
+        {
+            MonitorName = monitor.DisplayName;
+            _originalBlocks = monitor.DisabledVcpValues
+                .Where(block => block != null)
+                .GroupBy(block => block.VcpCode)
+                .ToDictionary(group => group.Key, group => group.SelectMany(block => block.Values).ToHashSet());
+
+            var codes = new List<VcpCodeBlockItem>();
+            foreach (var entry in monitor.VcpCodesFormatted)
+            {
+                if (entry is null || !TryParseHex(entry.Code, byte.MaxValue, out int code) || entry.ValueList is null)
+                {
+                    continue;
+                }
+
+                byte vcpCode = (byte)code;
+                var values = new List<VcpValueBlockItem>();
+                var seenValues = new HashSet<int>();
+                foreach (var valueInfo in entry.ValueList)
+                {
+                    if (valueInfo is null || !TryParseHex(valueInfo.Value, ushort.MaxValue, out int value) || !seenValues.Add(value))
+                    {
+                        continue;
+                    }
+
+                    bool isUserDisabled = _originalBlocks.TryGetValue(vcpCode, out var blockedValues) && blockedValues.Contains(value);
+                    values.Add(new VcpValueBlockItem(
+                        value,
+                        valueInfo.Name,
+                        isUserDisabled,
+                        VcpValueRestrictions.IsBlockedByHardware(monitor.Id, vcpCode, value),
+                        VcpValueRestrictions.GetHardwareBlockReason(monitor.Id, vcpCode, value)));
+                }
+
+                if (values.Count > 0)
+                {
+                    codes.Add(new VcpCodeBlockItem(vcpCode, entry.Title, values));
+                }
+            }
+
+            AvailableCodes = codes;
+            _selectedCode = codes.FirstOrDefault();
+        }
+
+        public string MonitorName { get; }
+
+        public IReadOnlyList<VcpCodeBlockItem> AvailableCodes { get; }
+
+        public bool HasOptions => AvailableCodes.Count > 0;
+
+        public VcpCodeBlockItem? SelectedCode
+        {
+            get => _selectedCode;
+            set
+            {
+                if (_selectedCode != value)
+                {
+                    _selectedCode = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(SelectedCode)));
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(AvailableValues)));
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(HasHardwareBlocks)));
+                }
+            }
+        }
+
+        public IReadOnlyList<VcpValueBlockItem> AvailableValues => SelectedCode?.Values ?? Array.Empty<VcpValueBlockItem>();
+
+        public bool HasHardwareBlocks => AvailableValues.Any(value => value.IsHardwareBlocked);
+
+        /// <summary>
+        /// Creates numeric settings, retaining rules that are absent from the current capabilities.
+        /// Hardware restrictions remain independent of user settings.
+        /// </summary>
+        public List<VcpValueBlock> CreateValueBlocks()
+        {
+            var result = _originalBlocks.ToDictionary(pair => pair.Key, pair => new HashSet<int>(pair.Value));
+            foreach (var code in AvailableCodes)
+            {
+                if (!result.TryGetValue(code.Code, out var values))
+                {
+                    values = new HashSet<int>();
+                    result.Add(code.Code, values);
+                }
+
+                foreach (var option in code.Values.Where(value => !value.IsHardwareBlocked))
+                {
+                    if (option.IsDisabled)
+                    {
+                        values.Add(option.Value);
+                    }
+                    else
+                    {
+                        values.Remove(option.Value);
+                    }
+                }
+            }
+
+            return result
+                .Where(pair => pair.Value.Count > 0)
+                .OrderBy(pair => pair.Key)
+                .Select(pair => new VcpValueBlock { VcpCode = pair.Key, Values = pair.Value.OrderBy(value => value).ToList() })
+                .ToList();
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        private static bool TryParseHex(string? text, int maximum, out int value)
+        {
+            value = 0;
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return false;
+            }
+
+            var hex = text.StartsWith("0x", StringComparison.OrdinalIgnoreCase) ? text[2..] : text;
+            return int.TryParse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out value) && value >= 0 && value <= maximum;
+        }
+    }
+}

--- a/src/settings-ui/Settings.UI/ViewModels/VcpValueBlockItem.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/VcpValueBlockItem.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.ComponentModel;
+
+namespace Microsoft.PowerToys.Settings.UI.ViewModels
+{
+    public class VcpValueBlockItem : INotifyPropertyChanged
+    {
+        private bool _isDisabled;
+
+        public VcpValueBlockItem(int value, string name, bool isUserDisabled, bool isHardwareBlocked, string? hardwareBlockReason)
+        {
+            Value = value;
+            var hexValue = $"0x{value:X2}";
+            DisplayName = string.IsNullOrWhiteSpace(name) || string.Equals(name, hexValue, StringComparison.OrdinalIgnoreCase)
+                ? hexValue
+                : $"{name} ({hexValue})";
+            IsHardwareBlocked = isHardwareBlocked;
+            HardwareBlockReason = hardwareBlockReason ?? string.Empty;
+            _isDisabled = isUserDisabled || isHardwareBlocked;
+        }
+
+        public int Value { get; }
+
+        public string DisplayName { get; }
+
+        public bool IsHardwareBlocked { get; }
+
+        public string HardwareBlockReason { get; }
+
+        public bool IsDisabled
+        {
+            get => _isDisabled;
+            set
+            {
+                if (!IsHardwareBlocked && _isDisabled != value)
+                {
+                    _isDisabled = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsDisabled)));
+                }
+            }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+    }
+}


### PR DESCRIPTION
## Summary of the Pull Request

Allow users to disable individual monitor options, such as Off (Hard), while keeping other supported options available. A per-monitor editor shows formatted option names and saves numeric VCP codes and values. Disabled options are filtered from controls and rejected at the shared raw DDC write boundary used by the GUI and CLI.

Combine user preferences with an embedded hardware restriction. The initial rule blocks VCP 0xD6 value 0x05 for Samsung SAM105C monitors; user settings cannot override it. Restrictions survive monitor/settings refreshes. The cause of the second incident in #50449 remains unresolved. Monitor discovery and VCP reads are unchanged.

Related to #50208 and #50449.

## Dependencies and review base

This draft contains only the VCP feature and its integration tests. Its prerequisites are separate drafts targeting `main`:

- #50509 — profile editing and preservation across unavailable monitors/capabilities.
- #50510 — persist only monitor preferences edited in Settings.

The temporary base `codex/powerdisplay-vcp-prerequisites` contains exactly those two prerequisite commits on `main`. It exists only to keep this draft's diff focused; **do not merge this PR into the temporary base**. After both prerequisites land, rebase this feature onto the resulting `main` and change the PR target back to `main`.

## PR Checklist

- [ ] Closes: no automatic issue closure; related issues are linked above.
- [ ] **Communication:** Draft for maintainer review.
- [ ] **Tests:** Relevant tests pass; the complete Settings suite has the existing certificate-fixture failure documented below.
- [x] **Localization:** Editor labels and explanations use resource strings; embedded hardware-rule comments follow the existing blacklist convention.
- [ ] **Dev docs:** Not added.
- [x] **New binaries:** Not applicable; no new binary or test project.
- [ ] **Documentation updated:** No separate documentation PR.

## Validation Steps Performed

- Validated commit `230a56495c4a5b04ea76ec715359e58cda36100b`, containing this feature on the two prerequisite commits.
- Built Settings UI, Settings.UI.UnitTests, PowerDisplay.Lib.UnitTests, and PowerDisplay with the repository scripts, x64 Debug: all exited with code 0. Settings retained the existing CsWinRT1028 warning in unchanged `ManagedCommon/HotkeySettingsControlHook.cs`.
- PowerDisplay Settings tests: **68/68 passed**. Complete PowerDisplay.Lib tests: **351/351 passed**, with no skips.
- Complete Settings suite: **312/313 passed**. The unchanged main test `MouseWithoutBordersIpcSecurityTests.CustomRootTrustChainAcceptsIntermediateFromExtraStore` failed while constructing test certificates; its independently calculated `UtcNow.AddDays(7)` values crossed a second boundary, placing a child certificate's expiry one second after its issuer. A targeted retry reproduced the same fixture failure at another certificate level. The test file is byte-for-byte identical to main; it was not changed or excluded to make the suite green.
- **1,024** new-profile state combinations and **1,440** existing-profile preservation combinations passed.
- Built and ran the real WinUI ComboBox/generated-binding probe: refresh preservation, blocked selection clearing, preserved original values, unblocking restoration, and invalid new selection handling passed; process exit code 0.
- Verified the combined production source matches the reviewed original PR on updated main, except for the internal notification test seam and preserved XAML BOM. Tests are partitioned between the three PRs. `git diff --check` passed.

DDC tests inject readers and writers rather than accessing monitor hardware. No physical SAM105C, full Settings dialog layout, multi-monitor DPI, or end-to-end cross-process race verification is claimed.
