### PR TITLE
[Light Switch] Add CLI for status and theme control

### DIFF
--- a/.pipelines/ESRPSigning_core.json
+++ b/.pipelines/ESRPSigning_core.json
@@ -154,6 +154,8 @@
 
             "PowerToys.LightSwitchModuleInterface.dll",
             "LightSwitchService\\PowerToys.LightSwitchService.exe",
+            "PowerToys.LightSwitch.Cli.exe",
+            "PowerToys.LightSwitch.Cli.dll",
 
             "PowerToys.KeyboardManager.dll",
             "KeyboardManagerEditor\\PowerToys.KeyboardManagerEditor.exe",

--- a/PowerToys.slnx
+++ b/PowerToys.slnx
@@ -820,11 +820,20 @@
     </Project>
   </Folder>
   <Folder Name="/modules/LightSwitch/">
+    <Project Path="src/modules/LightSwitch/LightSwitch.Cli/LightSwitch.Cli.csproj">
+      <Platform Solution="*|ARM64" Project="ARM64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
     <Project Path="src/modules/LightSwitch/LightSwitchLib/LightSwitchLib.vcxproj" Id="79267138-2895-4346-9021-21408d65379f" />
     <Project Path="src/modules/LightSwitch/LightSwitchModuleInterface/LightSwitchModuleInterface.vcxproj" Id="38177d56-6ad1-4adf-88c9-2843a7932166" />
     <Project Path="src/modules/LightSwitch/LightSwitchService/LightSwitchService.vcxproj" Id="08e71c67-6a7e-4ca1-b04e-2fb336410bac" />
   </Folder>
   <Folder Name="/modules/LightSwitch/Tests/">
+    <Project Path="src/modules/LightSwitch/Tests/LightSwitch.Cli.UnitTests/LightSwitch.Cli.UnitTests.csproj">
+      <Platform Solution="*|ARM64" Project="ARM64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
+    <Project Path="src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/LightSwitchService.UnitTests.vcxproj" />
     <Project Path="src/modules/LightSwitch/Tests/LightSwitch.UITests/LightSwitch.UITests.csproj">
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />

--- a/doc/devdocs/modules/lightswitch-cli.md
+++ b/doc/devdocs/modules/lightswitch-cli.md
@@ -49,6 +49,9 @@ schedule. If the mode is `Off`, it fails with exit code 2 and asks for an explic
 mode. Re-selecting the current mode does not clear a manual theme override.
 
 All commands support `--json`. `--help` and `--version` work without the service.
+Boolean options also accept explicit values, such as `--help=true`,
+`--version:true`, and `--json false`. A false help or version option does not
+suppress the command. Options after the literal `--` remain arguments.
 
 ## Output and exit codes
 
@@ -134,6 +137,14 @@ modifying Windows and sending a delayed completion notification. The Command
 Palette's existing toggle event still reaches that shortcut adapter. This
 preserves the number of requests received by the module and avoids an old
 completion event cancelling a newer CLI override.
+
+Manual overrides use a full local date/time baseline. Scheduled boundaries that
+pass during sleep expire an override, while a backward clock adjustment does
+not masquerade as midnight. Sun times are cached by their full calendar date.
+New manual commands account for already-occurring schedule or Night Light
+transitions before establishing their override; delayed notifications cannot
+cancel that newer choice. Unchanged settings notifications preserve detected
+external theme choices while genuine plan changes still take effect.
 
 ## Validation
 

--- a/doc/devdocs/modules/lightswitch-cli.md
+++ b/doc/devdocs/modules/lightswitch-cli.md
@@ -4,6 +4,12 @@
 service in the current Windows user session. Enable Light Switch in PowerToys
 before using it. The CLI does not start PowerToys or enable the module.
 
+On its first startup, the service creates the default settings if the module's
+settings file does not exist: scheduling is off and both theme targets are
+enabled. Existing, malformed, or unreadable files are never replaced with
+defaults. This also supports enabling the module through preconfigured general
+settings or policy before visiting the settings page.
+
 The PATH-visible executable is a [CLI shim](../cli-conventions.md). Its target,
 `PowerToys.LightSwitch.Cli.exe`, is installed in the PowerToys installation root.
 Terminals opened before installation may need to be reopened to pick up PATH.
@@ -104,6 +110,10 @@ server executable, sends one request, reads one response, and closes.
 
 The pipe name is `PowerToys_LightSwitch_Cli_<sessionId>`. Its access control
 restricts callers to the service's user/logon scope and rejects remote clients.
+After reading a bounded frame, the service obtains the connection's identification
+token and verifies its user SID, desktop session, and logon SID. This accepts the
+same user's linked UAC tokens while rejecting independent logons. The service
+reverts to its own identity before parsing or executing commands.
 Wire messages are single-line JSON encoded as BOM-less UTF-16LE, with a maximum
 of 32,768 UTF-16 code units per request or response. Version 1 requests contain
 `version`, `command`, and, only for `schedule-enable`, an optional `mode`.

--- a/doc/devdocs/modules/lightswitch-cli.md
+++ b/doc/devdocs/modules/lightswitch-cli.md
@@ -52,6 +52,8 @@ All commands support `--json`. `--help` and `--version` work without the service
 Boolean options also accept explicit values, such as `--help=true`,
 `--version:true`, and `--json false`. A false help or version option does not
 suppress the command. Options after the literal `--` remain arguments.
+Parser directives such as `[parse]` and `[suggest]` are unsupported and are
+rejected as arguments, including when supplied through response files.
 
 ## Output and exit codes
 
@@ -145,6 +147,12 @@ New manual commands account for already-occurring schedule or Night Light
 transitions before establishing their override; delayed notifications cannot
 cancel that newer choice. Unchanged settings notifications preserve detected
 external theme choices while genuine plan changes still take effect.
+
+The worker also reconciles Night Light on minute ticks, recovering from a
+settings read or theme write failure without requiring another notification.
+Calculated sun times share the schedule command's settings lock and are saved
+only while their effective configuration remains current. An older calculation
+cannot restore a mode that a completed schedule command has replaced.
 
 ## Validation
 

--- a/doc/devdocs/modules/lightswitch-cli.md
+++ b/doc/devdocs/modules/lightswitch-cli.md
@@ -1,0 +1,138 @@
+# Light Switch CLI
+
+`PowerToys.LightSwitch.CLI.exe` queries and controls the running Light Switch
+service in the current Windows user session. Enable Light Switch in PowerToys
+before using it. The CLI does not start PowerToys or enable the module.
+
+The PATH-visible executable is a [CLI shim](../cli-conventions.md). Its target,
+`PowerToys.LightSwitch.Cli.exe`, is installed in the PowerToys installation root.
+Terminals opened before installation may need to be reopened to pick up PATH.
+
+## Commands
+
+```console
+PowerToys.LightSwitch.CLI.exe status
+PowerToys.LightSwitch.CLI.exe status --json
+PowerToys.LightSwitch.CLI.exe light
+PowerToys.LightSwitch.CLI.exe dark
+PowerToys.LightSwitch.CLI.exe toggle
+PowerToys.LightSwitch.CLI.exe schedule disable
+PowerToys.LightSwitch.CLI.exe schedule enable --mode fixed-hours
+PowerToys.LightSwitch.CLI.exe schedule enable --mode sunset-to-sunrise
+PowerToys.LightSwitch.CLI.exe schedule enable --mode follow-night-light
+```
+
+`light` and `dark` set the targets selected in Light Switch settings (system,
+applications, or both). Repeating the same command does not toggle the manual
+override flag. A theme different from the current automatic plan is held using
+Light Switch's existing manual override behavior, until a scheduled boundary or
+a relevant settings change.
+
+`toggle` uses the same service operation as the shortcut. It retains the existing
+behavior: invert each selected target, toggle manual override, then evaluate the
+schedule. In particular, mixed system/application themes can be reconciled to
+the automatic plan when the operation releases an existing override.
+
+`schedule disable` saves the existing `scheduleMode` property as `Off`.
+`schedule enable --mode` selects one of the existing modes and uses the values
+already saved for its times, coordinates, and offsets. It changes only the
+schedule mode; it does not reset time values or record a previous mode.
+
+Without `--mode`, `schedule enable` succeeds without changing an already-enabled
+schedule. If the mode is `Off`, it fails with exit code 2 and asks for an explicit
+mode. Re-selecting the current mode does not clear a manual theme override.
+
+All commands support `--json`. `--help` and `--version` work without the service.
+
+## Output and exit codes
+
+Successful service responses use a versioned JSON envelope:
+
+```json
+{
+  "version": 1,
+  "success": true,
+  "state": {
+    "systemTheme": "dark",
+    "appsTheme": "dark",
+    "changeSystem": true,
+    "changeApps": true,
+    "scheduleMode": "FixedHours",
+    "manualOverride": true
+  }
+}
+```
+
+The mode is the service's accepted configuration, not its last applied-mode
+cache. System and application themes are read separately. Reading a theme can
+fail; an error response may include a state with that value set to `unknown`.
+
+Errors contain `version`, `success: false`, and an `error` object with stable
+`code` and human-readable `message` fields. When available, `state` describes the
+observed result, including partial theme changes. JSON output is one object on
+stdout. Human-readable errors go to stderr; logs do not mix with JSON.
+
+| Exit code | Meaning |
+| --- | --- |
+| 0 | The command completed successfully. |
+| 1 | Execution, theme access, or protocol failure. |
+| 2 | Invalid arguments or invalid configuration. |
+| 3 | The service is unavailable or cannot accept the request. |
+| 4 | Timeout or a lost connection after sending a request; the result may be unknown. |
+
+The shim can additionally return its documented 9009-9011 startup errors.
+
+A successful schedule command has saved the mode and completed the service's
+settings handling, including any required Night Light observer lifecycle change.
+Observer initialization runs asynchronously. The settings window
+continues to refresh through its existing file watcher. Concurrent settings
+editors retain the existing whole-file save behavior: a later save, including a
+stale UI snapshot, can replace an earlier update. The CLI does not add field-level
+conflict merging.
+
+A request timeout does not roll back Windows changes. The CLI never
+automatically retries a mutation, especially `toggle`. Query status before
+deciding whether to issue another command. Windows theme broadcasts can take
+time; successful theme application does not mean every application has finished
+redrawing or that a downstream PowerDisplay profile has completed.
+
+## Implementation
+
+The C# CLI parses arguments with the repository's pinned System.CommandLine
+package. It connects to the service through a duplex named pipe, verifies the
+server executable, sends one request, reads one response, and closes.
+
+The pipe name is `PowerToys_LightSwitch_Cli_<sessionId>`. Its access control
+restricts callers to the service's user/logon scope and rejects remote clients.
+Wire messages are single-line JSON encoded as BOM-less UTF-16LE, with a maximum
+of 32,768 UTF-16 code units per request or response. Version 1 requests contain
+`version`, `command`, and, only for `schedule-enable`, an optional `mode`.
+
+Wire command names are `status`, `light`, `dark`, `toggle`, `schedule-enable`,
+and `schedule-disable`. Wire modes use the existing setting values:
+`FixedHours`, `SunsetToSunrise`, and `FollowNightLight`. Unknown versions,
+commands, modes, and unexpected properties are rejected before execution.
+
+Theme commands and snapshots use the existing StateManager mutex. A command
+uses one configuration snapshot throughout its theme application and state
+update. Schedule requests are handed to the existing service worker because it
+owns the Night Light observer's lifetime. Observer joins never run while holding
+the StateManager lock.
+
+The shortcut submits a counted toggle request to the service instead of
+modifying Windows and sending a delayed completion notification. The Command
+Palette's existing toggle event still reaches that shortcut adapter. This
+preserves the number of requests received by the module and avoids an old
+completion event cancelling a newer CLI override.
+
+## Validation
+
+The managed tests cover argument parsing, text/JSON output, exit codes, bounded
+pipe reads, server identity, and response validation. Native tests cover strict
+request parsing, pipe lifetime/framing, theme operations with fake Windows
+dependencies, and settings handling without changing the desktop theme.
+
+Manual acceptance should include all three target selections, mixed themes,
+shortcut/CLI sequences, Off-to-mode transitions, all three automatic modes,
+delayed settings notifications, settings read/write failures, and stopping the
+module while a client is connected.

--- a/doc/devdocs/modules/lightswitch.md
+++ b/doc/devdocs/modules/lightswitch.md
@@ -14,6 +14,8 @@ The **Light Switch** module lets users automatically transition between light an
 
 ## Features
 
+* [Query and control the running service from the command line](lightswitch-cli.md).
+
 * Set custom times to start and stop dark mode.
 * Use geolocation to determine local sunrise and sunset times.
 * Apply offsets in sunrise mode (e.g., 15 minutes before sunset).

--- a/installer/PowerToysSetupCustomActionsVNext/CustomAction.cpp
+++ b/installer/PowerToysSetupCustomActionsVNext/CustomAction.cpp
@@ -1606,6 +1606,8 @@ UINT __stdcall TerminateProcessesCA(MSIHANDLE hInstall)
         L"PowerToys.ImageResizerCLI.exe",
         L"PowerToys.ImageResizer.CLI.exe",
         L"PowerToys.LightSwitchService.exe",
+        // Also matches the installed shim PowerToys.LightSwitch.CLI.exe.
+        L"PowerToys.LightSwitch.Cli.exe",
         L"PowerToys.PowerDisplay.exe",
         // Also matches the installed shim PowerToys.PowerDisplay.CLI.exe.
         L"PowerToys.PowerDisplay.Cli.exe",

--- a/installer/PowerToysSetupVNext/CliShims.wxs
+++ b/installer/PowerToysSetupVNext/CliShims.wxs
@@ -36,6 +36,13 @@
         <File Source="$(var.BinDir)CliShim\PowerToys.CliShim.exe" Name="PowerToys.PowerDisplay.CLI.exe" Id="CliShim_PowerToys.PowerDisplay.CLI.exe" Checksum="yes" />
       </Component>
 
+      <Component Id="CliShim_PowerToys_LightSwitch_CLI_exe" Guid="120770E1-E5A0-4DAC-A4BE-014C446BF48C" Bitness="always64">
+        <RegistryKey Root="$(var.RegistryScope)" Key="Software\Classes\powertoys\components">
+          <RegistryValue Type="string" Name="CliShim_PowerToys_LightSwitch_CLI_exe" Value="" KeyPath="yes" />
+        </RegistryKey>
+        <File Source="$(var.BinDir)CliShim\PowerToys.CliShim.exe" Name="PowerToys.LightSwitch.CLI.exe" Id="CliShim_PowerToys.LightSwitch.CLI.exe" Checksum="yes" />
+      </Component>
+
       <!-- MSI broadcasts WM_SETTINGCHANGE; terminals open before install must be reopened. -->
       <?if $(var.PerUser) = "true" ?>
       <Component Id="cli_env_path_user" Guid="87AA86E8-81E8-44CB-9519-FC70CF7BEA56" Bitness="always64">
@@ -74,6 +81,7 @@
       <ComponentRef Id="CliShim_PowerToys_ImageResizer_CLI_exe" />
       <ComponentRef Id="CliShim_PowerToys_FileLocksmith_CLI_exe" />
       <ComponentRef Id="CliShim_PowerToys_PowerDisplay_CLI_exe" />
+      <ComponentRef Id="CliShim_PowerToys_LightSwitch_CLI_exe" />
       <?if $(var.PerUser) = "true" ?>
       <ComponentRef Id="cli_env_path_user" />
       <?else?>

--- a/src/modules/LightSwitch/LightSwitch.Cli/CliApplication.cs
+++ b/src/modules/LightSwitch/LightSwitch.Cli/CliApplication.cs
@@ -1,0 +1,163 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using LightSwitch.Cli.Protocol;
+
+namespace LightSwitch.Cli;
+
+internal sealed class CliApplication
+{
+    // Theme changes include several synchronous Windows broadcasts. Keep the overall deadline
+    // independent of the shorter connect deadline, and never retry a possibly executed command.
+    internal static readonly TimeSpan OperationTimeout = TimeSpan.FromSeconds(60);
+
+    private readonly Func<string, CancellationToken, Task<string>> _send;
+    private readonly Action<string>? _logError;
+    private readonly TimeSpan _operationTimeout;
+
+    internal CliApplication(Func<string, CancellationToken, Task<string>> send, Action<string>? logError = null, TimeSpan? operationTimeout = null)
+    {
+        _send = send ?? throw new ArgumentNullException(nameof(send));
+        _logError = logError;
+        _operationTimeout = operationTimeout ?? OperationTimeout;
+    }
+
+    internal static string CliVersion => typeof(CliApplication).Assembly.GetName().Version?.ToString() ?? "unknown";
+
+    internal async Task<int> RunAsync(string[] args, TextWriter stdout, TextWriter stderr, CancellationToken cancellationToken = default)
+    {
+        bool json = CliCommandLine.HasFlag(args, "--json");
+
+        try
+        {
+            if (CliCommandLine.IsHelpRequest(args))
+            {
+                WriteInformation(new CliInformation { Help = CliCommandLine.HelpText }, json, stdout);
+                return 0;
+            }
+
+            if (CliCommandLine.HasFlag(args, "--version"))
+            {
+                WriteInformation(new CliInformation { CliVersion = CliVersion }, json, stdout);
+                return 0;
+            }
+
+            var commandLine = new CliCommandLine();
+            var parsed = commandLine.Parse(args);
+
+            if (parsed.Errors.Count != 0)
+            {
+                throw new CliException("INVALID_ARGUMENT", string.Join(" ", parsed.Errors.Select(error => error.Message)));
+            }
+
+            var request = commandLine.CreateRequest(parsed);
+            string requestJson = JsonSerializer.Serialize(request, CliJsonContext.Default.CliRequest);
+            using var deadline = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            deadline.CancelAfter(_operationTimeout);
+            string responseJson = await _send(requestJson, deadline.Token).WaitAsync(deadline.Token).ConfigureAwait(false);
+            var response = CliProtocol.ParseResponse(responseJson);
+            if (!response.Success)
+            {
+                LogError($"{response.Error!.Code}: {response.Error.Message}");
+            }
+
+            WriteResponse(response, json, stdout, stderr);
+            return response.Success ? 0 : CliProtocol.ExitCode(response.Error!.Code);
+        }
+        catch (OperationCanceledException)
+        {
+            return WriteFailure(
+                "TIMEOUT",
+                "The request timed out or was cancelled. It may already have taken effect; run status before trying again.",
+                json,
+                stdout,
+                stderr);
+        }
+        catch (CliException ex)
+        {
+            return WriteFailure(ex.Code, ex.Message, json, stdout, stderr);
+        }
+        catch (Exception ex)
+        {
+            LogError(ex.ToString());
+            return WriteUnexpectedFailure(json, stdout, stderr);
+        }
+    }
+
+    internal static int WriteUnexpectedFailure(bool json, TextWriter stdout, TextWriter stderr)
+    {
+        WriteResponse(
+            new CliResponse
+            {
+                Success = false,
+                Error = new CliError
+                {
+                    Code = "EXECUTION_FAILED",
+                    Message = "The Light Switch command could not be completed. See the Light Switch log for details.",
+                },
+            },
+            json,
+            stdout,
+            stderr);
+        return 1;
+    }
+
+    private static void WriteInformation(CliInformation information, bool json, TextWriter stdout)
+    {
+        stdout.WriteLine(json
+            ? JsonSerializer.Serialize(information, CliJsonContext.Default.CliInformation)
+            : information.Help ?? information.CliVersion);
+    }
+
+    private static void WriteResponse(CliResponse response, bool json, TextWriter stdout, TextWriter stderr)
+    {
+        if (json)
+        {
+            stdout.WriteLine(JsonSerializer.Serialize(response, CliJsonContext.Default.CliResponse));
+        }
+        else if (!response.Success)
+        {
+            stderr.WriteLine($"{response.Error!.Code}: {response.Error.Message}");
+            if (response.Error.Code == "INVALID_ARGUMENT")
+            {
+                stderr.WriteLine("Use 'PowerToys.LightSwitch.CLI.exe --help' for usage.");
+            }
+        }
+        else
+        {
+            var state = response.State!;
+            stdout.WriteLine($"System theme: {state.SystemTheme}");
+            stdout.WriteLine($"Apps theme: {state.AppsTheme}");
+            stdout.WriteLine($"System theme changes: {(state.ChangeSystem ? "enabled" : "disabled")}");
+            stdout.WriteLine($"App theme changes: {(state.ChangeApps ? "enabled" : "disabled")}");
+            stdout.WriteLine($"Schedule mode: {state.ScheduleMode}");
+            stdout.WriteLine($"Manual override: {(state.ManualOverride ? "active" : "inactive")}");
+        }
+    }
+
+    private int WriteFailure(string code, string message, bool json, TextWriter stdout, TextWriter stderr)
+    {
+        LogError($"{code}: {message}");
+        WriteResponse(new CliResponse { Success = false, Error = new CliError { Code = code, Message = message } }, json, stdout, stderr);
+        return CliProtocol.ExitCode(code);
+    }
+
+    private void LogError(string message)
+    {
+        try
+        {
+            _logError?.Invoke(message);
+        }
+        catch (Exception)
+        {
+            // Logging must not corrupt or replace the single CLI response.
+        }
+    }
+}

--- a/src/modules/LightSwitch/LightSwitch.Cli/CliApplication.cs
+++ b/src/modules/LightSwitch/LightSwitch.Cli/CliApplication.cs
@@ -33,24 +33,31 @@ internal sealed class CliApplication
 
     internal async Task<int> RunAsync(string[] args, TextWriter stdout, TextWriter stderr, CancellationToken cancellationToken = default)
     {
-        bool json = CliCommandLine.HasFlag(args, "--json");
+        bool json = false;
 
         try
         {
-            if (CliCommandLine.IsHelpRequest(args))
+            var presentation = CliCommandLine.ParsePresentationOptions(args);
+            json = presentation.Json;
+            if (presentation.Error is not null)
+            {
+                throw new CliException("INVALID_ARGUMENT", presentation.Error);
+            }
+
+            if (presentation.Help)
             {
                 WriteInformation(new CliInformation { Help = CliCommandLine.HelpText }, json, stdout);
                 return 0;
             }
 
-            if (CliCommandLine.HasFlag(args, "--version"))
+            if (presentation.Version)
             {
                 WriteInformation(new CliInformation { CliVersion = CliVersion }, json, stdout);
                 return 0;
             }
 
             var commandLine = new CliCommandLine();
-            var parsed = commandLine.Parse(args);
+            var parsed = commandLine.Parse(presentation.Arguments);
 
             if (parsed.Errors.Count != 0)
             {

--- a/src/modules/LightSwitch/LightSwitch.Cli/CliCommandLine.cs
+++ b/src/modules/LightSwitch/LightSwitch.Cli/CliCommandLine.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using LightSwitch.Cli.Protocol;
+
+namespace LightSwitch.Cli;
+
+internal sealed class CliCommandLine
+{
+    internal const string HelpText = """
+        PowerToys Light Switch
+        Control the running Light Switch service. Enable Light Switch in PowerToys first.
+
+        Usage:
+          PowerToys.LightSwitch.CLI.exe <command> [options]
+
+        Commands:
+          status                         Show the current themes and scheduling state.
+          light                          Apply the light theme to the configured targets.
+          dark                           Apply the dark theme to the configured targets.
+          toggle                         Toggle the configured theme targets.
+          schedule enable [--mode MODE]  Enable scheduling, optionally selecting a mode.
+          schedule disable               Disable scheduling.
+
+        Schedule modes:
+          fixed-hours, sunset-to-sunrise, follow-night-light
+
+        Options:
+          --json                         Write one JSON object, including errors.
+          -h, --help                     Show help without contacting the service.
+          --version                      Show the CLI version without contacting the service.
+
+        JSON command output uses the service response envelope: version, success, state or error.
+        JSON help/version output is local: version, success, and help or cliVersion.
+        """;
+
+    private static readonly string[] HelpAliases = { "--help", "-h", "-?" };
+
+    private readonly RootCommand _root = new("Control the running PowerToys Light Switch service.");
+    private readonly Command _schedule = new("schedule", "Enable or disable scheduling.");
+    private readonly Command _enable = new("enable", "Enable scheduling.");
+    private readonly Command _disable = new("disable", "Disable scheduling.");
+    private readonly Option<string?> _mode = new("--mode", "fixed-hours, sunset-to-sunrise, or follow-night-light") { Arity = ArgumentArity.ExactlyOne };
+
+    internal CliCommandLine()
+    {
+        _root.AddGlobalOption(Json);
+        _root.AddGlobalOption(Help);
+        _root.AddGlobalOption(Version);
+        _root.AddCommand(new Command("status", "Show themes and scheduling state."));
+        _root.AddCommand(new Command("light", "Apply the light theme."));
+        _root.AddCommand(new Command("dark", "Apply the dark theme."));
+        _root.AddCommand(new Command("toggle", "Toggle the configured theme targets."));
+        _enable.AddOption(_mode);
+        _schedule.AddCommand(_enable);
+        _schedule.AddCommand(_disable);
+        _root.AddCommand(_schedule);
+    }
+
+    internal Option<bool> Json { get; } = new("--json", "Write one JSON object.");
+
+    internal Option<bool> Help { get; } = new(HelpAliases, "Show help.");
+
+    internal Option<bool> Version { get; } = new("--version", "Show the CLI version.");
+
+    internal ParseResult Parse(string[] args) => new Parser(_root).Parse(args);
+
+    // The pinned parser can consume an option-looking token as the preceding --mode value.
+    // These global presentation flags still express intent, but only before the literal --.
+    internal static bool HasFlag(string[] args, string flag)
+    {
+        foreach (string argument in args)
+        {
+            if (argument == "--")
+            {
+                break;
+            }
+
+            if (argument == flag)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    internal static bool IsHelpRequest(string[] args)
+    {
+        bool onlyJson = true;
+        foreach (string argument in args)
+        {
+            if (argument != "--json")
+            {
+                onlyJson = false;
+                break;
+            }
+        }
+
+        return onlyJson || HasFlag(args, "--help") || HasFlag(args, "-h") || HasFlag(args, "-?");
+    }
+
+    internal CliRequest CreateRequest(ParseResult result)
+    {
+        if (result.CommandResult.Command == _enable)
+        {
+            string? mode = result.GetValueForOption(_mode) switch
+            {
+                null => null,
+                "fixed-hours" => "FixedHours",
+                "sunset-to-sunrise" => "SunsetToSunrise",
+                "follow-night-light" => "FollowNightLight",
+                _ => throw new CliException("INVALID_ARGUMENT", "Unknown schedule mode. Use fixed-hours, sunset-to-sunrise, or follow-night-light."),
+            };
+
+            return new CliRequest { Command = "schedule-enable", Mode = mode };
+        }
+
+        if (result.CommandResult.Command == _disable)
+        {
+            return new CliRequest { Command = "schedule-disable" };
+        }
+
+        return result.CommandResult.Command.Name switch
+        {
+            "status" or "light" or "dark" or "toggle" => new CliRequest { Command = result.CommandResult.Command.Name },
+            _ => throw new CliException("INVALID_ARGUMENT", "Specify a command. The schedule command requires enable or disable."),
+        };
+    }
+}

--- a/src/modules/LightSwitch/LightSwitch.Cli/CliCommandLine.cs
+++ b/src/modules/LightSwitch/LightSwitch.Cli/CliCommandLine.cs
@@ -4,6 +4,7 @@
 
 using System.CommandLine;
 using System.CommandLine.Parsing;
+using System.Linq;
 using LightSwitch.Cli.Protocol;
 
 namespace LightSwitch.Cli;
@@ -46,10 +47,20 @@ internal sealed class CliCommandLine
     private readonly Option<string?> _mode = new("--mode", "fixed-hours, sunset-to-sunrise, or follow-night-light") { Arity = ArgumentArity.ExactlyOne };
 
     internal CliCommandLine()
+        : this(presentationOnly: false)
+    {
+    }
+
+    private CliCommandLine(bool presentationOnly)
     {
         _root.AddGlobalOption(Json);
         _root.AddGlobalOption(Help);
         _root.AddGlobalOption(Version);
+        if (presentationOnly)
+        {
+            return;
+        }
+
         _root.AddCommand(new Command("status", "Show themes and scheduling state."));
         _root.AddCommand(new Command("light", "Apply the light theme."));
         _root.AddCommand(new Command("dark", "Apply the dark theme."));
@@ -66,41 +77,52 @@ internal sealed class CliCommandLine
 
     internal Option<bool> Version { get; } = new("--version", "Show the CLI version.");
 
-    internal ParseResult Parse(string[] args) => new Parser(_root).Parse(args);
+    internal ParseResult Parse(string[] expandedArgs)
+        => new Parser(new CommandLineConfiguration(_root, enableTokenReplacement: false)).Parse(expandedArgs);
 
-    // The pinned parser can consume an option-looking token as the preceding --mode value.
-    // These global presentation flags still express intent, but only before the literal --.
-    internal static bool HasFlag(string[] args, string flag)
+    internal static (string[] Arguments, bool Json, bool Help, bool Version, string? Error) ParsePresentationOptions(string[] args)
     {
-        foreach (string argument in args)
+        // Expand response files once, without interpreting options. The command parser's
+        // tokens cannot distinguish --mode --help from --mode=--help, so preserve the
+        // expanded argument text for both parsing passes. Neither pass reopens a file.
+        var expansionRoot = new RootCommand { TreatUnmatchedTokensAsErrors = false };
+        var expansion = new Parser(new CommandLineConfiguration(expansionRoot, enableDirectives: false)).Parse(args);
+        string[] expandedArgs = expansion.Tokens.Select(token => token.Value).ToArray();
+
+        // Parse presentation options independently: the pinned parser can otherwise consume
+        // --help or --json as a missing --mode value. Use its Boolean parsing in both passes
+        // so aliases, explicit false values, duplicates, and the literal -- agree.
+        var presentation = new CliCommandLine(presentationOnly: true);
+        presentation._root.TreatUnmatchedTokensAsErrors = false;
+        var parsed = presentation.Parse(expandedArgs);
+        var errors = expansion.Errors.Concat(parsed.Errors).Select(error => error.Message).ToList();
+        var assignmentValidator = new CliCommandLine(presentationOnly: true);
+        foreach (string argument in expandedArgs)
         {
             if (argument == "--")
             {
                 break;
             }
 
-            if (argument == flag)
+            // The parser leaves an invalid Boolean assignment such as --help=invalid
+            // unmatched and treats the option as true. Validate individual tokens using
+            // the parser rather than reimplementing its aliases or assignment syntax.
+            var token = assignmentValidator.Parse(new[] { argument });
+            if (token.Errors.Count != 0 && token.RootCommandResult.Children.OfType<OptionResult>().Any())
             {
-                return true;
+                errors.AddRange(token.Errors.Select(error => error.Message));
             }
         }
 
-        return false;
-    }
+        var jsonResult = parsed.FindResultFor(presentation.Json);
+        bool json = jsonResult?.ErrorMessage is null && parsed.GetValueForOption(presentation.Json);
+        bool onlyJson = parsed.UnmatchedTokens.Count == 0 && parsed.UnparsedTokens.Count == 0 &&
+            parsed.FindResultFor(presentation.Help) is null && parsed.FindResultFor(presentation.Version) is null &&
+            !parsed.Tokens.Any(token => token.Type == TokenType.DoubleDash);
 
-    internal static bool IsHelpRequest(string[] args)
-    {
-        bool onlyJson = true;
-        foreach (string argument in args)
-        {
-            if (argument != "--json")
-            {
-                onlyJson = false;
-                break;
-            }
-        }
-
-        return onlyJson || HasFlag(args, "--help") || HasFlag(args, "-h") || HasFlag(args, "-?");
+        return errors.Count == 0
+            ? (expandedArgs, json, onlyJson || parsed.GetValueForOption(presentation.Help), parsed.GetValueForOption(presentation.Version), null)
+            : (expandedArgs, json, false, false, string.Join(" ", errors.Distinct()));
     }
 
     internal CliRequest CreateRequest(ParseResult result)

--- a/src/modules/LightSwitch/LightSwitch.Cli/CliCommandLine.cs
+++ b/src/modules/LightSwitch/LightSwitch.Cli/CliCommandLine.cs
@@ -78,7 +78,7 @@ internal sealed class CliCommandLine
     internal Option<bool> Version { get; } = new("--version", "Show the CLI version.");
 
     internal ParseResult Parse(string[] expandedArgs)
-        => new Parser(new CommandLineConfiguration(_root, enableTokenReplacement: false)).Parse(expandedArgs);
+        => new Parser(new CommandLineConfiguration(_root, enableDirectives: false, enableTokenReplacement: false)).Parse(expandedArgs);
 
     internal static (string[] Arguments, bool Json, bool Help, bool Version, string? Error) ParsePresentationOptions(string[] args)
     {

--- a/src/modules/LightSwitch/LightSwitch.Cli/CliException.cs
+++ b/src/modules/LightSwitch/LightSwitch.Cli/CliException.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace LightSwitch.Cli;
+
+internal sealed class CliException : Exception
+{
+    internal CliException(string code, string message)
+        : base(message)
+    {
+        Code = code;
+    }
+
+    internal string Code { get; }
+}

--- a/src/modules/LightSwitch/LightSwitch.Cli/Ipc/CliPipeClient.cs
+++ b/src/modules/LightSwitch/LightSwitch.Cli/Ipc/CliPipeClient.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Security.Principal;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using LightSwitch.Cli.Protocol;
+
+namespace LightSwitch.Cli.Ipc;
+
+internal sealed class CliPipeClient
+{
+    internal static readonly TimeSpan ConnectTimeout = TimeSpan.FromSeconds(2);
+
+    private readonly string _pipeName;
+    private readonly Func<PipeStream, bool> _verifyServer;
+    private readonly TimeSpan _connectTimeout;
+
+    internal CliPipeClient()
+        : this(CliProtocol.PipeName, PipeServerIdentity.IsTrustedServer, ConnectTimeout)
+    {
+    }
+
+    // Tests use a unique pipe and a stand-in verifier; production always verifies the actual exe.
+    internal CliPipeClient(string pipeName, Func<PipeStream, bool> verifyServer, TimeSpan connectTimeout)
+    {
+        _pipeName = pipeName;
+        _verifyServer = verifyServer;
+        _connectTimeout = connectTimeout;
+    }
+
+    internal async Task<string> SendAsync(string requestJson, CancellationToken cancellationToken)
+    {
+        if (requestJson.Length > CliProtocol.MaxMessageChars || requestJson.Contains('\n') || requestJson.Contains('\r'))
+        {
+            throw new CliException("PROTOCOL_ERROR", "The Light Switch request exceeds the protocol limits.");
+        }
+
+        bool requestStarted = false;
+        try
+        {
+            using var client = new NamedPipeClientStream(
+                ".",
+                _pipeName,
+                PipeDirection.InOut,
+                PipeOptions.Asynchronous,
+                TokenImpersonationLevel.Identification,
+                HandleInheritability.None);
+
+            await client.ConnectAsync((int)_connectTimeout.TotalMilliseconds, cancellationToken).ConfigureAwait(false);
+            if (!_verifyServer(client))
+            {
+                throw new CliException("SERVICE_UNAVAILABLE", "The pipe is not owned by this installation's Light Switch service.");
+            }
+
+            // A failed/cancelled write can still have delivered bytes. From this point onward,
+            // connection loss must not be described as "the service was not running".
+            byte[] requestBytes = CliProtocol.Encoding.GetBytes(requestJson + "\n");
+            requestStarted = true;
+            await client.WriteAsync(requestBytes, cancellationToken).ConfigureAwait(false);
+
+            using var reader = new StreamReader(client, CliProtocol.Encoding, false, CliProtocol.BufferSize, leaveOpen: true);
+            return await ReadResponseLineAsync(reader, cancellationToken).ConfigureAwait(false);
+        }
+        catch (TimeoutException)
+        {
+            throw new CliException("SERVICE_UNAVAILABLE", "Light Switch is not available. Enable it in PowerToys and try again.");
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            throw requestStarted
+                ? new CliException("TIMEOUT", "The connection closed before a complete response arrived. The command may already have taken effect; run status before trying again.")
+                : new CliException("SERVICE_UNAVAILABLE", "Light Switch is not available. Enable it in PowerToys and try again.");
+        }
+        catch (DecoderFallbackException)
+        {
+            throw new CliException("PROTOCOL_ERROR", "Light Switch returned invalid UTF-16 data.");
+        }
+    }
+
+    internal static async Task<string> ReadResponseLineAsync(TextReader reader, CancellationToken cancellationToken)
+    {
+        var line = new StringBuilder();
+        var buffer = new char[CliProtocol.BufferSize];
+        while (true)
+        {
+            int count = await reader.ReadAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false);
+            if (count == 0)
+            {
+                // A truncated JSON object is not a completed response, even if it happens to parse.
+                throw new EndOfStreamException("The response did not contain a line terminator.");
+            }
+
+            for (int i = 0; i < count; i++)
+            {
+                char character = buffer[i];
+                if (character == '\n')
+                {
+                    if (line.Length > 0 && line[^1] == '\r')
+                    {
+                        line.Length--;
+                    }
+
+                    return line.ToString();
+                }
+
+                if (line.Length >= CliProtocol.MaxMessageChars && !(line.Length == CliProtocol.MaxMessageChars && character == '\r'))
+                {
+                    throw new CliException("PROTOCOL_ERROR", "The Light Switch response exceeds the protocol limit.");
+                }
+
+                line.Append(character);
+            }
+        }
+    }
+}

--- a/src/modules/LightSwitch/LightSwitch.Cli/Ipc/PipeServerIdentity.cs
+++ b/src/modules/LightSwitch/LightSwitch.Cli/Ipc/PipeServerIdentity.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace LightSwitch.Cli.Ipc;
+
+internal static partial class PipeServerIdentity
+{
+    private const uint ProcessQueryLimitedInformation = 0x1000;
+
+    internal static string ExpectedServerPath => Path.Combine(AppContext.BaseDirectory, "LightSwitchService", "PowerToys.LightSwitchService.exe");
+
+    internal static bool IsTrustedServer(PipeStream pipe) => IsTrustedServer(pipe, ExpectedServerPath);
+
+    internal static unsafe bool IsTrustedServer(PipeStream pipe, string expectedPath)
+    {
+        if (!GetNamedPipeServerProcessId(pipe.SafePipeHandle, out uint processId))
+        {
+            return false;
+        }
+
+        // Keep the process handle open throughout validation so its PID cannot be reused.
+        using SafeProcessHandle process = OpenProcess(ProcessQueryLimitedInformation, false, processId);
+        if (process.IsInvalid)
+        {
+            return false;
+        }
+
+        Span<char> buffer = stackalloc char[4096];
+        uint length = (uint)buffer.Length;
+        fixed (char* imagePath = buffer)
+        {
+            if (!QueryFullProcessImageNameW(process, 0, imagePath, ref length))
+            {
+                return false;
+            }
+        }
+
+        return PathsMatch(new string(buffer[..(int)length]), expectedPath);
+    }
+
+    internal static bool PathsMatch(string actualPath, string expectedPath)
+        => string.Equals(Path.GetFullPath(actualPath), Path.GetFullPath(expectedPath), StringComparison.OrdinalIgnoreCase);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool GetNamedPipeServerProcessId(SafePipeHandle pipe, out uint serverProcessId);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    private static partial SafeProcessHandle OpenProcess(uint access, [MarshalAs(UnmanagedType.Bool)] bool inheritHandle, uint processId);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static unsafe partial bool QueryFullProcessImageNameW(SafeProcessHandle process, uint flags, char* imageName, ref uint length);
+}

--- a/src/modules/LightSwitch/LightSwitch.Cli/LightSwitch.Cli.csproj
+++ b/src/modules/LightSwitch/LightSwitch.Cli/LightSwitch.Cli.csproj
@@ -1,0 +1,31 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. See LICENSE file in the project root for license information. -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(RepoRoot)src\Common.Dotnet.CsWinRT.props" />
+  <Import Project="$(RepoRoot)src\Common.SelfContained.props" />
+  <Import Project="$(RepoRoot)src\Common.Dotnet.AotCompatibility.props" />
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>LightSwitch.Cli</RootNamespace>
+    <AssemblyName>PowerToys.LightSwitch.Cli</AssemblyName>
+    <ApplicationIcon>..\LightSwitchService\LightSwitch.ico</ApplicationIcon>
+    <Platforms>x64;ARM64</Platforms>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <OutputPath>$(RepoRoot)$(Platform)\$(Configuration)\</OutputPath>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PublishAot>true</PublishAot>
+    <PublishSingleFile>false</PublishSingleFile>
+    <DisableRuntimeMarshalling>false</DisableRuntimeMarshalling>
+    <InvariantGlobalization>false</InvariantGlobalization>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Remove="*.log" />
+    <None Remove="*.binlog" />
+    <InternalsVisibleTo Include="LightSwitch.Cli.UnitTests" />
+    <FrameworkReference Include="Microsoft.WindowsDesktop.App" />
+    <PackageReference Include="System.CommandLine" />
+    <ProjectReference Include="$(RepoRoot)src\common\ManagedCommon\ManagedCommon.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/modules/LightSwitch/LightSwitch.Cli/Program.cs
+++ b/src/modules/LightSwitch/LightSwitch.Cli/Program.cs
@@ -73,7 +73,7 @@ public static class Program
             LogError(ex.ToString());
             try
             {
-                return CliApplication.WriteUnexpectedFailure(CliCommandLine.HasFlag(args, "--json"), Console.Out, Console.Error);
+                return CliApplication.WriteUnexpectedFailure(CliCommandLine.ParsePresentationOptions(args).Json, Console.Out, Console.Error);
             }
             catch (Exception)
             {

--- a/src/modules/LightSwitch/LightSwitch.Cli/Program.cs
+++ b/src/modules/LightSwitch/LightSwitch.Cli/Program.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using LightSwitch.Cli.Ipc;
+using ManagedCommon;
+
+namespace LightSwitch.Cli;
+
+public static class Program
+{
+    private static readonly Lazy<bool> LoggerInitialized = new(() =>
+    {
+        try
+        {
+            Logger.InitializeLogger("\\LightSwitch\\Logs");
+        }
+        catch (Exception)
+        {
+            // An unavailable log directory must not replace the CLI error response.
+        }
+
+        return true;
+    });
+
+    public static async Task<int> Main(string[] args)
+    {
+        try
+        {
+            try
+            {
+                Console.OutputEncoding = new UTF8Encoding(false);
+            }
+            catch (Exception)
+            {
+                // A host can provide a console whose encoding cannot be changed.
+            }
+
+            using var cancellation = new CancellationTokenSource();
+            ConsoleCancelEventHandler cancelHandler = (_, eventArgs) =>
+            {
+                eventArgs.Cancel = true;
+                try
+                {
+                    cancellation.Cancel();
+                }
+                catch (ObjectDisposedException)
+                {
+                }
+            };
+
+            Console.CancelKeyPress += cancelHandler;
+            try
+            {
+                // Construct the client only for actual IPC, so local help/version do not even
+                // resolve process/pipe details. Both construction and parsing have error guards.
+                var application = new CliApplication(
+                    static (request, token) => new CliPipeClient().SendAsync(request, token),
+                    LogError);
+                return await application.RunAsync(args, Console.Out, Console.Error, cancellation.Token).ConfigureAwait(false);
+            }
+            finally
+            {
+                Console.CancelKeyPress -= cancelHandler;
+            }
+        }
+        catch (Exception ex)
+        {
+            LogError(ex.ToString());
+            try
+            {
+                return CliApplication.WriteUnexpectedFailure(CliCommandLine.HasFlag(args, "--json"), Console.Out, Console.Error);
+            }
+            catch (Exception)
+            {
+                // A closed output stream cannot display an error, but should still yield a
+                // failure exit code instead of an unhandled exception and raw stack trace.
+                return 1;
+            }
+        }
+    }
+
+    private static void LogError(string message)
+    {
+        try
+        {
+            // Parse/validation failures also log, while help/version never initialize a log.
+            _ = LoggerInitialized.Value;
+            Logger.LogError(message);
+        }
+        catch (Exception)
+        {
+        }
+    }
+}

--- a/src/modules/LightSwitch/LightSwitch.Cli/Protocol/CliError.cs
+++ b/src/modules/LightSwitch/LightSwitch.Cli/Protocol/CliError.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json.Serialization;
+
+namespace LightSwitch.Cli.Protocol;
+
+internal sealed class CliError
+{
+    [JsonRequired]
+    public string Code { get; init; } = string.Empty;
+
+    [JsonRequired]
+    public string Message { get; init; } = string.Empty;
+}

--- a/src/modules/LightSwitch/LightSwitch.Cli/Protocol/CliInformation.cs
+++ b/src/modules/LightSwitch/LightSwitch.Cli/Protocol/CliInformation.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace LightSwitch.Cli.Protocol;
+
+// Help/version are produced locally, never sent over the service pipe. Keeping this separate
+// from CliResponse makes their additional JSON fields explicit without changing the IPC schema.
+internal sealed class CliInformation
+{
+    public int Version { get; init; } = CliProtocol.Version;
+
+    public bool Success { get; init; } = true;
+
+    public string? Help { get; init; }
+
+    public string? CliVersion { get; init; }
+}

--- a/src/modules/LightSwitch/LightSwitch.Cli/Protocol/CliJsonContext.cs
+++ b/src/modules/LightSwitch/LightSwitch.Cli/Protocol/CliJsonContext.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json.Serialization;
+
+namespace LightSwitch.Cli.Protocol;
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(CliRequest))]
+[JsonSerializable(typeof(CliResponse))]
+[JsonSerializable(typeof(CliInformation))]
+internal sealed partial class CliJsonContext : JsonSerializerContext
+{
+}

--- a/src/modules/LightSwitch/LightSwitch.Cli/Protocol/CliProtocol.cs
+++ b/src/modules/LightSwitch/LightSwitch.Cli/Protocol/CliProtocol.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+
+namespace LightSwitch.Cli.Protocol;
+
+internal static class CliProtocol
+{
+    internal const int Version = 1;
+    internal const int MaxMessageChars = 32 * 1024;
+    internal const int BufferSize = 1024;
+
+    // C++ wchar_t payloads and this encoding agree on UTF-16 LE. Do not emit or detect a BOM.
+    internal static readonly Encoding Encoding = new UnicodeEncoding(false, false, true);
+
+    internal static string PipeName
+    {
+        get
+        {
+            using var process = Process.GetCurrentProcess();
+            return $"PowerToys_LightSwitch_Cli_{process.SessionId}";
+        }
+    }
+
+    internal static CliResponse ParseResponse(string json)
+    {
+        if (json.Length > MaxMessageChars)
+        {
+            throw InvalidResponse();
+        }
+
+        CliResponse? response;
+        try
+        {
+            response = JsonSerializer.Deserialize(json, CliJsonContext.Default.CliResponse);
+        }
+        catch (JsonException)
+        {
+            throw InvalidResponse();
+        }
+
+        if (response is null || response.Version != Version ||
+            (response.Success && (response.State is null || response.Error is not null)) ||
+            (!response.Success && (response.Error is null || string.IsNullOrWhiteSpace(response.Error.Code) || string.IsNullOrWhiteSpace(response.Error.Message))))
+        {
+            throw InvalidResponse();
+        }
+
+        if (response.State is not null &&
+            (response.State.SystemTheme is not ("light" or "dark" or "unknown") ||
+             response.State.AppsTheme is not ("light" or "dark" or "unknown") ||
+             response.State.ScheduleMode is not ("Off" or "FixedHours" or "SunsetToSunrise" or "FollowNightLight")))
+        {
+            throw InvalidResponse();
+        }
+
+        return response;
+    }
+
+    internal static int ExitCode(string code) => code switch
+    {
+        "INVALID_ARGUMENT" or "INVALID_CONFIGURATION" => 2,
+        "SERVICE_UNAVAILABLE" or "SERVER_BUSY" => 3,
+        "TIMEOUT" => 4,
+        _ => 1,
+    };
+
+    private static CliException InvalidResponse() => new("PROTOCOL_ERROR", "Light Switch returned an invalid or incompatible response.");
+}

--- a/src/modules/LightSwitch/LightSwitch.Cli/Protocol/CliRequest.cs
+++ b/src/modules/LightSwitch/LightSwitch.Cli/Protocol/CliRequest.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace LightSwitch.Cli.Protocol;
+
+internal sealed class CliRequest
+{
+    public int Version { get; init; } = CliProtocol.Version;
+
+    public string Command { get; init; } = string.Empty;
+
+    public string? Mode { get; init; }
+}

--- a/src/modules/LightSwitch/LightSwitch.Cli/Protocol/CliResponse.cs
+++ b/src/modules/LightSwitch/LightSwitch.Cli/Protocol/CliResponse.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json.Serialization;
+
+namespace LightSwitch.Cli.Protocol;
+
+internal sealed class CliResponse
+{
+    [JsonRequired]
+    public int Version { get; init; } = CliProtocol.Version;
+
+    [JsonRequired]
+    public bool Success { get; init; }
+
+    public CliState? State { get; init; }
+
+    public CliError? Error { get; init; }
+}

--- a/src/modules/LightSwitch/LightSwitch.Cli/Protocol/CliState.cs
+++ b/src/modules/LightSwitch/LightSwitch.Cli/Protocol/CliState.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json.Serialization;
+
+namespace LightSwitch.Cli.Protocol;
+
+internal sealed class CliState
+{
+    [JsonRequired]
+    public string SystemTheme { get; init; } = string.Empty;
+
+    [JsonRequired]
+    public string AppsTheme { get; init; } = string.Empty;
+
+    [JsonRequired]
+    public bool ChangeSystem { get; init; }
+
+    [JsonRequired]
+    public bool ChangeApps { get; init; }
+
+    [JsonRequired]
+    public string ScheduleMode { get; init; } = string.Empty;
+
+    [JsonRequired]
+    public bool ManualOverride { get; init; }
+}

--- a/src/modules/LightSwitch/LightSwitchLib/ThemeHelper.cpp
+++ b/src/modules/LightSwitch/LightSwitchLib/ThemeHelper.cpp
@@ -2,112 +2,154 @@
 #include "ThemeHelper.h"
 #include <logger/logger.h>
 
-// Controls changing the themes.
-
-static void ResetColorPrevalence()
+namespace LightSwitchThemeHelpers
 {
-    HKEY hKey;
-    if (RegOpenKeyEx(HKEY_CURRENT_USER,
-                     PERSONALIZATION_REGISTRY_PATH,
-                     0,
-                     KEY_SET_VALUE,
-                     &hKey) == ERROR_SUCCESS)
+    LSTATUS ReadThemeValue(HKEY key, const wchar_t* name, bool& isLight)
     {
-        DWORD value = 0; // back to default value
-        RegSetValueEx(hKey, L"ColorPrevalence", 0, REG_DWORD, reinterpret_cast<const BYTE*>(&value), sizeof(value));
-        RegCloseKey(hKey);
-
-        SendMessageTimeout(HWND_BROADCAST, WM_SETTINGCHANGE, 0, reinterpret_cast<LPARAM>(L"ImmersiveColorSet"), SMTO_ABORTIFHUNG, 5000, nullptr);
-
-        SendMessageTimeout(HWND_BROADCAST, WM_THEMECHANGED, 0, 0, SMTO_ABORTIFHUNG, 5000, nullptr);
-
-        SendMessageTimeout(HWND_BROADCAST, WM_DWMCOLORIZATIONCOLORCHANGED, 0, 0, SMTO_ABORTIFHUNG, 5000, nullptr);
-    }
-}
-
-void SetAppsTheme(bool mode)
-{
-    HKEY hKey;
-    if (RegOpenKeyEx(HKEY_CURRENT_USER,
-                     PERSONALIZATION_REGISTRY_PATH,
-                     0,
-                     KEY_SET_VALUE,
-                     &hKey) == ERROR_SUCCESS)
-    {
-        DWORD value = mode;
-        RegSetValueEx(hKey, L"AppsUseLightTheme", 0, REG_DWORD, reinterpret_cast<const BYTE*>(&value), sizeof(value));
-        RegCloseKey(hKey);
-
-        SendMessageTimeout(HWND_BROADCAST, WM_SETTINGCHANGE, 0, reinterpret_cast<LPARAM>(L"ImmersiveColorSet"), SMTO_ABORTIFHUNG, 5000, nullptr);
-
-        SendMessageTimeout(HWND_BROADCAST, WM_THEMECHANGED, 0, 0, SMTO_ABORTIFHUNG, 5000, nullptr);
-    }
-}
-
-void SetSystemTheme(bool mode)
-{
-    HKEY hKey;
-    if (RegOpenKeyEx(HKEY_CURRENT_USER,
-                     PERSONALIZATION_REGISTRY_PATH,
-                     0,
-                     KEY_SET_VALUE,
-                     &hKey) == ERROR_SUCCESS)
-    {
-        DWORD value = mode;
-        RegSetValueEx(hKey, L"SystemUsesLightTheme", 0, REG_DWORD, reinterpret_cast<const BYTE*>(&value), sizeof(value));
-        RegCloseKey(hKey);
-
-        if (mode) // if are changing to light mode 
+        DWORD value = 0;
+        DWORD size = sizeof(value);
+        const auto result = RegGetValueW(key, nullptr, name, RRF_RT_REG_DWORD, nullptr, &value, &size);
+        if (result != ERROR_SUCCESS)
         {
-            ResetColorPrevalence();
-            Logger::info(L"[LightSwitchLib] Reset ColorPrevalence to default when switching to light mode.");
+            return result;
+        }
+        if (size != sizeof(value) || value > 1)
+        {
+            return ERROR_INVALID_DATA;
+        }
+        isLight = value == 1;
+        return ERROR_SUCCESS;
+    }
+
+    LSTATUS WriteThemeValue(HKEY key, const wchar_t* name, bool isLight)
+    {
+        const DWORD value = isLight ? 1 : 0;
+        auto result = RegSetValueExW(key, name, 0, REG_DWORD, reinterpret_cast<const BYTE*>(&value), sizeof(value));
+        if (result != ERROR_SUCCESS)
+        {
+            return result;
+        }
+        bool actual = false;
+        result = ReadThemeValue(key, name, actual);
+        if (result != ERROR_SUCCESS)
+        {
+            return result;
+        }
+        return actual == isLight ? ERROR_SUCCESS : ERROR_WRITE_FAULT;
+    }
+}
+
+namespace
+{
+    LSTATUS ReadPersonalizationTheme(const wchar_t* name, bool& isLight)
+    {
+        HKEY key = nullptr;
+        auto result = RegOpenKeyExW(HKEY_CURRENT_USER, PERSONALIZATION_REGISTRY_PATH, 0, KEY_QUERY_VALUE, &key);
+        if (result == ERROR_SUCCESS)
+        {
+            result = LightSwitchThemeHelpers::ReadThemeValue(key, name, isLight);
+            RegCloseKey(key);
+        }
+        return result;
+    }
+
+    void BroadcastThemeChange()
+    {
+        SendMessageTimeoutW(HWND_BROADCAST, WM_SETTINGCHANGE, 0, reinterpret_cast<LPARAM>(L"ImmersiveColorSet"), SMTO_ABORTIFHUNG, 5000, nullptr);
+        SendMessageTimeoutW(HWND_BROADCAST, WM_THEMECHANGED, 0, 0, SMTO_ABORTIFHUNG, 5000, nullptr);
+    }
+
+    LSTATUS WritePersonalizationTheme(const wchar_t* name, bool isLight, bool system)
+    {
+        HKEY key = nullptr;
+        auto result = RegOpenKeyExW(HKEY_CURRENT_USER, PERSONALIZATION_REGISTRY_PATH, 0, KEY_QUERY_VALUE | KEY_SET_VALUE, &key);
+        if (result != ERROR_SUCCESS)
+        {
+            return result;
         }
 
-        SendMessageTimeout(HWND_BROADCAST, WM_SETTINGCHANGE, 0, reinterpret_cast<LPARAM>(L"ImmersiveColorSet"), SMTO_ABORTIFHUNG, 5000, nullptr);
+        result = LightSwitchThemeHelpers::WriteThemeValue(key, name, isLight);
+        if (result == ERROR_SUCCESS && system && isLight)
+        {
+            const DWORD value = 0;
+            const auto colorResult = RegSetValueExW(key, L"ColorPrevalence", 0, REG_DWORD, reinterpret_cast<const BYTE*>(&value), sizeof(value));
+            if (colorResult != ERROR_SUCCESS)
+            {
+                Logger::warn(L"[LightSwitchLib] Could not reset ColorPrevalence (error: {}).", colorResult);
+            }
+        }
+        RegCloseKey(key);
 
-        SendMessageTimeout(HWND_BROADCAST, WM_THEMECHANGED, 0, 0, SMTO_ABORTIFHUNG, 5000, nullptr);
+        if (result == ERROR_SUCCESS)
+        {
+            BroadcastThemeChange();
+            if (system && isLight)
+            {
+                SendMessageTimeoutW(HWND_BROADCAST, WM_DWMCOLORIZATIONCOLORCHANGED, 0, 0, SMTO_ABORTIFHUNG, 5000, nullptr);
+            }
+            // The broadcasts may take time. Report the final registry state as well.
+            bool actual = false;
+            result = ReadPersonalizationTheme(name, actual);
+            if (result == ERROR_SUCCESS && actual != isLight)
+            {
+                result = ERROR_WRITE_FAULT;
+            }
+        }
+        return result;
     }
 }
 
-// Can think of this as "is the current theme light?"
+LSTATUS TryGetSystemTheme(bool& isLight)
+{
+    return ReadPersonalizationTheme(L"SystemUsesLightTheme", isLight);
+}
+
+LSTATUS TryGetAppsTheme(bool& isLight)
+{
+    return ReadPersonalizationTheme(L"AppsUseLightTheme", isLight);
+}
+
+LSTATUS TrySetSystemTheme(bool isLight)
+{
+    return WritePersonalizationTheme(L"SystemUsesLightTheme", isLight, true);
+}
+
+LSTATUS TrySetAppsTheme(bool isLight)
+{
+    return WritePersonalizationTheme(L"AppsUseLightTheme", isLight, false);
+}
+
+void SetSystemTheme(bool isLight)
+{
+    const auto result = TrySetSystemTheme(isLight);
+    if (result != ERROR_SUCCESS)
+    {
+        Logger::warn(L"[LightSwitchLib] Could not set system theme (error: {}).", result);
+    }
+}
+
+void SetAppsTheme(bool isLight)
+{
+    const auto result = TrySetAppsTheme(isLight);
+    if (result != ERROR_SUCCESS)
+    {
+        Logger::warn(L"[LightSwitchLib] Could not set apps theme (error: {}).", result);
+    }
+}
+
 bool GetCurrentSystemTheme()
 {
-    HKEY hKey;
-    DWORD value = 1; // default = light
-    DWORD size = sizeof(value);
-
-    if (RegOpenKeyEx(HKEY_CURRENT_USER,
-                     PERSONALIZATION_REGISTRY_PATH,
-                     0,
-                     KEY_READ,
-                     &hKey) == ERROR_SUCCESS)
-    {
-        RegQueryValueEx(hKey, L"SystemUsesLightTheme", nullptr, nullptr, reinterpret_cast<LPBYTE>(&value), &size);
-        RegCloseKey(hKey);
-    }
-
-    return value == 1; // true = light, false = dark
+    bool isLight = true;
+    TryGetSystemTheme(isLight);
+    return isLight;
 }
 
 bool GetCurrentAppsTheme()
 {
-    HKEY hKey;
-    DWORD value = 1;
-    DWORD size = sizeof(value);
-
-    if (RegOpenKeyEx(HKEY_CURRENT_USER,
-                     PERSONALIZATION_REGISTRY_PATH,
-                     0,
-                     KEY_READ,
-                     &hKey) == ERROR_SUCCESS)
-    {
-        RegQueryValueEx(hKey, L"AppsUseLightTheme", nullptr, nullptr, reinterpret_cast<LPBYTE>(&value), &size);
-        RegCloseKey(hKey);
-    }
-
-    return value == 1; // true = light, false = dark
+    bool isLight = true;
+    TryGetAppsTheme(isLight);
+    return isLight;
 }
-
 bool IsNightLightEnabled()
 {
     HKEY hKey;

--- a/src/modules/LightSwitch/LightSwitchLib/ThemeHelper.h
+++ b/src/modules/LightSwitch/LightSwitchLib/ThemeHelper.h
@@ -1,7 +1,23 @@
 #pragma once
 
+#include <windows.h>
+
 inline constexpr wchar_t PERSONALIZATION_REGISTRY_PATH[] = L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";
 inline constexpr wchar_t NIGHT_LIGHT_REGISTRY_PATH[] = L"Software\\Microsoft\\Windows\\CurrentVersion\\CloudStore\\Store\\DefaultAccount\\Current\\default$windows.data.bluelightreduction.bluelightreductionstate\\windows.data.bluelightreduction.bluelightreductionstate";
+inline constexpr wchar_t LIGHT_SWITCH_TOGGLE_REQUEST_SEMAPHORE[] = L"Local\\PowerToys-LightSwitch-ToggleRequest-49904";
+
+// These functions report registry and read-back failures without guessing a theme.
+LSTATUS TryGetSystemTheme(bool& isLight);
+LSTATUS TryGetAppsTheme(bool& isLight);
+LSTATUS TrySetSystemTheme(bool isLight);
+LSTATUS TrySetAppsTheme(bool isLight);
+
+namespace LightSwitchThemeHelpers
+{
+    // The caller owns an open personalization key. These helpers do not broadcast.
+    LSTATUS ReadThemeValue(HKEY key, const wchar_t* name, bool& isLight);
+    LSTATUS WriteThemeValue(HKEY key, const wchar_t* name, bool isLight);
+}
 
 void SetSystemTheme(bool isLight);
 void SetAppsTheme(bool isLight);

--- a/src/modules/LightSwitch/LightSwitchModuleInterface/dllmain.cpp
+++ b/src/modules/LightSwitch/LightSwitchModuleInterface/dllmain.cpp
@@ -10,6 +10,7 @@
 #include "ThemeHelper.h"
 #include <thread>
 #include <atomic>
+#include <climits>
 
 extern "C" IMAGE_DOS_HEADER __ImageBase;
 
@@ -104,7 +105,7 @@ private:
     HANDLE m_process{ nullptr };
     HANDLE m_force_light_event_handle;
     HANDLE m_force_dark_event_handle;
-    HANDLE m_manual_override_event_handle;
+    HANDLE m_toggle_request_semaphore{ nullptr };
     HANDLE m_toggle_event_handle{ nullptr };
     std::thread m_toggle_thread;
     std::atomic<bool> m_toggle_thread_running{ false };
@@ -125,7 +126,7 @@ public:
 
         m_force_light_event_handle = CreateDefaultEvent(L"POWERTOYS_LIGHTSWITCH_FORCE_LIGHT");
         m_force_dark_event_handle = CreateDefaultEvent(L"POWERTOYS_LIGHTSWITCH_FORCE_DARK");
-        m_manual_override_event_handle = CreateEventW(nullptr, TRUE, FALSE, L"POWERTOYS_LIGHTSWITCH_MANUAL_OVERRIDE");
+        m_toggle_request_semaphore = CreateSemaphoreW(nullptr, 0, LONG_MAX, LIGHT_SWITCH_TOGGLE_REQUEST_SEMAPHORE);
         m_toggle_event_handle = CreateDefaultEvent(L"Local\\PowerToys-LightSwitch-ToggleEvent-d8dc2f29-8c94-4ca1-8c5f-3e2b1e3c4f5a");
 
         init_settings();
@@ -184,8 +185,7 @@ public:
             { { L"Off", L"Disable the schedule" },
               { L"FixedHours", L"Set hours manually" },
               { L"SunsetToSunrise", L"Use sunrise/sunset times" },
-              { L"FollowNightLight", L"Follow Windows Night Light state" }
-            });
+              { L"FollowNightLight", L"Follow Windows Night Light state" } });
 
         // Integer spinners
         settings.add_int_spinner(
@@ -407,6 +407,16 @@ public:
         Logger::info(L"Enabling Light Switch module...");
         Trace::Enable(true);
 
+        if (!m_toggle_request_semaphore)
+        {
+            m_toggle_request_semaphore = CreateSemaphoreW(nullptr, 0, LONG_MAX, LIGHT_SWITCH_TOGGLE_REQUEST_SEMAPHORE);
+            if (!m_toggle_request_semaphore)
+            {
+                Logger::error(L"[Light Switch] Could not create toggle request semaphore (error: {}).", GetLastError());
+                return;
+            }
+        }
+
         unsigned long powertoys_pid = GetCurrentProcessId();
         std::wstring args = L"--pid " + std::to_wstring(powertoys_pid);
         std::wstring exe_name = L"LightSwitchService\\PowerToys.LightSwitchService.exe";
@@ -465,6 +475,7 @@ public:
     {
         Logger::info("Light Switch disabling");
         m_enabled = false;
+        StopToggleListener();
 
         if (m_process)
         {
@@ -477,15 +488,16 @@ public:
                 TerminateProcess(m_process, 0);
             }
 
-            CloseHandle(m_manual_override_event_handle);
-            m_manual_override_event_handle = nullptr;
-
             CloseHandle(m_process);
             m_process = nullptr;
         }
-        
+
+        if (m_toggle_request_semaphore)
+        {
+            CloseHandle(m_toggle_request_semaphore);
+            m_toggle_request_semaphore = nullptr;
+        }
         Trace::Enable(false);
-        StopToggleListener();
     }
 
     // Returns if the powertoys is enabled
@@ -563,33 +575,15 @@ public:
     {
         return WaitForSingleObject(m_process, 0) == WAIT_TIMEOUT;
     }
-
 };
 
 void LightSwitchInterface::ToggleTheme()
 {
-    if (g_settings.m_changeSystem)
+    // The service applies the theme and updates its scheduler state as one operation.
+    // A semaphore retains every hotkey request while an earlier theme change is running.
+    if (!m_toggle_request_semaphore || !ReleaseSemaphore(m_toggle_request_semaphore, 1, nullptr))
     {
-        SetSystemTheme(!GetCurrentSystemTheme());
-    }
-    if (g_settings.m_changeApps)
-    {
-        SetAppsTheme(!GetCurrentAppsTheme());
-    }
-
-    if (!m_manual_override_event_handle)
-    {
-        m_manual_override_event_handle = OpenEventW(SYNCHRONIZE | EVENT_MODIFY_STATE, FALSE, L"POWERTOYS_LIGHTSWITCH_MANUAL_OVERRIDE");
-        if (!m_manual_override_event_handle)
-        {
-            m_manual_override_event_handle = CreateEventW(nullptr, TRUE, FALSE, L"POWERTOYS_LIGHTSWITCH_MANUAL_OVERRIDE");
-        }
-    }
-
-    if (m_manual_override_event_handle)
-    {
-        SetEvent(m_manual_override_event_handle);
-        Logger::debug(L"[Light Switch] Manual override event set");
+        Logger::warn(L"[Light Switch] Could not queue a toggle request (error: {}).", m_toggle_request_semaphore ? GetLastError() : ERROR_INVALID_HANDLE);
     }
 }
 

--- a/src/modules/LightSwitch/LightSwitchService/CliIdentity.cpp
+++ b/src/modules/LightSwitch/LightSwitchService/CliIdentity.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "CliIdentity.h"
+
+#include <winrt/base.h>
+
+namespace light_switch_cli
+{
+    namespace
+    {
+        std::vector<BYTE> QueryToken(HANDLE token, TOKEN_INFORMATION_CLASS informationClass)
+        {
+            DWORD size = 0;
+            GetTokenInformation(token, informationClass, nullptr, 0, &size);
+            if (GetLastError() != ERROR_INSUFFICIENT_BUFFER || size == 0)
+            {
+                winrt::throw_last_error();
+            }
+            std::vector<BYTE> result(size);
+            winrt::check_bool(GetTokenInformation(token, informationClass, result.data(), size, &size));
+            return result;
+        }
+
+        std::vector<BYTE> CopyIdentitySid(PSID sid)
+        {
+            if (!sid || !IsValidSid(sid))
+            {
+                throw winrt::hresult_error(HRESULT_FROM_WIN32(ERROR_INVALID_SID));
+            }
+            std::vector<BYTE> result(GetLengthSid(sid));
+            winrt::check_bool(CopySid(static_cast<DWORD>(result.size()), result.data(), sid));
+            return result;
+        }
+    }
+
+    TokenIdentity ReadTokenIdentity(HANDLE token)
+    {
+        TokenIdentity identity;
+        const auto user = QueryToken(token, TokenUser);
+        identity.userSid = CopyIdentitySid(reinterpret_cast<const TOKEN_USER*>(user.data())->User.Sid);
+
+        DWORD sessionId = 0;
+        DWORD size = 0;
+        winrt::check_bool(GetTokenInformation(token, TokenSessionId, &sessionId, sizeof(sessionId), &size));
+        identity.sessionId = sessionId;
+
+        const auto groupsBuffer = QueryToken(token, TokenLogonSid);
+        const auto groups = reinterpret_cast<const TOKEN_GROUPS*>(groupsBuffer.data());
+        if (groups->GroupCount != 1 || (groups->Groups[0].Attributes & SE_GROUP_LOGON_ID) != SE_GROUP_LOGON_ID)
+        {
+            throw winrt::hresult_error(HRESULT_FROM_WIN32(ERROR_NO_SUCH_LOGON_SESSION));
+        }
+        identity.logonSid = CopyIdentitySid(groups->Groups[0].Sid);
+        return identity;
+    }
+
+    bool IsSameLogon(const TokenIdentity& first, const TokenIdentity& second) noexcept
+    {
+        return first.sessionId.has_value() && second.sessionId.has_value() &&
+               !first.userSid.empty() && !second.userSid.empty() &&
+               !first.logonSid.empty() && !second.logonSid.empty() &&
+               first.sessionId == second.sessionId &&
+               first.userSid == second.userSid && first.logonSid == second.logonSid;
+    }
+}

--- a/src/modules/LightSwitch/LightSwitchService/CliIdentity.h
+++ b/src/modules/LightSwitch/LightSwitchService/CliIdentity.h
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include <optional>
+#include <vector>
+#include <Windows.h>
+
+namespace light_switch_cli
+{
+    struct TokenIdentity
+    {
+        std::optional<DWORD> sessionId;
+        std::vector<BYTE> userSid;
+        std::vector<BYTE> logonSid;
+    };
+
+    // All three fields are required. UAC's linked tokens share a logon SID even
+    // though their TOKEN_STATISTICS.AuthenticationId values differ.
+    TokenIdentity ReadTokenIdentity(HANDLE token);
+    bool IsSameLogon(const TokenIdentity& first, const TokenIdentity& second) noexcept;
+}

--- a/src/modules/LightSwitch/LightSwitchService/CliPipeServer.cpp
+++ b/src/modules/LightSwitch/LightSwitchService/CliPipeServer.cpp
@@ -3,15 +3,16 @@
 // See the LICENSE file in the project root for more information.
 
 #include "CliPipeServer.h"
+#include "CliIdentity.h"
 
 #include <array>
 #include <future>
 #include <mutex>
 #include <thread>
 #include <utility>
-#include <vector>
 #include <sddl.h>
 #include <roapi.h>
+#include <wil/resource.h>
 
 using namespace winrt::Windows::Data::Json;
 
@@ -51,61 +52,11 @@ namespace light_switch_cli
             ~LocalMemory() { LocalFree(value); }
         };
 
-        struct TokenIdentity
-        {
-            DWORD sessionId = 0;
-            LUID logonId{};
-            std::vector<BYTE> userSid;
-            std::wstring logonSid;
-        };
-
-        std::vector<BYTE> QueryToken(HANDLE token, TOKEN_INFORMATION_CLASS informationClass)
-        {
-            DWORD size = 0;
-            GetTokenInformation(token, informationClass, nullptr, 0, &size);
-            if (GetLastError() != ERROR_INSUFFICIENT_BUFFER || size == 0)
-            {
-                winrt::throw_last_error();
-            }
-            std::vector<BYTE> result(size);
-            winrt::check_bool(GetTokenInformation(token, informationClass, result.data(), size, &size));
-            return result;
-        }
-
         std::wstring SidString(PSID sid)
         {
             LocalMemory text;
             winrt::check_bool(ConvertSidToStringSidW(sid, reinterpret_cast<LPWSTR*>(&text.value)));
             return static_cast<const wchar_t*>(text.value);
-        }
-
-        TokenIdentity ReadIdentity(HANDLE process, bool includeLogonSid)
-        {
-            Handle token;
-            winrt::check_bool(OpenProcessToken(process, TOKEN_QUERY, token.Put()));
-            TokenIdentity identity;
-            const auto user = QueryToken(token.Get(), TokenUser);
-            const auto userSid = reinterpret_cast<const TOKEN_USER*>(user.data())->User.Sid;
-            identity.userSid.resize(GetLengthSid(userSid));
-            winrt::check_bool(CopySid(static_cast<DWORD>(identity.userSid.size()), identity.userSid.data(), userSid));
-
-            DWORD size = 0;
-            winrt::check_bool(GetTokenInformation(token.Get(), TokenSessionId, &identity.sessionId, sizeof(identity.sessionId), &size));
-            TOKEN_STATISTICS statistics{};
-            winrt::check_bool(GetTokenInformation(token.Get(), TokenStatistics, &statistics, sizeof(statistics), &size));
-            identity.logonId = statistics.AuthenticationId;
-
-            if (includeLogonSid)
-            {
-                const auto groupsBuffer = QueryToken(token.Get(), TokenLogonSid);
-                const auto groups = reinterpret_cast<const TOKEN_GROUPS*>(groupsBuffer.data());
-                if (groups->GroupCount != 1)
-                {
-                    throw winrt::hresult_error(HRESULT_FROM_WIN32(ERROR_NO_SUCH_LOGON_SESSION));
-                }
-                identity.logonSid = SidString(groups->Groups[0].Sid);
-            }
-            return identity;
         }
 
         DWORD RemainingTime(ULONGLONG deadline) noexcept
@@ -157,7 +108,9 @@ namespace light_switch_cli
                     m_options.pipeName = GetPipeName();
                 }
 
-                m_identity = ReadIdentity(GetCurrentProcess(), true);
+                Handle token;
+                winrt::check_bool(OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, token.Put()));
+                m_identity = ReadTokenIdentity(token.Get());
                 m_stopEvent.Reset(CreateEventW(nullptr, TRUE, FALSE, nullptr));
                 winrt::check_bool(m_stopEvent.Get() != nullptr);
 
@@ -165,7 +118,7 @@ namespace light_switch_cli
                 // when PowerToys is elevated. GR/GW includes the pipe-instance right, so keep
                 // the single, first instance open until Stop; never release/reacquire its name.
                 const auto descriptorText = L"O:" + SidString(m_identity.userSid.data()) +
-                                            L"D:P(A;;GRGW;;;" + m_identity.logonSid + L")S:(ML;;NW;;;ME)";
+                                            L"D:P(A;;GRGW;;;" + SidString(m_identity.logonSid.data()) + L")S:(ML;;NW;;;ME)";
                 LocalMemory descriptor;
                 winrt::check_bool(ConvertStringSecurityDescriptorToSecurityDescriptorW(
                     descriptorText.c_str(), SDDL_REVISION_1, &descriptor.value, nullptr));
@@ -297,21 +250,32 @@ namespace light_switch_cli
 
         bool AuthenticateClient()
         {
-            ULONG pid = 0;
-            if (!GetNamedPipeClientProcessId(m_pipe.Get(), &pid))
+            // ReadRequest has consumed a bounded frame, so the pipe can identify its
+            // sender. Identification-level impersonation needs no SeImpersonatePrivilege
+            // and avoids opening an elevated client's process or primary token.
+            if (!ImpersonateNamedPipeClient(m_pipe.Get()))
             {
                 return false;
             }
-            Handle process(OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid));
-            if (!process.Get())
+            Handle token;
+            {
+                const auto revert = wil::scope_exit([]() {
+                    // Continuing with a client's thread token would compromise later requests.
+                    FAIL_FAST_IF_WIN32_BOOL_FALSE(RevertToSelf());
+                });
+                if (!OpenThreadToken(GetCurrentThread(), TOKEN_QUERY, TRUE, token.Put()))
+                {
+                    return false;
+                }
+            }
+            try
+            {
+                return IsSameLogon(m_identity, ReadTokenIdentity(token.Get()));
+            }
+            catch (...)
             {
                 return false;
             }
-            auto client = ReadIdentity(process.Get(), false);
-            return client.sessionId == m_identity.sessionId &&
-                   client.logonId.LowPart == m_identity.logonId.LowPart &&
-                   client.logonId.HighPart == m_identity.logonId.HighPart &&
-                   EqualSid(client.userSid.data(), m_identity.userSid.data());
         }
 
         std::wstring ReadRequest()
@@ -420,13 +384,14 @@ namespace light_switch_cli
             JsonObject response;
             try
             {
+                const auto message = ReadRequest();
                 if (!AuthenticateClient())
                 {
                     response = MakeError(L"SERVICE_UNAVAILABLE", L"The client is not in the Light Switch user's logon session.");
                 }
                 else
                 {
-                    const auto request = ParseRequest(ReadRequest());
+                    const auto request = ParseRequest(message);
                     response = IsStopped() ? MakeError(L"SERVICE_UNAVAILABLE", L"Light Switch is stopping.") : m_handler(request);
                     if (!response)
                     {

--- a/src/modules/LightSwitch/LightSwitchService/CliPipeServer.cpp
+++ b/src/modules/LightSwitch/LightSwitchService/CliPipeServer.cpp
@@ -1,0 +1,517 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "CliPipeServer.h"
+
+#include <array>
+#include <future>
+#include <mutex>
+#include <thread>
+#include <utility>
+#include <vector>
+#include <sddl.h>
+#include <roapi.h>
+
+using namespace winrt::Windows::Data::Json;
+
+namespace light_switch_cli
+{
+    namespace
+    {
+        class Handle
+        {
+        public:
+            explicit Handle(HANDLE value = nullptr) noexcept : m_value(value) {}
+            ~Handle() { Reset(); }
+            Handle(const Handle&) = delete;
+            Handle& operator=(const Handle&) = delete;
+            HANDLE Get() const noexcept { return m_value; }
+            HANDLE* Put() noexcept
+            {
+                Reset();
+                return &m_value;
+            }
+            void Reset(HANDLE value = nullptr) noexcept
+            {
+                if (m_value && m_value != INVALID_HANDLE_VALUE)
+                {
+                    CloseHandle(m_value);
+                }
+                m_value = value;
+            }
+
+        private:
+            HANDLE m_value;
+        };
+
+        struct LocalMemory
+        {
+            void* value = nullptr;
+            ~LocalMemory() { LocalFree(value); }
+        };
+
+        struct TokenIdentity
+        {
+            DWORD sessionId = 0;
+            LUID logonId{};
+            std::vector<BYTE> userSid;
+            std::wstring logonSid;
+        };
+
+        std::vector<BYTE> QueryToken(HANDLE token, TOKEN_INFORMATION_CLASS informationClass)
+        {
+            DWORD size = 0;
+            GetTokenInformation(token, informationClass, nullptr, 0, &size);
+            if (GetLastError() != ERROR_INSUFFICIENT_BUFFER || size == 0)
+            {
+                winrt::throw_last_error();
+            }
+            std::vector<BYTE> result(size);
+            winrt::check_bool(GetTokenInformation(token, informationClass, result.data(), size, &size));
+            return result;
+        }
+
+        std::wstring SidString(PSID sid)
+        {
+            LocalMemory text;
+            winrt::check_bool(ConvertSidToStringSidW(sid, reinterpret_cast<LPWSTR*>(&text.value)));
+            return static_cast<const wchar_t*>(text.value);
+        }
+
+        TokenIdentity ReadIdentity(HANDLE process, bool includeLogonSid)
+        {
+            Handle token;
+            winrt::check_bool(OpenProcessToken(process, TOKEN_QUERY, token.Put()));
+            TokenIdentity identity;
+            const auto user = QueryToken(token.Get(), TokenUser);
+            const auto userSid = reinterpret_cast<const TOKEN_USER*>(user.data())->User.Sid;
+            identity.userSid.resize(GetLengthSid(userSid));
+            winrt::check_bool(CopySid(static_cast<DWORD>(identity.userSid.size()), identity.userSid.data(), userSid));
+
+            DWORD size = 0;
+            winrt::check_bool(GetTokenInformation(token.Get(), TokenSessionId, &identity.sessionId, sizeof(identity.sessionId), &size));
+            TOKEN_STATISTICS statistics{};
+            winrt::check_bool(GetTokenInformation(token.Get(), TokenStatistics, &statistics, sizeof(statistics), &size));
+            identity.logonId = statistics.AuthenticationId;
+
+            if (includeLogonSid)
+            {
+                const auto groupsBuffer = QueryToken(token.Get(), TokenLogonSid);
+                const auto groups = reinterpret_cast<const TOKEN_GROUPS*>(groupsBuffer.data());
+                if (groups->GroupCount != 1)
+                {
+                    throw winrt::hresult_error(HRESULT_FROM_WIN32(ERROR_NO_SUCH_LOGON_SESSION));
+                }
+                identity.logonSid = SidString(groups->Groups[0].Sid);
+            }
+            return identity;
+        }
+
+        DWORD RemainingTime(ULONGLONG deadline) noexcept
+        {
+            const auto now = GetTickCount64();
+            return now >= deadline ? 0 : static_cast<DWORD>(deadline - now);
+        }
+
+        enum class IoResult
+        {
+            Completed,
+            Closed,
+            Stopped,
+            TimedOut,
+            Failed,
+        };
+    }
+
+    std::wstring GetPipeName()
+    {
+        DWORD sessionId = 0;
+        winrt::check_bool(ProcessIdToSessionId(GetCurrentProcessId(), &sessionId));
+        return L"\\\\.\\pipe\\PowerToys_LightSwitch_Cli_" + std::to_wstring(sessionId);
+    }
+
+    class CliPipeServer::Impl
+    {
+    public:
+        Impl(Handler handler, Options options) : m_handler(std::move(handler)), m_options(std::move(options)) {}
+
+        bool Start()
+        {
+            std::lock_guard lock(m_lifecycleMutex);
+            if (m_thread.joinable())
+            {
+                return true;
+            }
+
+            DWORD error = ERROR_GEN_FAILURE;
+            try
+            {
+                if (!m_handler || m_options.readTimeoutMs == 0 || m_options.writeTimeoutMs == 0)
+                {
+                    SetLastError(ERROR_INVALID_PARAMETER);
+                    return false;
+                }
+                if (m_options.pipeName.empty())
+                {
+                    m_options.pipeName = GetPipeName();
+                }
+
+                m_identity = ReadIdentity(GetCurrentProcess(), true);
+                m_stopEvent.Reset(CreateEventW(nullptr, TRUE, FALSE, nullptr));
+                winrt::check_bool(m_stopEvent.Get() != nullptr);
+
+                // Restrict clients to this logon. A medium label also permits the normal CLI
+                // when PowerToys is elevated. GR/GW includes the pipe-instance right, so keep
+                // the single, first instance open until Stop; never release/reacquire its name.
+                const auto descriptorText = L"O:" + SidString(m_identity.userSid.data()) +
+                                            L"D:P(A;;GRGW;;;" + m_identity.logonSid + L")S:(ML;;NW;;;ME)";
+                LocalMemory descriptor;
+                winrt::check_bool(ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                    descriptorText.c_str(), SDDL_REVISION_1, &descriptor.value, nullptr));
+                SECURITY_ATTRIBUTES attributes{ sizeof(attributes), descriptor.value, FALSE };
+                m_pipe.Reset(CreateNamedPipeW(
+                    m_options.pipeName.c_str(),
+                    PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED | FILE_FLAG_FIRST_PIPE_INSTANCE,
+                    PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS,
+                    1,
+                    static_cast<DWORD>((MaxMessageCharacters + 1) * sizeof(wchar_t)),
+                    static_cast<DWORD>((MaxMessageCharacters + 1) * sizeof(wchar_t)),
+                    0,
+                    &attributes));
+                winrt::check_bool(m_pipe.Get() != INVALID_HANDLE_VALUE);
+
+                std::promise<HRESULT> ready;
+                auto initialized = ready.get_future();
+                m_thread = std::thread([this, ready = std::move(ready)]() mutable {
+                    const auto result = RoInitialize(RO_INIT_MULTITHREADED);
+                    ready.set_value(result);
+                    if (SUCCEEDED(result))
+                    {
+                        Run();
+                        RoUninitialize();
+                    }
+                });
+                const auto result = initialized.get();
+                if (SUCCEEDED(result))
+                {
+                    return true;
+                }
+                error = static_cast<DWORD>(result);
+                m_thread.join();
+            }
+            catch (const winrt::hresult_error& exception)
+            {
+                const HRESULT code = exception.code();
+                error = HRESULT_FACILITY(code) == FACILITY_WIN32 ? HRESULT_CODE(code) : static_cast<DWORD>(code);
+            }
+            catch (...)
+            {
+                error = ERROR_GEN_FAILURE;
+            }
+            if (m_thread.joinable())
+            {
+                SetEvent(m_stopEvent.Get());
+                CancelIoEx(m_pipe.Get(), nullptr);
+                m_thread.join();
+            }
+            m_pipe.Reset();
+            m_stopEvent.Reset();
+            SetLastError(error);
+            return false;
+        }
+
+        void Stop() noexcept
+        {
+            std::lock_guard lock(m_lifecycleMutex);
+            if (m_thread.joinable())
+            {
+                SetEvent(m_stopEvent.Get());
+                CancelIoEx(m_pipe.Get(), nullptr);
+                // The worker drains cancelled OVERLAPPED operations and finishes any active
+                // handler before these handles or the handler's captured state can be freed.
+                m_thread.join();
+            }
+            m_pipe.Reset();
+            m_stopEvent.Reset();
+        }
+
+    private:
+        bool IsStopped() const noexcept
+        {
+            return WaitForSingleObject(m_stopEvent.Get(), 0) == WAIT_OBJECT_0;
+        }
+
+        template<typename BeginOperation>
+        IoResult PerformIo(BeginOperation beginOperation, DWORD timeoutMs, DWORD& transferred)
+        {
+            transferred = 0;
+            if (IsStopped())
+            {
+                return IoResult::Stopped;
+            }
+            Handle completed(CreateEventW(nullptr, TRUE, FALSE, nullptr));
+            if (!completed.Get())
+            {
+                return IoResult::Failed;
+            }
+            OVERLAPPED operation{};
+            operation.hEvent = completed.Get();
+            if (beginOperation(operation))
+            {
+                return GetOverlappedResult(m_pipe.Get(), &operation, &transferred, FALSE) ? IoResult::Completed : IoResult::Failed;
+            }
+
+            const auto error = GetLastError();
+            if (error == ERROR_PIPE_CONNECTED)
+            {
+                return IoResult::Completed;
+            }
+            if (error != ERROR_IO_PENDING)
+            {
+                return error == ERROR_BROKEN_PIPE || error == ERROR_NO_DATA || error == ERROR_PIPE_NOT_CONNECTED ? IoResult::Closed : IoResult::Failed;
+            }
+
+            const HANDLE waits[]{ m_stopEvent.Get(), completed.Get() };
+            const auto wait = WaitForMultipleObjects(2, waits, FALSE, timeoutMs);
+            if (wait == WAIT_OBJECT_0 + 1)
+            {
+                if (GetOverlappedResult(m_pipe.Get(), &operation, &transferred, FALSE))
+                {
+                    return IoResult::Completed;
+                }
+                const auto completionError = GetLastError();
+                return completionError == ERROR_BROKEN_PIPE || completionError == ERROR_NO_DATA || completionError == ERROR_PIPE_NOT_CONNECTED ? IoResult::Closed : IoResult::Failed;
+            }
+
+            CancelIoEx(m_pipe.Get(), &operation);
+            // Even if completion raced cancellation, the kernel no longer references this
+            // OVERLAPPED or its caller-owned buffer once GetOverlappedResult has returned.
+            GetOverlappedResult(m_pipe.Get(), &operation, &transferred, TRUE);
+            if (wait == WAIT_OBJECT_0)
+            {
+                return IoResult::Stopped;
+            }
+            return wait == WAIT_TIMEOUT ? IoResult::TimedOut : IoResult::Failed;
+        }
+
+        bool AuthenticateClient()
+        {
+            ULONG pid = 0;
+            if (!GetNamedPipeClientProcessId(m_pipe.Get(), &pid))
+            {
+                return false;
+            }
+            Handle process(OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid));
+            if (!process.Get())
+            {
+                return false;
+            }
+            auto client = ReadIdentity(process.Get(), false);
+            return client.sessionId == m_identity.sessionId &&
+                   client.logonId.LowPart == m_identity.logonId.LowPart &&
+                   client.logonId.HighPart == m_identity.logonId.HighPart &&
+                   EqualSid(client.userSid.data(), m_identity.userSid.data());
+        }
+
+        std::wstring ReadRequest()
+        {
+            std::wstring message;
+            std::optional<BYTE> firstByte;
+            const auto deadline = GetTickCount64() + m_options.readTimeoutMs;
+            while (!IsStopped())
+            {
+                std::array<BYTE, 4096> bytes{};
+                DWORD count = 0;
+                const auto result = PerformIo(
+                    [&](OVERLAPPED& operation) { return ReadFile(m_pipe.Get(), bytes.data(), static_cast<DWORD>(bytes.size()), nullptr, &operation); },
+                    RemainingTime(deadline),
+                    count);
+                if (result == IoResult::TimedOut)
+                {
+                    throw RequestError(L"TIMEOUT", L"Timed out waiting for a complete request.");
+                }
+                if (result == IoResult::Stopped)
+                {
+                    throw RequestError(L"SERVICE_UNAVAILABLE", L"Light Switch is stopping.");
+                }
+                if (result != IoResult::Completed || count == 0)
+                {
+                    throw RequestError(L"PROTOCOL_ERROR", L"The UTF-16LE request must end with a newline.");
+                }
+
+                for (DWORD index = 0; index < count; ++index)
+                {
+                    if (!firstByte)
+                    {
+                        firstByte = bytes[index];
+                        continue;
+                    }
+                    const auto value = static_cast<wchar_t>(*firstByte | (static_cast<unsigned int>(bytes[index]) << 8));
+                    firstByte.reset();
+                    if (value == L'\n')
+                    {
+                        if (index + 1 != count)
+                        {
+                            throw RequestError(L"PROTOCOL_ERROR", L"Only one request is allowed per connection.");
+                        }
+                        return message;
+                    }
+                    if (message.size() == MaxMessageCharacters)
+                    {
+                        throw RequestError(L"PROTOCOL_ERROR", L"The request exceeds the 32768-character limit.");
+                    }
+                    message.push_back(value);
+                }
+            }
+            throw RequestError(L"SERVICE_UNAVAILABLE", L"Light Switch is stopping.");
+        }
+
+        void WaitForClientClose()
+        {
+            // DisconnectNamedPipe can discard unread output. Wait for the client to consume
+            // its response and close instead of flushing synchronously (which could hang).
+            // Any further input is discarded; it can never invoke the handler a second time.
+            const auto deadline = GetTickCount64() + m_options.readTimeoutMs;
+            while (!IsStopped() && RemainingTime(deadline) > 0)
+            {
+                std::array<BYTE, 256> ignored{};
+                DWORD count = 0;
+                const auto result = PerformIo(
+                    [&](OVERLAPPED& operation) { return ReadFile(m_pipe.Get(), ignored.data(), static_cast<DWORD>(ignored.size()), nullptr, &operation); },
+                    RemainingTime(deadline),
+                    count);
+                if (result != IoResult::Completed || count == 0)
+                {
+                    return;
+                }
+            }
+        }
+
+        void WriteResponse(JsonObject response)
+        {
+            std::wstring text(response.Stringify());
+            if (text.size() > MaxMessageCharacters)
+            {
+                text = MakeError(L"PROTOCOL_ERROR", L"The response exceeds the 32768-character limit.").Stringify();
+            }
+            text.push_back(L'\n');
+            const auto size = static_cast<DWORD>(text.size() * sizeof(wchar_t));
+            const auto deadline = GetTickCount64() + m_options.writeTimeoutMs;
+            DWORD offset = 0;
+            while (offset < size)
+            {
+                DWORD count = 0;
+                const auto result = PerformIo(
+                    [&](OVERLAPPED& operation) { return WriteFile(m_pipe.Get(), reinterpret_cast<const BYTE*>(text.data()) + offset, size - offset, nullptr, &operation); },
+                    RemainingTime(deadline),
+                    count);
+                if (result != IoResult::Completed || count == 0)
+                {
+                    return;
+                }
+                offset += count;
+            }
+            WaitForClientClose();
+        }
+
+        void HandleConnection()
+        {
+            JsonObject response;
+            try
+            {
+                if (!AuthenticateClient())
+                {
+                    response = MakeError(L"SERVICE_UNAVAILABLE", L"The client is not in the Light Switch user's logon session.");
+                }
+                else
+                {
+                    const auto request = ParseRequest(ReadRequest());
+                    response = IsStopped() ? MakeError(L"SERVICE_UNAVAILABLE", L"Light Switch is stopping.") : m_handler(request);
+                    if (!response)
+                    {
+                        response = MakeError(L"EXECUTION_FAILED", L"Light Switch did not return a response.");
+                    }
+                }
+            }
+            catch (const RequestError& error)
+            {
+                response = MakeError(error.Code(), error.Message());
+            }
+            catch (...)
+            {
+                response = MakeError(L"EXECUTION_FAILED", L"Light Switch could not process the command.");
+            }
+            if (!IsStopped())
+            {
+                WriteResponse(response);
+            }
+        }
+
+        void Run() noexcept
+        {
+            while (!IsStopped())
+            {
+                try
+                {
+                    DWORD ignored = 0;
+                    const auto result = PerformIo(
+                        [&](OVERLAPPED& operation) { return ConnectNamedPipe(m_pipe.Get(), &operation); },
+                        INFINITE,
+                        ignored);
+                    if (result == IoResult::Stopped)
+                    {
+                        break;
+                    }
+                    if (result == IoResult::Failed)
+                    {
+                        break;
+                    }
+                    if (result == IoResult::Completed)
+                    {
+                        HandleConnection();
+                    }
+                }
+                catch (...)
+                {
+                    // Serialization and allocation failures also must not terminate the
+                    // process or release the owned pipe name between connections.
+                    try
+                    {
+                        if (!IsStopped())
+                        {
+                            WriteResponse(MakeError(L"EXECUTION_FAILED", L"Light Switch could not complete the request."));
+                        }
+                    }
+                    catch (...)
+                    {
+                    }
+                }
+                DisconnectNamedPipe(m_pipe.Get());
+            }
+        }
+
+        Handler m_handler;
+        Options m_options;
+        TokenIdentity m_identity;
+        Handle m_pipe;
+        Handle m_stopEvent;
+        std::thread m_thread;
+        std::mutex m_lifecycleMutex;
+    };
+
+    CliPipeServer::CliPipeServer(Handler handler) : CliPipeServer(std::move(handler), Options{}) {}
+    CliPipeServer::CliPipeServer(Handler handler, Options options) : m_impl(std::make_unique<Impl>(std::move(handler), std::move(options))) {}
+    CliPipeServer::~CliPipeServer()
+    {
+        Stop();
+    }
+    bool CliPipeServer::Start()
+    {
+        return m_impl->Start();
+    }
+    void CliPipeServer::Stop() noexcept
+    {
+        m_impl->Stop();
+    }
+}

--- a/src/modules/LightSwitch/LightSwitchService/CliPipeServer.h
+++ b/src/modules/LightSwitch/LightSwitchService/CliPipeServer.h
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include "CliProtocol.h"
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <Windows.h>
+
+namespace light_switch_cli
+{
+    std::wstring GetPipeName();
+
+    class CliPipeServer
+    {
+    public:
+        using Handler = std::function<winrt::Windows::Data::Json::JsonObject(const Request&)>;
+
+        struct Options
+        {
+            std::wstring pipeName;
+            DWORD readTimeoutMs = 10000;
+            DWORD writeTimeoutMs = 10000;
+        };
+
+        explicit CliPipeServer(Handler handler);
+        CliPipeServer(Handler handler, Options options);
+        ~CliPipeServer();
+
+        CliPipeServer(const CliPipeServer&) = delete;
+        CliPipeServer& operator=(const CliPipeServer&) = delete;
+
+        // Acquires the only pipe instance before returning. Failure leaves GetLastError set.
+        bool Start();
+
+        // Cancels pipe I/O and joins the server thread. A running handler is allowed to finish;
+        // callers must retain the state captured by the handler until Stop has returned.
+        // Start/Stop must not be called from the handler itself.
+        void Stop() noexcept;
+
+    private:
+        class Impl;
+        std::unique_ptr<Impl> m_impl;
+    };
+}

--- a/src/modules/LightSwitch/LightSwitchService/CliProtocol.cpp
+++ b/src/modules/LightSwitch/LightSwitchService/CliProtocol.cpp
@@ -1,0 +1,256 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "CliProtocol.h"
+
+#include <set>
+#include <utility>
+
+using namespace winrt::Windows::Data::Json;
+
+namespace light_switch_cli
+{
+    namespace
+    {
+        void ValidateEncoding(std::wstring_view message)
+        {
+            if (message.empty() || message.size() > MaxMessageCharacters || message.front() == L'\xfeff')
+            {
+                throw RequestError(L"PROTOCOL_ERROR", L"The request must be a nonempty, BOM-less JSON object of at most 32768 characters.");
+            }
+
+            for (size_t index = 0; index < message.size(); ++index)
+            {
+                const auto value = static_cast<unsigned int>(message[index]);
+                if (value == 0 || (value >= 0xdc00 && value <= 0xdfff))
+                {
+                    throw RequestError(L"PROTOCOL_ERROR", L"The request contains invalid UTF-16 data.");
+                }
+                if (value >= 0xd800 && value <= 0xdbff)
+                {
+                    if (++index == message.size() || message[index] < 0xdc00 || message[index] > 0xdfff)
+                    {
+                        throw RequestError(L"PROTOCOL_ERROR", L"The request contains invalid UTF-16 data.");
+                    }
+                }
+            }
+        }
+
+        void RejectNestedValues(std::wstring_view message)
+        {
+            bool inString = false;
+            bool escaped = false;
+            int depth = 0;
+            for (const auto value : message)
+            {
+                if (inString)
+                {
+                    if (escaped)
+                    {
+                        escaped = false;
+                    }
+                    else if (value == L'\\')
+                    {
+                        escaped = true;
+                    }
+                    else if (value == L'"')
+                    {
+                        inString = false;
+                    }
+                }
+                else if (value == L'"')
+                {
+                    inString = true;
+                }
+                else if (value == L'[' || (value == L'{' && ++depth > 1))
+                {
+                    // Every supported field is a primitive. Reject nested containers before
+                    // invoking the JSON parser, including arbitrarily deep untrusted input.
+                    throw RequestError(L"PROTOCOL_ERROR", L"Request properties must be primitive JSON values.");
+                }
+                else if (value == L'}')
+                {
+                    --depth;
+                }
+            }
+        }
+
+        // Windows.Data.Json keeps only the final value of duplicate object keys. Inspect the
+        // already validated JSON text as well so duplicates cannot change a command's meaning.
+        void RejectDuplicateProperties(std::wstring_view message)
+        {
+            std::set<std::wstring> properties;
+            int depth = 0;
+            bool expectingProperty = false;
+            for (size_t index = 0; index < message.size(); ++index)
+            {
+                const auto value = message[index];
+                if (value == L'"')
+                {
+                    const auto start = index++;
+                    while (index < message.size())
+                    {
+                        if (message[index] == L'\\')
+                        {
+                            index += 2;
+                        }
+                        else if (message[index] == L'"')
+                        {
+                            break;
+                        }
+                        else
+                        {
+                            ++index;
+                        }
+                    }
+                    if (depth == 1 && expectingProperty)
+                    {
+                        const auto key = JsonValue::Parse(winrt::hstring(message.substr(start, index - start + 1))).GetString();
+                        if (!properties.emplace(key.c_str(), key.size()).second)
+                        {
+                            throw RequestError(L"PROTOCOL_ERROR", L"Duplicate request properties are not allowed.");
+                        }
+                        expectingProperty = false;
+                    }
+                }
+                else if (value == L'{' || value == L'[')
+                {
+                    ++depth;
+                    if (depth == 1)
+                    {
+                        expectingProperty = true;
+                    }
+                }
+                else if (value == L'}' || value == L']')
+                {
+                    --depth;
+                }
+                else if (value == L',' && depth == 1)
+                {
+                    expectingProperty = true;
+                }
+            }
+        }
+    }
+
+    RequestError::RequestError(std::wstring code, std::wstring message) :
+        std::runtime_error("Invalid Light Switch CLI request"),
+        m_code(std::move(code)),
+        m_message(std::move(message))
+    {
+    }
+
+    const std::wstring& RequestError::Code() const noexcept
+    {
+        return m_code;
+    }
+
+    const std::wstring& RequestError::Message() const noexcept
+    {
+        return m_message;
+    }
+
+    Request ParseRequest(std::wstring_view message)
+    {
+        ValidateEncoding(message);
+        RejectNestedValues(message);
+
+        JsonObject object;
+        if (!JsonObject::TryParse(winrt::hstring(message), object))
+        {
+            throw RequestError(L"PROTOCOL_ERROR", L"The request must be a valid JSON object.");
+        }
+        RejectDuplicateProperties(message);
+
+        for (const auto& property : object)
+        {
+            if (property.Key() != L"version" && property.Key() != L"command" && property.Key() != L"mode")
+            {
+                throw RequestError(L"INVALID_ARGUMENT", L"The request contains an unsupported property.");
+            }
+        }
+
+        if (!object.HasKey(L"version") || object.GetNamedValue(L"version").ValueType() != JsonValueType::Number ||
+            object.GetNamedNumber(L"version") != ProtocolVersion)
+        {
+            throw RequestError(L"PROTOCOL_ERROR", L"The request must specify protocol version 1.");
+        }
+        if (!object.HasKey(L"command") || object.GetNamedValue(L"command").ValueType() != JsonValueType::String)
+        {
+            throw RequestError(L"INVALID_ARGUMENT", L"The request must specify a command string.");
+        }
+
+        const auto command = object.GetNamedString(L"command");
+        Request request{};
+        if (command == L"status")
+        {
+            request.command = Command::Status;
+        }
+        else if (command == L"light")
+        {
+            request.command = Command::Light;
+        }
+        else if (command == L"dark")
+        {
+            request.command = Command::Dark;
+        }
+        else if (command == L"toggle")
+        {
+            request.command = Command::Toggle;
+        }
+        else if (command == L"schedule-enable")
+        {
+            request.command = Command::ScheduleEnable;
+        }
+        else if (command == L"schedule-disable")
+        {
+            request.command = Command::ScheduleDisable;
+        }
+        else
+        {
+            throw RequestError(L"INVALID_ARGUMENT", L"The request specifies an unsupported command.");
+        }
+
+        if (object.HasKey(L"mode"))
+        {
+            if (request.command != Command::ScheduleEnable || object.GetNamedValue(L"mode").ValueType() != JsonValueType::String)
+            {
+                throw RequestError(L"INVALID_ARGUMENT", L"Only schedule-enable accepts a mode string.");
+            }
+            const auto mode = object.GetNamedString(L"mode");
+            if (mode != L"FixedHours" && mode != L"SunsetToSunrise" && mode != L"FollowNightLight")
+            {
+                throw RequestError(L"INVALID_ARGUMENT", L"Mode must be FixedHours, SunsetToSunrise, or FollowNightLight.");
+            }
+            request.mode = std::wstring(mode.c_str(), mode.size());
+        }
+
+        return request;
+    }
+
+    JsonObject MakeSuccess(const JsonObject& state)
+    {
+        JsonObject response;
+        response.SetNamedValue(L"version", JsonValue::CreateNumberValue(ProtocolVersion));
+        response.SetNamedValue(L"success", JsonValue::CreateBooleanValue(true));
+        response.SetNamedValue(L"state", state);
+        return response;
+    }
+
+    JsonObject MakeError(std::wstring_view code, std::wstring_view message, const JsonObject& state)
+    {
+        JsonObject error;
+        error.SetNamedValue(L"code", JsonValue::CreateStringValue(winrt::hstring(code)));
+        error.SetNamedValue(L"message", JsonValue::CreateStringValue(winrt::hstring(message)));
+        JsonObject response;
+        response.SetNamedValue(L"version", JsonValue::CreateNumberValue(ProtocolVersion));
+        response.SetNamedValue(L"success", JsonValue::CreateBooleanValue(false));
+        response.SetNamedValue(L"error", error);
+        if (state)
+        {
+            response.SetNamedValue(L"state", state);
+        }
+        return response;
+    }
+}

--- a/src/modules/LightSwitch/LightSwitchService/CliProtocol.h
+++ b/src/modules/LightSwitch/LightSwitchService/CliProtocol.h
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.Data.Json.h>
+
+namespace light_switch_cli
+{
+    inline constexpr int ProtocolVersion = 1;
+    inline constexpr size_t MaxMessageCharacters = 32768;
+
+    enum class Command
+    {
+        Status,
+        Light,
+        Dark,
+        Toggle,
+        ScheduleEnable,
+        ScheduleDisable,
+    };
+
+    struct Request
+    {
+        Command command;
+        std::optional<std::wstring> mode;
+    };
+
+    class RequestError : public std::runtime_error
+    {
+    public:
+        RequestError(std::wstring code, std::wstring message);
+
+        const std::wstring& Code() const noexcept;
+        const std::wstring& Message() const noexcept;
+
+    private:
+        std::wstring m_code;
+        std::wstring m_message;
+    };
+
+    // Accepts the JSON payload without its UTF-16LE newline frame delimiter.
+    // Malformed protocol data throws RequestError; no command is executed while parsing.
+    Request ParseRequest(std::wstring_view message);
+
+    winrt::Windows::Data::Json::JsonObject MakeSuccess(const winrt::Windows::Data::Json::JsonObject& state);
+    winrt::Windows::Data::Json::JsonObject MakeError(
+        std::wstring_view code,
+        std::wstring_view message,
+        const winrt::Windows::Data::Json::JsonObject& state = nullptr);
+}

--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchService.cpp
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchService.cpp
@@ -1,4 +1,4 @@
-﻿#include <windows.h>
+#include <windows.h>
 #include <tchar.h>
 #include "ThemeScheduler.h"
 #include "ThemeHelper.h"
@@ -15,16 +15,21 @@
 #include <LightSwitchUtils.h>
 #include <NightLightRegistryObserver.h>
 #include <trace.h>
+#include "CliPipeServer.h"
+#include "CliProtocol.h"
+#include "ScheduleCommandQueue.h"
+#include <array>
+#include <algorithm>
+#include <roapi.h>
+#include <wil/resource.h>
 
 SERVICE_STATUS g_ServiceStatus = {};
 SERVICE_STATUS_HANDLE g_StatusHandle = nullptr;
 HANDLE g_ServiceStopEvent = nullptr;
-static LightSwitchStateManager* g_stateManagerPtr = nullptr;
 
 VOID WINAPI ServiceMain(DWORD argc, LPTSTR* argv);
 VOID WINAPI ServiceCtrlHandler(DWORD dwCtrl);
 DWORD WINAPI ServiceWorkerThread(LPVOID lpParam);
-void ApplyTheme(bool shouldBeLight);
 
 // Entry point for the executable
 int _tmain(int argc, TCHAR* argv[])
@@ -125,234 +130,257 @@ VOID WINAPI ServiceCtrlHandler(DWORD dwCtrl)
     }
 }
 
-void ApplyTheme(bool shouldBeLight)
+namespace
 {
-    const auto& s = LightSwitchSettings::settings();
+    using winrt::Windows::Data::Json::JsonObject;
+    using winrt::Windows::Data::Json::JsonValue;
 
-    if (s.changeSystem)
+    JsonObject SerializeStatus(const StatusSnapshot& status)
     {
-        bool isSystemCurrentlyLight = GetCurrentSystemTheme();
-        if (shouldBeLight != isSystemCurrentlyLight)
-        {
-            SetSystemTheme(shouldBeLight);
-            Logger::info(L"[LightSwitchService] Changed system theme to {}.", shouldBeLight ? L"light" : L"dark");
-        }
+        JsonObject state;
+        const auto themeName = [](const std::optional<bool>& value) {
+            return value ? (*value ? L"light" : L"dark") : L"unknown";
+        };
+        state.SetNamedValue(L"systemTheme", JsonValue::CreateStringValue(themeName(status.systemLight)));
+        state.SetNamedValue(L"appsTheme", JsonValue::CreateStringValue(themeName(status.appsLight)));
+        state.SetNamedValue(L"changeSystem", JsonValue::CreateBooleanValue(status.config.changeSystem));
+        state.SetNamedValue(L"changeApps", JsonValue::CreateBooleanValue(status.config.changeApps));
+        state.SetNamedValue(L"scheduleMode", JsonValue::CreateStringValue(ToString(status.config.scheduleMode)));
+        state.SetNamedValue(L"manualOverride", JsonValue::CreateBooleanValue(status.manualOverride));
+        return state;
     }
 
-    if (s.changeApps)
+    JsonObject SerializeResult(const ThemeCommandResult& result)
     {
-        bool isAppsCurrentlyLight = GetCurrentAppsTheme();
-        if (shouldBeLight != isAppsCurrentlyLight)
-        {
-            SetAppsTheme(shouldBeLight);
-            Logger::info(L"[LightSwitchService] Changed apps theme to {}.", shouldBeLight ? L"light" : L"dark");
-        }
+        auto state = SerializeStatus(result.status);
+        const wchar_t* code = result.errorCode.c_str();
+        if (result.errorCode == L"SETTINGS_READ_FAILED")
+            code = L"INVALID_CONFIGURATION";
+        else if (result.errorCode == L"THEME_READ_FAILED" || result.errorCode == L"THEME_WRITE_FAILED")
+            code = L"EXECUTION_FAILED";
+        return result.success ? light_switch_cli::MakeSuccess(state) : light_switch_cli::MakeError(code, result.message, state);
     }
 }
 
-static void DetectAndHandleExternalThemeChange(LightSwitchStateManager& stateManager)
+static DWORD RunServiceWorker(LPVOID lpParam)
 {
-    const auto& s = LightSwitchSettings::settings();
-    if (s.scheduleMode == ScheduleMode::Off)
-        return;
+    using light_switch_cli::Command;
+    using light_switch_cli::Request;
 
-    SYSTEMTIME st;
-    GetLocalTime(&st);
-    int nowMinutes = st.wHour * 60 + st.wMinute;
+    const DWORD parentPid = static_cast<DWORD>(reinterpret_cast<ULONG_PTR>(lpParam));
+    wil::unique_handle parent(parentPid ? OpenProcess(SYNCHRONIZE, FALSE, parentPid) : nullptr);
+    wil::unique_handle toggleRequests(OpenSemaphoreW(SYNCHRONIZE, FALSE, LIGHT_SWITCH_TOGGLE_REQUEST_SEMAPHORE));
+    LightSwitchStateManager stateManager;
+    auto& settingsStore = LightSwitchSettings::instance();
+    ScheduleCommandQueue scheduleCommands;
+    std::unique_ptr<NightLightRegistryObserver> nightLightWatcher;
 
-    // Compute effective boundaries (with offsets if needed)
-    int effectiveLight = s.lightTime;
-    int effectiveDark = s.darkTime;
+    Logger::info(L"[LightSwitchService] Worker thread starting, parent PID: {}", parentPid);
+    settingsStore.InitFileWatcher();
+    HANDLE settingsChanged = settingsStore.GetSettingsChangedEvent();
 
-    if (s.scheduleMode == ScheduleMode::SunsetToSunrise)
-    {
-        effectiveLight = (s.lightTime + s.sunrise_offset) % 1440;
-        effectiveDark = (s.darkTime + s.sunset_offset) % 1440;
-    }
+    // Observer lifetime stays on the existing worker. In particular, Stop() joins
+    // its callback thread and must never run while holding the state-manager lock.
+    const auto updateNightLightWatcher = [&]() {
+        const bool needed = LightSwitchSettings::settings().scheduleMode == ScheduleMode::FollowNightLight;
+        if (needed && !nightLightWatcher)
+        {
+            nightLightWatcher = std::make_unique<NightLightRegistryObserver>(
+                HKEY_CURRENT_USER, NIGHT_LIGHT_REGISTRY_PATH, [&stateManager]() { stateManager.OnNightLightChange(); });
+        }
+        else if (!needed && nightLightWatcher)
+        {
+            nightLightWatcher->Stop();
+            nightLightWatcher.reset();
+        }
+    };
 
-    // Use shared helper (handles wraparound logic)
-    bool shouldBeLight = false;
-    if (s.scheduleMode == ScheduleMode::FollowNightLight)
-    {
-        shouldBeLight = !IsNightLightEnabled();
-    } 
-    else
-    {
-        shouldBeLight = ShouldBeLight(nowMinutes, effectiveLight, effectiveDark);
-    }
-
-    // Compare current system/apps theme
-    bool currentSystemLight = GetCurrentSystemTheme();
-    bool currentAppsLight = GetCurrentAppsTheme();
-
-    bool systemMismatch = s.changeSystem && (currentSystemLight != shouldBeLight);
-    bool appsMismatch = s.changeApps && (currentAppsLight != shouldBeLight);
-
-    // Trigger manual override only if mismatch and not already active
-    if ((systemMismatch || appsMismatch) && !stateManager.GetState().isManualOverride)
-    {
-        Logger::info(L"[LightSwitchService] External theme change detected (Windows Settings). Entering manual override mode.");
-        stateManager.OnManualOverride();
-    }
-}
-
-DWORD WINAPI ServiceWorkerThread(LPVOID lpParam)
-{
-    DWORD parentPid = static_cast<DWORD>(reinterpret_cast<ULONG_PTR>(lpParam));
-    HANDLE hParent = nullptr;
-    if (parentPid)
-        hParent = OpenProcess(SYNCHRONIZE, FALSE, parentPid);
-
-    Logger::info(L"[LightSwitchService] Worker thread starting...");
-    Logger::info(L"[LightSwitchService] Parent PID: {}", parentPid);
-
-    // ────────────────────────────────────────────────────────────────
-    // Initialization
-    // ────────────────────────────────────────────────────────────────
-    static LightSwitchStateManager stateManager;
-    g_stateManagerPtr = &stateManager;
-
-    LightSwitchSettings::instance().InitFileWatcher();
-
-    HANDLE hManualOverride = OpenEventW(SYNCHRONIZE | EVENT_MODIFY_STATE, FALSE, L"POWERTOYS_LIGHTSWITCH_MANUAL_OVERRIDE");
-    HANDLE hSettingsChanged = LightSwitchSettings::instance().GetSettingsChangedEvent();
-
-    static std::unique_ptr<NightLightRegistryObserver> g_nightLightWatcher;
-
-    LightSwitchSettings::instance().LoadSettings();
-    const auto& settings = LightSwitchSettings::instance().settings();
-
-    // after loading settings:
-    bool nightLightNeeded = (settings.scheduleMode == ScheduleMode::FollowNightLight);
-
-    if (nightLightNeeded && !g_nightLightWatcher)
-    {
-        Logger::info(L"[LightSwitchService] Starting Night Light registry watcher...");
-
-        g_nightLightWatcher = std::make_unique<NightLightRegistryObserver>(
-            HKEY_CURRENT_USER,
-            NIGHT_LIGHT_REGISTRY_PATH,
-            []() {
-                if (g_stateManagerPtr)
-                    g_stateManagerPtr->OnNightLightChange();
-            });
-    }
-    else if (!nightLightNeeded && g_nightLightWatcher)
-    {
-        Logger::info(L"[LightSwitchService] Stopping Night Light registry watcher...");
-        g_nightLightWatcher->Stop();
-        g_nightLightWatcher.reset();
-    }
-
-    SYSTEMTIME st;
-    GetLocalTime(&st);
-    int nowMinutes = st.wHour * 60 + st.wMinute;
-
-    Logger::info(L"[LightSwitchService] Initialized at {:02d}:{:02d}.", st.wHour, st.wMinute);
+    settingsStore.LoadSettings();
+    updateNightLightWatcher();
     stateManager.SyncInitialThemeState();
 
-    // ────────────────────────────────────────────────────────────────
-    // Worker Loop
-    // ────────────────────────────────────────────────────────────────
+    const auto applyScheduleRequest = [&](const Request& request) -> JsonObject {
+        LightSwitchConfig current;
+        std::wstring error;
+        if (!settingsStore.TryLoadSettings(current, error))
+        {
+            return light_switch_cli::MakeError(L"INVALID_CONFIGURATION", error);
+        }
+
+        ScheduleMode target = current.scheduleMode;
+        if (request.command == Command::ScheduleDisable)
+        {
+            target = ScheduleMode::Off;
+        }
+        else if (request.mode)
+        {
+            // The protocol parser only accepts the three explicit enabled modes.
+            target = FromString(*request.mode);
+        }
+        else if (target == ScheduleMode::Off)
+        {
+            return light_switch_cli::MakeError(
+                L"INVALID_ARGUMENT", L"The schedule is off. Specify --mode fixed-hours, sunset-to-sunrise, or follow-night-light.");
+        }
+
+        if (target != current.scheduleMode && !settingsStore.TrySetScheduleMode(target, current, error))
+        {
+            return light_switch_cli::MakeError(L"EXECUTION_FAILED", error);
+        }
+
+        // The state manager ignores unchanged configurations, including the late
+        // file-watcher echo of this same save. A no-op enable must not clear a
+        // manual theme override.
+        updateNightLightWatcher();
+        const auto applied = stateManager.OnSettingsChanged();
+        if (!applied.success)
+        {
+            return SerializeResult(applied);
+        }
+        const auto status = stateManager.GetStatusSnapshot();
+        if (status.config.scheduleMode != target)
+        {
+            return light_switch_cli::MakeError(
+                L"EXECUTION_FAILED", L"The schedule was changed by another settings update. Query status and try again.", SerializeStatus(status));
+        }
+        return light_switch_cli::MakeSuccess(SerializeStatus(status));
+    };
+
+    light_switch_cli::CliPipeServer cliServer([&](const Request& request) -> JsonObject {
+        if (WaitForSingleObject(g_ServiceStopEvent, 0) == WAIT_OBJECT_0)
+        {
+            return light_switch_cli::MakeError(L"SERVICE_UNAVAILABLE", L"Light Switch is stopping.");
+        }
+        switch (request.command)
+        {
+        case Command::Status:
+        {
+            const auto status = stateManager.GetStatusSnapshot();
+            if (!status.configurationAvailable)
+            {
+                return light_switch_cli::MakeError(L"INVALID_CONFIGURATION", L"Light Switch settings have not been loaded successfully.");
+            }
+            return status.systemLight && status.appsLight ? light_switch_cli::MakeSuccess(SerializeStatus(status)) : light_switch_cli::MakeError(L"EXECUTION_FAILED", L"Windows theme state could not be read.", SerializeStatus(status));
+        }
+        case Command::Light:
+            return SerializeResult(stateManager.SetTheme(true));
+        case Command::Dark:
+            return SerializeResult(stateManager.SetTheme(false));
+        case Command::Toggle:
+            return SerializeResult(stateManager.ToggleTheme());
+        case Command::ScheduleEnable:
+        case Command::ScheduleDisable:
+            return scheduleCommands.Submit(request);
+        default:
+            return light_switch_cli::MakeError(L"INVALID_ARGUMENT", L"Unknown Light Switch command.");
+        }
+    });
+    const auto stopCli = wil::scope_exit([&]() {
+        scheduleCommands.Stop();
+        cliServer.Stop();
+    });
+    if (!cliServer.Start())
+    {
+        Logger::error(L"[LightSwitchService] Could not start the CLI pipe (error: {}).", GetLastError());
+    }
+
+    std::array<HANDLE, 5> waits{};
+    DWORD count = 0;
+    const DWORD stopIndex = count;
+    waits[count++] = g_ServiceStopEvent;
+    DWORD parentIndex = MAXDWORD;
+    DWORD toggleIndex = MAXDWORD;
+    if (parent)
+    {
+        parentIndex = count;
+        waits[count++] = parent.get();
+    }
+    if (toggleRequests)
+    {
+        toggleIndex = count;
+        waits[count++] = toggleRequests.get();
+    }
+    const DWORD settingsIndex = count;
+    waits[count++] = settingsChanged;
+    const DWORD scheduleIndex = count;
+    waits[count++] = scheduleCommands.Event();
+
     for (;;)
     {
-        HANDLE waits[4];
-        DWORD count = 0;
-        waits[count++] = g_ServiceStopEvent;
-        if (hParent)
-            waits[count++] = hParent;
-        if (hManualOverride)
-            waits[count++] = hManualOverride;
-        waits[count++] = hSettingsChanged;
-
-        // Wait for one of these to trigger or for a new minute tick
-        SYSTEMTIME st;
-        GetLocalTime(&st);
-        int msToNextMinute = (60 - st.wSecond) * 1000 - st.wMilliseconds;
-        if (msToNextMinute < 50)
-            msToNextMinute = 50;
-
-        DWORD wait = WaitForMultipleObjects(count, waits, FALSE, msToNextMinute);
-
+        SYSTEMTIME now;
+        GetLocalTime(&now);
+        const DWORD untilNextMinute = static_cast<DWORD>((std::max)(50, (60 - now.wSecond) * 1000 - now.wMilliseconds));
+        const DWORD wait = WaitForMultipleObjects(count, waits.data(), FALSE, untilNextMinute);
         if (wait == WAIT_TIMEOUT)
         {
-            // regular minute tick
-            GetLocalTime(&st);
-            nowMinutes = st.wHour * 60 + st.wMinute;
-            DetectAndHandleExternalThemeChange(stateManager);
+            stateManager.DetectExternalThemeChange();
             stateManager.OnTick();
-            continue;
         }
-
-        if (wait == WAIT_OBJECT_0)
+        else if (wait == WAIT_FAILED)
         {
-            Logger::info(L"[LightSwitchService] Stop event triggered — exiting.");
+            Logger::error(L"[LightSwitchService] Worker wait failed (error: {}).", GetLastError());
             break;
         }
-
-        if (hParent && wait == WAIT_OBJECT_0 + 1)
+        else
         {
-            Logger::info(L"[LightSwitchService] Parent process exited — stopping service.");
-            break;
-        }
-
-        if (hManualOverride && wait == WAIT_OBJECT_0 + (hParent ? 2 : 1))
-        {
-            Logger::info(L"[LightSwitchService] Manual override event detected.");
-            stateManager.OnManualOverride();
-            ResetEvent(hManualOverride);
-            continue;
-        }
-
-        if (wait == WAIT_OBJECT_0 + (hParent ? (hManualOverride ? 3 : 2) : 2))
-        {
-            ResetEvent(hSettingsChanged);
-            LightSwitchSettings::instance().LoadSettings();
-            stateManager.OnSettingsChanged();
-
-            const auto& settings = LightSwitchSettings::instance().settings();
-            bool nightLightNeeded = (settings.scheduleMode == ScheduleMode::FollowNightLight);
-
-            if (nightLightNeeded && !g_nightLightWatcher)
+            const DWORD index = wait - WAIT_OBJECT_0;
+            if (index == stopIndex || index == parentIndex)
             {
-                Logger::info(L"[LightSwitchService] Starting Night Light registry watcher...");
-
-                g_nightLightWatcher = std::make_unique<NightLightRegistryObserver>(
-                    HKEY_CURRENT_USER,
-                    NIGHT_LIGHT_REGISTRY_PATH,
-                    []() {
-                        if (g_stateManagerPtr)
-                            g_stateManagerPtr->OnNightLightChange();
-                    });
-
-                stateManager.OnNightLightChange();
+                break;
             }
-            else if (!nightLightNeeded && g_nightLightWatcher)
+            if (index == toggleIndex)
             {
-                Logger::info(L"[LightSwitchService] Stopping Night Light registry watcher...");
-                g_nightLightWatcher->Stop();
-                g_nightLightWatcher.reset();
+                const auto result = stateManager.ToggleTheme();
+                if (!result.success)
+                {
+                    Logger::warn(L"[LightSwitchService] Toggle failed: {}", result.message);
+                }
             }
-
-            continue;
+            else if (index == settingsIndex)
+            {
+                ResetEvent(settingsChanged);
+                settingsStore.LoadSettings();
+                updateNightLightWatcher();
+                stateManager.OnSettingsChanged();
+            }
+            else if (index == scheduleIndex)
+            {
+                scheduleCommands.ProcessPending(applyScheduleRequest);
+            }
         }
     }
 
-    // ────────────────────────────────────────────────────────────────
-    // Cleanup
-    // ────────────────────────────────────────────────────────────────
-    if (hManualOverride)
-        CloseHandle(hManualOverride);
-    if (hParent)
-        CloseHandle(hParent);
-    if (g_nightLightWatcher)
+    // Release pipe callbacks waiting for this worker before joining the server.
+    // In-flight theme operations retain access to stateManager until Stop returns.
+    SetEvent(g_ServiceStopEvent);
+    scheduleCommands.Stop();
+    cliServer.Stop();
+    if (nightLightWatcher)
     {
-        g_nightLightWatcher->Stop();
-        g_nightLightWatcher.reset();
+        nightLightWatcher->Stop();
+        nightLightWatcher.reset();
     }
-
     Logger::info(L"[LightSwitchService] Worker thread exiting cleanly.");
     return 0;
+}
+DWORD WINAPI ServiceWorkerThread(LPVOID lpParam)
+{
+    try
+    {
+        winrt::check_hresult(RoInitialize(RO_INIT_MULTITHREADED));
+        const auto apartmentCleanup = wil::scope_exit([]() { RoUninitialize(); });
+        return RunServiceWorker(lpParam);
+    }
+    catch (const winrt::hresult_error& error)
+    {
+        Logger::error(L"[LightSwitchService] Worker failed: {}", error.message().c_str());
+        return static_cast<DWORD>(error.code());
+    }
+    catch (...)
+    {
+        Logger::error(L"[LightSwitchService] Worker failed unexpectedly.");
+        return ERROR_GEN_FAILURE;
+    }
 }
 
 int APIENTRY wWinMain(HINSTANCE, HINSTANCE, PWSTR, int)

--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchService.vcxproj
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchService.vcxproj
@@ -70,10 +70,12 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>Advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;RuntimeObject.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="CliPipeServer.cpp" />
+    <ClCompile Include="CliProtocol.cpp" />
     <ClCompile Include="LightSwitchService.cpp" />
     <ClCompile Include="LightSwitchSettings.cpp" />
     <ClCompile Include="LightSwitchStateManager.cpp" />
@@ -87,6 +89,9 @@
     <ResourceCompile Include="LightSwitchService.rc" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="CliPipeServer.h" />
+    <ClInclude Include="CliProtocol.h" />
+    <ClInclude Include="ScheduleCommandQueue.h" />
     <ClInclude Include="LightSwitchSettings.h" />
     <ClInclude Include="LightSwitchStateManager.h" />
     <ClInclude Include="LightSwitchUtils.h" />

--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchService.vcxproj
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchService.vcxproj
@@ -74,6 +74,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="CliIdentity.cpp" />
     <ClCompile Include="CliPipeServer.cpp" />
     <ClCompile Include="CliProtocol.cpp" />
     <ClCompile Include="LightSwitchService.cpp" />
@@ -89,6 +90,7 @@
     <ResourceCompile Include="LightSwitchService.rc" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="CliIdentity.h" />
     <ClInclude Include="CliPipeServer.h" />
     <ClInclude Include="CliProtocol.h" />
     <ClInclude Include="ScheduleCommandQueue.h" />

--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchService.vcxproj.filters
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchService.vcxproj.filters
@@ -18,6 +18,12 @@
     <ClCompile Include="LightSwitchService.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="CliPipeServer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="CliProtocol.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="ThemeScheduler.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -45,6 +51,15 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ThemeScheduler.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="CliPipeServer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="CliProtocol.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ScheduleCommandQueue.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="ThemeHelper.h">

--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchService.vcxproj.filters
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchService.vcxproj.filters
@@ -21,6 +21,9 @@
     <ClCompile Include="CliPipeServer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="CliIdentity.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="CliProtocol.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -54,6 +57,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="CliPipeServer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="CliIdentity.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="CliProtocol.h">

--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchSettings.cpp
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchSettings.cpp
@@ -2,6 +2,7 @@
 #include <common/utils/json.h>
 #include <common/SettingsAPI/settings_helpers.h>
 #include "SettingsObserver.h"
+#include <array>
 #include <filesystem>
 #include <fstream>
 #include <cmath>
@@ -29,6 +30,33 @@ namespace
             return SUCCEEDED(result) || result == RPC_E_CHANGED_MODE;
         }
     };
+
+    std::optional<json::JsonObject> ReadInitialSettings(HANDLE file, std::wstring& error)
+    {
+        // Keep the share-delete handle open throughout the read. Reopening with
+        // std::ifstream can conflict with another initializer publishing its file.
+        std::string contents;
+        std::array<char, 4096> buffer{};
+        for (;;)
+        {
+            DWORD read = 0;
+            if (!ReadFile(file, buffer.data(), static_cast<DWORD>(buffer.size()), &read, nullptr))
+            {
+                error = L"Light Switch settings could not be read (error " + std::to_wstring(GetLastError()) + L").";
+                return std::nullopt;
+            }
+            if (read == 0)
+                break;
+            contents.append(buffer.data(), read);
+        }
+        json::JsonObject document;
+        if (!json::JsonObject::TryParse(winrt::to_hstring(contents), document))
+        {
+            error = L"Light Switch settings contain invalid JSON.";
+            return std::nullopt;
+        }
+        return document;
+    }
 
     class TemporarySettingsFile
     {
@@ -336,22 +364,23 @@ bool TryInitializeLightSwitchSettings(const std::wstring& path, LightSwitchConfi
 
             // Publish the complete document without replacing a concurrent first
             // save from Settings UI or another service. Read whichever file won.
-            if (!temporary.Publish(path, MOVEFILE_WRITE_THROUGH))
+            const auto published = temporary.Publish(path, MOVEFILE_WRITE_THROUGH);
+            const auto publishError = published ? ERROR_SUCCESS : GetLastError();
+            existing.reset(CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
+            if (!existing)
             {
-                const auto moveError = GetLastError();
-                if (moveError != ERROR_ALREADY_EXISTS && moveError != ERROR_FILE_EXISTS)
-                {
-                    error = L"Light Switch default settings could not be saved (error " + std::to_wstring(moveError) + L").";
-                    return false;
-                }
+                const auto readError = GetLastError();
+                error = L"Light Switch settings could not be opened after initialization (open error " +
+                        std::to_wstring(readError) + L", publish error " + std::to_wstring(publishError) + L").";
+                return false;
             }
+            // A failed publish is only acceptable when a readable, valid file
+            // actually won the race. Never replace it or return guessed defaults.
         }
-        existing.reset();
 
-        const auto document = json::from_file(path);
+        const auto document = ReadInitialSettings(existing.get(), error);
         if (!document)
         {
-            error = L"Light Switch settings could not be read or contain invalid JSON.";
             return false;
         }
         return TryParseLightSwitchConfig(*document, config, error);

--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchSettings.cpp
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchSettings.cpp
@@ -8,6 +8,7 @@
 #include <climits>
 #include <stdexcept>
 #include <roapi.h>
+#include <wil/resource.h>
 #include <logger.h>
 #include <LightSwitchService/trace.h>
 
@@ -28,6 +29,81 @@ namespace
             return SUCCEEDED(result) || result == RPC_E_CHANGED_MODE;
         }
     };
+
+    class TemporarySettingsFile
+    {
+    public:
+        TemporarySettingsFile(const std::wstring& destination, const wchar_t* operation)
+        {
+            static std::atomic<unsigned long> sequence{ 0 };
+            _path = destination + L"." + operation + L"." + std::to_wstring(GetCurrentProcessId()) + L"." + std::to_wstring(GetTickCount64()) + L"." + std::to_wstring(++sequence) + L".tmp";
+        }
+
+        ~TemporarySettingsFile()
+        {
+            if (_created)
+                DeleteFileW(_path.c_str());
+        }
+
+        TemporarySettingsFile(const TemporarySettingsFile&) = delete;
+        TemporarySettingsFile& operator=(const TemporarySettingsFile&) = delete;
+
+        bool Write(const std::string& contents, std::wstring& error)
+        {
+            wil::unique_hfile file(CreateFileW(_path.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, nullptr));
+            if (!file)
+            {
+                error = L"A temporary settings file could not be created (error " + std::to_wstring(GetLastError()) + L").";
+                return false;
+            }
+            _created = true;
+            DWORD written = 0;
+            if (contents.size() > MAXDWORD ||
+                !WriteFile(file.get(), contents.data(), static_cast<DWORD>(contents.size()), &written, nullptr) ||
+                written != contents.size() || !FlushFileBuffers(file.get()))
+            {
+                error = L"Light Switch settings could not be written.";
+                return false;
+            }
+            return true;
+        }
+
+        bool Publish(const std::wstring& destination, DWORD flags)
+        {
+            if (!MoveFileExW(_path.c_str(), destination.c_str(), flags))
+                return false;
+            _created = false;
+            return true;
+        }
+
+    private:
+        std::wstring _path;
+        bool _created = false;
+    };
+
+    std::string DefaultSettingsJson()
+    {
+        // Match LightSwitchProperties in Settings UI and the module's hotkey defaults.
+        const LightSwitchConfig defaults;
+        PowerToysSettings::PowerToyValues values(L"LightSwitch", L"LightSwitch");
+        values.add_property(L"scheduleMode", L"Off");
+        values.add_property(L"changeSystem", true);
+        values.add_property(L"changeApps", true);
+        values.add_property(L"lightTime", defaults.lightTime);
+        values.add_property(L"darkTime", defaults.darkTime);
+        values.add_property(L"latitude", defaults.latitude);
+        values.add_property(L"longitude", defaults.longitude);
+        values.add_property(L"sunrise_offset", defaults.sunrise_offset);
+        values.add_property(L"sunset_offset", defaults.sunset_offset);
+        values.add_property(L"toggle-theme-hotkey", PowerToysSettings::HotkeyObject::from_settings(true, true, false, true, 'D').get_json());
+        values.add_property(L"enableDarkModeProfile", false);
+        values.add_property(L"enableLightModeProfile", false);
+        values.add_property(L"darkModeProfile", L"");
+        values.add_property(L"lightModeProfile", L"");
+        values.add_property(L"darkModeProfileId", 0);
+        values.add_property(L"lightModeProfileId", 0);
+        return winrt::to_string(values.serialize());
+    }
 }
 
 LightSwitchSettings& LightSwitchSettings::instance()
@@ -38,7 +114,16 @@ LightSwitchSettings& LightSwitchSettings::instance()
 
 LightSwitchSettings::LightSwitchSettings()
 {
-    LoadSettings();
+    LightSwitchConfig config;
+    std::wstring error;
+    if (TryInitializeLightSwitchSettings(GetSettingsFileName(), config, error))
+    {
+        ApplySettingsLocked(config);
+    }
+    else
+    {
+        Logger::warn(L"[LightSwitchSettings] Could not initialize settings: {}", error);
+    }
 }
 
 std::wstring LightSwitchSettings::GetSettingsFileName()
@@ -220,6 +305,64 @@ bool HasSameEffectiveLightSwitchSettings(const LightSwitchConfig& left, const Li
            (!compareTimes || (left.lightTime == right.lightTime && left.darkTime == right.darkTime));
 }
 
+bool TryInitializeLightSwitchSettings(const std::wstring& path, LightSwitchConfig& config, std::wstring& error)
+{
+    const ApartmentScope apartment;
+    if (!apartment.IsReady())
+    {
+        error = L"The settings JSON runtime could not be initialized.";
+        return false;
+    }
+
+    try
+    {
+        wil::unique_hfile existing(CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
+        if (!existing)
+        {
+            const auto openError = GetLastError();
+            // The settings helper has already created the module directory. Missing
+            // parents and unreadable files are errors, not a first-run configuration.
+            if (openError != ERROR_FILE_NOT_FOUND)
+            {
+                error = L"Light Switch settings could not be opened (error " + std::to_wstring(openError) + L").";
+                return false;
+            }
+
+            TemporarySettingsFile temporary(path, L"init");
+            if (!temporary.Write(DefaultSettingsJson(), error))
+            {
+                return false;
+            }
+
+            // Publish the complete document without replacing a concurrent first
+            // save from Settings UI or another service. Read whichever file won.
+            if (!temporary.Publish(path, MOVEFILE_WRITE_THROUGH))
+            {
+                const auto moveError = GetLastError();
+                if (moveError != ERROR_ALREADY_EXISTS && moveError != ERROR_FILE_EXISTS)
+                {
+                    error = L"Light Switch default settings could not be saved (error " + std::to_wstring(moveError) + L").";
+                    return false;
+                }
+            }
+        }
+        existing.reset();
+
+        const auto document = json::from_file(path);
+        if (!document)
+        {
+            error = L"Light Switch settings could not be read or contain invalid JSON.";
+            return false;
+        }
+        return TryParseLightSwitchConfig(*document, config, error);
+    }
+    catch (...)
+    {
+        error = L"Light Switch settings could not be initialized.";
+        return false;
+    }
+}
+
 bool TryPatchLightSwitchScheduleMode(const std::wstring& path, ScheduleMode mode, LightSwitchConfig& config, std::wstring& error)
 {
     const ApartmentScope apartment;
@@ -234,8 +377,6 @@ bool TryPatchLightSwitchScheduleMode(const std::wstring& path, ScheduleMode mode
         error = L"The requested schedule mode is not supported.";
         return false;
     }
-    std::wstring temporaryPath;
-    HANDLE file = INVALID_HANDLE_VALUE;
     try
     {
         auto document = json::from_file(path);
@@ -258,25 +399,9 @@ bool TryPatchLightSwitchScheduleMode(const std::wstring& path, ScheduleMode mode
         const std::wstring original = document->Stringify().c_str();
         auto property = document->GetNamedObject(L"properties").GetNamedObject(L"scheduleMode");
         property.SetNamedValue(L"value", json::value(ToString(mode)));
-        const auto serialized = winrt::to_string(document->Stringify());
-        static std::atomic<unsigned long> sequence{ 0 };
-        temporaryPath = path + L".cli." + std::to_wstring(GetCurrentProcessId()) + L"." + std::to_wstring(++sequence) + L".tmp";
-        file = CreateFileW(temporaryPath.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, nullptr);
-        if (file == INVALID_HANDLE_VALUE)
+        TemporarySettingsFile temporary(path, L"cli");
+        if (!temporary.Write(winrt::to_string(document->Stringify()), error))
         {
-            error = L"A temporary settings file could not be created (error " + std::to_wstring(GetLastError()) + L").";
-            return false;
-        }
-        DWORD written = 0;
-        const bool saved = serialized.size() <= MAXDWORD &&
-                           WriteFile(file, serialized.data(), static_cast<DWORD>(serialized.size()), &written, nullptr) &&
-                           written == serialized.size() && FlushFileBuffers(file);
-        CloseHandle(file);
-        file = INVALID_HANDLE_VALUE;
-        if (!saved)
-        {
-            DeleteFileW(temporaryPath.c_str());
-            error = L"Light Switch settings could not be written.";
             return false;
         }
 
@@ -284,18 +409,15 @@ bool TryPatchLightSwitchScheduleMode(const std::wstring& path, ScheduleMode mode
         const auto latest = json::from_file(path);
         if (!latest || std::wstring(latest->Stringify().c_str()) != original)
         {
-            DeleteFileW(temporaryPath.c_str());
             error = L"Light Switch settings changed during the update. Try the command again.";
             return false;
         }
-        if (!MoveFileExW(temporaryPath.c_str(), path.c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH))
+        if (!temporary.Publish(path, MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH))
         {
             const auto replacementError = GetLastError();
-            DeleteFileW(temporaryPath.c_str());
             error = L"Light Switch settings could not be replaced (error " + std::to_wstring(replacementError) + L").";
             return false;
         }
-        temporaryPath.clear();
         const auto savedDocument = json::from_file(path);
         if (!savedDocument || !TryParseLightSwitchConfig(*savedDocument, config, error) ||
             config.scheduleMode != mode || savedDocument->Stringify() != document->Stringify())
@@ -308,14 +430,6 @@ bool TryPatchLightSwitchScheduleMode(const std::wstring& path, ScheduleMode mode
     }
     catch (...)
     {
-        if (file != INVALID_HANDLE_VALUE)
-        {
-            CloseHandle(file);
-        }
-        if (!temporaryPath.empty())
-        {
-            DeleteFileW(temporaryPath.c_str());
-        }
         error = L"Light Switch settings could not be updated.";
         return false;
     }

--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchSettings.cpp
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchSettings.cpp
@@ -109,6 +109,57 @@ namespace
         bool _created = false;
     };
 
+    enum class SettingsFileSaveResult
+    {
+        Saved,
+        Superseded,
+        Failed,
+    };
+
+    SettingsFileSaveResult SaveSettingsDocument(
+        const std::wstring& path,
+        const std::wstring& original,
+        const json::JsonObject& document,
+        const wchar_t* operation,
+        LightSwitchConfig& config,
+        std::wstring& error)
+    {
+        const auto serialized = document.Stringify();
+        TemporarySettingsFile temporary(path, operation);
+        if (!temporary.Write(winrt::to_string(serialized), error))
+            return SettingsFileSaveResult::Failed;
+
+        // Avoid replacing an external edit received while preparing the patch.
+        const auto latest = json::from_file(path);
+        if (!latest)
+        {
+            error = L"Light Switch settings could not be read during the update.";
+            return SettingsFileSaveResult::Failed;
+        }
+        if (std::wstring(latest->Stringify().c_str()) != original)
+        {
+            error = L"Light Switch settings changed during the update. Try the command again.";
+            return SettingsFileSaveResult::Superseded;
+        }
+        if (!temporary.Publish(path, MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH))
+        {
+            const auto replacementError = GetLastError();
+            error = L"Light Switch settings could not be replaced (error " + std::to_wstring(replacementError) + L").";
+            return SettingsFileSaveResult::Failed;
+        }
+
+        const auto savedDocument = json::from_file(path);
+        LightSwitchConfig saved;
+        if (!savedDocument || !TryParseLightSwitchConfig(*savedDocument, saved, error) || savedDocument->Stringify() != serialized)
+        {
+            error = L"The saved Light Switch settings could not be verified.";
+            return SettingsFileSaveResult::Failed;
+        }
+        config = std::move(saved);
+        error.clear();
+        return SettingsFileSaveResult::Saved;
+    }
+
     std::string DefaultSettingsJson()
     {
         // Match LightSwitchProperties in Settings UI and the module's hotkey defaults.
@@ -428,39 +479,73 @@ bool TryPatchLightSwitchScheduleMode(const std::wstring& path, ScheduleMode mode
         const std::wstring original = document->Stringify().c_str();
         auto property = document->GetNamedObject(L"properties").GetNamedObject(L"scheduleMode");
         property.SetNamedValue(L"value", json::value(ToString(mode)));
-        TemporarySettingsFile temporary(path, L"cli");
-        if (!temporary.Write(winrt::to_string(document->Stringify()), error))
-        {
-            return false;
-        }
-
-        // Avoid replacing a settings edit that arrived while we prepared the patch.
-        const auto latest = json::from_file(path);
-        if (!latest || std::wstring(latest->Stringify().c_str()) != original)
-        {
-            error = L"Light Switch settings changed during the update. Try the command again.";
-            return false;
-        }
-        if (!temporary.Publish(path, MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH))
-        {
-            const auto replacementError = GetLastError();
-            error = L"Light Switch settings could not be replaced (error " + std::to_wstring(replacementError) + L").";
-            return false;
-        }
-        const auto savedDocument = json::from_file(path);
-        if (!savedDocument || !TryParseLightSwitchConfig(*savedDocument, config, error) ||
-            config.scheduleMode != mode || savedDocument->Stringify() != document->Stringify())
-        {
-            error = L"The saved Light Switch settings could not be verified.";
-            return false;
-        }
-        error.clear();
-        return true;
+        return SaveSettingsDocument(path, original, *document, L"cli", config, error) == SettingsFileSaveResult::Saved;
     }
     catch (...)
     {
         error = L"Light Switch settings could not be updated.";
         return false;
+    }
+}
+
+SunTimesSaveResult SaveLightSwitchSunTimes(const std::wstring& path, const LightSwitchConfig& expected, int lightMinutes, int darkMinutes, LightSwitchConfig& config, std::wstring& error)
+{
+    const ApartmentScope apartment;
+    if (!apartment.IsReady())
+    {
+        error = L"The settings JSON runtime could not be initialized.";
+        return SunTimesSaveResult::Failed;
+    }
+    try
+    {
+        auto document = json::from_file(path);
+        LightSwitchConfig current;
+        if (!document || !TryParseLightSwitchConfig(*document, current, error))
+        {
+            if (!document)
+                error = L"Light Switch settings could not be read.";
+            return SunTimesSaveResult::Failed;
+        }
+        // Calculated values belong to one effective configuration. A later
+        // schedule or location edit must win over an in-flight cache update.
+        if (expected.scheduleMode != ScheduleMode::SunsetToSunrise ||
+            current.scheduleMode != ScheduleMode::SunsetToSunrise ||
+            !HasSameEffectiveLightSwitchSettings(expected, current))
+        {
+            error.clear();
+            return SunTimesSaveResult::Superseded;
+        }
+        if (current.lightTime == lightMinutes && current.darkTime == darkMinutes)
+        {
+            config = std::move(current);
+            error.clear();
+            return SunTimesSaveResult::Saved;
+        }
+
+        const std::wstring original = document->Stringify().c_str();
+        const auto properties = document->GetNamedObject(L"properties");
+        const auto updateTime = [&](const wchar_t* name, int minutes) {
+            auto property = properties.GetNamedObject(name, json::JsonObject{});
+            property.SetNamedValue(L"value", json::value(minutes));
+            properties.SetNamedValue(name, property);
+        };
+        updateTime(L"lightTime", lightMinutes);
+        updateTime(L"darkTime", darkMinutes);
+        switch (SaveSettingsDocument(path, original, *document, L"sun", config, error))
+        {
+        case SettingsFileSaveResult::Saved:
+            return SunTimesSaveResult::Saved;
+        case SettingsFileSaveResult::Superseded:
+            error.clear();
+            return SunTimesSaveResult::Superseded;
+        default:
+            return SunTimesSaveResult::Failed;
+        }
+    }
+    catch (...)
+    {
+        error = L"Light Switch sun times could not be saved.";
+        return SunTimesSaveResult::Failed;
     }
 }
 
@@ -505,6 +590,17 @@ bool LightSwitchSettings::TrySetScheduleMode(ScheduleMode mode, LightSwitchConfi
     }
     ApplySettingsLocked(config);
     return true;
+}
+
+SunTimesSaveResult LightSwitchSettings::SaveSunTimes(const LightSwitchConfig& expected, int lightMinutes, int darkMinutes, std::wstring& error)
+{
+    // Share the complete read-modify-write lock with CLI schedule persistence.
+    std::lock_guard<std::mutex> guard(m_settingsMutex);
+    LightSwitchConfig config;
+    const auto result = SaveLightSwitchSunTimes(GetSettingsFileName(), expected, lightMinutes, darkMinutes, config, error);
+    if (result == SunTimesSaveResult::Saved)
+        ApplySettingsLocked(config);
+    return result;
 }
 
 void LightSwitchSettings::ApplySettingsLocked(const LightSwitchConfig& config)

--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchSettings.cpp
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchSettings.cpp
@@ -4,10 +4,31 @@
 #include "SettingsObserver.h"
 #include <filesystem>
 #include <fstream>
+#include <cmath>
+#include <climits>
+#include <stdexcept>
+#include <roapi.h>
 #include <logger.h>
 #include <LightSwitchService/trace.h>
 
 using namespace std;
+
+namespace
+{
+    struct ApartmentScope
+    {
+        HRESULT result = RoInitialize(RO_INIT_MULTITHREADED);
+        ~ApartmentScope()
+        {
+            if (SUCCEEDED(result))
+                RoUninitialize();
+        }
+        bool IsReady() const
+        {
+            return SUCCEEDED(result) || result == RPC_E_CHANGED_MODE;
+        }
+    };
+}
 
 LightSwitchSettings& LightSwitchSettings::instance()
 {
@@ -52,11 +73,14 @@ void LightSwitchSettings::InitFileWatcher()
                     while (!stop.stop_requested())
                     {
                         std::this_thread::sleep_for(seconds(3));
-
-                        auto elapsed = steady_clock::now() - m_lastChangeTime;
+                        std::lock_guard<std::mutex> lock(m_debounceMutex);
+                        const auto elapsed = steady_clock::now() - m_lastChangeTime;
                         if (elapsed >= seconds(1))
                             break;
                     }
+
+                    if (stop.stop_requested())
+                        return;
 
                     {
                         std::lock_guard<std::mutex> lock(m_debounceMutex);
@@ -85,17 +109,17 @@ LightSwitchSettings::~LightSwitchSettings()
 {
     Logger::info(L"[LightSwitchSettings] Cleaning up settings resources...");
 
-    // Stop and join the debounce thread (std::jthread auto-joins, but we can signal stop too)
-    if (m_debounceThread.joinable())
-    {
-        m_debounceThread.request_stop();
-    }
-
     // Release the file watcher so it closes file handles and background threads
     if (m_settingsFileWatcher)
     {
         m_settingsFileWatcher.reset();
         Logger::info(L"[LightSwitchSettings] File watcher stopped.");
+    }
+
+    if (m_debounceThread.joinable())
+    {
+        m_debounceThread.request_stop();
+        m_debounceThread.join();
     }
 
     // Close the Windows event handle
@@ -108,7 +132,6 @@ LightSwitchSettings::~LightSwitchSettings()
 
     Logger::info(L"[LightSwitchSettings] Cleanup complete.");
 }
-
 
 void LightSwitchSettings::AddObserver(SettingsObserver& observer)
 {
@@ -136,126 +159,238 @@ HANDLE LightSwitchSettings::GetSettingsChangedEvent() const
     return m_settingsChangedEvent;
 }
 
-void LightSwitchSettings::LoadSettings()
+bool TryParseLightSwitchConfig(const json::JsonObject& values, LightSwitchConfig& config, std::wstring& error)
 {
-    std::lock_guard<std::mutex> guard(m_settingsMutex);
     try
     {
-        PowerToysSettings::PowerToyValues values =
-            PowerToysSettings::PowerToyValues::load_from_settings_file(L"LightSwitch");
-
-
-        if (const auto jsonVal = values.get_string_value(L"scheduleMode"))
+        auto properties = values.GetNamedObject(L"properties");
+        LightSwitchConfig parsed;
+        const std::wstring mode = properties.GetNamedObject(L"scheduleMode").GetNamedString(L"value").c_str();
+        if (mode != L"Off" && mode != L"FixedHours" && mode != L"SunsetToSunrise" && mode != L"FollowNightLight")
         {
-            auto val = *jsonVal;
-            auto newMode = FromString(val);
-            if (m_settings.scheduleMode != newMode)
+            error = L"The configured scheduleMode is not supported.";
+            return false;
+        }
+        parsed.scheduleMode = FromString(mode);
+        parsed.changeSystem = properties.GetNamedObject(L"changeSystem").GetNamedBoolean(L"value");
+        parsed.changeApps = properties.GetNamedObject(L"changeApps").GetNamedBoolean(L"value");
+
+        const auto readString = [&](const wchar_t* name, std::wstring& destination) {
+            if (properties.HasKey(name))
             {
-                m_settings.scheduleMode = newMode;
-                Trace::LightSwitch::ScheduleModeToggled(val);
-                NotifyObservers(SettingId::ScheduleMode);
+                destination = properties.GetNamedObject(name).GetNamedString(L"value").c_str();
             }
-        }
-
-        // Latitude
-        if (const auto jsonVal = values.get_string_value(L"latitude"))
-        {
-            auto val = *jsonVal;
-            if (m_settings.latitude != val)
+        };
+        const auto readInteger = [&](const wchar_t* name, int& destination) {
+            if (properties.HasKey(name))
             {
-                m_settings.latitude = val;
-                NotifyObservers(SettingId::Latitude);
+                const double value = properties.GetNamedObject(name).GetNamedNumber(L"value");
+                if (!std::isfinite(value) || std::trunc(value) != value || value < INT_MIN || value > INT_MAX)
+                {
+                    throw std::invalid_argument("Invalid integer setting");
+                }
+                destination = static_cast<int>(value);
             }
-        }
-
-        // Longitude
-        if (const auto jsonVal = values.get_string_value(L"longitude"))
-        {
-            auto val = *jsonVal;
-            if (m_settings.longitude != val)
-            {
-                m_settings.longitude = val;
-                NotifyObservers(SettingId::Longitude);
-            }
-        }
-
-        // LightTime
-        if (const auto jsonVal = values.get_int_value(L"lightTime"))
-        {
-            auto val = *jsonVal;
-            if (m_settings.lightTime != val)
-            {
-                m_settings.lightTime = val;
-                NotifyObservers(SettingId::LightTime);
-            }
-        }
-
-        // DarkTime
-        if (const auto jsonVal = values.get_int_value(L"darkTime"))
-        {
-            auto val = *jsonVal;
-            if (m_settings.darkTime != val)
-            {
-                m_settings.darkTime = val;
-                NotifyObservers(SettingId::DarkTime);
-            }
-        }
-
-        // Offset
-        if (const auto jsonVal = values.get_int_value(L"sunrise_offset")) 
-        {
-            auto val = *jsonVal;
-            if (m_settings.sunrise_offset != val)
-            {
-                m_settings.sunrise_offset = val;
-                NotifyObservers(SettingId::Sunrise_Offset);
-            }
-        }
-
-        if (const auto jsonVal = values.get_int_value(L"sunset_offset"))
-        {
-            auto val = *jsonVal;
-            if (m_settings.sunset_offset != val)
-            {
-                m_settings.sunset_offset = val;
-                NotifyObservers(SettingId::Sunset_Offset);
-            }
-        }
-
-        bool themeTargetChanged = false;
-
-        // ChangeSystem
-        if (const auto jsonVal = values.get_bool_value(L"changeSystem"))
-        {
-            auto val = *jsonVal;
-            if (m_settings.changeSystem != val)
-            {
-                m_settings.changeSystem = val;
-                themeTargetChanged = true;
-                NotifyObservers(SettingId::ChangeSystem);
-            }
-        }
-
-        // ChangeApps
-        if (const auto jsonVal = values.get_bool_value(L"changeApps"))
-        {
-            auto val = *jsonVal;
-            if (m_settings.changeApps != val)
-            {
-                m_settings.changeApps = val;
-                themeTargetChanged = true;
-                NotifyObservers(SettingId::ChangeApps);
-            }
-        }
-
-        // For ChangeSystem/ChangeApps changes, log telemetry
-        if (themeTargetChanged)
-        {
-            Trace::LightSwitch::ThemeTargetChanged(m_settings.changeApps, m_settings.changeSystem);
-        }
+        };
+        readString(L"latitude", parsed.latitude);
+        readString(L"longitude", parsed.longitude);
+        readInteger(L"lightTime", parsed.lightTime);
+        readInteger(L"darkTime", parsed.darkTime);
+        readInteger(L"sunrise_offset", parsed.sunrise_offset);
+        readInteger(L"sunset_offset", parsed.sunset_offset);
+        config = std::move(parsed);
+        error.clear();
+        return true;
     }
     catch (...)
     {
-        // Keeps defaults if load fails
+        error = L"Light Switch settings contain missing or invalid properties.";
+        return false;
+    }
+}
+
+bool HasSameEffectiveLightSwitchSettings(const LightSwitchConfig& left, const LightSwitchConfig& right)
+{
+    // Sun times are calculated by the service and echoed back through settings.json.
+    const bool compareTimes = left.scheduleMode != ScheduleMode::SunsetToSunrise;
+    return left.scheduleMode == right.scheduleMode &&
+           left.latitude == right.latitude && left.longitude == right.longitude &&
+           left.sunrise_offset == right.sunrise_offset && left.sunset_offset == right.sunset_offset &&
+           left.changeSystem == right.changeSystem && left.changeApps == right.changeApps &&
+           (!compareTimes || (left.lightTime == right.lightTime && left.darkTime == right.darkTime));
+}
+
+bool TryPatchLightSwitchScheduleMode(const std::wstring& path, ScheduleMode mode, LightSwitchConfig& config, std::wstring& error)
+{
+    const ApartmentScope apartment;
+    if (!apartment.IsReady())
+    {
+        error = L"The settings JSON runtime could not be initialized.";
+        return false;
+    }
+    if (mode != ScheduleMode::Off && mode != ScheduleMode::FixedHours &&
+        mode != ScheduleMode::SunsetToSunrise && mode != ScheduleMode::FollowNightLight)
+    {
+        error = L"The requested schedule mode is not supported.";
+        return false;
+    }
+    std::wstring temporaryPath;
+    HANDLE file = INVALID_HANDLE_VALUE;
+    try
+    {
+        auto document = json::from_file(path);
+        LightSwitchConfig current;
+        if (!document || !TryParseLightSwitchConfig(*document, current, error))
+        {
+            if (!document)
+            {
+                error = L"Light Switch settings could not be read.";
+            }
+            return false;
+        }
+        if (current.scheduleMode == mode)
+        {
+            config = std::move(current);
+            error.clear();
+            return true;
+        }
+
+        const std::wstring original = document->Stringify().c_str();
+        auto property = document->GetNamedObject(L"properties").GetNamedObject(L"scheduleMode");
+        property.SetNamedValue(L"value", json::value(ToString(mode)));
+        const auto serialized = winrt::to_string(document->Stringify());
+        static std::atomic<unsigned long> sequence{ 0 };
+        temporaryPath = path + L".cli." + std::to_wstring(GetCurrentProcessId()) + L"." + std::to_wstring(++sequence) + L".tmp";
+        file = CreateFileW(temporaryPath.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, nullptr);
+        if (file == INVALID_HANDLE_VALUE)
+        {
+            error = L"A temporary settings file could not be created (error " + std::to_wstring(GetLastError()) + L").";
+            return false;
+        }
+        DWORD written = 0;
+        const bool saved = serialized.size() <= MAXDWORD &&
+                           WriteFile(file, serialized.data(), static_cast<DWORD>(serialized.size()), &written, nullptr) &&
+                           written == serialized.size() && FlushFileBuffers(file);
+        CloseHandle(file);
+        file = INVALID_HANDLE_VALUE;
+        if (!saved)
+        {
+            DeleteFileW(temporaryPath.c_str());
+            error = L"Light Switch settings could not be written.";
+            return false;
+        }
+
+        // Avoid replacing a settings edit that arrived while we prepared the patch.
+        const auto latest = json::from_file(path);
+        if (!latest || std::wstring(latest->Stringify().c_str()) != original)
+        {
+            DeleteFileW(temporaryPath.c_str());
+            error = L"Light Switch settings changed during the update. Try the command again.";
+            return false;
+        }
+        if (!MoveFileExW(temporaryPath.c_str(), path.c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH))
+        {
+            const auto replacementError = GetLastError();
+            DeleteFileW(temporaryPath.c_str());
+            error = L"Light Switch settings could not be replaced (error " + std::to_wstring(replacementError) + L").";
+            return false;
+        }
+        temporaryPath.clear();
+        const auto savedDocument = json::from_file(path);
+        if (!savedDocument || !TryParseLightSwitchConfig(*savedDocument, config, error) ||
+            config.scheduleMode != mode || savedDocument->Stringify() != document->Stringify())
+        {
+            error = L"The saved Light Switch settings could not be verified.";
+            return false;
+        }
+        error.clear();
+        return true;
+    }
+    catch (...)
+    {
+        if (file != INVALID_HANDLE_VALUE)
+        {
+            CloseHandle(file);
+        }
+        if (!temporaryPath.empty())
+        {
+            DeleteFileW(temporaryPath.c_str());
+        }
+        error = L"Light Switch settings could not be updated.";
+        return false;
+    }
+}
+
+void LightSwitchSettings::LoadSettings()
+{
+    LightSwitchConfig config;
+    std::wstring error;
+    TryLoadSettings(config, error);
+}
+
+bool LightSwitchSettings::TryLoadSettings(LightSwitchConfig& config, std::wstring& error)
+{
+    const ApartmentScope apartment;
+    if (!apartment.IsReady())
+    {
+        error = L"The settings JSON runtime could not be initialized.";
+        return false;
+    }
+    std::lock_guard<std::mutex> guard(m_settingsMutex);
+    const auto document = json::from_file(GetSettingsFileName());
+    if (!document)
+    {
+        error = L"Light Switch settings could not be read or contain invalid JSON.";
+        return false;
+    }
+    LightSwitchConfig loaded;
+    if (!TryParseLightSwitchConfig(*document, loaded, error))
+    {
+        return false;
+    }
+    ApplySettingsLocked(loaded);
+    config = m_settings;
+    return true;
+}
+
+bool LightSwitchSettings::TrySetScheduleMode(ScheduleMode mode, LightSwitchConfig& config, std::wstring& error)
+{
+    std::lock_guard<std::mutex> guard(m_settingsMutex);
+    if (!TryPatchLightSwitchScheduleMode(GetSettingsFileName(), mode, config, error))
+    {
+        return false;
+    }
+    ApplySettingsLocked(config);
+    return true;
+}
+
+void LightSwitchSettings::ApplySettingsLocked(const LightSwitchConfig& config)
+{
+    const auto previous = m_settings;
+    m_settings = config;
+    if (previous.scheduleMode != config.scheduleMode)
+    {
+        Trace::LightSwitch::ScheduleModeToggled(ToString(config.scheduleMode));
+        NotifyObservers(SettingId::ScheduleMode);
+    }
+    if (previous.latitude != config.latitude)
+        NotifyObservers(SettingId::Latitude);
+    if (previous.longitude != config.longitude)
+        NotifyObservers(SettingId::Longitude);
+    if (previous.lightTime != config.lightTime)
+        NotifyObservers(SettingId::LightTime);
+    if (previous.darkTime != config.darkTime)
+        NotifyObservers(SettingId::DarkTime);
+    if (previous.sunrise_offset != config.sunrise_offset)
+        NotifyObservers(SettingId::Sunrise_Offset);
+    if (previous.sunset_offset != config.sunset_offset)
+        NotifyObservers(SettingId::Sunset_Offset);
+    if (previous.changeSystem != config.changeSystem)
+        NotifyObservers(SettingId::ChangeSystem);
+    if (previous.changeApps != config.changeApps)
+        NotifyObservers(SettingId::ChangeApps);
+    if (previous.changeSystem != config.changeSystem || previous.changeApps != config.changeApps)
+    {
+        Trace::LightSwitch::ThemeTargetChanged(config.changeApps, config.changeSystem);
     }
 }

--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchSettings.h
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchSettings.h
@@ -69,11 +69,22 @@ struct LightSwitchConfig
     bool changeApps = false;
 };
 
+enum class SunTimesSaveResult
+{
+    // Includes an unchanged cache that required no write.
+    Saved,
+    // A newer effective configuration takes precedence over the calculation.
+    Superseded,
+    Failed,
+};
+
 // Parsing and patching preserve the existing settings schema.
 bool TryParseLightSwitchConfig(const json::JsonObject& values, LightSwitchConfig& config, std::wstring& error);
 // Startup only: create defaults if the file is absent, preserving any existing file.
 bool TryInitializeLightSwitchSettings(const std::wstring& path, LightSwitchConfig& config, std::wstring& error);
 bool TryPatchLightSwitchScheduleMode(const std::wstring& path, ScheduleMode mode, LightSwitchConfig& config, std::wstring& error);
+// The service calls this through SaveSunTimes to serialize its settings writes.
+SunTimesSaveResult SaveLightSwitchSunTimes(const std::wstring& path, const LightSwitchConfig& expected, int lightMinutes, int darkMinutes, LightSwitchConfig& config, std::wstring& error);
 bool HasSameEffectiveLightSwitchSettings(const LightSwitchConfig& left, const LightSwitchConfig& right);
 
 class LightSwitchSettings
@@ -97,6 +108,7 @@ public:
     void LoadSettings();
     bool TryLoadSettings(LightSwitchConfig& config, std::wstring& error);
     bool TrySetScheduleMode(ScheduleMode mode, LightSwitchConfig& config, std::wstring& error);
+    SunTimesSaveResult SaveSunTimes(const LightSwitchConfig& expected, int lightMinutes, int darkMinutes, std::wstring& error);
 
     HANDLE GetSettingsChangedEvent() const;
 

--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchSettings.h
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchSettings.h
@@ -71,6 +71,8 @@ struct LightSwitchConfig
 
 // Parsing and patching preserve the existing settings schema.
 bool TryParseLightSwitchConfig(const json::JsonObject& values, LightSwitchConfig& config, std::wstring& error);
+// Startup only: create defaults if the file is absent, preserving any existing file.
+bool TryInitializeLightSwitchSettings(const std::wstring& path, LightSwitchConfig& config, std::wstring& error);
 bool TryPatchLightSwitchScheduleMode(const std::wstring& path, ScheduleMode mode, LightSwitchConfig& config, std::wstring& error);
 bool HasSameEffectiveLightSwitchSettings(const LightSwitchConfig& left, const LightSwitchConfig& right);
 

--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchSettings.h
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchSettings.h
@@ -69,14 +69,21 @@ struct LightSwitchConfig
     bool changeApps = false;
 };
 
+// Parsing and patching preserve the existing settings schema.
+bool TryParseLightSwitchConfig(const json::JsonObject& values, LightSwitchConfig& config, std::wstring& error);
+bool TryPatchLightSwitchScheduleMode(const std::wstring& path, ScheduleMode mode, LightSwitchConfig& config, std::wstring& error);
+bool HasSameEffectiveLightSwitchSettings(const LightSwitchConfig& left, const LightSwitchConfig& right);
+
 class LightSwitchSettings
 {
 public:
     static LightSwitchSettings& instance();
 
-    static inline const LightSwitchConfig& settings()
+    static inline LightSwitchConfig settings()
     {
-        return instance().m_settings;
+        auto& instanceRef = instance();
+        std::lock_guard<std::mutex> guard(instanceRef.m_settingsMutex);
+        return instanceRef.m_settings;
     }
 
     void InitFileWatcher();
@@ -86,6 +93,8 @@ public:
     void RemoveObserver(SettingsObserver& observer);
 
     void LoadSettings();
+    bool TryLoadSettings(LightSwitchConfig& config, std::wstring& error);
+    bool TrySetScheduleMode(ScheduleMode mode, LightSwitchConfig& config, std::wstring& error);
 
     HANDLE GetSettingsChangedEvent() const;
 
@@ -98,6 +107,7 @@ private:
     std::unordered_set<SettingsObserver*> m_observers;
 
     void NotifyObservers(SettingId id) const;
+    void ApplySettingsLocked(const LightSwitchConfig& config);
 
     HANDLE m_settingsChangedEvent = nullptr;
     mutable std::mutex m_settingsMutex;

--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchStateManager.cpp
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchStateManager.cpp
@@ -1,111 +1,216 @@
-﻿#include "pch.h"
+#include "pch.h"
 #include "LightSwitchStateManager.h"
 #include <logger.h>
 #include <LightSwitchUtils.h>
 #include "ThemeScheduler.h"
 #include <ThemeHelper.h>
 #include <common/interop/shared_constants.h>
+#include <stdexcept>
 
-void ApplyTheme(bool shouldBeLight);
-
-// Constructor
-LightSwitchStateManager::LightSwitchStateManager()
+namespace
 {
-    Logger::info(L"[LightSwitchStateManager] Initialized");
-}
-
-// Called when settings.json changes
-void LightSwitchStateManager::OnSettingsChanged()
-{
-    std::lock_guard<std::mutex> lock(_stateMutex);
-
-    // If manual override was active, clear it so new settings take effect
-    if (_state.isManualOverride)
+    int Minutes(const SYSTEMTIME& time)
     {
-        _state.isManualOverride = false;
+        return time.wHour * 60 + time.wMinute;
     }
 
-    EvaluateAndApplyIfNeeded();
+    std::pair<int, int> UpdateSunTimes(const LightSwitchConfig& settings, const SYSTEMTIME& time)
+    {
+        const auto sun = CalculateSunriseSunset(std::stod(settings.latitude), std::stod(settings.longitude), time.wYear, time.wMonth, time.wDay);
+        const int light = sun.sunriseHour * 60 + sun.sunriseMinute;
+        const int dark = sun.sunsetHour * 60 + sun.sunsetMinute;
+        try
+        {
+            auto values = PowerToysSettings::PowerToyValues::load_from_settings_file(L"LightSwitch");
+            values.add_property(L"lightTime", light);
+            values.add_property(L"darkTime", dark);
+            values.save_to_settings_file();
+        }
+        catch (...)
+        {
+            Logger::error(L"[LightSwitchStateManager] Could not save calculated sun times.");
+        }
+        return { light, dark };
+    }
+
+    LightSwitchStateManagerDependencies DefaultDependencies()
+    {
+        LightSwitchStateManagerDependencies dependencies;
+        dependencies.loadSettings = [](LightSwitchConfig& config, std::wstring& error) {
+            return LightSwitchSettings::instance().TryLoadSettings(config, error);
+        };
+        dependencies.readTheme = [](bool system, bool& light) {
+            return system ? TryGetSystemTheme(light) : TryGetAppsTheme(light);
+        };
+        dependencies.writeTheme = [](bool system, bool light) {
+            return system ? TrySetSystemTheme(light) : TrySetAppsTheme(light);
+        };
+        dependencies.readNightLight = IsNightLightEnabled;
+        dependencies.localTime = []() {
+            SYSTEMTIME now{};
+            GetLocalTime(&now);
+            return now;
+        };
+        dependencies.updateSunTimes = UpdateSunTimes;
+        return dependencies;
+    }
+
+    std::wstring ThemeError(LSTATUS result)
+    {
+        return L"The requested theme could not be applied or verified (Windows error " + std::to_wstring(result) + L").";
+    }
 }
 
-// Called once per minute
+LightSwitchStateManager::LightSwitchStateManager() :
+    LightSwitchStateManager(DefaultDependencies())
+{
+}
+
+LightSwitchStateManager::LightSwitchStateManager(LightSwitchStateManagerDependencies dependencies) :
+    _dependencies(std::move(dependencies))
+{
+    if (!_dependencies.loadSettings || !_dependencies.readTheme || !_dependencies.writeTheme ||
+        !_dependencies.readNightLight || !_dependencies.localTime || !_dependencies.updateSunTimes)
+    {
+        throw std::invalid_argument("Incomplete Light Switch state manager dependencies");
+    }
+}
+
+bool LightSwitchStateManager::LoadSettingsLocked(std::wstring& error)
+{
+    LightSwitchConfig config;
+    if (!_dependencies.loadSettings(config, error))
+    {
+        return false;
+    }
+    if (!_hasSettingsSnapshot || !HasSameEffectiveLightSwitchSettings(_settingsSnapshot, config))
+    {
+        const bool enteringNightLight = !_hasSettingsSnapshot || _settingsSnapshot.scheduleMode != ScheduleMode::FollowNightLight;
+        _state.isManualOverride = false;
+        _state.lastEvaluatedDay = -1;
+        if (config.scheduleMode == ScheduleMode::FollowNightLight && enteringNightLight)
+        {
+            _state.isNightLightActive = _dependencies.readNightLight();
+        }
+        _state.lastAppliedMode = config.scheduleMode;
+    }
+    _settingsSnapshot = std::move(config);
+    _hasSettingsSnapshot = true;
+    return true;
+}
+
+LightSwitchState LightSwitchStateManager::GetState() const
+{
+    std::lock_guard<std::mutex> lock(_stateMutex);
+    return _state;
+}
+
+StatusSnapshot LightSwitchStateManager::GetStatusSnapshotLocked(const LightSwitchConfig& config)
+{
+    StatusSnapshot snapshot;
+    snapshot.config = config;
+    snapshot.manualOverride = _state.isManualOverride;
+    snapshot.configurationAvailable = _hasSettingsSnapshot;
+    bool light = false;
+    if (_dependencies.readTheme(true, light) == ERROR_SUCCESS)
+        snapshot.systemLight = light;
+    if (_dependencies.readTheme(false, light) == ERROR_SUCCESS)
+        snapshot.appsLight = light;
+    return snapshot;
+}
+
+StatusSnapshot LightSwitchStateManager::GetStatusSnapshot()
+{
+    std::lock_guard<std::mutex> lock(_stateMutex);
+    return GetStatusSnapshotLocked(_settingsSnapshot);
+}
+
+void LightSwitchStateManager::SyncThemeStateLocked(const StatusSnapshot& snapshot)
+{
+    if (snapshot.systemLight)
+        _state.isSystemLightActive = *snapshot.systemLight;
+    if (snapshot.appsLight)
+        _state.isAppsLightActive = *snapshot.appsLight;
+}
+
+ThemeCommandResult LightSwitchStateManager::CompleteCommandLocked(const LightSwitchConfig& config, const wchar_t* errorCode, const std::wstring& message)
+{
+    auto snapshot = GetStatusSnapshotLocked(config);
+    SyncThemeStateLocked(snapshot);
+    return { errorCode[0] == L'\0', errorCode, message, std::move(snapshot) };
+}
+
+ThemeCommandResult LightSwitchStateManager::OnSettingsChanged()
+{
+    std::lock_guard<std::mutex> lock(_stateMutex);
+    std::wstring error;
+    if (!LoadSettingsLocked(error))
+        return CompleteCommandLocked(_settingsSnapshot, L"SETTINGS_READ_FAILED", error);
+    const auto config = _settingsSnapshot;
+    const auto result = EvaluateAndApplyIfNeededLocked(config, _dependencies.localTime());
+    return result == ERROR_SUCCESS ? CompleteCommandLocked(config) : CompleteCommandLocked(config, L"THEME_WRITE_FAILED", ThemeError(result));
+}
+
 void LightSwitchStateManager::OnTick()
 {
     std::lock_guard<std::mutex> lock(_stateMutex);
-    if (_state.lastAppliedMode != ScheduleMode::FollowNightLight)
+    std::wstring error;
+    if (LoadSettingsLocked(error) && _settingsSnapshot.scheduleMode != ScheduleMode::FollowNightLight)
     {
-        EvaluateAndApplyIfNeeded();
+        EvaluateAndApplyIfNeededLocked(_settingsSnapshot, _dependencies.localTime());
     }
 }
 
-// Called when manual override is triggered (via hotkey)
 void LightSwitchStateManager::OnManualOverride()
 {
     std::lock_guard<std::mutex> lock(_stateMutex);
-    Logger::info(L"[LightSwitchStateManager] Manual override triggered");
-    _state.isManualOverride = !_state.isManualOverride;
-
-    // ModuleInterface has already flipped the Windows theme before signaling this event,
-    // regardless of which direction isManualOverride just toggled. Sync cached state so the
-    // scheduler compares against the actual current theme on the next evaluation.
-    _state.isSystemLightActive = GetCurrentSystemTheme();
-    _state.isAppsLightActive = GetCurrentAppsTheme();
-
-    Logger::debug(L"[LightSwitchStateManager] Synced internal theme state to current system theme ({}) and apps theme ({}).",
-                  (_state.isSystemLightActive ? L"light" : L"dark"),
-                  (_state.isAppsLightActive ? L"light" : L"dark"));
-
-    const auto& settings = LightSwitchSettings::settings();
-    if (settings.changeSystem)
-    {
-        NotifyPowerDisplayThemeChanged(_state.isSystemLightActive);
-    }
-    else if (settings.changeApps)
-    {
-        NotifyPowerDisplayThemeChanged(_state.isAppsLightActive);
-    }
-
-    EvaluateAndApplyIfNeeded();
+    std::wstring error;
+    if (LoadSettingsLocked(error))
+        OnManualOverrideLocked(_settingsSnapshot, _dependencies.localTime());
 }
 
-// Runs with the registry observer detects a change in Night Light settings.
+LSTATUS LightSwitchStateManager::OnManualOverrideLocked(const LightSwitchConfig& config, const SYSTEMTIME& now)
+{
+    _state.isManualOverride = !_state.isManualOverride;
+    const auto snapshot = GetStatusSnapshotLocked(config);
+    SyncThemeStateLocked(snapshot);
+    NotifyAppliedThemeLocked(config, snapshot);
+    return EvaluateAndApplyIfNeededLocked(config, now);
+}
+
 void LightSwitchStateManager::OnNightLightChange()
 {
     std::lock_guard<std::mutex> lock(_stateMutex);
-
-    bool newNightLightState = IsNightLightEnabled();
-
-    // In Follow Night Light mode, treat a Night Light toggle as a boundary
-    if (_state.lastAppliedMode == ScheduleMode::FollowNightLight && _state.isManualOverride)
+    std::wstring error;
+    if (!LoadSettingsLocked(error))
+        return;
+    const bool nightLight = _dependencies.readNightLight();
+    if (_state.isNightLightActive != nightLight)
     {
-        Logger::info(L"[LightSwitchStateManager] Night Light changed while manual override active; "
-                     L"treating as a boundary and clearing manual override.");
-        _state.isManualOverride = false;
+        if (_settingsSnapshot.scheduleMode == ScheduleMode::FollowNightLight)
+            _state.isManualOverride = false;
+        _state.isNightLightActive = nightLight;
     }
-
-    if (newNightLightState != _state.isNightLightActive)
-    {
-        Logger::info(L"[LightSwitchStateManager] Night Light toggled to {}",
-                     newNightLightState ? L"ON" : L"OFF");
-
-        _state.isNightLightActive = newNightLightState;
-    }
-    else
-    {
-        Logger::debug(L"[LightSwitchStateManager] Night Light change event fired, but no actual change.");
-    }
-
-    EvaluateAndApplyIfNeeded();
+    EvaluateAndApplyIfNeededLocked(_settingsSnapshot, _dependencies.localTime());
 }
 
-// Helpers
+void LightSwitchStateManager::SyncInitialThemeState()
+{
+    std::lock_guard<std::mutex> lock(_stateMutex);
+    SyncThemeStateLocked(GetStatusSnapshotLocked(_settingsSnapshot));
+    _state.isNightLightActive = _dependencies.readNightLight();
+    std::wstring error;
+    if (LoadSettingsLocked(error))
+        EvaluateAndApplyIfNeededLocked(_settingsSnapshot, _dependencies.localTime());
+}
+
 bool LightSwitchStateManager::CoordinatesAreValid(const std::wstring& lat, const std::wstring& lon)
 {
     try
     {
-        double latVal = std::stod(lat);
-        double lonVal = std::stod(lon);
-        return !(latVal == 0 && lonVal == 0) && (latVal >= -90.0 && latVal <= 90.0) && (lonVal >= -180.0 && lonVal <= 180.0);
+        const double latitude = std::stod(lat);
+        const double longitude = std::stod(lon);
+        return !(latitude == 0 && longitude == 0) && latitude >= -90 && latitude <= 90 && longitude >= -180 && longitude <= 180;
     }
     catch (...)
     {
@@ -113,178 +218,203 @@ bool LightSwitchStateManager::CoordinatesAreValid(const std::wstring& lat, const
     }
 }
 
-void LightSwitchStateManager::SyncInitialThemeState()
+void LightSwitchStateManager::UpdateEffectiveTimesLocked(const LightSwitchConfig& config, const SYSTEMTIME& now)
 {
-    std::lock_guard<std::mutex> lock(_stateMutex);
-    _state.isSystemLightActive = GetCurrentSystemTheme();
-    _state.isAppsLightActive = GetCurrentAppsTheme();
-    _state.isNightLightActive = IsNightLightEnabled();
-    Logger::debug(L"[LightSwitchStateManager] Synced initial state to current system theme ({})",
-                  _state.isSystemLightActive ? L"light" : L"dark");
-    Logger::debug(L"[LightSwitchStateManager] Synced initial state to current apps theme ({})",
-                  _state.isAppsLightActive ? L"light" : L"dark");
-    
-    // This will ensure that the theme is applied according to current settings at startup
-    EvaluateAndApplyIfNeeded();
-}
-
-static std::pair<int, int> update_sun_times(auto& settings)
-{
-    double latitude = std::stod(settings.latitude);
-    double longitude = std::stod(settings.longitude);
-
-    SYSTEMTIME st;
-    GetLocalTime(&st);
-
-    SunTimes newTimes = CalculateSunriseSunset(latitude, longitude, st.wYear, st.wMonth, st.wDay);
-
-    int newLightTime = newTimes.sunriseHour * 60 + newTimes.sunriseMinute;
-    int newDarkTime = newTimes.sunsetHour * 60 + newTimes.sunsetMinute;
-
-    try
+    if (config.scheduleMode == ScheduleMode::SunsetToSunrise && CoordinatesAreValid(config.latitude, config.longitude))
     {
-        auto values = PowerToysSettings::PowerToyValues::load_from_settings_file(L"LightSwitch");
-        values.add_property(L"lightTime", newLightTime);
-        values.add_property(L"darkTime", newDarkTime);
-        values.save_to_settings_file();
-
-        Logger::info(L"[LightSwitchService] Updated sun times and saved to config.");
-    }
-    catch (const std::exception& e)
-    {
-        std::string msg = e.what();
-        std::wstring wmsg(msg.begin(), msg.end());
-        Logger::error(L"[LightSwitchService] Exception during sun time update: {}", wmsg);
-    }
-
-    return { newLightTime, newDarkTime };
-}
-
-// Internal: decide what should happen now
-void LightSwitchStateManager::EvaluateAndApplyIfNeeded()
-{
-    LightSwitchSettings::instance().LoadSettings();
-    const auto& _currentSettings = LightSwitchSettings::settings();
-    auto now = GetNowMinutes();
-
-    // Early exit: OFF mode just pauses activity
-    if (_currentSettings.scheduleMode == ScheduleMode::Off)
-    {
-        _state.lastTickMinutes = now;
-        return;
-    }
-
-    bool coordsValid = CoordinatesAreValid(_currentSettings.latitude, _currentSettings.longitude);
-
-    // Handle Sun Mode recalculation
-    if (_currentSettings.scheduleMode == ScheduleMode::SunsetToSunrise && coordsValid)
-    {
-        SYSTEMTIME st;
-        GetLocalTime(&st);
-        bool newDay = (_state.lastEvaluatedDay != st.wDay);
-        bool modeChangedToSun = (_state.lastAppliedMode != ScheduleMode::SunsetToSunrise &&
-                                 _currentSettings.scheduleMode == ScheduleMode::SunsetToSunrise);
-
-        if (newDay || modeChangedToSun)
+        if (_state.lastEvaluatedDay != now.wDay)
         {
-            auto [newLightTime, newDarkTime] = update_sun_times(_currentSettings);
-            _state.lastEvaluatedDay = st.wDay;
-            _state.effectiveLightMinutes = newLightTime + _currentSettings.sunrise_offset;
-            _state.effectiveDarkMinutes = newDarkTime + _currentSettings.sunset_offset;
-        }
-        else
-        {
-            _state.effectiveLightMinutes = _currentSettings.lightTime + _currentSettings.sunrise_offset;
-            _state.effectiveDarkMinutes = _currentSettings.darkTime + _currentSettings.sunset_offset;
+            const auto [light, dark] = _dependencies.updateSunTimes(config, now);
+            _state.lastEvaluatedDay = now.wDay;
+            _state.effectiveLightMinutes = light + config.sunrise_offset;
+            _state.effectiveDarkMinutes = dark + config.sunset_offset;
         }
     }
-    else if (_currentSettings.scheduleMode == ScheduleMode::FixedHours)
+    else if (config.scheduleMode == ScheduleMode::FixedHours)
     {
-        _state.effectiveLightMinutes = _currentSettings.lightTime;
-        _state.effectiveDarkMinutes = _currentSettings.darkTime;
+        _state.effectiveLightMinutes = config.lightTime;
+        _state.effectiveDarkMinutes = config.darkTime;
     }
+}
 
-    // Handle manual override logic
+bool LightSwitchStateManager::ScheduledThemeLocked(const LightSwitchConfig& config, const SYSTEMTIME& now)
+{
+    return config.scheduleMode == ScheduleMode::FollowNightLight ? !_state.isNightLightActive :
+                                                                   ShouldBeLight(Minutes(now), _state.effectiveLightMinutes, _state.effectiveDarkMinutes);
+}
+
+LSTATUS LightSwitchStateManager::ApplyThemeLocked(bool light, const LightSwitchConfig& config, bool& changed)
+{
+    LSTATUS result = ERROR_SUCCESS;
+    changed = false;
+    for (const bool system : { true, false })
+    {
+        if (!(system ? config.changeSystem : config.changeApps))
+            continue;
+        bool actual = false;
+        if (_dependencies.readTheme(system, actual) != ERROR_SUCCESS || actual != light)
+        {
+            const auto writeResult = _dependencies.writeTheme(system, light);
+            if (writeResult != ERROR_SUCCESS && result == ERROR_SUCCESS)
+                result = writeResult;
+            changed = true;
+        }
+    }
+    const auto snapshot = GetStatusSnapshotLocked(config);
+    SyncThemeStateLocked(snapshot);
+    if ((config.changeSystem && snapshot.systemLight != std::optional<bool>(light)) ||
+        (config.changeApps && snapshot.appsLight != std::optional<bool>(light)))
+    {
+        if (result == ERROR_SUCCESS)
+            result = ERROR_WRITE_FAULT;
+    }
+    return result;
+}
+
+LSTATUS LightSwitchStateManager::EvaluateAndApplyIfNeededLocked(const LightSwitchConfig& config, const SYSTEMTIME& now)
+{
+    const int minutes = Minutes(now);
+    if (config.scheduleMode == ScheduleMode::Off)
+    {
+        _state.lastTickMinutes = minutes;
+        return ERROR_SUCCESS;
+    }
+    UpdateEffectiveTimesLocked(config, now);
     if (_state.isManualOverride)
     {
+        // Night Light overrides end on an actual Night Light transition, not a clock tick.
+        if (config.scheduleMode == ScheduleMode::FollowNightLight)
+        {
+            _state.lastTickMinutes = minutes;
+            return ERROR_SUCCESS;
+        }
         bool crossedBoundary = false;
         if (_state.lastTickMinutes != -1)
         {
-            int prev = _state.lastTickMinutes;
-
-            // Handle midnight wraparound safely
-            if (now < prev)
+            const int previous = _state.lastTickMinutes;
+            if (minutes < previous)
             {
-                crossedBoundary =
-                    (prev <= _state.effectiveLightMinutes || now >= _state.effectiveLightMinutes) ||
-                    (prev <= _state.effectiveDarkMinutes || now >= _state.effectiveDarkMinutes);
+                crossedBoundary = (previous <= _state.effectiveLightMinutes || minutes >= _state.effectiveLightMinutes) ||
+                                  (previous <= _state.effectiveDarkMinutes || minutes >= _state.effectiveDarkMinutes);
             }
             else
             {
-                crossedBoundary =
-                    (prev < _state.effectiveLightMinutes && now >= _state.effectiveLightMinutes) ||
-                    (prev < _state.effectiveDarkMinutes && now >= _state.effectiveDarkMinutes);
+                crossedBoundary = (previous < _state.effectiveLightMinutes && minutes >= _state.effectiveLightMinutes) ||
+                                  (previous < _state.effectiveDarkMinutes && minutes >= _state.effectiveDarkMinutes);
             }
         }
-
-        if (crossedBoundary)
+        if (!crossedBoundary)
         {
-            _state.isManualOverride = false;
+            _state.lastTickMinutes = minutes;
+            return ERROR_SUCCESS;
         }
-        else
-        {
-            _state.lastTickMinutes = now;
-            return;
-        }
+        _state.isManualOverride = false;
     }
-
-    _state.lastAppliedMode = _currentSettings.scheduleMode;
-
-    bool shouldBeLight = false;
-    if (_currentSettings.scheduleMode == ScheduleMode::FollowNightLight)
-    {
-        shouldBeLight = !_state.isNightLightActive;
-    }
-    else
-    {
-        shouldBeLight = ShouldBeLight(now, _state.effectiveLightMinutes, _state.effectiveDarkMinutes);
-    }
-
-    bool appsNeedsToChange = _currentSettings.changeApps && (_state.isAppsLightActive != shouldBeLight);
-    bool systemNeedsToChange = _currentSettings.changeSystem && (_state.isSystemLightActive != shouldBeLight);
-
-    /* Logger::debug(
-        L"[LightSwitchStateManager] now = {:02d}:{:02d}, light boundary = {:02d}:{:02d} ({}), dark boundary = {:02d}:{:02d} ({})",
-        now / 60,
-        now % 60,
-        _state.effectiveLightMinutes / 60,
-        _state.effectiveLightMinutes % 60,
-        _state.effectiveLightMinutes,
-        _state.effectiveDarkMinutes / 60,
-        _state.effectiveDarkMinutes % 60,
-        _state.effectiveDarkMinutes); */
-
-    /* Logger::debug("should be light = {}, apps needs change = {}, system needs change = {}",
-                  shouldBeLight ? "true" : "false",
-                  appsNeedsToChange ? "true" : "false",
-                  systemNeedsToChange ? "true" : "false"); */
-
-    // Only apply theme if there's a change or no override active
-    if (!_state.isManualOverride && (appsNeedsToChange || systemNeedsToChange))
-    {
-        Logger::info(L"[LightSwitchStateManager] Applying {} theme", shouldBeLight ? L"light" : L"dark");
-        ApplyTheme(shouldBeLight);
-
-        _state.isSystemLightActive = GetCurrentSystemTheme();
-        _state.isAppsLightActive = GetCurrentAppsTheme();
-
-        // Notify PowerDisplay after the theme transition is complete.
-        NotifyPowerDisplayThemeChanged(shouldBeLight);
-    }
-
-    _state.lastTickMinutes = now;
+    _state.lastAppliedMode = config.scheduleMode;
+    bool changed = false;
+    const auto result = ApplyThemeLocked(ScheduledThemeLocked(config, now), config, changed);
+    if (result == ERROR_SUCCESS && changed)
+        NotifyAppliedThemeLocked(config, GetStatusSnapshotLocked(config));
+    else if (result != ERROR_SUCCESS)
+        Logger::warn(L"[LightSwitchStateManager] Scheduled theme application failed (error: {}).", result);
+    _state.lastTickMinutes = minutes;
+    return result;
 }
 
+void LightSwitchStateManager::NotifyAppliedThemeLocked(const LightSwitchConfig& config, const StatusSnapshot& snapshot)
+{
+    const auto theme = config.changeSystem ? snapshot.systemLight : (config.changeApps ? snapshot.appsLight : std::nullopt);
+    if (!theme)
+        return;
+    if (_dependencies.notifyThemeChanged)
+        _dependencies.notifyThemeChanged(*theme);
+    else
+        NotifyPowerDisplayThemeChanged(*theme);
+}
+
+ThemeCommandResult LightSwitchStateManager::SetTheme(bool light)
+{
+    std::lock_guard<std::mutex> lock(_stateMutex);
+    std::wstring error;
+    if (!LoadSettingsLocked(error))
+        return CompleteCommandLocked(_settingsSnapshot, L"SETTINGS_READ_FAILED", error);
+    const auto config = _settingsSnapshot;
+    if (!config.changeSystem && !config.changeApps)
+        return CompleteCommandLocked(config, L"NO_TARGETS", L"No theme targets are enabled in Light Switch settings.");
+    bool changed = false;
+    const auto result = ApplyThemeLocked(light, config, changed);
+    if (result != ERROR_SUCCESS)
+        return CompleteCommandLocked(config, L"THEME_WRITE_FAILED", ThemeError(result));
+
+    const auto now = _dependencies.localTime();
+    UpdateEffectiveTimesLocked(config, now);
+    _state.isManualOverride = config.scheduleMode != ScheduleMode::Off && light != ScheduledThemeLocked(config, now);
+    _state.lastTickMinutes = Minutes(now);
+    if (changed)
+        NotifyAppliedThemeLocked(config, GetStatusSnapshotLocked(config));
+    return CompleteCommandLocked(config);
+}
+
+ThemeCommandResult LightSwitchStateManager::ToggleTheme()
+{
+    std::lock_guard<std::mutex> lock(_stateMutex);
+    std::wstring error;
+    if (!LoadSettingsLocked(error))
+        return CompleteCommandLocked(_settingsSnapshot, L"SETTINGS_READ_FAILED", error);
+    const auto config = _settingsSnapshot;
+    if (!config.changeSystem && !config.changeApps)
+        return CompleteCommandLocked(config, L"NO_TARGETS", L"No theme targets are enabled in Light Switch settings.");
+    const auto before = GetStatusSnapshotLocked(config);
+    if ((config.changeSystem && !before.systemLight) || (config.changeApps && !before.appsLight))
+        return CompleteCommandLocked(config, L"THEME_READ_FAILED", L"The current theme could not be read. No themes were changed.");
+
+    LSTATUS result = ERROR_SUCCESS;
+    for (const bool system : { true, false })
+    {
+        if (!(system ? config.changeSystem : config.changeApps))
+            continue;
+        const auto writeResult = _dependencies.writeTheme(system, !(system ? *before.systemLight : *before.appsLight));
+        if (writeResult != ERROR_SUCCESS && result == ERROR_SUCCESS)
+            result = writeResult;
+    }
+    const auto after = GetStatusSnapshotLocked(config);
+    SyncThemeStateLocked(after);
+    if ((config.changeSystem && after.systemLight != std::optional<bool>(!*before.systemLight)) ||
+        (config.changeApps && after.appsLight != std::optional<bool>(!*before.appsLight)))
+    {
+        if (result == ERROR_SUCCESS)
+            result = ERROR_WRITE_FAULT;
+    }
+    if (result == ERROR_SUCCESS)
+        result = OnManualOverrideLocked(config, _dependencies.localTime());
+    return result == ERROR_SUCCESS ? CompleteCommandLocked(config) : CompleteCommandLocked(config, L"THEME_WRITE_FAILED", ThemeError(result));
+}
+
+void LightSwitchStateManager::DetectExternalThemeChange()
+{
+    std::lock_guard<std::mutex> lock(_stateMutex);
+    const bool hadSettingsSnapshot = _hasSettingsSnapshot;
+    const auto previousConfig = _settingsSnapshot;
+    std::wstring error;
+    if (!LoadSettingsLocked(error) || _settingsSnapshot.scheduleMode == ScheduleMode::Off || _state.isManualOverride)
+        return;
+    // A minute tick can read an edit before its debounced settings notification.
+    // Let the scheduler apply that edit before comparing Windows with the new plan.
+    if (hadSettingsSnapshot && !HasSameEffectiveLightSwitchSettings(previousConfig, _settingsSnapshot))
+        return;
+    const auto config = _settingsSnapshot;
+    const auto now = _dependencies.localTime();
+    UpdateEffectiveTimesLocked(config, now);
+    const bool scheduledLight = config.scheduleMode == ScheduleMode::FollowNightLight ? !_dependencies.readNightLight() : ScheduledThemeLocked(config, now);
+    const auto snapshot = GetStatusSnapshotLocked(config);
+    const bool mismatch = (config.changeSystem && snapshot.systemLight && *snapshot.systemLight != scheduledLight) ||
+                          (config.changeApps && snapshot.appsLight && *snapshot.appsLight != scheduledLight);
+    if (mismatch)
+    {
+        Logger::info(L"[LightSwitchStateManager] External theme change detected.");
+        OnManualOverrideLocked(config, now);
+    }
+}
 // Notify PowerDisplay that LightSwitch applied a new theme.
 void LightSwitchStateManager::NotifyPowerDisplayThemeChanged(bool isLight)
 {
@@ -292,9 +422,7 @@ void LightSwitchStateManager::NotifyPowerDisplayThemeChanged(bool isLight)
     {
         // The event carries only the resulting theme. PowerDisplay owns profile
         // enablement, reference validation, and application.
-        const wchar_t* eventName = isLight
-            ? CommonSharedConstants::LIGHT_SWITCH_LIGHT_THEME_EVENT
-            : CommonSharedConstants::LIGHT_SWITCH_DARK_THEME_EVENT;
+        const wchar_t* eventName = isLight ? CommonSharedConstants::LIGHT_SWITCH_LIGHT_THEME_EVENT : CommonSharedConstants::LIGHT_SWITCH_DARK_THEME_EVENT;
 
         Logger::info(L"[LightSwitchStateManager] Notifying PowerDisplay about theme change (isLight: {})", isLight);
 

--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchStateManager.cpp
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchStateManager.cpp
@@ -9,9 +9,30 @@
 
 namespace
 {
+    constexpr int MinutesPerDay = 24 * 60;
+
     int Minutes(const SYSTEMTIME& time)
     {
         return time.wHour * 60 + time.wMinute;
+    }
+
+    constexpr int NormalizeMinutes(int minutes, int offset = 0)
+    {
+        const auto total = static_cast<std::int64_t>(minutes) + offset;
+        return static_cast<int>((total % MinutesPerDay + MinutesPerDay) % MinutesPerDay);
+    }
+
+    std::optional<std::uint64_t> LocalMinutes(const SYSTEMTIME& time)
+    {
+        // Encode the complete local wall-clock date without a time-zone conversion.
+        // A backward clock adjustment must not look like a forward midnight wrap.
+        FILETIME fileTime{};
+        if (!SystemTimeToFileTime(&time, &fileTime))
+            return std::nullopt;
+        ULARGE_INTEGER value{};
+        value.LowPart = fileTime.dwLowDateTime;
+        value.HighPart = fileTime.dwHighDateTime;
+        return value.QuadPart / (60ULL * 10000000ULL);
     }
 
     std::pair<int, int> UpdateSunTimes(const LightSwitchConfig& settings, const SYSTEMTIME& time)
@@ -87,7 +108,7 @@ bool LightSwitchStateManager::LoadSettingsLocked(std::wstring& error)
     {
         const bool enteringNightLight = !_hasSettingsSnapshot || _settingsSnapshot.scheduleMode != ScheduleMode::FollowNightLight;
         _state.isManualOverride = false;
-        _state.lastEvaluatedDay = -1;
+        _state.lastEvaluatedDate.reset();
         if (config.scheduleMode == ScheduleMode::FollowNightLight && enteringNightLight)
         {
             _state.isNightLightActive = _dependencies.readNightLight();
@@ -125,29 +146,44 @@ StatusSnapshot LightSwitchStateManager::GetStatusSnapshot()
     return GetStatusSnapshotLocked(_settingsSnapshot);
 }
 
-void LightSwitchStateManager::SyncThemeStateLocked(const StatusSnapshot& snapshot)
+void LightSwitchStateManager::SyncThemeStateLocked(const StatusSnapshot& snapshot, bool recordObservation)
 {
     if (snapshot.systemLight)
+    {
         _state.isSystemLightActive = *snapshot.systemLight;
+        if (recordObservation)
+            _lastObservedSystemTheme = snapshot.systemLight;
+    }
     if (snapshot.appsLight)
+    {
         _state.isAppsLightActive = *snapshot.appsLight;
+        if (recordObservation)
+            _lastObservedAppsTheme = snapshot.appsLight;
+    }
 }
 
 ThemeCommandResult LightSwitchStateManager::CompleteCommandLocked(const LightSwitchConfig& config, const wchar_t* errorCode, const std::wstring& message)
 {
     auto snapshot = GetStatusSnapshotLocked(config);
-    SyncThemeStateLocked(snapshot);
+    // Reporting an error must not consume an external change that the scheduler
+    // has not handled yet (for example, when the settings file is unreadable).
+    SyncThemeStateLocked(snapshot, false);
     return { errorCode[0] == L'\0', errorCode, message, std::move(snapshot) };
 }
 
 ThemeCommandResult LightSwitchStateManager::OnSettingsChanged()
 {
     std::lock_guard<std::mutex> lock(_stateMutex);
+    const bool hadSettingsSnapshot = _hasSettingsSnapshot;
+    const auto previousConfig = _settingsSnapshot;
     std::wstring error;
     if (!LoadSettingsLocked(error))
         return CompleteCommandLocked(_settingsSnapshot, L"SETTINGS_READ_FAILED", error);
     const auto config = _settingsSnapshot;
-    const auto result = EvaluateAndApplyIfNeededLocked(config, _dependencies.localTime());
+    const auto now = _dependencies.localTime();
+    if (hadSettingsSnapshot && HasSameEffectiveLightSwitchSettings(previousConfig, config))
+        DetectExternalThemeChangeLocked(config, now);
+    const auto result = EvaluateAndApplyIfNeededLocked(config, now);
     return result == ERROR_SUCCESS ? CompleteCommandLocked(config) : CompleteCommandLocked(config, L"THEME_WRITE_FAILED", ThemeError(result));
 }
 
@@ -171,8 +207,32 @@ void LightSwitchStateManager::OnManualOverride()
 
 LSTATUS LightSwitchStateManager::OnManualOverrideLocked(const LightSwitchConfig& config, const SYSTEMTIME& now)
 {
-    _state.isManualOverride = !_state.isManualOverride;
+    UpdateEffectiveTimesLocked(config, now);
+    bool crossedBoundary = false;
+    if (config.scheduleMode == ScheduleMode::FollowNightLight)
+    {
+        const bool nightLight = _dependencies.readNightLight();
+        crossedBoundary = _state.isNightLightActive != nightLight;
+        _state.isNightLightActive = nightLight;
+    }
+    else if (config.scheduleMode != ScheduleMode::Off)
+    {
+        crossedBoundary = HasCrossedScheduleBoundaryLocked(now);
+    }
     const auto snapshot = GetStatusSnapshotLocked(config);
+    if (crossedBoundary)
+    {
+        // The old override expired before this toggle. Keep the new selection
+        // only when it differs from the current plan, as for an explicit set.
+        const bool scheduledLight = ScheduledThemeLocked(config, now);
+        _state.isManualOverride = (config.changeSystem && snapshot.systemLight && *snapshot.systemLight != scheduledLight) ||
+                                  (config.changeApps && snapshot.appsLight && *snapshot.appsLight != scheduledLight);
+        RecordEvaluationTimeLocked(now);
+    }
+    else
+    {
+        _state.isManualOverride = !_state.isManualOverride;
+    }
     SyncThemeStateLocked(snapshot);
     NotifyAppliedThemeLocked(config, snapshot);
     return EvaluateAndApplyIfNeededLocked(config, now);
@@ -181,17 +241,20 @@ LSTATUS LightSwitchStateManager::OnManualOverrideLocked(const LightSwitchConfig&
 void LightSwitchStateManager::OnNightLightChange()
 {
     std::lock_guard<std::mutex> lock(_stateMutex);
+    const bool hadSettingsSnapshot = _hasSettingsSnapshot;
+    const auto previousConfig = _settingsSnapshot;
     std::wstring error;
     if (!LoadSettingsLocked(error))
         return;
     const bool nightLight = _dependencies.readNightLight();
-    if (_state.isNightLightActive != nightLight)
-    {
-        if (_settingsSnapshot.scheduleMode == ScheduleMode::FollowNightLight)
-            _state.isManualOverride = false;
-        _state.isNightLightActive = nightLight;
-    }
-    EvaluateAndApplyIfNeededLocked(_settingsSnapshot, _dependencies.localTime());
+    const bool crossedBoundary = _settingsSnapshot.scheduleMode == ScheduleMode::FollowNightLight && _state.isNightLightActive != nightLight;
+    if (crossedBoundary)
+        _state.isManualOverride = false;
+    _state.isNightLightActive = nightLight;
+    const auto now = _dependencies.localTime();
+    if (!crossedBoundary && hadSettingsSnapshot && HasSameEffectiveLightSwitchSettings(previousConfig, _settingsSnapshot))
+        DetectExternalThemeChangeLocked(_settingsSnapshot, now);
+    EvaluateAndApplyIfNeededLocked(_settingsSnapshot, now);
 }
 
 void LightSwitchStateManager::SyncInitialThemeState()
@@ -222,19 +285,50 @@ void LightSwitchStateManager::UpdateEffectiveTimesLocked(const LightSwitchConfig
 {
     if (config.scheduleMode == ScheduleMode::SunsetToSunrise && CoordinatesAreValid(config.latitude, config.longitude))
     {
-        if (_state.lastEvaluatedDay != now.wDay)
+        const auto localMinutes = LocalMinutes(now);
+        if (!localMinutes)
+            return;
+        const auto date = *localMinutes / MinutesPerDay;
+        if (_state.lastEvaluatedDate != date)
         {
             const auto [light, dark] = _dependencies.updateSunTimes(config, now);
-            _state.lastEvaluatedDay = now.wDay;
-            _state.effectiveLightMinutes = light + config.sunrise_offset;
-            _state.effectiveDarkMinutes = dark + config.sunset_offset;
+            _state.lastEvaluatedDate = date;
+            _state.effectiveLightMinutes = NormalizeMinutes(light, config.sunrise_offset);
+            _state.effectiveDarkMinutes = NormalizeMinutes(dark, config.sunset_offset);
         }
     }
     else if (config.scheduleMode == ScheduleMode::FixedHours)
     {
-        _state.effectiveLightMinutes = config.lightTime;
-        _state.effectiveDarkMinutes = config.darkTime;
+        _state.effectiveLightMinutes = NormalizeMinutes(config.lightTime);
+        _state.effectiveDarkMinutes = NormalizeMinutes(config.darkTime);
     }
+}
+
+void LightSwitchStateManager::RecordEvaluationTimeLocked(const SYSTEMTIME& now)
+{
+    _lastTickTime = LocalMinutes(now);
+    _lastTickLightMinutes = _state.effectiveLightMinutes;
+    _lastTickDarkMinutes = _state.effectiveDarkMinutes;
+}
+
+bool LightSwitchStateManager::HasCrossedScheduleBoundaryLocked(const SYSTEMTIME& now) const
+{
+    const auto current = LocalMinutes(now);
+    if (!_lastTickTime || !current || *current <= *_lastTickTime)
+        return false;
+    if (*current - *_lastTickTime >= static_cast<std::uint64_t>(MinutesPerDay))
+        return true;
+
+    const int previousMinutes = static_cast<int>(*_lastTickTime % MinutesPerDay);
+    const int currentMinutes = static_cast<int>(*current % MinutesPerDay);
+    if (*_lastTickTime / MinutesPerDay != *current / MinutesPerDay)
+    {
+        // Sun times can change at midnight. Use each date's own boundaries.
+        return previousMinutes < _lastTickLightMinutes || previousMinutes < _lastTickDarkMinutes ||
+               currentMinutes >= _state.effectiveLightMinutes || currentMinutes >= _state.effectiveDarkMinutes;
+    }
+    return (previousMinutes < _state.effectiveLightMinutes && currentMinutes >= _state.effectiveLightMinutes) ||
+           (previousMinutes < _state.effectiveDarkMinutes && currentMinutes >= _state.effectiveDarkMinutes);
 }
 
 bool LightSwitchStateManager::ScheduledThemeLocked(const LightSwitchConfig& config, const SYSTEMTIME& now)
@@ -273,10 +367,9 @@ LSTATUS LightSwitchStateManager::ApplyThemeLocked(bool light, const LightSwitchC
 
 LSTATUS LightSwitchStateManager::EvaluateAndApplyIfNeededLocked(const LightSwitchConfig& config, const SYSTEMTIME& now)
 {
-    const int minutes = Minutes(now);
     if (config.scheduleMode == ScheduleMode::Off)
     {
-        _state.lastTickMinutes = minutes;
+        RecordEvaluationTimeLocked(now);
         return ERROR_SUCCESS;
     }
     UpdateEffectiveTimesLocked(config, now);
@@ -285,27 +378,12 @@ LSTATUS LightSwitchStateManager::EvaluateAndApplyIfNeededLocked(const LightSwitc
         // Night Light overrides end on an actual Night Light transition, not a clock tick.
         if (config.scheduleMode == ScheduleMode::FollowNightLight)
         {
-            _state.lastTickMinutes = minutes;
+            RecordEvaluationTimeLocked(now);
             return ERROR_SUCCESS;
         }
-        bool crossedBoundary = false;
-        if (_state.lastTickMinutes != -1)
+        if (!HasCrossedScheduleBoundaryLocked(now))
         {
-            const int previous = _state.lastTickMinutes;
-            if (minutes < previous)
-            {
-                crossedBoundary = (previous <= _state.effectiveLightMinutes || minutes >= _state.effectiveLightMinutes) ||
-                                  (previous <= _state.effectiveDarkMinutes || minutes >= _state.effectiveDarkMinutes);
-            }
-            else
-            {
-                crossedBoundary = (previous < _state.effectiveLightMinutes && minutes >= _state.effectiveLightMinutes) ||
-                                  (previous < _state.effectiveDarkMinutes && minutes >= _state.effectiveDarkMinutes);
-            }
-        }
-        if (!crossedBoundary)
-        {
-            _state.lastTickMinutes = minutes;
+            RecordEvaluationTimeLocked(now);
             return ERROR_SUCCESS;
         }
         _state.isManualOverride = false;
@@ -317,7 +395,7 @@ LSTATUS LightSwitchStateManager::EvaluateAndApplyIfNeededLocked(const LightSwitc
         NotifyAppliedThemeLocked(config, GetStatusSnapshotLocked(config));
     else if (result != ERROR_SUCCESS)
         Logger::warn(L"[LightSwitchStateManager] Scheduled theme application failed (error: {}).", result);
-    _state.lastTickMinutes = minutes;
+    RecordEvaluationTimeLocked(now);
     return result;
 }
 
@@ -348,8 +426,10 @@ ThemeCommandResult LightSwitchStateManager::SetTheme(bool light)
 
     const auto now = _dependencies.localTime();
     UpdateEffectiveTimesLocked(config, now);
+    if (config.scheduleMode == ScheduleMode::FollowNightLight)
+        _state.isNightLightActive = _dependencies.readNightLight();
     _state.isManualOverride = config.scheduleMode != ScheduleMode::Off && light != ScheduledThemeLocked(config, now);
-    _state.lastTickMinutes = Minutes(now);
+    RecordEvaluationTimeLocked(now);
     if (changed)
         NotifyAppliedThemeLocked(config, GetStatusSnapshotLocked(config));
     return CompleteCommandLocked(config);
@@ -402,17 +482,30 @@ void LightSwitchStateManager::DetectExternalThemeChange()
     // Let the scheduler apply that edit before comparing Windows with the new plan.
     if (hadSettingsSnapshot && !HasSameEffectiveLightSwitchSettings(previousConfig, _settingsSnapshot))
         return;
-    const auto config = _settingsSnapshot;
-    const auto now = _dependencies.localTime();
+    DetectExternalThemeChangeLocked(_settingsSnapshot, _dependencies.localTime());
+}
+
+void LightSwitchStateManager::DetectExternalThemeChangeLocked(const LightSwitchConfig& config, const SYSTEMTIME& now)
+{
+    if (config.scheduleMode == ScheduleMode::Off || _state.isManualOverride)
+        return;
     UpdateEffectiveTimesLocked(config, now);
-    const bool scheduledLight = config.scheduleMode == ScheduleMode::FollowNightLight ? !_dependencies.readNightLight() : ScheduledThemeLocked(config, now);
+    const bool nightLight = config.scheduleMode == ScheduleMode::FollowNightLight ? _dependencies.readNightLight() : _state.isNightLightActive;
+    const bool scheduledLight = config.scheduleMode == ScheduleMode::FollowNightLight ? !nightLight : ScheduledThemeLocked(config, now);
     const auto snapshot = GetStatusSnapshotLocked(config);
-    const bool mismatch = (config.changeSystem && snapshot.systemLight && *snapshot.systemLight != scheduledLight) ||
-                          (config.changeApps && snapshot.appsLight && *snapshot.appsLight != scheduledLight);
+    // An unchanged Windows theme at a new scheduled boundary is not an external
+    // edit. Require a change from the last observation as well as a plan mismatch.
+    const bool mismatch = (config.changeSystem && snapshot.systemLight && *snapshot.systemLight != scheduledLight && snapshot.systemLight != _lastObservedSystemTheme) ||
+                          (config.changeApps && snapshot.appsLight && *snapshot.appsLight != scheduledLight && snapshot.appsLight != _lastObservedAppsTheme);
     if (mismatch)
     {
         Logger::info(L"[LightSwitchStateManager] External theme change detected.");
-        OnManualOverrideLocked(config, now);
+        _state.isManualOverride = true;
+        if (config.scheduleMode == ScheduleMode::FollowNightLight)
+            _state.isNightLightActive = nightLight;
+        SyncThemeStateLocked(snapshot);
+        RecordEvaluationTimeLocked(now);
+        NotifyAppliedThemeLocked(config, snapshot);
     }
 }
 // Notify PowerDisplay that LightSwitch applied a new theme.

--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchStateManager.cpp
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchStateManager.cpp
@@ -42,10 +42,9 @@ namespace
         const int dark = sun.sunsetHour * 60 + sun.sunsetMinute;
         try
         {
-            auto values = PowerToysSettings::PowerToyValues::load_from_settings_file(L"LightSwitch");
-            values.add_property(L"lightTime", light);
-            values.add_property(L"darkTime", dark);
-            values.save_to_settings_file();
+            std::wstring error;
+            if (LightSwitchSettings::instance().SaveSunTimes(settings, light, dark, error) == SunTimesSaveResult::Failed)
+                Logger::error(L"[LightSwitchStateManager] Could not save calculated sun times: {}", error);
         }
         catch (...)
         {
@@ -126,6 +125,16 @@ LightSwitchState LightSwitchStateManager::GetState() const
     return _state;
 }
 
+bool LightSwitchStateManager::RefreshNightLightStateLocked(const LightSwitchConfig& config)
+{
+    const bool nightLight = _dependencies.readNightLight();
+    const bool crossedBoundary = config.scheduleMode == ScheduleMode::FollowNightLight && _state.isNightLightActive != nightLight;
+    if (crossedBoundary)
+        _state.isManualOverride = false;
+    _state.isNightLightActive = nightLight;
+    return crossedBoundary;
+}
+
 StatusSnapshot LightSwitchStateManager::GetStatusSnapshotLocked(const LightSwitchConfig& config)
 {
     StatusSnapshot snapshot;
@@ -183,6 +192,10 @@ ThemeCommandResult LightSwitchStateManager::OnSettingsChanged()
     const auto now = _dependencies.localTime();
     if (hadSettingsSnapshot && HasSameEffectiveLightSwitchSettings(previousConfig, config))
         DetectExternalThemeChangeLocked(config, now);
+    // External detection records the current Night Light baseline when it finds
+    // a new manual choice. Sampling afterwards preserves that newer override.
+    if (config.scheduleMode == ScheduleMode::FollowNightLight)
+        RefreshNightLightStateLocked(config);
     const auto result = EvaluateAndApplyIfNeededLocked(config, now);
     return result == ERROR_SUCCESS ? CompleteCommandLocked(config) : CompleteCommandLocked(config, L"THEME_WRITE_FAILED", ThemeError(result));
 }
@@ -191,8 +204,12 @@ void LightSwitchStateManager::OnTick()
 {
     std::lock_guard<std::mutex> lock(_stateMutex);
     std::wstring error;
-    if (LoadSettingsLocked(error) && _settingsSnapshot.scheduleMode != ScheduleMode::FollowNightLight)
+    if (LoadSettingsLocked(error))
     {
+        // A notification can be missed while settings are unreadable, and a
+        // failed theme write still needs a retry even without another transition.
+        if (_settingsSnapshot.scheduleMode == ScheduleMode::FollowNightLight)
+            RefreshNightLightStateLocked(_settingsSnapshot);
         EvaluateAndApplyIfNeededLocked(_settingsSnapshot, _dependencies.localTime());
     }
 }
@@ -246,11 +263,7 @@ void LightSwitchStateManager::OnNightLightChange()
     std::wstring error;
     if (!LoadSettingsLocked(error))
         return;
-    const bool nightLight = _dependencies.readNightLight();
-    const bool crossedBoundary = _settingsSnapshot.scheduleMode == ScheduleMode::FollowNightLight && _state.isNightLightActive != nightLight;
-    if (crossedBoundary)
-        _state.isManualOverride = false;
-    _state.isNightLightActive = nightLight;
+    const bool crossedBoundary = RefreshNightLightStateLocked(_settingsSnapshot);
     const auto now = _dependencies.localTime();
     if (!crossedBoundary && hadSettingsSnapshot && HasSameEffectiveLightSwitchSettings(previousConfig, _settingsSnapshot))
         DetectExternalThemeChangeLocked(_settingsSnapshot, now);
@@ -348,6 +361,9 @@ LSTATUS LightSwitchStateManager::ApplyThemeLocked(bool light, const LightSwitchC
         bool actual = false;
         if (_dependencies.readTheme(system, actual) != ERROR_SUCCESS || actual != light)
         {
+            // If readback fails, this write's result must not later look like
+            // an external edit relative to the value observed before the write.
+            (system ? _lastObservedSystemTheme : _lastObservedAppsTheme).reset();
             const auto writeResult = _dependencies.writeTheme(system, light);
             if (writeResult != ERROR_SUCCESS && result == ERROR_SUCCESS)
                 result = writeResult;
@@ -453,6 +469,7 @@ ThemeCommandResult LightSwitchStateManager::ToggleTheme()
     {
         if (!(system ? config.changeSystem : config.changeApps))
             continue;
+        (system ? _lastObservedSystemTheme : _lastObservedAppsTheme).reset();
         const auto writeResult = _dependencies.writeTheme(system, !(system ? *before.systemLight : *before.appsLight));
         if (writeResult != ERROR_SUCCESS && result == ERROR_SUCCESS)
             result = writeResult;
@@ -494,9 +511,10 @@ void LightSwitchStateManager::DetectExternalThemeChangeLocked(const LightSwitchC
     const bool scheduledLight = config.scheduleMode == ScheduleMode::FollowNightLight ? !nightLight : ScheduledThemeLocked(config, now);
     const auto snapshot = GetStatusSnapshotLocked(config);
     // An unchanged Windows theme at a new scheduled boundary is not an external
-    // edit. Require a change from the last observation as well as a plan mismatch.
-    const bool mismatch = (config.changeSystem && snapshot.systemLight && *snapshot.systemLight != scheduledLight && snapshot.systemLight != _lastObservedSystemTheme) ||
-                          (config.changeApps && snapshot.appsLight && *snapshot.appsLight != scheduledLight && snapshot.appsLight != _lastObservedAppsTheme);
+    // edit. Require a known earlier observation: recovering access to an unreadable
+    // theme alone is not evidence that an external editor changed it.
+    const bool mismatch = (config.changeSystem && snapshot.systemLight && _lastObservedSystemTheme && *snapshot.systemLight != scheduledLight && snapshot.systemLight != _lastObservedSystemTheme) ||
+                          (config.changeApps && snapshot.appsLight && _lastObservedAppsTheme && *snapshot.appsLight != scheduledLight && snapshot.appsLight != _lastObservedAppsTheme);
     if (mismatch)
     {
         Logger::info(L"[LightSwitchStateManager] External theme change detected.");

--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchStateManager.h
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchStateManager.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "LightSwitchSettings.h"
+#include <cstdint>
 #include <functional>
 #include <optional>
 #include <utility>
@@ -12,8 +13,7 @@ struct LightSwitchState
     bool isSystemLightActive = false;
     bool isAppsLightActive = false;
     bool isNightLightActive = false;
-    int lastEvaluatedDay = -1;
-    int lastTickMinutes = -1;
+    std::optional<std::uint64_t> lastEvaluatedDate;
     int effectiveLightMinutes = 0;
     int effectiveDarkMinutes = 0;
 };
@@ -71,11 +71,19 @@ private:
     LightSwitchStateManagerDependencies _dependencies;
     LightSwitchConfig _settingsSnapshot;
     bool _hasSettingsSnapshot = false;
+    std::optional<bool> _lastObservedSystemTheme;
+    std::optional<bool> _lastObservedAppsTheme;
+    std::optional<std::uint64_t> _lastTickTime;
+    int _lastTickLightMinutes = 0;
+    int _lastTickDarkMinutes = 0;
 
     bool LoadSettingsLocked(std::wstring& error);
     StatusSnapshot GetStatusSnapshotLocked(const LightSwitchConfig& config);
-    void SyncThemeStateLocked(const StatusSnapshot& snapshot);
+    void SyncThemeStateLocked(const StatusSnapshot& snapshot, bool recordObservation = true);
+    void DetectExternalThemeChangeLocked(const LightSwitchConfig& config, const SYSTEMTIME& now);
     void UpdateEffectiveTimesLocked(const LightSwitchConfig& config, const SYSTEMTIME& now);
+    void RecordEvaluationTimeLocked(const SYSTEMTIME& now);
+    bool HasCrossedScheduleBoundaryLocked(const SYSTEMTIME& now) const;
     bool ScheduledThemeLocked(const LightSwitchConfig& config, const SYSTEMTIME& now);
     LSTATUS ApplyThemeLocked(bool light, const LightSwitchConfig& config, bool& changed);
     LSTATUS EvaluateAndApplyIfNeededLocked(const LightSwitchConfig& config, const SYSTEMTIME& now);

--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchStateManager.h
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchStateManager.h
@@ -1,8 +1,10 @@
 #pragma once
 #include "LightSwitchSettings.h"
+#include <functional>
 #include <optional>
+#include <utility>
 
-// Represents runtime-only information (not saved in settings.json)
+// Represents runtime-only information (not saved in settings.json).
 struct LightSwitchState
 {
     ScheduleMode lastAppliedMode = ScheduleMode::Off;
@@ -12,43 +14,74 @@ struct LightSwitchState
     bool isNightLightActive = false;
     int lastEvaluatedDay = -1;
     int lastTickMinutes = -1;
-
-    // Derived, runtime-resolved times
-    int effectiveLightMinutes = 0; // the boundary we actually act on
-    int effectiveDarkMinutes = 0; // includes offsets if needed
+    int effectiveLightMinutes = 0;
+    int effectiveDarkMinutes = 0;
 };
 
-// The controller that reacts to settings changes, time ticks, and manual overrides.
+struct StatusSnapshot
+{
+    std::optional<bool> systemLight;
+    std::optional<bool> appsLight;
+    LightSwitchConfig config;
+    bool manualOverride = false;
+    bool configurationAvailable = false;
+};
+
+struct ThemeCommandResult
+{
+    bool success = false;
+    std::wstring errorCode;
+    std::wstring message;
+    StatusSnapshot status;
+};
+
+// Test seams for the existing state manager's Windows and settings operations.
+struct LightSwitchStateManagerDependencies
+{
+    std::function<bool(LightSwitchConfig&, std::wstring&)> loadSettings;
+    std::function<LSTATUS(bool system, bool& light)> readTheme;
+    std::function<LSTATUS(bool system, bool light)> writeTheme;
+    std::function<bool()> readNightLight;
+    std::function<SYSTEMTIME()> localTime;
+    std::function<void(bool light)> notifyThemeChanged;
+    std::function<std::pair<int, int>(const LightSwitchConfig&, const SYSTEMTIME&)> updateSunTimes;
+};
+
 class LightSwitchStateManager
 {
 public:
     LightSwitchStateManager();
+    explicit LightSwitchStateManager(LightSwitchStateManagerDependencies dependencies);
 
-    // Called when settings.json changes or stabilizes.
-    void OnSettingsChanged();
-
-    // Called every minute (from service worker tick).
+    ThemeCommandResult OnSettingsChanged();
     void OnTick();
-
-    // Called when manual override is toggled (via shortcut or system change).
     void OnManualOverride();
-
-    // Called when night light changes in windows settings
     void OnNightLightChange();
-
-    // Initial sync at startup to align internal state with system theme
     void SyncInitialThemeState();
+    void DetectExternalThemeChange();
 
-    // Accessor for current state (optional, for debugging or telemetry)
-    const LightSwitchState& GetState() const { return _state; }
+    LightSwitchState GetState() const;
+    StatusSnapshot GetStatusSnapshot();
+    ThemeCommandResult SetTheme(bool light);
+    ThemeCommandResult ToggleTheme();
 
 private:
     LightSwitchState _state;
-    std::mutex _stateMutex;
+    mutable std::mutex _stateMutex;
+    LightSwitchStateManagerDependencies _dependencies;
+    LightSwitchConfig _settingsSnapshot;
+    bool _hasSettingsSnapshot = false;
 
-    void EvaluateAndApplyIfNeeded();
+    bool LoadSettingsLocked(std::wstring& error);
+    StatusSnapshot GetStatusSnapshotLocked(const LightSwitchConfig& config);
+    void SyncThemeStateLocked(const StatusSnapshot& snapshot);
+    void UpdateEffectiveTimesLocked(const LightSwitchConfig& config, const SYSTEMTIME& now);
+    bool ScheduledThemeLocked(const LightSwitchConfig& config, const SYSTEMTIME& now);
+    LSTATUS ApplyThemeLocked(bool light, const LightSwitchConfig& config, bool& changed);
+    LSTATUS EvaluateAndApplyIfNeededLocked(const LightSwitchConfig& config, const SYSTEMTIME& now);
+    LSTATUS OnManualOverrideLocked(const LightSwitchConfig& config, const SYSTEMTIME& now);
+    void NotifyAppliedThemeLocked(const LightSwitchConfig& config, const StatusSnapshot& snapshot);
+    ThemeCommandResult CompleteCommandLocked(const LightSwitchConfig& config, const wchar_t* errorCode = L"", const std::wstring& message = L"");
     bool CoordinatesAreValid(const std::wstring& lat, const std::wstring& lon);
-
-    // Notify PowerDisplay that LightSwitch applied a new theme.
     void NotifyPowerDisplayThemeChanged(bool isLight);
 };

--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchStateManager.h
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchStateManager.h
@@ -78,6 +78,7 @@ private:
     int _lastTickDarkMinutes = 0;
 
     bool LoadSettingsLocked(std::wstring& error);
+    bool RefreshNightLightStateLocked(const LightSwitchConfig& config);
     StatusSnapshot GetStatusSnapshotLocked(const LightSwitchConfig& config);
     void SyncThemeStateLocked(const StatusSnapshot& snapshot, bool recordObservation = true);
     void DetectExternalThemeChangeLocked(const LightSwitchConfig& config, const SYSTEMTIME& now);

--- a/src/modules/LightSwitch/LightSwitchService/ScheduleCommandQueue.h
+++ b/src/modules/LightSwitch/LightSwitchService/ScheduleCommandQueue.h
@@ -1,0 +1,150 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root.
+
+#pragma once
+
+#include "CliProtocol.h"
+#include <wil/resource.h>
+#include <chrono>
+#include <deque>
+#include <functional>
+#include <future>
+#include <memory>
+#include <mutex>
+
+// Schedule changes also start/stop the Night Light observer, which belongs to the
+// service worker. The pipe thread waits for that worker's result, never while
+// holding a state/settings lock. Theme commands do not use this queue.
+class ScheduleCommandQueue
+{
+public:
+    using Response = winrt::Windows::Data::Json::JsonObject;
+    using Handler = std::function<Response(const light_switch_cli::Request&)>;
+
+    ScheduleCommandQueue() :
+        _event(CreateEventW(nullptr, FALSE, FALSE, nullptr))
+    {
+        if (!_event)
+        {
+            winrt::throw_last_error();
+        }
+    }
+
+    ~ScheduleCommandQueue()
+    {
+        Stop();
+    }
+
+    HANDLE Event() const noexcept
+    {
+        return _event.get();
+    }
+
+    Response Submit(
+        const light_switch_cli::Request& request,
+        std::chrono::milliseconds timeout = std::chrono::seconds(55))
+    {
+        auto pending = std::make_shared<Pending>(request);
+        auto result = pending->completion.get_future();
+        {
+            std::lock_guard lock(_mutex);
+            if (_stopped)
+            {
+                return Unavailable();
+            }
+            if (_pending.size() >= 8)
+            {
+                return light_switch_cli::MakeError(L"SERVER_BUSY", L"Light Switch is busy. Try again.");
+            }
+            _pending.push_back(pending);
+            if (!SetEvent(_event.get()))
+            {
+                _pending.pop_back();
+                return light_switch_cli::MakeError(L"EXECUTION_FAILED", L"Could not notify the Light Switch worker.");
+            }
+        }
+
+        if (result.wait_for(timeout) == std::future_status::ready)
+        {
+            return result.get();
+        }
+
+        std::lock_guard lock(_mutex);
+        // Never run a queued operation after its caller has already timed out.
+        // An operation that has started cannot be rolled back by cancelling IPC.
+        pending->cancelled = true;
+        return light_switch_cli::MakeError(
+            L"TIMEOUT",
+            pending->started ? L"Light Switch did not finish in time. The schedule may have changed; query status before retrying." : L"The schedule request timed out before it could be executed.");
+    }
+
+    void ProcessPending(const Handler& handler)
+    {
+        for (;;)
+        {
+            std::shared_ptr<Pending> pending;
+            {
+                std::lock_guard lock(_mutex);
+                if (_pending.empty() || _stopped)
+                {
+                    return;
+                }
+                pending = std::move(_pending.front());
+                _pending.pop_front();
+                if (pending->cancelled)
+                {
+                    continue;
+                }
+                pending->started = true;
+            }
+
+            try
+            {
+                pending->completion.set_value(handler(pending->request));
+            }
+            catch (...)
+            {
+                pending->completion.set_value(light_switch_cli::MakeError(
+                    L"EXECUTION_FAILED", L"Light Switch could not apply the schedule."));
+            }
+        }
+    }
+
+    void Stop()
+    {
+        std::deque<std::shared_ptr<Pending>> abandoned;
+        {
+            std::lock_guard lock(_mutex);
+            _stopped = true;
+            abandoned.swap(_pending);
+        }
+        for (const auto& pending : abandoned)
+        {
+            pending->completion.set_value(Unavailable());
+        }
+    }
+
+private:
+    struct Pending
+    {
+        explicit Pending(const light_switch_cli::Request& value) :
+            request(value)
+        {
+        }
+
+        light_switch_cli::Request request;
+        std::promise<Response> completion;
+        bool started = false;
+        bool cancelled = false;
+    };
+
+    static Response Unavailable()
+    {
+        return light_switch_cli::MakeError(L"SERVICE_UNAVAILABLE", L"Light Switch is stopping.");
+    }
+
+    wil::unique_handle _event;
+    std::mutex _mutex;
+    std::deque<std::shared_ptr<Pending>> _pending;
+    bool _stopped = false;
+};

--- a/src/modules/LightSwitch/LightSwitchService/SettingsObserver.h
+++ b/src/modules/LightSwitch/LightSwitchService/SettingsObserver.h
@@ -21,7 +21,7 @@ public:
     }
 
     // Override this in your class to respond to updates
-    virtual void SettingsUpdate(SettingId type) {}
+    virtual void SettingsUpdate(SettingId) {}
 
     virtual bool WantsToBeNotified(SettingId type) const noexcept
     {

--- a/src/modules/LightSwitch/Tests/LightSwitch.Cli.UnitTests/CliApplicationTests.cs
+++ b/src/modules/LightSwitch/Tests/LightSwitch.Cli.UnitTests/CliApplicationTests.cs
@@ -83,6 +83,9 @@ public sealed class CliApplicationTests
     [DataRow("--json toggle")]
     [DataRow("toggle --json")]
     [DataRow("schedule --json enable")]
+    [DataRow("--json=true toggle")]
+    [DataRow("toggle --json:true")]
+    [DataRow("schedule --json True enable")]
     public async Task JsonOptionIsGlobal(string arguments)
     {
         var application = new CliApplication(static (_, _) => Task.FromResult(SuccessfulResponse));
@@ -106,6 +109,19 @@ public sealed class CliApplicationTests
     [DataRow("schedule enable --mode=--json")]
     [DataRow("schedule enable --mode=--help")]
     [DataRow("schedule enable --mode=--version")]
+    [DataRow("light --help=invalid")]
+    [DataRow("light --help:invalid")]
+    [DataRow("light --help=light")]
+    [DataRow("light -h:invalid")]
+    [DataRow("toggle --version=invalid")]
+    [DataRow("toggle --version:invalid")]
+    [DataRow("status --json=invalid")]
+    [DataRow("status --json:invalid")]
+    [DataRow("light --help=--json")]
+    [DataRow("schedule enable --mode --help=invalid")]
+    [DataRow("light --help=true --help=false")]
+    [DataRow("light --help=false --help=true")]
+    [DataRow("toggle --version=false --version=true")]
     public async Task InvalidArgumentsProduceOneJsonErrorWithoutCallingTheService(string arguments)
     {
         int calls = 0;
@@ -135,6 +151,17 @@ public sealed class CliApplicationTests
     [DataRow("schedule enable --mode --help")]
     [DataRow("schedule enable --mode -h")]
     [DataRow("schedule enable --mode -?")]
+    [DataRow("light --help=true")]
+    [DataRow("light --help:true")]
+    [DataRow("light -h:true")]
+    [DataRow("light -?:true")]
+    [DataRow("light --help True")]
+    [DataRow("light --help --help")]
+    [DataRow("light --help=true --help")]
+    [DataRow("--json=false")]
+    [DataRow("--json false")]
+    [DataRow("--json=false --help=true")]
+    [DataRow("schedule enable --mode --json false --help")]
     public async Task HelpAndNoArgumentsDoNotContactTheService(string arguments)
     {
         var application = new CliApplication(static (_, _) => throw new InvalidOperationException("Help must not invoke IPC."));
@@ -159,6 +186,18 @@ public sealed class CliApplicationTests
     [DataRow("schedule enable --mode --json --help", "help")]
     [DataRow("schedule enable --mode --version --json", "cliVersion")]
     [DataRow("schedule enable --mode --json --version", "cliVersion")]
+    [DataRow("--json=true", "help")]
+    [DataRow("--json:True", "help")]
+    [DataRow("--json true", "help")]
+    [DataRow("light --help=true --json=true", "help")]
+    [DataRow("light --help:true --json:true", "help")]
+    [DataRow("--help=true --json=true", "help")]
+    [DataRow("toggle --version=true --json=true", "cliVersion")]
+    [DataRow("toggle --version:true --json:true", "cliVersion")]
+    [DataRow("toggle --version True --json true", "cliVersion")]
+    [DataRow("toggle --help=false --version=true --json", "cliVersion")]
+    [DataRow("--version=true --json=true", "cliVersion")]
+    [DataRow("schedule enable --mode --help=true --json=true", "help")]
     public async Task JsonInformationUsesTheLocalInformationEnvelope(string arguments, string informationField)
     {
         var application = new CliApplication(static (_, _) => throw new InvalidOperationException("Information must not invoke IPC."));
@@ -188,6 +227,176 @@ public sealed class CliApplicationTests
     }
 
     [TestMethod]
+    [DataRow("light --help=false")]
+    [DataRow("light --help false")]
+    [DataRow("light -h:false")]
+    [DataRow("light --help --help=false")]
+    [DataRow("toggle --version=false")]
+    [DataRow("toggle --version false")]
+    [DataRow("toggle --version --version=false")]
+    [DataRow("status --json=false")]
+    [DataRow("status --json false")]
+    [DataRow("status --json --json=false")]
+    [DataRow("status --json=false --json")]
+    public async Task FalsePresentationOptionsDoNotSuppressCommandsOrEnableJson(string arguments)
+    {
+        int calls = 0;
+        var application = new CliApplication((request, _) =>
+        {
+            calls++;
+            using var parsed = JsonDocument.Parse(request);
+            Assert.AreEqual(arguments.Split(' ')[0], parsed.RootElement.GetProperty("command").GetString());
+            return Task.FromResult(SuccessfulResponse);
+        });
+        using var stdout = new StringWriter(CultureInfo.InvariantCulture);
+        using var stderr = new StringWriter(CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(0, await application.RunAsync(arguments.Split(' '), stdout, stderr));
+        Assert.AreEqual(1, calls);
+        StringAssert.StartsWith(stdout.ToString(), "System theme:");
+        Assert.AreEqual(string.Empty, stderr.ToString());
+    }
+
+    [TestMethod]
+    [DataRow("status --json=true --json=false")]
+    [DataRow("status --json:false --json:true")]
+    public async Task ConflictingJsonValuesFailWithoutCallingTheService(string arguments)
+    {
+        var application = new CliApplication(static (_, _) => throw new InvalidOperationException("Invalid input must not invoke IPC."));
+        using var stdout = new StringWriter(CultureInfo.InvariantCulture);
+        using var stderr = new StringWriter(CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(2, await application.RunAsync(arguments.Split(' '), stdout, stderr));
+        Assert.AreEqual(string.Empty, stdout.ToString());
+        StringAssert.Contains(stderr.ToString(), "INVALID_ARGUMENT");
+    }
+
+    [TestMethod]
+    [DataRow("light --help=true --json", "help", 0, 0)]
+    [DataRow("toggle --version:true --json", "cliVersion", 0, 0)]
+    [DataRow("status --json:true", "state", 0, 1)]
+    [DataRow("light --help=invalid --json", "error", 2, 0)]
+    public async Task ResponseFilesKeepPresentationAndCommandParsingConsistent(string contents, string outputField, int expectedExit, int expectedCalls)
+    {
+        string path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(path, contents);
+            int calls = 0;
+            var application = new CliApplication((_, _) =>
+            {
+                calls++;
+                return Task.FromResult(SuccessfulResponse);
+            });
+            using var stdout = new StringWriter(CultureInfo.InvariantCulture);
+            using var stderr = new StringWriter(CultureInfo.InvariantCulture);
+
+            Assert.AreEqual(expectedExit, await application.RunAsync(new[] { "@" + path }, stdout, stderr));
+            Assert.AreEqual(expectedCalls, calls);
+            using var response = JsonDocument.Parse(stdout.ToString());
+            Assert.IsTrue(response.RootElement.TryGetProperty(outputField, out _));
+            Assert.AreEqual(string.Empty, stderr.ToString());
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [TestMethod]
+    [DataRow("--mode fixed-hours --json", "state", 0, 1)]
+    [DataRow("--mode fixed-hours --help --json", "help", 0, 0)]
+    [DataRow("--help --json", "help", 0, 0)]
+    [DataRow("--mode --help --json", "help", 0, 0)]
+    [DataRow("--mode --help=true --json", "help", 0, 0)]
+    [DataRow("--mode=--help --json", "error", 2, 0)]
+    public async Task ResponseFilesCanSupplyOptionsForAnExistingCommand(string contents, string outputField, int expectedExit, int expectedCalls)
+    {
+        string path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(path, contents);
+            int calls = 0;
+            var application = new CliApplication((request, _) =>
+            {
+                calls++;
+                using var parsed = JsonDocument.Parse(request);
+                Assert.AreEqual("schedule-enable", parsed.RootElement.GetProperty("command").GetString());
+                Assert.AreEqual("FixedHours", parsed.RootElement.GetProperty("mode").GetString());
+                return Task.FromResult(SuccessfulResponse);
+            });
+            using var stdout = new StringWriter(CultureInfo.InvariantCulture);
+            using var stderr = new StringWriter(CultureInfo.InvariantCulture);
+
+            Assert.AreEqual(expectedExit, await application.RunAsync(new[] { "schedule", "enable", "@" + path }, stdout, stderr));
+            Assert.AreEqual(expectedCalls, calls);
+            using var response = JsonDocument.Parse(stdout.ToString());
+            Assert.IsTrue(response.RootElement.TryGetProperty(outputField, out _));
+            Assert.AreEqual(string.Empty, stderr.ToString());
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [TestMethod]
+    [DataRow("--help", "--json=invalid", 0)]
+    [DataRow("--json", "--help=true", 2)]
+    public async Task ResponseFileTerminatorAppliesToLaterArguments(string before, string after, int expectedExit)
+    {
+        string path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(path, "--");
+            var application = new CliApplication(static (_, _) => throw new InvalidOperationException("These arguments must not invoke IPC."));
+            using var stdout = new StringWriter(CultureInfo.InvariantCulture);
+            using var stderr = new StringWriter(CultureInfo.InvariantCulture);
+
+            Assert.AreEqual(expectedExit, await application.RunAsync(new[] { "light", before, "@" + path, after }, stdout, stderr));
+            if (expectedExit == 0)
+            {
+                StringAssert.StartsWith(stdout.ToString(), "PowerToys Light Switch");
+            }
+            else
+            {
+                using var response = JsonDocument.Parse(stdout.ToString());
+                Assert.AreEqual("INVALID_ARGUMENT", response.RootElement.GetProperty("error").GetProperty("code").GetString());
+            }
+
+            Assert.AreEqual(string.Empty, stderr.ToString());
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [TestMethod]
+    public void CommandParsingReusesTheResponseFileSnapshot()
+    {
+        string path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(path, "--mode fixed-hours --json");
+            var presentation = CliCommandLine.ParsePresentationOptions(new[] { "schedule", "enable", "@" + path });
+            Assert.IsNull(presentation.Error);
+            Assert.IsTrue(presentation.Json);
+            Assert.IsFalse(presentation.Help);
+
+            File.WriteAllText(path, "--mode follow-night-light");
+            var commandLine = new CliCommandLine();
+            var parsed = commandLine.Parse(presentation.Arguments);
+            Assert.AreEqual(0, parsed.Errors.Count);
+            Assert.AreEqual("FixedHours", commandLine.CreateRequest(parsed).Mode);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [TestMethod]
     public async Task OptionTerminatorDoesNotTurnAnArgumentIntoHelp()
     {
         var application = new CliApplication(static (_, _) => Task.FromResult(SuccessfulResponse));
@@ -205,6 +414,9 @@ public sealed class CliApplicationTests
     [DataRow("schedule enable --mode -- --version")]
     [DataRow("status -- --json")]
     [DataRow("status -- --version")]
+    [DataRow("light -- --help=true")]
+    [DataRow("toggle -- --version:true")]
+    [DataRow("status -- --json=true")]
     public async Task FlagsAfterTheTerminatorRemainArguments(string arguments)
     {
         int calls = 0;
@@ -225,6 +437,8 @@ public sealed class CliApplicationTests
     [TestMethod]
     [DataRow("schedule enable --mode --json -- --help")]
     [DataRow("schedule enable --mode --json -- --version")]
+    [DataRow("status --json=true -- --help=true")]
+    [DataRow("schedule enable --mode --json:true -- --version:true")]
     public async Task JsonBeforeTheTerminatorStillFormatsInvalidArgumentsAfterIt(string arguments)
     {
         var application = new CliApplication(static (_, _) => throw new InvalidOperationException("Invalid input must not invoke IPC."));
@@ -257,6 +471,8 @@ public sealed class CliApplicationTests
     [DataRow("--json")]
     [DataRow("schedule enable --mode --help")]
     [DataRow("schedule enable --mode --version --json")]
+    [DataRow("light --help:true --json:true")]
+    [DataRow("toggle --version=true --json=false")]
     public async Task InformationDoesNotInitializeLogging(string arguments)
     {
         int logCalls = 0;

--- a/src/modules/LightSwitch/Tests/LightSwitch.Cli.UnitTests/CliApplicationTests.cs
+++ b/src/modules/LightSwitch/Tests/LightSwitch.Cli.UnitTests/CliApplicationTests.cs
@@ -1,0 +1,389 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LightSwitch.Cli.UnitTests;
+
+[TestClass]
+public sealed class CliApplicationTests
+{
+    internal const string SuccessfulResponse = """
+        {"version":1,"success":true,"state":{"systemTheme":"light","appsTheme":"dark","changeSystem":true,"changeApps":false,"scheduleMode":"FixedHours","manualOverride":true}}
+        """;
+
+    private static readonly string[] VersionArguments = { "--version" };
+    private static readonly string[] TerminatorArguments = { "status", "--", "--help" };
+    private static readonly string[] StatusArguments = { "status" };
+    private static readonly string[] LightArguments = { "light" };
+    private static readonly string[] ToggleJsonArguments = { "toggle", "--json" };
+    private static readonly string[] LightJsonArguments = { "light", "--json" };
+    private static readonly string[] StatusJsonArguments = { "status", "--json" };
+
+    [TestMethod]
+    [DataRow("status", "status", null)]
+    [DataRow("light", "light", null)]
+    [DataRow("dark", "dark", null)]
+    [DataRow("toggle", "toggle", null)]
+    [DataRow("schedule enable", "schedule-enable", null)]
+    [DataRow("schedule disable", "schedule-disable", null)]
+    [DataRow("schedule enable --mode fixed-hours", "schedule-enable", "FixedHours")]
+    [DataRow("schedule enable --mode sunset-to-sunrise", "schedule-enable", "SunsetToSunrise")]
+    [DataRow("schedule enable --mode follow-night-light", "schedule-enable", "FollowNightLight")]
+    public async Task CommandsSendExactlyTheExpectedRequest(string arguments, string command, string? mode)
+    {
+        string? receivedRequest = null;
+        int calls = 0;
+        var application = new CliApplication((request, _) =>
+        {
+            receivedRequest = request;
+            calls++;
+            return Task.FromResult(SuccessfulResponse);
+        });
+
+        using var stdout = new StringWriter(CultureInfo.InvariantCulture);
+        using var stderr = new StringWriter(CultureInfo.InvariantCulture);
+        int exit = await application.RunAsync((arguments + " --json").Split(' '), stdout, stderr);
+
+        Assert.AreEqual(0, exit);
+        Assert.AreEqual(1, calls);
+        Assert.IsNotNull(receivedRequest);
+        using var requestDocument = JsonDocument.Parse(receivedRequest);
+        Assert.AreEqual(1, requestDocument.RootElement.GetProperty("version").GetInt32());
+        Assert.AreEqual(command, requestDocument.RootElement.GetProperty("command").GetString());
+        if (mode is null)
+        {
+            Assert.IsFalse(requestDocument.RootElement.TryGetProperty("mode", out _));
+        }
+        else
+        {
+            Assert.AreEqual(mode, requestDocument.RootElement.GetProperty("mode").GetString());
+        }
+
+        int propertyCount = 0;
+        foreach (var property in requestDocument.RootElement.EnumerateObject())
+        {
+            propertyCount++;
+        }
+
+        Assert.AreEqual(mode is null ? 2 : 3, propertyCount, "The native endpoint rejects unknown request fields.");
+        using var output = JsonDocument.Parse(stdout.ToString());
+        Assert.IsTrue(output.RootElement.GetProperty("success").GetBoolean());
+        Assert.AreEqual(string.Empty, stderr.ToString());
+    }
+
+    [TestMethod]
+    [DataRow("--json toggle")]
+    [DataRow("toggle --json")]
+    [DataRow("schedule --json enable")]
+    public async Task JsonOptionIsGlobal(string arguments)
+    {
+        var application = new CliApplication(static (_, _) => Task.FromResult(SuccessfulResponse));
+        using var stdout = new StringWriter(CultureInfo.InvariantCulture);
+        using var stderr = new StringWriter(CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(0, await application.RunAsync(arguments.Split(' '), stdout, stderr));
+        using var response = JsonDocument.Parse(stdout.ToString());
+        Assert.IsTrue(response.RootElement.GetProperty("success").GetBoolean());
+    }
+
+    [TestMethod]
+    [DataRow("schedule enable --mode automatic")]
+    [DataRow("schedule enable --mode Off")]
+    [DataRow("schedule enable --mode")]
+    [DataRow("schedule disable --mode fixed-hours")]
+    [DataRow("schedule")]
+    [DataRow("light unexpected")]
+    [DataRow("missing-command")]
+    [DataRow("status --unknown --another-unknown")]
+    [DataRow("schedule enable --mode=--json")]
+    [DataRow("schedule enable --mode=--help")]
+    [DataRow("schedule enable --mode=--version")]
+    public async Task InvalidArgumentsProduceOneJsonErrorWithoutCallingTheService(string arguments)
+    {
+        int calls = 0;
+        var application = new CliApplication((_, _) =>
+        {
+            calls++;
+            return Task.FromResult(SuccessfulResponse);
+        });
+        using var stdout = new StringWriter(CultureInfo.InvariantCulture);
+        using var stderr = new StringWriter(CultureInfo.InvariantCulture);
+
+        int exit = await application.RunAsync((arguments + " --json").Split(' '), stdout, stderr);
+
+        Assert.AreEqual(2, exit);
+        Assert.AreEqual(0, calls);
+        using var response = JsonDocument.Parse(stdout.ToString());
+        Assert.IsFalse(response.RootElement.GetProperty("success").GetBoolean());
+        Assert.AreEqual("INVALID_ARGUMENT", response.RootElement.GetProperty("error").GetProperty("code").GetString());
+        Assert.AreEqual(string.Empty, stderr.ToString());
+    }
+
+    [TestMethod]
+    [DataRow("")]
+    [DataRow("--help")]
+    [DataRow("-h")]
+    [DataRow("schedule enable --help")]
+    [DataRow("schedule enable --mode --help")]
+    [DataRow("schedule enable --mode -h")]
+    [DataRow("schedule enable --mode -?")]
+    public async Task HelpAndNoArgumentsDoNotContactTheService(string arguments)
+    {
+        var application = new CliApplication(static (_, _) => throw new InvalidOperationException("Help must not invoke IPC."));
+        using var stdout = new StringWriter(CultureInfo.InvariantCulture);
+        using var stderr = new StringWriter(CultureInfo.InvariantCulture);
+
+        int exit = await application.RunAsync(arguments.Split(' ', StringSplitOptions.RemoveEmptyEntries), stdout, stderr);
+
+        Assert.AreEqual(0, exit);
+        StringAssert.Contains(stdout.ToString(), "schedule enable");
+        StringAssert.Contains(stdout.ToString(), "--mode");
+        Assert.AreEqual(string.Empty, stderr.ToString());
+    }
+
+    [TestMethod]
+    [DataRow("--json", "help")]
+    [DataRow("--json --help", "help")]
+    [DataRow("schedule enable --json --help", "help")]
+    [DataRow("--json --version", "cliVersion")]
+    [DataRow("light --version --json", "cliVersion")]
+    [DataRow("schedule enable --mode --help --json", "help")]
+    [DataRow("schedule enable --mode --json --help", "help")]
+    [DataRow("schedule enable --mode --version --json", "cliVersion")]
+    [DataRow("schedule enable --mode --json --version", "cliVersion")]
+    public async Task JsonInformationUsesTheLocalInformationEnvelope(string arguments, string informationField)
+    {
+        var application = new CliApplication(static (_, _) => throw new InvalidOperationException("Information must not invoke IPC."));
+        using var stdout = new StringWriter(CultureInfo.InvariantCulture);
+        using var stderr = new StringWriter(CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(0, await application.RunAsync(arguments.Split(' '), stdout, stderr));
+
+        using var information = JsonDocument.Parse(stdout.ToString());
+        Assert.AreEqual(1, information.RootElement.GetProperty("version").GetInt32());
+        Assert.IsTrue(information.RootElement.GetProperty("success").GetBoolean());
+        Assert.IsFalse(string.IsNullOrWhiteSpace(information.RootElement.GetProperty(informationField).GetString()));
+        Assert.IsFalse(information.RootElement.TryGetProperty("state", out _));
+        Assert.IsFalse(information.RootElement.TryGetProperty("error", out _));
+        Assert.AreEqual(string.Empty, stderr.ToString());
+    }
+
+    [TestMethod]
+    public async Task VersionIsLocalAndPrintedAsText()
+    {
+        var application = new CliApplication(static (_, _) => throw new InvalidOperationException("Version must not invoke IPC."));
+        using var stdout = new StringWriter(CultureInfo.InvariantCulture);
+        using var stderr = new StringWriter(CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(0, await application.RunAsync(VersionArguments, stdout, stderr));
+        Assert.AreEqual(CliApplication.CliVersion, stdout.ToString().Trim());
+    }
+
+    [TestMethod]
+    public async Task OptionTerminatorDoesNotTurnAnArgumentIntoHelp()
+    {
+        var application = new CliApplication(static (_, _) => Task.FromResult(SuccessfulResponse));
+        using var stdout = new StringWriter(CultureInfo.InvariantCulture);
+        using var stderr = new StringWriter(CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(2, await application.RunAsync(TerminatorArguments, stdout, stderr));
+        Assert.AreEqual(string.Empty, stdout.ToString());
+        StringAssert.Contains(stderr.ToString(), "INVALID_ARGUMENT");
+    }
+
+    [TestMethod]
+    [DataRow("schedule enable --mode -- --json")]
+    [DataRow("schedule enable --mode -- --help")]
+    [DataRow("schedule enable --mode -- --version")]
+    [DataRow("status -- --json")]
+    [DataRow("status -- --version")]
+    public async Task FlagsAfterTheTerminatorRemainArguments(string arguments)
+    {
+        int calls = 0;
+        var application = new CliApplication((_, _) =>
+        {
+            calls++;
+            return Task.FromResult(SuccessfulResponse);
+        });
+        using var stdout = new StringWriter(CultureInfo.InvariantCulture);
+        using var stderr = new StringWriter(CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(2, await application.RunAsync(arguments.Split(' '), stdout, stderr));
+        Assert.AreEqual(0, calls);
+        Assert.AreEqual(string.Empty, stdout.ToString());
+        StringAssert.Contains(stderr.ToString(), "INVALID_ARGUMENT");
+    }
+
+    [TestMethod]
+    [DataRow("schedule enable --mode --json -- --help")]
+    [DataRow("schedule enable --mode --json -- --version")]
+    public async Task JsonBeforeTheTerminatorStillFormatsInvalidArgumentsAfterIt(string arguments)
+    {
+        var application = new CliApplication(static (_, _) => throw new InvalidOperationException("Invalid input must not invoke IPC."));
+        using var stdout = new StringWriter(CultureInfo.InvariantCulture);
+        using var stderr = new StringWriter(CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(2, await application.RunAsync(arguments.Split(' '), stdout, stderr));
+        using var response = JsonDocument.Parse(stdout.ToString());
+        Assert.AreEqual("INVALID_ARGUMENT", response.RootElement.GetProperty("error").GetProperty("code").GetString());
+        Assert.AreEqual(string.Empty, stderr.ToString());
+    }
+
+    [TestMethod]
+    public async Task InvalidArgumentsReachTheErrorLoggerBeforeAnyTransportCall()
+    {
+        string? logged = null;
+        var application = new CliApplication(
+            static (_, _) => throw new InvalidOperationException("Invalid input must not invoke IPC."),
+            message => logged = message);
+        using var stdout = new StringWriter(CultureInfo.InvariantCulture);
+        using var stderr = new StringWriter(CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(2, await application.RunAsync(TerminatorArguments, stdout, stderr));
+        Assert.IsNotNull(logged);
+        StringAssert.Contains(logged, "INVALID_ARGUMENT");
+    }
+
+    [TestMethod]
+    [DataRow("")]
+    [DataRow("--json")]
+    [DataRow("schedule enable --mode --help")]
+    [DataRow("schedule enable --mode --version --json")]
+    public async Task InformationDoesNotInitializeLogging(string arguments)
+    {
+        int logCalls = 0;
+        var application = new CliApplication(
+            static (_, _) => throw new InvalidOperationException("Information must not invoke IPC."),
+            _ => logCalls++);
+        using var stdout = new StringWriter(CultureInfo.InvariantCulture);
+        using var stderr = new StringWriter(CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(0, await application.RunAsync(arguments.Split(' ', StringSplitOptions.RemoveEmptyEntries), stdout, stderr));
+        Assert.AreEqual(0, logCalls);
+    }
+
+    [TestMethod]
+    public async Task TextStatusIncludesBothTargetsAndTheManualOverride()
+    {
+        var application = new CliApplication(static (_, _) => Task.FromResult(SuccessfulResponse));
+        using var stdout = new StringWriter(CultureInfo.InvariantCulture);
+        using var stderr = new StringWriter(CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(0, await application.RunAsync(StatusArguments, stdout, stderr));
+        StringAssert.Contains(stdout.ToString(), "System theme: light");
+        StringAssert.Contains(stdout.ToString(), "Apps theme: dark");
+        StringAssert.Contains(stdout.ToString(), "App theme changes: disabled");
+        StringAssert.Contains(stdout.ToString(), "Manual override: active");
+        Assert.AreEqual(string.Empty, stderr.ToString());
+    }
+
+    [TestMethod]
+    public async Task TextErrorsGoToStderr()
+    {
+        var application = new CliApplication(static (_, _) => throw new CliException("SERVICE_UNAVAILABLE", "Service unavailable."));
+        using var stdout = new StringWriter(CultureInfo.InvariantCulture);
+        using var stderr = new StringWriter(CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(3, await application.RunAsync(LightArguments, stdout, stderr));
+        Assert.AreEqual(string.Empty, stdout.ToString());
+        StringAssert.Contains(stderr.ToString(), "SERVICE_UNAVAILABLE");
+    }
+
+    [TestMethod]
+    [DataRow("INVALID_ARGUMENT", 2)]
+    [DataRow("INVALID_CONFIGURATION", 2)]
+    [DataRow("SERVICE_UNAVAILABLE", 3)]
+    [DataRow("SERVER_BUSY", 3)]
+    [DataRow("TIMEOUT", 4)]
+    [DataRow("EXECUTION_FAILED", 1)]
+    [DataRow("NO_TARGETS", 1)]
+    [DataRow("PROTOCOL_ERROR", 1)]
+    [DataRow("FUTURE_SERVICE_ERROR", 1)]
+    public async Task ServiceErrorsPreserveTheCodeAndMapToAnExitCode(string code, int expectedExit)
+    {
+        string responseJson = "{\"version\":1,\"success\":false,\"error\":{\"code\":\"" + code + "\",\"message\":\"Failed.\"}}";
+        var application = new CliApplication((_, _) => Task.FromResult(responseJson));
+        using var stdout = new StringWriter(CultureInfo.InvariantCulture);
+        using var stderr = new StringWriter(CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(expectedExit, await application.RunAsync(ToggleJsonArguments, stdout, stderr));
+        using var response = JsonDocument.Parse(stdout.ToString());
+        Assert.AreEqual(code, response.RootElement.GetProperty("error").GetProperty("code").GetString());
+        Assert.AreEqual(string.Empty, stderr.ToString());
+    }
+
+    [TestMethod]
+    public async Task InvalidServiceResponseProducesOneProtocolError()
+    {
+        var application = new CliApplication(static (_, _) => Task.FromResult("{}"));
+        using var stdout = new StringWriter(CultureInfo.InvariantCulture);
+        using var stderr = new StringWriter(CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(1, await application.RunAsync(StatusJsonArguments, stdout, stderr));
+        using var response = JsonDocument.Parse(stdout.ToString());
+        Assert.IsFalse(response.RootElement.GetProperty("success").GetBoolean());
+        Assert.AreEqual("PROTOCOL_ERROR", response.RootElement.GetProperty("error").GetProperty("code").GetString());
+        Assert.AreEqual(string.Empty, stderr.ToString());
+    }
+
+    [TestMethod]
+    [Timeout(5000)]
+    public async Task OverallDeadlineDoesNotRetryAMutation()
+    {
+        int calls = 0;
+        var neverCompletes = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var application = new CliApplication(
+            (_, _) =>
+            {
+                calls++;
+                return neverCompletes.Task;
+            },
+            operationTimeout: TimeSpan.FromMilliseconds(50));
+        using var stdout = new StringWriter(CultureInfo.InvariantCulture);
+        using var stderr = new StringWriter(CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(4, await application.RunAsync(ToggleJsonArguments, stdout, stderr));
+        Assert.AreEqual(1, calls);
+        using var response = JsonDocument.Parse(stdout.ToString());
+        Assert.AreEqual("TIMEOUT", response.RootElement.GetProperty("error").GetProperty("code").GetString());
+        StringAssert.Contains(response.RootElement.GetProperty("error").GetProperty("message").GetString()!, "may already have taken effect");
+    }
+
+    [TestMethod]
+    public async Task CancellationProducesASingleTimeoutEnvelope()
+    {
+        var application = new CliApplication(static (_, token) => Task.FromCanceled<string>(token));
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        using var stdout = new StringWriter(CultureInfo.InvariantCulture);
+        using var stderr = new StringWriter(CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(4, await application.RunAsync(LightJsonArguments, stdout, stderr, cancellation.Token));
+        using var response = JsonDocument.Parse(stdout.ToString());
+        Assert.AreEqual("TIMEOUT", response.RootElement.GetProperty("error").GetProperty("code").GetString());
+    }
+
+    [TestMethod]
+    public async Task UnexpectedFailureAndBrokenLoggerDoNotLeakStackTracesIntoJson()
+    {
+        var application = new CliApplication(
+            static (_, _) => throw new InvalidOperationException("Private diagnostic detail."),
+            static _ => throw new IOException("Log unavailable."));
+        using var stdout = new StringWriter(CultureInfo.InvariantCulture);
+        using var stderr = new StringWriter(CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(1, await application.RunAsync(StatusJsonArguments, stdout, stderr));
+        using var response = JsonDocument.Parse(stdout.ToString());
+        Assert.AreEqual("EXECUTION_FAILED", response.RootElement.GetProperty("error").GetProperty("code").GetString());
+        Assert.IsFalse(stdout.ToString().Contains("Private diagnostic detail", StringComparison.Ordinal));
+        Assert.AreEqual(string.Empty, stderr.ToString());
+    }
+}

--- a/src/modules/LightSwitch/Tests/LightSwitch.Cli.UnitTests/CliApplicationTests.cs
+++ b/src/modules/LightSwitch/Tests/LightSwitch.Cli.UnitTests/CliApplicationTests.cs
@@ -122,6 +122,12 @@ public sealed class CliApplicationTests
     [DataRow("light --help=true --help=false")]
     [DataRow("light --help=false --help=true")]
     [DataRow("toggle --version=false --version=true")]
+    [DataRow("[parse] toggle")]
+    [DataRow("[parse] dark --help=false")]
+    [DataRow("[suggest] light")]
+    [DataRow("[suggest:6] dark")]
+    [DataRow("[bogus] schedule disable")]
+    [DataRow("[env:FOO=bar] schedule enable --mode fixed-hours")]
     public async Task InvalidArgumentsProduceOneJsonErrorWithoutCallingTheService(string arguments)
     {
         int calls = 0;
@@ -162,6 +168,9 @@ public sealed class CliApplicationTests
     [DataRow("--json false")]
     [DataRow("--json=false --help=true")]
     [DataRow("schedule enable --mode --json false --help")]
+    [DataRow("[parse] light --help")]
+    [DataRow("[suggest] dark --help=true")]
+    [DataRow("light --help -- [parse]")]
     public async Task HelpAndNoArgumentsDoNotContactTheService(string arguments)
     {
         var application = new CliApplication(static (_, _) => throw new InvalidOperationException("Help must not invoke IPC."));
@@ -276,6 +285,9 @@ public sealed class CliApplicationTests
     [DataRow("toggle --version:true --json", "cliVersion", 0, 0)]
     [DataRow("status --json:true", "state", 0, 1)]
     [DataRow("light --help=invalid --json", "error", 2, 0)]
+    [DataRow("[parse] toggle --json", "error", 2, 0)]
+    [DataRow("[suggest] dark --json", "error", 2, 0)]
+    [DataRow("[bogus] schedule disable --json", "error", 2, 0)]
     public async Task ResponseFilesKeepPresentationAndCommandParsingConsistent(string contents, string outputField, int expectedExit, int expectedCalls)
     {
         string path = Path.GetTempFileName();
@@ -417,6 +429,9 @@ public sealed class CliApplicationTests
     [DataRow("light -- --help=true")]
     [DataRow("toggle -- --version:true")]
     [DataRow("status -- --json=true")]
+    [DataRow("light -- [parse]")]
+    [DataRow("toggle -- [suggest]")]
+    [DataRow("schedule disable -- [bogus]")]
     public async Task FlagsAfterTheTerminatorRemainArguments(string arguments)
     {
         int calls = 0;

--- a/src/modules/LightSwitch/Tests/LightSwitch.Cli.UnitTests/CliPipeClientTests.cs
+++ b/src/modules/LightSwitch/Tests/LightSwitch.Cli.UnitTests/CliPipeClientTests.cs
@@ -1,0 +1,231 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Threading;
+using System.Threading.Tasks;
+using LightSwitch.Cli.Ipc;
+using LightSwitch.Cli.Protocol;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LightSwitch.Cli.UnitTests;
+
+[TestClass]
+public sealed class CliPipeClientTests
+{
+    private const string Request = "{\"version\":1,\"command\":\"status\"}";
+
+    private static readonly byte[] InvalidUtf16Line = { 0x00, 0xD8, 0x0A, 0x00 };
+
+    [TestMethod]
+    [Timeout(10000)]
+    public async Task ResponseSplitAtEveryBytePreservesUtf16AndTheRequestHasNoBom()
+    {
+        string name = NewPipeName();
+        using var server = CreateServer(name);
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        const string Response = "{\"version\":1,\"success\":false,\"error\":{\"code\":\"EXECUTION_FAILED\",\"message\":\"主题 🌙\"}}";
+        var serverTask = Task.Run(async () =>
+        {
+            await server.WaitForConnectionAsync(cancellation.Token);
+            string? actualRequest = await ReadRequestAsync(server, cancellation.Token);
+            Assert.AreEqual(Request, actualRequest, "A BOM or altered framing would change the request.");
+            byte[] bytes = CliProtocol.Encoding.GetBytes(Response + "\n");
+            for (int i = 0; i < bytes.Length; i++)
+            {
+                await server.WriteAsync(bytes.AsMemory(i, 1), cancellation.Token);
+            }
+
+            await WaitForClientCloseAsync(server, cancellation.Token);
+        });
+
+        var client = CreateClient(name);
+        Assert.AreEqual(Response, await client.SendAsync(Request, cancellation.Token));
+        await serverTask;
+    }
+
+    [TestMethod]
+    [Timeout(10000)]
+    public async Task UntrustedServerReceivesNoRequestBytes()
+    {
+        string name = NewPipeName();
+        using var server = CreateServer(name);
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var serverTask = Task.Run(async () =>
+        {
+            await server.WaitForConnectionAsync(cancellation.Token);
+            await WaitForClientCloseAsync(server, cancellation.Token);
+        });
+
+        var client = new CliPipeClient(name, static _ => false, TimeSpan.FromSeconds(2));
+        var error = await Assert.ThrowsExceptionAsync<CliException>(() => client.SendAsync(Request, cancellation.Token));
+        Assert.AreEqual("SERVICE_UNAVAILABLE", error.Code);
+        await serverTask;
+    }
+
+    [TestMethod]
+    [Timeout(5000)]
+    public async Task MissingServiceIsUnavailableWithinTheConnectDeadline()
+    {
+        var client = new CliPipeClient(NewPipeName(), static _ => true, TimeSpan.FromMilliseconds(100));
+        var error = await Assert.ThrowsExceptionAsync<CliException>(() => client.SendAsync(Request, CancellationToken.None));
+        Assert.AreEqual("SERVICE_UNAVAILABLE", error.Code);
+    }
+
+    [TestMethod]
+    [Timeout(10000)]
+    [DataRow("")]
+    [DataRow("{\"version\":1,\"success\":false}")]
+    public async Task DisconnectAfterRequestIsAnUnknownOutcomeEvenForParseableTail(string incompleteResponse)
+    {
+        string name = NewPipeName();
+        using var server = CreateServer(name);
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var serverTask = Task.Run(async () =>
+        {
+            await server.WaitForConnectionAsync(cancellation.Token);
+            Assert.AreEqual(Request, await ReadRequestAsync(server, cancellation.Token));
+            if (incompleteResponse.Length > 0)
+            {
+                await server.WriteAsync(CliProtocol.Encoding.GetBytes(incompleteResponse), cancellation.Token);
+            }
+
+            server.Dispose();
+        });
+
+        var error = await Assert.ThrowsExceptionAsync<CliException>(() => CreateClient(name).SendAsync(Request, cancellation.Token));
+        Assert.AreEqual("TIMEOUT", error.Code);
+        StringAssert.Contains(error.Message, "may already have taken effect");
+        await serverTask;
+    }
+
+    [TestMethod]
+    [Timeout(10000)]
+    public async Task InvalidUtf16IsAProtocolError()
+    {
+        string name = NewPipeName();
+        using var server = CreateServer(name);
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var serverTask = Task.Run(async () =>
+        {
+            await server.WaitForConnectionAsync(cancellation.Token);
+            _ = await ReadRequestAsync(server, cancellation.Token);
+            await server.WriteAsync(InvalidUtf16Line, cancellation.Token);
+            await WaitForClientCloseAsync(server, cancellation.Token);
+        });
+
+        var error = await Assert.ThrowsExceptionAsync<CliException>(() => CreateClient(name).SendAsync(Request, cancellation.Token));
+        Assert.AreEqual("PROTOCOL_ERROR", error.Code);
+        await serverTask;
+    }
+
+    [TestMethod]
+    [Timeout(10000)]
+    public async Task CancellingAConnectedRequestClosesTheConnection()
+    {
+        string name = NewPipeName();
+        using var server = CreateServer(name);
+        using var serverDeadline = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        using var clientCancellation = new CancellationTokenSource();
+        var requestRead = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var serverTask = Task.Run(async () =>
+        {
+            await server.WaitForConnectionAsync(serverDeadline.Token);
+            _ = await ReadRequestAsync(server, serverDeadline.Token);
+            requestRead.SetResult();
+            await WaitForClientCloseAsync(server, serverDeadline.Token);
+        });
+
+        var exchange = CreateClient(name).SendAsync(Request, clientCancellation.Token);
+        await requestRead.Task.WaitAsync(serverDeadline.Token);
+        clientCancellation.Cancel();
+        try
+        {
+            await exchange;
+            Assert.Fail("The connected read should have been cancelled.");
+        }
+        catch (OperationCanceledException)
+        {
+        }
+
+        await serverTask;
+    }
+
+    [TestMethod]
+    public async Task BoundedReaderAcceptsTheLimitAndCrLf()
+    {
+        string text = new('a', CliProtocol.MaxMessageChars);
+        using var reader = new StringReader(text + "\r\n");
+        Assert.AreEqual(text, await CliPipeClient.ReadResponseLineAsync(reader, CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task BoundedReaderRejectsMoreThanTheLimit()
+    {
+        using var reader = new StringReader(new string('a', CliProtocol.MaxMessageChars + 1) + "\n");
+        var error = await Assert.ThrowsExceptionAsync<CliException>(() => CliPipeClient.ReadResponseLineAsync(reader, CancellationToken.None));
+        Assert.AreEqual("PROTOCOL_ERROR", error.Code);
+    }
+
+    [TestMethod]
+    public async Task BoundedReaderDoesNotDiscardEmbeddedCarriageReturns()
+    {
+        using var reader = new StringReader("a\rb\n");
+        Assert.AreEqual("a\rb", await CliPipeClient.ReadResponseLineAsync(reader, CancellationToken.None));
+    }
+
+    [TestMethod]
+    [DataRow("C:\\PowerToys\\LightSwitchService\\PowerToys.LightSwitchService.exe", "c:\\powertoys\\LightSwitchService\\PowerToys.LightSwitchService.exe", true)]
+    [DataRow("C:\\Other\\LightSwitchService\\PowerToys.LightSwitchService.exe", "C:\\PowerToys\\LightSwitchService\\PowerToys.LightSwitchService.exe", false)]
+    [DataRow("C:\\PowerToys\\LightSwitchService\\Other.exe", "C:\\PowerToys\\LightSwitchService\\PowerToys.LightSwitchService.exe", false)]
+    public void ServerIdentityRequiresTheExactInstalledExecutable(string actualPath, string expectedPath, bool expected)
+    {
+        Assert.AreEqual(expected, PipeServerIdentity.PathsMatch(actualPath, expectedPath));
+    }
+
+    [TestMethod]
+    public void ServerIdentityUsesTheServiceSubfolderOfTheInstallationRoot()
+    {
+        Assert.AreEqual(Path.Combine(AppContext.BaseDirectory, "LightSwitchService", "PowerToys.LightSwitchService.exe"), PipeServerIdentity.ExpectedServerPath);
+    }
+
+    [TestMethod]
+    [Timeout(10000)]
+    public async Task ServerIdentityChecksTheProcessAtTheOtherEndOfThePipe()
+    {
+        string name = NewPipeName();
+        using var server = CreateServer(name);
+        using var client = new NamedPipeClientStream(".", name, PipeDirection.InOut, PipeOptions.Asynchronous);
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        Task accepted = server.WaitForConnectionAsync(cancellation.Token);
+        await client.ConnectAsync(cancellation.Token);
+        await accepted;
+        string? imagePath = Environment.ProcessPath;
+        Assert.IsNotNull(imagePath);
+        Assert.IsTrue(PipeServerIdentity.IsTrustedServer(client, imagePath));
+        Assert.IsFalse(PipeServerIdentity.IsTrustedServer(client, Path.Combine(Path.GetTempPath(), "Other.exe")));
+    }
+
+    private static string NewPipeName() => "LightSwitch_Cli_Test_" + Guid.NewGuid().ToString("N");
+
+    private static NamedPipeServerStream CreateServer(string name)
+        => new(name, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+
+    private static CliPipeClient CreateClient(string name)
+        => new(name, static _ => true, TimeSpan.FromSeconds(2));
+
+    private static async Task<string?> ReadRequestAsync(Stream stream, CancellationToken cancellationToken)
+    {
+        using var reader = new StreamReader(stream, CliProtocol.Encoding, false, CliProtocol.BufferSize, leaveOpen: true);
+        return await reader.ReadLineAsync(cancellationToken);
+    }
+
+    private static async Task WaitForClientCloseAsync(Stream stream, CancellationToken cancellationToken)
+    {
+        var buffer = new byte[1];
+        Assert.AreEqual(0, await stream.ReadAsync(buffer, cancellationToken));
+    }
+}

--- a/src/modules/LightSwitch/Tests/LightSwitch.Cli.UnitTests/CliProtocolTests.cs
+++ b/src/modules/LightSwitch/Tests/LightSwitch.Cli.UnitTests/CliProtocolTests.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using LightSwitch.Cli.Protocol;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LightSwitch.Cli.UnitTests;
+
+[TestClass]
+public sealed class CliProtocolTests
+{
+    private static readonly byte[] ExpectedEncodedLine = { 0x41, 0x00, 0x0A, 0x00 };
+
+    [TestMethod]
+    [DataRow("null")]
+    [DataRow("not-json")]
+    [DataRow("{}")]
+    [DataRow("{\"version\":1,\"state\":{}}")]
+    [DataRow("{\"version\":1,\"success\":true}")]
+    [DataRow("{\"version\":1,\"success\":false}")]
+    [DataRow("{\"version\":2,\"success\":false,\"error\":{\"code\":\"EXECUTION_FAILED\",\"message\":\"Failed.\"}}")]
+    [DataRow("{\"success\":false,\"error\":{\"code\":\"EXECUTION_FAILED\",\"message\":\"Failed.\"}}")]
+    [DataRow("{\"version\":1,\"success\":false,\"error\":{\"code\":\"\",\"message\":\"Failed.\"}}")]
+    [DataRow("{\"version\":1,\"success\":false,\"error\":{\"code\":\"EXECUTION_FAILED\",\"message\":null}}")]
+    [DataRow("{\"version\":1,\"success\":false,\"error\":{\"code\":\"EXECUTION_FAILED\"}}")]
+    [DataRow("{\"version\":1,\"success\":false,\"error\":{\"message\":\"Failed.\"}}")]
+    public void InvalidEnvelopesAreProtocolErrors(string json)
+    {
+        var error = Assert.ThrowsException<CliException>(() => CliProtocol.ParseResponse(json));
+        Assert.AreEqual("PROTOCOL_ERROR", error.Code);
+    }
+
+    [TestMethod]
+    [DataRow("systemTheme", "null")]
+    [DataRow("systemTheme", "\"sepia\"")]
+    [DataRow("appsTheme", "\"Dark\"")]
+    [DataRow("scheduleMode", "\"automatic\"")]
+    [DataRow("changeSystem", "\"true\"")]
+    public void InvalidStateMembersAreRejected(string property, string replacement)
+    {
+        string original = property switch
+        {
+            "systemTheme" => "\"light\"",
+            "appsTheme" => "\"dark\"",
+            "scheduleMode" => "\"FixedHours\"",
+            _ => "true",
+        };
+        string json = CliApplicationTests.SuccessfulResponse.Replace("\"" + property + "\":" + original, "\"" + property + "\":" + replacement, StringComparison.Ordinal);
+
+        var error = Assert.ThrowsException<CliException>(() => CliProtocol.ParseResponse(json));
+        Assert.AreEqual("PROTOCOL_ERROR", error.Code);
+    }
+
+    [TestMethod]
+    public void MissingFalseValuedStateMembersAreNotSilentlyDefaulted()
+    {
+        string json = CliApplicationTests.SuccessfulResponse.Replace("\"changeApps\":false,", string.Empty, StringComparison.Ordinal);
+        Assert.ThrowsException<CliException>(() => CliProtocol.ParseResponse(json));
+    }
+
+    [TestMethod]
+    public void ContradictorySuccessAndErrorAreRejected()
+    {
+        string json = CliApplicationTests.SuccessfulResponse.Replace("\"success\":true,", "\"success\":true,\"error\":{\"code\":\"EXECUTION_FAILED\",\"message\":\"Failed.\"},", StringComparison.Ordinal);
+        Assert.ThrowsException<CliException>(() => CliProtocol.ParseResponse(json));
+    }
+
+    [TestMethod]
+    public void UnknownThemeIsAValidState()
+    {
+        string json = CliApplicationTests.SuccessfulResponse.Replace("\"systemTheme\":\"light\"", "\"systemTheme\":\"unknown\"", StringComparison.Ordinal);
+        Assert.AreEqual("unknown", CliProtocol.ParseResponse(json).State!.SystemTheme);
+    }
+
+    [TestMethod]
+    public void ErrorCanIncludeTheResultingState()
+    {
+        string json = CliApplicationTests.SuccessfulResponse.Replace("\"success\":true,", "\"success\":false,\"error\":{\"code\":\"EXECUTION_FAILED\",\"message\":\"Partially applied.\"},", StringComparison.Ordinal);
+        var response = CliProtocol.ParseResponse(json);
+        Assert.IsFalse(response.Success);
+        Assert.IsNotNull(response.State);
+        Assert.AreEqual("EXECUTION_FAILED", response.Error!.Code);
+    }
+
+    [TestMethod]
+    public void OversizedEnvelopeIsRejectedBeforeDeserialization()
+    {
+        Assert.ThrowsException<CliException>(() => CliProtocol.ParseResponse(new string(' ', CliProtocol.MaxMessageChars + 1)));
+    }
+
+    [TestMethod]
+    public void PipeEncodingHasNoBomAndUsesLittleEndianUtf16()
+    {
+        Assert.AreEqual(0, CliProtocol.Encoding.GetPreamble().Length);
+        CollectionAssert.AreEqual(ExpectedEncodedLine, CliProtocol.Encoding.GetBytes("A\n"));
+    }
+}

--- a/src/modules/LightSwitch/Tests/LightSwitch.Cli.UnitTests/LightSwitch.Cli.UnitTests.csproj
+++ b/src/modules/LightSwitch/Tests/LightSwitch.Cli.UnitTests/LightSwitch.Cli.UnitTests.csproj
@@ -1,0 +1,28 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. See LICENSE file in the project root for license information. -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(RepoRoot)src\Common.Dotnet.CsWinRT.props" />
+  <Import Project="$(RepoRoot)src\Common.SelfContained.props" />
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RootNamespace>LightSwitch.Cli.UnitTests</RootNamespace>
+    <Platforms>x64;ARM64</Platforms>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <OutputPath>$(RepoRoot)$(Platform)\$(Configuration)\tests\LightSwitch.Cli.UnitTests\</OutputPath>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Remove="*.log" />
+    <None Remove="*.binlog" />
+    <PackageReference Include="MSTest" />
+    <PackageReference Include="System.CodeDom">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+    <PackageReference Include="System.Diagnostics.EventLog">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+    <ProjectReference Include="..\..\LightSwitch.Cli\LightSwitch.Cli.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/CliIdentityTests.cpp
+++ b/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/CliIdentityTests.cpp
@@ -1,0 +1,119 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include <CppUnitTest.h>
+#include "CliIdentity.h"
+
+#include <sddl.h>
+#include <wil/resource.h>
+#include <winrt/base.h>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace light_switch_cli;
+
+namespace LightSwitchServiceUnitTests
+{
+    namespace
+    {
+        std::vector<BYTE> TestSid(const wchar_t* text)
+        {
+            PSID raw = nullptr;
+            winrt::check_bool(ConvertStringSidToSidW(text, &raw));
+            wil::unique_hlocal sid(raw);
+            std::vector<BYTE> result(GetLengthSid(sid.get()));
+            winrt::check_bool(CopySid(static_cast<DWORD>(result.size()), result.data(), sid.get()));
+            return result;
+        }
+
+        TokenIdentity TestIdentity()
+        {
+            return { 2, TestSid(L"S-1-5-21-1-2-3-1000"), TestSid(L"S-1-5-5-10-20") };
+        }
+    }
+
+    TEST_CLASS (CliIdentityTests)
+    {
+    public:
+        TEST_METHOD (RejectsADifferentUserInTheSameSessionAndLogon)
+        {
+            const auto server = TestIdentity();
+            auto client = server;
+            client.userSid = TestSid(L"S-1-5-21-1-2-3-1001");
+            Assert::IsFalse(IsSameLogon(server, client));
+        }
+
+        TEST_METHOD (RejectsADifferentDesktopSessionForTheSameUserAndLogon)
+        {
+            const auto server = TestIdentity();
+            auto client = server;
+            client.sessionId = 3;
+            Assert::IsFalse(IsSameLogon(server, client));
+        }
+
+        TEST_METHOD (RejectsAnIndependentLogonForTheSameUserAndDesktopSession)
+        {
+            const auto server = TestIdentity();
+            auto client = server;
+            client.logonSid = TestSid(L"S-1-5-5-10-21");
+            Assert::IsFalse(IsSameLogon(server, client));
+        }
+
+        TEST_METHOD (MissingIdentityFieldsNeverAuthenticate)
+        {
+            const auto complete = TestIdentity();
+            Assert::IsTrue(IsSameLogon(complete, complete));
+            auto incomplete = complete;
+            incomplete.sessionId.reset();
+            Assert::IsFalse(IsSameLogon(complete, incomplete));
+            Assert::IsFalse(IsSameLogon(incomplete, complete));
+            incomplete = complete;
+            incomplete.userSid.clear();
+            Assert::IsFalse(IsSameLogon(complete, incomplete));
+            Assert::IsFalse(IsSameLogon(incomplete, complete));
+            incomplete = complete;
+            incomplete.logonSid.clear();
+            Assert::IsFalse(IsSameLogon(complete, incomplete));
+            Assert::IsFalse(IsSameLogon(incomplete, complete));
+            Assert::IsFalse(IsSameLogon({}, {}));
+        }
+
+        TEST_METHOD (AnUnreadableTokenCannotProduceAnIdentity)
+        {
+            Assert::ExpectException<winrt::hresult_error>([]() { ReadTokenIdentity(nullptr); });
+        }
+
+        TEST_METHOD (CurrentTokenAndAnyLinkedUacTokenShareTheAcceptedIdentity)
+        {
+            wil::unique_handle current;
+            winrt::check_bool(OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, current.put()));
+            const auto currentIdentity = ReadTokenIdentity(current.get());
+            Assert::IsTrue(IsSameLogon(currentIdentity, currentIdentity));
+            TOKEN_ELEVATION_TYPE elevation{};
+            DWORD size = 0;
+            winrt::check_bool(GetTokenInformation(current.get(), TokenElevationType, &elevation, sizeof(elevation), &size));
+            if (elevation == TokenElevationTypeDefault)
+            {
+                Logger::WriteMessage(L"The current token was validated; linked UAC token coverage is unavailable for this account.");
+                return;
+            }
+
+            // Query the existing pair without impersonating it or starting an elevated process.
+            TOKEN_LINKED_TOKEN linkedInfo{};
+            winrt::check_bool(GetTokenInformation(current.get(), TokenLinkedToken, &linkedInfo, sizeof(linkedInfo), &size));
+            wil::unique_handle linked(linkedInfo.LinkedToken);
+            TOKEN_STATISTICS currentStatistics{};
+            TOKEN_STATISTICS linkedStatistics{};
+            winrt::check_bool(GetTokenInformation(current.get(), TokenStatistics, &currentStatistics, sizeof(currentStatistics), &size));
+            winrt::check_bool(GetTokenInformation(linked.get(), TokenStatistics, &linkedStatistics, sizeof(linkedStatistics), &size));
+            Assert::IsTrue(currentStatistics.AuthenticationId.LowPart != linkedStatistics.AuthenticationId.LowPart ||
+                           currentStatistics.AuthenticationId.HighPart != linkedStatistics.AuthenticationId.HighPart,
+                           L"This regression requires UAC's distinct authentication IDs.");
+
+            const auto linkedIdentity = ReadTokenIdentity(linked.get());
+            Assert::IsTrue(IsSameLogon(currentIdentity, linkedIdentity));
+            Assert::IsTrue(IsSameLogon(linkedIdentity, currentIdentity));
+            Logger::WriteMessage(L"Validated both directions of a real UAC token pair with different authentication IDs.");
+        }
+    };
+}

--- a/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/CliPipeServerTests.cpp
+++ b/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/CliPipeServerTests.cpp
@@ -55,12 +55,12 @@ namespace LightSwitchServiceUnitTests
             return options;
         }
 
-        TestHandle Connect(const std::wstring& name)
+        TestHandle Connect(const std::wstring& name, DWORD identificationLevel = SECURITY_IDENTIFICATION)
         {
             const auto deadline = GetTickCount64() + 5000;
             while (true)
             {
-                HANDLE pipe = CreateFileW(name.c_str(), GENERIC_READ | GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, FILE_FLAG_OVERLAPPED | SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION, nullptr);
+                HANDLE pipe = CreateFileW(name.c_str(), GENERIC_READ | GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, FILE_FLAG_OVERLAPPED | SECURITY_SQOS_PRESENT | identificationLevel, nullptr);
                 if (pipe != INVALID_HANDLE_VALUE)
                 {
                     return TestHandle(pipe);
@@ -203,6 +203,54 @@ namespace LightSwitchServiceUnitTests
             Assert::IsTrue(first.Start());
             Assert::IsFalse(second.Start());
             Assert::IsTrue(Exchange(options.pipeName, StatusRequest).GetNamedBoolean(L"success"));
+        }
+
+        TEST_METHOD (HandlerRunsAsTheServiceAfterClientIdentification)
+        {
+            Apartment apartment;
+            const auto options = TestOptions();
+            std::atomic<bool> ranWithoutImpersonation = false;
+            CliPipeServer server([&](const Request&) {
+                HANDLE token = nullptr;
+                const BOOL opened = OpenThreadToken(GetCurrentThread(), TOKEN_QUERY, TRUE, &token);
+                const auto error = GetLastError();
+                TestHandle cleanup(token);
+                ranWithoutImpersonation = !opened && error == ERROR_NO_TOKEN;
+                return MakeSuccess(TestState());
+            },
+                                 options);
+            Assert::IsTrue(server.Start());
+            Assert::IsTrue(Exchange(options.pipeName, StatusRequest).GetNamedBoolean(L"success"));
+            server.Stop();
+            Assert::IsTrue(ranWithoutImpersonation.load());
+        }
+
+        TEST_METHOD (AnonymousClientsAreRejectedAndDoNotAffectTheNextClient)
+        {
+            Apartment apartment;
+            const auto options = TestOptions();
+            std::atomic<int> calls = 0;
+            std::atomic<bool> ranWithoutImpersonation = false;
+            CliPipeServer server([&](const Request&) {
+                ++calls;
+                HANDLE token = nullptr;
+                const BOOL opened = OpenThreadToken(GetCurrentThread(), TOKEN_QUERY, TRUE, &token);
+                const auto error = GetLastError();
+                TestHandle cleanup(token);
+                ranWithoutImpersonation = !opened && error == ERROR_NO_TOKEN;
+                return MakeSuccess(TestState());
+            },
+                                 options);
+            Assert::IsTrue(server.Start());
+            auto anonymous = Connect(options.pipeName, SECURITY_ANONYMOUS);
+            WriteRequest(anonymous.Get(), StatusRequest);
+            AssertError(ReadResponse(anonymous.Get()), L"SERVICE_UNAVAILABLE");
+            anonymous.Reset();
+            Assert::AreEqual(0, calls.load());
+            Assert::IsTrue(Exchange(options.pipeName, StatusRequest).GetNamedBoolean(L"success"));
+            server.Stop();
+            Assert::AreEqual(1, calls.load());
+            Assert::IsTrue(ranWithoutImpersonation.load());
         }
 
         TEST_METHOD (HandlesUtf16CodeUnitsSplitAcrossWrites)

--- a/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/CliPipeServerTests.cpp
+++ b/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/CliPipeServerTests.cpp
@@ -1,0 +1,377 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include <CppUnitTest.h>
+#include "CliPipeServer.h"
+#include "TestSupport.h"
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <thread>
+#include <utility>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace light_switch_cli;
+using namespace winrt::Windows::Data::Json;
+using namespace std::chrono_literals;
+
+namespace LightSwitchServiceUnitTests
+{
+    namespace
+    {
+        class TestHandle
+        {
+        public:
+            explicit TestHandle(HANDLE value = nullptr) noexcept : m_value(value) {}
+            ~TestHandle() { Reset(); }
+            TestHandle(const TestHandle&) = delete;
+            TestHandle& operator=(const TestHandle&) = delete;
+            TestHandle(TestHandle&& other) noexcept : m_value(std::exchange(other.m_value, nullptr)) {}
+            HANDLE Get() const noexcept { return m_value; }
+            void Reset() noexcept
+            {
+                if (m_value && m_value != INVALID_HANDLE_VALUE)
+                {
+                    CloseHandle(m_value);
+                }
+                m_value = nullptr;
+            }
+
+        private:
+            HANDLE m_value;
+        };
+
+        CliPipeServer::Options TestOptions()
+        {
+            static std::atomic<unsigned int> sequence = 0;
+            CliPipeServer::Options options;
+            options.pipeName = L"\\\\.\\pipe\\PowerToys_LightSwitch_Cli_Test_" + std::to_wstring(GetCurrentProcessId()) +
+                               L"_" + std::to_wstring(GetTickCount64()) + L"_" + std::to_wstring(++sequence);
+            options.readTimeoutMs = 2000;
+            options.writeTimeoutMs = 2000;
+            return options;
+        }
+
+        TestHandle Connect(const std::wstring& name)
+        {
+            const auto deadline = GetTickCount64() + 5000;
+            while (true)
+            {
+                HANDLE pipe = CreateFileW(name.c_str(), GENERIC_READ | GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, FILE_FLAG_OVERLAPPED | SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION, nullptr);
+                if (pipe != INVALID_HANDLE_VALUE)
+                {
+                    return TestHandle(pipe);
+                }
+                const auto error = GetLastError();
+                if (error != ERROR_PIPE_BUSY || GetTickCount64() >= deadline)
+                {
+                    throw winrt::hresult_error(HRESULT_FROM_WIN32(error));
+                }
+                WaitNamedPipeW(name.c_str(), 50);
+            }
+        }
+
+        template<typename BeginOperation>
+        DWORD ClientIo(HANDLE pipe, BeginOperation beginOperation)
+        {
+            TestHandle event(CreateEventW(nullptr, TRUE, FALSE, nullptr));
+            winrt::check_bool(event.Get() != nullptr);
+            OVERLAPPED operation{};
+            operation.hEvent = event.Get();
+            DWORD count = 0;
+            if (!beginOperation(operation))
+            {
+                const auto error = GetLastError();
+                if (error != ERROR_IO_PENDING)
+                {
+                    throw winrt::hresult_error(HRESULT_FROM_WIN32(error));
+                }
+                if (WaitForSingleObject(event.Get(), 5000) != WAIT_OBJECT_0)
+                {
+                    CancelIoEx(pipe, &operation);
+                    GetOverlappedResult(pipe, &operation, &count, TRUE);
+                    throw winrt::hresult_error(HRESULT_FROM_WIN32(ERROR_TIMEOUT));
+                }
+            }
+            winrt::check_bool(GetOverlappedResult(pipe, &operation, &count, FALSE));
+            return count;
+        }
+
+        void WriteBytes(HANDLE pipe, const void* data, DWORD size)
+        {
+            DWORD offset = 0;
+            while (offset < size)
+            {
+                const auto count = ClientIo(pipe, [&](OVERLAPPED& operation) {
+                    return WriteFile(pipe, static_cast<const BYTE*>(data) + offset, size - offset, nullptr, &operation);
+                });
+                Assert::IsTrue(count > 0);
+                offset += count;
+            }
+        }
+
+        void WriteRequest(HANDLE pipe, std::wstring_view request)
+        {
+            std::wstring framed(request);
+            framed.push_back(L'\n');
+            WriteBytes(pipe, framed.data(), static_cast<DWORD>(framed.size() * sizeof(wchar_t)));
+        }
+
+        JsonObject ReadResponse(HANDLE pipe)
+        {
+            std::wstring text;
+            std::optional<BYTE> firstByte;
+            while (text.size() <= MaxMessageCharacters)
+            {
+                std::array<BYTE, 4096> bytes{};
+                const auto count = ClientIo(pipe, [&](OVERLAPPED& operation) {
+                    return ReadFile(pipe, bytes.data(), static_cast<DWORD>(bytes.size()), nullptr, &operation);
+                });
+                Assert::IsTrue(count > 0);
+                for (DWORD index = 0; index < count; ++index)
+                {
+                    if (!firstByte)
+                    {
+                        firstByte = bytes[index];
+                        continue;
+                    }
+                    const auto value = static_cast<wchar_t>(*firstByte | (static_cast<unsigned int>(bytes[index]) << 8));
+                    firstByte.reset();
+                    if (value == L'\n')
+                    {
+                        Assert::AreEqual(count, index + 1);
+                        Assert::IsTrue(text.empty() || text.front() != L'\xfeff');
+                        return JsonObject::Parse(text);
+                    }
+                    text.push_back(value);
+                }
+            }
+            throw std::runtime_error("The server response exceeded the protocol limit.");
+        }
+
+        JsonObject Exchange(const std::wstring& name, std::wstring_view request)
+        {
+            auto client = Connect(name);
+            WriteRequest(client.Get(), request);
+            return ReadResponse(client.Get());
+        }
+
+        void AssertError(const JsonObject& response, std::wstring_view code)
+        {
+            Assert::IsFalse(response.GetNamedBoolean(L"success"));
+            Assert::AreEqual(std::wstring(code), std::wstring(response.GetNamedObject(L"error").GetNamedString(L"code")));
+        }
+
+        constexpr std::wstring_view StatusRequest = L"{\"version\":1,\"command\":\"status\"}";
+    }
+
+    TEST_CLASS (CliPipeServerTests)
+    {
+    public:
+        TEST_METHOD (DispatchesOneRequestAndRetainsThePipeNameAcrossConnections)
+        {
+            Apartment apartment;
+            const auto options = TestOptions();
+            std::atomic<int> calls = 0;
+            CliPipeServer server([&](const Request& request) {
+                Assert::IsTrue(request.command == Command::Status);
+                ++calls;
+                return MakeSuccess(TestState());
+            },
+                                 options);
+            Assert::IsTrue(server.Start());
+            for (int index = 0; index < 3; ++index)
+            {
+                Assert::IsTrue(Exchange(options.pipeName, StatusRequest).GetNamedBoolean(L"success"));
+                TestHandle rogue(CreateNamedPipeW(options.pipeName.c_str(), PIPE_ACCESS_DUPLEX | FILE_FLAG_FIRST_PIPE_INSTANCE, PIPE_TYPE_BYTE, 1, 0, 0, 0, nullptr));
+                Assert::IsTrue(rogue.Get() == INVALID_HANDLE_VALUE);
+            }
+            server.Stop();
+            Assert::AreEqual(3, calls.load());
+        }
+
+        TEST_METHOD (SecondServerCannotAcquireAnOwnedName)
+        {
+            Apartment apartment;
+            const auto options = TestOptions();
+            const auto handler = [](const Request&) { return MakeSuccess(TestState()); };
+            CliPipeServer first(handler, options);
+            CliPipeServer second(handler, options);
+            Assert::IsTrue(first.Start());
+            Assert::IsFalse(second.Start());
+            Assert::IsTrue(Exchange(options.pipeName, StatusRequest).GetNamedBoolean(L"success"));
+        }
+
+        TEST_METHOD (HandlesUtf16CodeUnitsSplitAcrossWrites)
+        {
+            Apartment apartment;
+            const auto options = TestOptions();
+            CliPipeServer server([](const Request&) { return MakeSuccess(TestState()); }, options);
+            Assert::IsTrue(server.Start());
+            auto client = Connect(options.pipeName);
+            std::wstring framed(StatusRequest);
+            framed.push_back(L'\n');
+            const auto bytes = reinterpret_cast<const BYTE*>(framed.data());
+            const auto size = framed.size() * sizeof(wchar_t);
+            for (size_t index = 0; index < size; ++index)
+            {
+                WriteBytes(client.Get(), bytes + index, 1);
+            }
+            Assert::IsTrue(ReadResponse(client.Get()).GetNamedBoolean(L"success"));
+        }
+
+        TEST_METHOD (MalformedAndOversizedRequestsNeverInvokeTheHandler)
+        {
+            Apartment apartment;
+            const auto options = TestOptions();
+            std::atomic<int> calls = 0;
+            CliPipeServer server([&](const Request&) { ++calls; return MakeSuccess(TestState()); }, options);
+            Assert::IsTrue(server.Start());
+            AssertError(Exchange(options.pipeName, L"not json"), L"PROTOCOL_ERROR");
+            AssertError(Exchange(options.pipeName, std::wstring(MaxMessageCharacters + 1, L' ')), L"PROTOCOL_ERROR");
+            server.Stop();
+            Assert::AreEqual(0, calls.load());
+        }
+
+        TEST_METHOD (TwoFramesNeverInvokeTheHandlerMoreThanOnce)
+        {
+            Apartment apartment;
+            const auto options = TestOptions();
+            std::atomic<int> calls = 0;
+            CliPipeServer server([&](const Request&) { ++calls; return MakeSuccess(TestState()); }, options);
+            Assert::IsTrue(server.Start());
+            const auto response = Exchange(options.pipeName, std::wstring(StatusRequest) + L"\n" + std::wstring(StatusRequest));
+            // Byte-stream reads may split even one client write. Trailing data already read
+            // with the first frame is rejected; later data can never be a second command.
+            if (!response.GetNamedBoolean(L"success"))
+            {
+                AssertError(response, L"PROTOCOL_ERROR");
+            }
+            server.Stop();
+            Assert::IsTrue(calls.load() <= 1);
+        }
+
+        TEST_METHOD (AdditionalRequestsOnAnExistingConnectionAreNeverExecuted)
+        {
+            Apartment apartment;
+            const auto options = TestOptions();
+            std::atomic<int> calls = 0;
+            CliPipeServer server([&](const Request&) { ++calls; return MakeSuccess(TestState()); }, options);
+            Assert::IsTrue(server.Start());
+            auto client = Connect(options.pipeName);
+            WriteRequest(client.Get(), StatusRequest);
+            Assert::IsTrue(ReadResponse(client.Get()).GetNamedBoolean(L"success"));
+            WriteRequest(client.Get(), StatusRequest);
+            client.Reset();
+            server.Stop();
+            Assert::AreEqual(1, calls.load());
+        }
+
+        TEST_METHOD (ResponseIsNotDiscardedBeforeTheClientReadsIt)
+        {
+            Apartment apartment;
+            const auto options = TestOptions();
+            std::promise<void> invoked;
+            auto invocation = invoked.get_future();
+            CliPipeServer server([&](const Request&) { invoked.set_value(); return MakeSuccess(TestState()); }, options);
+            Assert::IsTrue(server.Start());
+            auto client = Connect(options.pipeName);
+            WriteRequest(client.Get(), StatusRequest);
+            Assert::IsTrue(invocation.wait_for(2s) == std::future_status::ready);
+            // A server that disconnects immediately after WriteFile discards its unread reply.
+            std::this_thread::sleep_for(50ms);
+            Assert::IsTrue(ReadResponse(client.Get()).GetNamedBoolean(L"success"));
+        }
+
+        TEST_METHOD (ReadTimeoutIsReportedAndTheNextClientCanConnect)
+        {
+            Apartment apartment;
+            auto options = TestOptions();
+            options.readTimeoutMs = 100;
+            std::atomic<int> calls = 0;
+            CliPipeServer server([&](const Request&) { ++calls; return MakeSuccess(TestState()); }, options);
+            Assert::IsTrue(server.Start());
+            auto stalled = Connect(options.pipeName);
+            const BYTE incompleteCodeUnit = '{';
+            WriteBytes(stalled.Get(), &incompleteCodeUnit, 1);
+            AssertError(ReadResponse(stalled.Get()), L"TIMEOUT");
+            stalled.Reset();
+            Assert::IsTrue(Exchange(options.pipeName, StatusRequest).GetNamedBoolean(L"success"));
+            server.Stop();
+            Assert::AreEqual(1, calls.load());
+        }
+
+        TEST_METHOD (HandlerExceptionsAndOversizedResponsesBecomeErrors)
+        {
+            Apartment apartment;
+            const auto options = TestOptions();
+            CliPipeServer server([](const Request& request) -> JsonObject {
+                if (request.command == Command::Status)
+                {
+                    throw std::runtime_error("An injected handler failure");
+                }
+                auto state = TestState();
+                state.SetNamedValue(L"extra", JsonValue::CreateStringValue(std::wstring(MaxMessageCharacters, L'x')));
+                return MakeSuccess(state);
+            },
+                                 options);
+            Assert::IsTrue(server.Start());
+            AssertError(Exchange(options.pipeName, StatusRequest), L"EXECUTION_FAILED");
+            AssertError(Exchange(options.pipeName, L"{\"version\":1,\"command\":\"light\"}"), L"PROTOCOL_ERROR");
+        }
+
+        TEST_METHOD (StopCancelsAcceptAndPartialReads)
+        {
+            Apartment apartment;
+            auto options = TestOptions();
+            options.readTimeoutMs = 10000;
+            std::atomic<int> calls = 0;
+            CliPipeServer server([&](const Request&) { ++calls; return MakeSuccess(TestState()); }, options);
+            Assert::IsTrue(server.Start());
+            auto start = GetTickCount64();
+            server.Stop();
+            Assert::IsTrue(GetTickCount64() - start < 2000);
+            Assert::IsTrue(server.Start());
+            auto client = Connect(options.pipeName);
+            const BYTE incompleteCodeUnit = '{';
+            WriteBytes(client.Get(), &incompleteCodeUnit, 1);
+            start = GetTickCount64();
+            server.Stop();
+            Assert::IsTrue(GetTickCount64() - start < 2000);
+            Assert::AreEqual(0, calls.load());
+        }
+
+        TEST_METHOD (StopWaitsForAnActiveHandlerBeforeReleasingState)
+        {
+            Apartment apartment;
+            const auto options = TestOptions();
+            std::promise<void> entered;
+            auto invocation = entered.get_future();
+            std::promise<void> release;
+            auto released = release.get_future().share();
+            std::atomic<bool> finished = false;
+            CliPipeServer server([&](const Request&) {
+                entered.set_value();
+                released.wait_for(5s);
+                finished = true;
+                return MakeSuccess(TestState());
+            },
+                                 options);
+            Assert::IsTrue(server.Start());
+            auto client = Connect(options.pipeName);
+            WriteRequest(client.Get(), StatusRequest);
+            const auto handlerStarted = invocation.wait_for(2s) == std::future_status::ready;
+            auto stopped = std::async(std::launch::async, [&]() { server.Stop(); });
+            const auto waitedForHandler = stopped.wait_for(50ms) == std::future_status::timeout;
+            release.set_value();
+            const auto stoppedCleanly = stopped.wait_for(2s) == std::future_status::ready;
+            Assert::IsTrue(handlerStarted);
+            Assert::IsTrue(waitedForHandler);
+            Assert::IsTrue(stoppedCleanly);
+            Assert::IsTrue(finished.load());
+        }
+    };
+}

--- a/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/CliProtocolTests.cpp
+++ b/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/CliProtocolTests.cpp
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include <CppUnitTest.h>
+#include "CliProtocol.h"
+#include "TestSupport.h"
+
+#include <array>
+#include <utility>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace light_switch_cli;
+using namespace winrt::Windows::Data::Json;
+
+namespace LightSwitchServiceUnitTests
+{
+    TEST_CLASS (CliProtocolTests)
+    {
+    public:
+        TEST_METHOD (AcceptsSupportedCommandsAndExplicitModes)
+        {
+            Apartment apartment;
+            const std::array<std::pair<std::wstring_view, Command>, 6> commands{
+                { { L"status", Command::Status }, { L"light", Command::Light }, { L"dark", Command::Dark }, { L"toggle", Command::Toggle }, { L"schedule-enable", Command::ScheduleEnable }, { L"schedule-disable", Command::ScheduleDisable } }
+            };
+            for (const auto& command : commands)
+            {
+                const auto request = ParseRequest(L"{\"version\":1,\"command\":\"" + std::wstring(command.first) + L"\"}");
+                Assert::IsTrue(command.second == request.command);
+                Assert::IsFalse(request.mode.has_value());
+            }
+            for (const auto mode : { L"FixedHours", L"SunsetToSunrise", L"FollowNightLight" })
+            {
+                const auto request = ParseRequest(L"{\"version\":1,\"command\":\"schedule-enable\",\"mode\":\"" + std::wstring(mode) + L"\"}");
+                Assert::IsTrue(request.command == Command::ScheduleEnable);
+                Assert::AreEqual(std::wstring(mode), request.mode.value());
+            }
+        }
+
+        TEST_METHOD (RejectsUnknownOrIncompatibleArguments)
+        {
+            Apartment apartment;
+            for (const auto message : {
+                     L"{\"version\":1,\"command\":\"unknown\"}",
+                     L"{\"version\":1,\"command\":true}",
+                     L"{\"version\":1}",
+                     L"{\"version\":1,\"command\":\"status\",\"mode\":\"FixedHours\"}",
+                     L"{\"version\":1,\"command\":\"schedule-disable\",\"mode\":\"FixedHours\"}",
+                     L"{\"version\":1,\"command\":\"schedule-enable\",\"mode\":null}",
+                     L"{\"version\":1,\"command\":\"schedule-enable\",\"mode\":\"Off\"}",
+                     L"{\"version\":1,\"command\":\"schedule-enable\",\"mode\":\"fixedhours\"}",
+                     L"{\"version\":1,\"command\":\"status\",\"extra\":0}" })
+            {
+                AssertRequestError(message, L"INVALID_ARGUMENT");
+            }
+        }
+
+        TEST_METHOD (RejectsMalformedAndUnsupportedProtocol)
+        {
+            Apartment apartment;
+            for (const auto message : {
+                     L"", L"not json", L"[]", L"null", L"{", L"{\"command\":\"status\"}", L"{\"version\":2,\"command\":\"status\"}", L"{\"version\":1.5,\"command\":\"status\"}", L"{\"version\":\"1\",\"command\":\"status\"}", L"{\"version\":1,\"command\":\"status\"} {}", L"{\"version\":1,\"command\":\"status\",\"command\":\"toggle\"}", L"{\"version\":1,\"command\":\"status\",\"\\u0063ommand\":\"toggle\"}" })
+            {
+                AssertRequestError(message, L"PROTOCOL_ERROR");
+            }
+        }
+
+        TEST_METHOD (EnforcesBomlessUtf16AndMessageLength)
+        {
+            Apartment apartment;
+            const std::wstring valid = L"{\"version\":1,\"command\":\"status\"}";
+            AssertRequestError(std::wstring(1, L'\xfeff') + valid, L"PROTOCOL_ERROR");
+            AssertRequestError(valid + std::wstring(1, L'\0'), L"PROTOCOL_ERROR");
+            AssertRequestError(valid + std::wstring(1, L'\xd800'), L"PROTOCOL_ERROR");
+            AssertRequestError(valid + std::wstring(1, L'\xdc00'), L"PROTOCOL_ERROR");
+            AssertRequestError(std::wstring(MaxMessageCharacters + 1, L' '), L"PROTOCOL_ERROR");
+            AssertRequestError(std::wstring(16000, L'[') + std::wstring(16000, L']'), L"PROTOCOL_ERROR");
+            const auto atLimit = std::wstring(MaxMessageCharacters - valid.size(), L' ') + valid;
+            Assert::IsTrue(ParseRequest(atLimit).command == Command::Status);
+        }
+
+        TEST_METHOD (ResponseEnvelopesRetainStateAndStructuredError)
+        {
+            Apartment apartment;
+            const auto state = TestState();
+            const auto success = MakeSuccess(state);
+            Assert::AreEqual(1.0, success.GetNamedNumber(L"version"));
+            Assert::IsTrue(success.GetNamedBoolean(L"success"));
+            Assert::IsFalse(success.HasKey(L"error"));
+            Assert::AreEqual(std::wstring(L"unknown"), std::wstring(success.GetNamedObject(L"state").GetNamedString(L"appsTheme")));
+
+            const auto failure = MakeError(L"EXECUTION_FAILED", L"A test failure", state);
+            Assert::IsFalse(failure.GetNamedBoolean(L"success"));
+            Assert::IsTrue(failure.HasKey(L"state"));
+            Assert::AreEqual(std::wstring(L"EXECUTION_FAILED"), std::wstring(failure.GetNamedObject(L"error").GetNamedString(L"code")));
+            Assert::IsFalse(MakeError(L"INVALID_ARGUMENT", L"Invalid request").HasKey(L"state"));
+        }
+
+    private:
+        static void AssertRequestError(std::wstring_view message, std::wstring_view expectedCode)
+        {
+            try
+            {
+                ParseRequest(message);
+                Assert::Fail(L"The request should have been rejected.");
+            }
+            catch (const RequestError& error)
+            {
+                Assert::AreEqual(std::wstring(expectedCode), error.Code());
+                Assert::IsFalse(error.Message().empty());
+            }
+        }
+    };
+}

--- a/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/LightSwitchService.UnitTests.vcxproj
+++ b/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/LightSwitchService.UnitTests.vcxproj
@@ -35,12 +35,14 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="CliIdentityTests.cpp" />
     <ClCompile Include="CliProtocolTests.cpp" />
     <ClCompile Include="CliPipeServerTests.cpp" />
     <ClCompile Include="ScheduleCommandQueueTests.cpp" />
     <ClCompile Include="StateManagerTests.cpp" />
     <ClCompile Include="SettingsTests.cpp" />
     <ClCompile Include="ThemeHelperTests.cpp" />
+    <ClCompile Include="..\..\LightSwitchService\CliIdentity.cpp" />
     <ClCompile Include="..\..\LightSwitchService\CliProtocol.cpp" />
     <ClCompile Include="..\..\LightSwitchService\CliPipeServer.cpp" />
     <ClCompile Include="..\..\LightSwitchService\LightSwitchStateManager.cpp" />
@@ -50,6 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="TestSupport.h" />
+    <ClInclude Include="..\..\LightSwitchService\CliIdentity.h" />
     <ClInclude Include="..\..\LightSwitchService\CliProtocol.h" />
     <ClInclude Include="..\..\LightSwitchService\CliPipeServer.h" />
   </ItemGroup>

--- a/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/LightSwitchService.UnitTests.vcxproj
+++ b/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/LightSwitchService.UnitTests.vcxproj
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <ProjectGuid>{6B4BC04D-59A7-44B2-9AB5-4ED9A5607AB9}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>LightSwitchServiceUnitTests</RootNamespace>
+    <ProjectSubType>NativeUnitTestProject</ProjectSubType>
+    <ProjectName>LightSwitchService.UnitTests</ProjectName>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <UsePrecompiledHeaders>false</UsePrecompiledHeaders>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup>
+    <OutDir>$(RepoRoot)$(Platform)\$(Configuration)\tests\LightSwitchService\</OutDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..;..\..\LightSwitchService;..\..\LightSwitchLib;$(RepoRoot)src;$(RepoRoot)src\common;$(RepoRoot)src\common\logger;$(RepoRoot)src\common\utils;$(RepoRoot)src\common\SettingsAPI;$(RepoRoot)src\common\Telemetry;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <UseFullPaths>true</UseFullPaths>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>RuntimeObject.lib;Advapi32.lib;Shell32.lib;User32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="CliProtocolTests.cpp" />
+    <ClCompile Include="CliPipeServerTests.cpp" />
+    <ClCompile Include="ScheduleCommandQueueTests.cpp" />
+    <ClCompile Include="StateManagerTests.cpp" />
+    <ClCompile Include="SettingsTests.cpp" />
+    <ClCompile Include="ThemeHelperTests.cpp" />
+    <ClCompile Include="..\..\LightSwitchService\CliProtocol.cpp" />
+    <ClCompile Include="..\..\LightSwitchService\CliPipeServer.cpp" />
+    <ClCompile Include="..\..\LightSwitchService\LightSwitchStateManager.cpp" />
+    <ClCompile Include="..\..\LightSwitchService\LightSwitchSettings.cpp" />
+    <ClCompile Include="..\..\LightSwitchService\ThemeScheduler.cpp" />
+    <ClCompile Include="..\..\LightSwitchService\trace.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="TestSupport.h" />
+    <ClInclude Include="..\..\LightSwitchService\CliProtocol.h" />
+    <ClInclude Include="..\..\LightSwitchService\CliPipeServer.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)src\common\SettingsAPI\SettingsAPI.vcxproj">
+      <Project>{6955446D-23F7-4023-9BB3-8657F904AF99}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\LightSwitchLib\LightSwitchLib.vcxproj">
+      <Project>{79267138-2895-4346-9021-21408D65379F}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="$(RepoRoot)deps\spdlog.props" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="$(RepoRoot)packages\Microsoft.Windows.ImplementationLibrary.1.0.260126.7\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('$(RepoRoot)packages\Microsoft.Windows.ImplementationLibrary.1.0.260126.7\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+  </ImportGroup>
+</Project>

--- a/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/ScheduleCommandQueueTests.cpp
+++ b/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/ScheduleCommandQueueTests.cpp
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root.
+
+#include <CppUnitTest.h>
+#include "TestSupport.h"
+#include "../../LightSwitchService/ScheduleCommandQueue.h"
+#include <atomic>
+#include <thread>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace winrt::Windows::Data::Json;
+using namespace light_switch_cli;
+using LightSwitchServiceUnitTests::Apartment;
+
+namespace LightSwitchServiceTests
+{
+    TEST_CLASS (ScheduleCommandQueueTests)
+    {
+    public:
+        TEST_METHOD (WorkerCompletesTheSubmittedRequest)
+        {
+            Apartment apartment;
+            ScheduleCommandQueue queue;
+            auto response = std::async(std::launch::async, [&]() {
+                Apartment apartment;
+                return queue.Submit({ Command::ScheduleEnable, L"FixedHours" });
+            });
+            Assert::AreEqual(static_cast<DWORD>(WAIT_OBJECT_0), WaitForSingleObject(queue.Event(), 5000));
+            queue.ProcessPending([](const Request& request) {
+                Assert::IsTrue(request.command == Command::ScheduleEnable);
+                Assert::AreEqual(L"FixedHours", request.mode->c_str());
+                return MakeSuccess(JsonObject{});
+            });
+            Assert::IsTrue(response.get().GetNamedBoolean(L"success"));
+        }
+
+        TEST_METHOD (TimedOutQueuedRequestIsNotExecuted)
+        {
+            Apartment apartment;
+            ScheduleCommandQueue queue;
+            const auto response = queue.Submit(
+                { Command::ScheduleDisable, std::nullopt }, std::chrono::milliseconds(1));
+            bool executed = false;
+            queue.ProcessPending([&](const Request&) {
+                executed = true;
+                return MakeSuccess(JsonObject{});
+            });
+            Assert::IsFalse(executed);
+            Assert::AreEqual(L"TIMEOUT", response.GetNamedObject(L"error").GetNamedString(L"code").c_str());
+        }
+
+        TEST_METHOD (StopReleasesWaitingCallerAndRejectsNewRequests)
+        {
+            Apartment apartment;
+            ScheduleCommandQueue queue;
+            auto response = std::async(std::launch::async, [&]() {
+                Apartment apartment;
+                return queue.Submit({ Command::ScheduleDisable, std::nullopt });
+            });
+            Assert::AreEqual(static_cast<DWORD>(WAIT_OBJECT_0), WaitForSingleObject(queue.Event(), 5000));
+            queue.Stop();
+            Assert::AreEqual(L"SERVICE_UNAVAILABLE", response.get().GetNamedObject(L"error").GetNamedString(L"code").c_str());
+            Assert::IsFalse(queue.Submit({ Command::ScheduleDisable, std::nullopt }).GetNamedBoolean(L"success"));
+        }
+
+        TEST_METHOD (HandlerExceptionBecomesAnErrorResponse)
+        {
+            Apartment apartment;
+            ScheduleCommandQueue queue;
+            auto response = std::async(std::launch::async, [&]() {
+                Apartment apartment;
+                return queue.Submit({ Command::ScheduleDisable, std::nullopt });
+            });
+            Assert::AreEqual(static_cast<DWORD>(WAIT_OBJECT_0), WaitForSingleObject(queue.Event(), 5000));
+            queue.ProcessPending([](const Request&) -> JsonObject {
+                throw std::runtime_error("Fake schedule failure");
+            });
+            Assert::AreEqual(L"EXECUTION_FAILED", response.get().GetNamedObject(L"error").GetNamedString(L"code").c_str());
+        }
+    };
+}

--- a/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/SettingsTests.cpp
+++ b/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/SettingsTests.cpp
@@ -151,6 +151,23 @@ namespace LightSwitchServiceUnitTests
             Assert::AreEqual(original, file.Read());
         }
 
+        TEST_METHOD (StartupReadsSettingsWhileAnotherHandleHasDeleteAccess)
+        {
+            TemporarySettings file;
+            file.Write(ValidSettings);
+            const auto original = file.Read();
+            wil::unique_hfile publisher(CreateFileW(file.path.c_str(), DELETE, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
+            Assert::IsTrue(static_cast<bool>(publisher));
+            LightSwitchConfig config;
+            std::wstring error;
+            Assert::IsTrue(TryInitializeLightSwitchSettings(file.path, config, error), error.c_str());
+            Assert::IsTrue(config.scheduleMode == ScheduleMode::FixedHours);
+            Assert::IsTrue(config.changeSystem);
+            Assert::IsFalse(config.changeApps);
+            publisher.reset();
+            Assert::AreEqual(original, file.Read());
+        }
+
         TEST_METHOD (StartupDoesNotTreatAMissingParentAsAMissingSettingsFile)
         {
             TemporarySettings file;
@@ -169,20 +186,25 @@ namespace LightSwitchServiceUnitTests
             Assert::IsTrue(DeleteFileW(file.path.c_str()));
             std::promise<void> start;
             auto ready = start.get_future().share();
-            std::vector<std::future<bool>> operations;
+            std::vector<std::future<std::wstring>> operations;
             for (int index = 0; index < 12; ++index)
             {
                 operations.push_back(std::async(std::launch::async, [&, ready]() {
                     ready.wait();
                     LightSwitchConfig config;
                     std::wstring error;
-                    return TryInitializeLightSwitchSettings(file.path, config, error) &&
-                           config.scheduleMode == ScheduleMode::Off && config.changeSystem && config.changeApps;
+                    if (!TryInitializeLightSwitchSettings(file.path, config, error))
+                        return error.empty() ? std::wstring{ L"Initialization failed without an error message." } : error;
+                    return config.scheduleMode == ScheduleMode::Off && config.changeSystem && config.changeApps ?
+                               std::wstring{} : std::wstring{ L"The published default configuration is inconsistent." };
                 }));
             }
             start.set_value();
             for (auto& operation : operations)
-                Assert::IsTrue(operation.get());
+            {
+                const auto error = operation.get();
+                Assert::IsTrue(error.empty(), error.c_str());
+            }
             Assert::IsTrue(json::from_file(file.path).has_value());
             WIN32_FIND_DATAW entry{};
             const auto leftover = FindFirstFileW((file.path + L".init.*").c_str(), &entry);

--- a/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/SettingsTests.cpp
+++ b/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/SettingsTests.cpp
@@ -48,6 +48,28 @@ namespace LightSwitchServiceUnitTests
                 return { std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>() };
             }
         };
+
+        json::JsonObject SunSettings()
+        {
+            auto document = json::JsonObject::Parse(ValidSettings);
+            const auto properties = document.GetNamedObject(L"properties");
+            properties.GetNamedObject(L"scheduleMode").SetNamedValue(L"value", json::value(L"SunsetToSunrise"));
+            json::JsonObject latitude;
+            latitude.SetNamedValue(L"value", json::value(L"22.3"));
+            properties.SetNamedValue(L"latitude", latitude);
+            json::JsonObject longitude;
+            longitude.SetNamedValue(L"value", json::value(L"114.2"));
+            properties.SetNamedValue(L"longitude", longitude);
+            return document;
+        }
+
+        LightSwitchConfig ParseConfig(const json::JsonObject& document)
+        {
+            LightSwitchConfig config;
+            std::wstring error;
+            Assert::IsTrue(TryParseLightSwitchConfig(document, config, error), error.c_str());
+            return config;
+        }
     }
 
     TEST_CLASS (SettingsTests)
@@ -287,6 +309,174 @@ namespace LightSwitchServiceUnitTests
             std::ifstream input(file.path.c_str(), std::ios::binary);
             const std::string remaining{ std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>() };
             Assert::AreEqual("not json", remaining.c_str());
+        }
+
+        TEST_METHOD (SunTimesSavePreservesLatestFieldsAndPropertyMetadata)
+        {
+            Apartment apartment;
+            TemporarySettings file;
+            auto document = SunSettings();
+            const auto expected = ParseConfig(document);
+            document.SetNamedValue(L"metadata", json::value(L"latest metadata"));
+            const auto properties = document.GetNamedObject(L"properties");
+            properties.GetNamedObject(L"futureProperty").SetNamedValue(L"value", json::value(L"latest future value"));
+            properties.GetNamedObject(L"lightTime").SetNamedValue(L"retained", json::value(L"light metadata"));
+            properties.GetNamedObject(L"darkTime").SetNamedValue(L"retained", json::value(L"dark metadata"));
+            // Cache values may have changed without invalidating the calculation.
+            properties.GetNamedObject(L"lightTime").SetNamedValue(L"value", json::value(490));
+            file.Write(document.Stringify().c_str());
+            LightSwitchConfig saved;
+            std::wstring error;
+            Assert::IsTrue(SaveLightSwitchSunTimes(file.path, expected, 500, 1210, saved, error) == SunTimesSaveResult::Saved, error.c_str());
+            Assert::AreEqual(500, saved.lightTime);
+            Assert::AreEqual(1210, saved.darkTime);
+            properties.GetNamedObject(L"lightTime").SetNamedValue(L"value", json::value(500));
+            properties.GetNamedObject(L"darkTime").SetNamedValue(L"value", json::value(1210));
+            Assert::AreEqual(document.Stringify().c_str(), json::from_file(file.path)->Stringify().c_str());
+        }
+
+        TEST_METHOD (SunTimesSaveAddsMissingCacheProperties)
+        {
+            Apartment apartment;
+            TemporarySettings file;
+            auto document = SunSettings();
+            document.GetNamedObject(L"properties").Remove(L"lightTime");
+            document.GetNamedObject(L"properties").Remove(L"darkTime");
+            const auto expected = ParseConfig(document);
+            file.Write(document.Stringify().c_str());
+            LightSwitchConfig saved;
+            std::wstring error;
+            Assert::IsTrue(SaveLightSwitchSunTimes(file.path, expected, 500, 1210, saved, error) == SunTimesSaveResult::Saved, error.c_str());
+            const auto properties = json::from_file(file.path)->GetNamedObject(L"properties");
+            Assert::AreEqual(500.0, properties.GetNamedObject(L"lightTime").GetNamedNumber(L"value"));
+            Assert::AreEqual(1210.0, properties.GetNamedObject(L"darkTime").GetNamedNumber(L"value"));
+        }
+
+        TEST_METHOD (UnchangedSunTimesDoNotRequireWriteOrDeleteAccess)
+        {
+            Apartment apartment;
+            TemporarySettings file;
+            const auto document = SunSettings();
+            const auto expected = ParseConfig(document);
+            file.Write(document.Stringify().c_str());
+            const auto original = file.Read();
+            wil::unique_hfile reader(CreateFileW(file.path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
+            Assert::IsTrue(static_cast<bool>(reader));
+            LightSwitchConfig saved;
+            std::wstring error;
+            Assert::IsTrue(SaveLightSwitchSunTimes(file.path, expected, expected.lightTime, expected.darkTime, saved, error) == SunTimesSaveResult::Saved, error.c_str());
+            reader.reset();
+            Assert::AreEqual(original, file.Read());
+        }
+
+        TEST_METHOD (SunCalculationCannotUndoALaterCliScheduleDisable)
+        {
+            Apartment apartment;
+            TemporarySettings file;
+            const auto document = SunSettings();
+            const auto expected = ParseConfig(document);
+            file.Write(document.Stringify().c_str());
+            LightSwitchConfig saved;
+            std::wstring error;
+            Assert::IsTrue(TryPatchLightSwitchScheduleMode(file.path, ScheduleMode::Off, saved, error), error.c_str());
+            const auto disabled = file.Read();
+            Assert::IsTrue(SaveLightSwitchSunTimes(file.path, expected, 500, 1210, saved, error) == SunTimesSaveResult::Superseded);
+            Assert::IsTrue(error.empty());
+            Assert::AreEqual(disabled, file.Read());
+            Assert::IsTrue(ParseConfig(*json::from_file(file.path)).scheduleMode == ScheduleMode::Off);
+        }
+
+        TEST_METHOD (CliScheduleDisableRetainsAnEarlierSolarCacheSave)
+        {
+            Apartment apartment;
+            TemporarySettings file;
+            const auto document = SunSettings();
+            const auto expected = ParseConfig(document);
+            file.Write(document.Stringify().c_str());
+            LightSwitchConfig saved;
+            std::wstring error;
+            Assert::IsTrue(SaveLightSwitchSunTimes(file.path, expected, 500, 1210, saved, error) == SunTimesSaveResult::Saved, error.c_str());
+            Assert::IsTrue(TryPatchLightSwitchScheduleMode(file.path, ScheduleMode::Off, saved, error), error.c_str());
+            Assert::IsTrue(saved.scheduleMode == ScheduleMode::Off);
+            Assert::AreEqual(500, saved.lightTime);
+            Assert::AreEqual(1210, saved.darkTime);
+        }
+
+        TEST_METHOD (SunTimesSaveSkipsSupersededEffectiveSettings)
+        {
+            Apartment apartment;
+            const std::vector<std::pair<std::wstring, json::JsonValue>> edits{
+                { L"scheduleMode", json::value(L"FixedHours") },
+                { L"scheduleMode", json::value(L"FollowNightLight") },
+                { L"latitude", json::value(L"23.3") },
+                { L"longitude", json::value(L"115.2") },
+                { L"sunrise_offset", json::value(1) },
+                { L"sunset_offset", json::value(-1) },
+                { L"changeSystem", json::value(false) },
+                { L"changeApps", json::value(true) },
+            };
+            const auto expected = ParseConfig(SunSettings());
+            for (const auto& [name, value] : edits)
+            {
+                TemporarySettings file;
+                auto document = SunSettings();
+                json::JsonObject property;
+                property.SetNamedValue(L"value", value);
+                document.GetNamedObject(L"properties").SetNamedValue(name, property);
+                file.Write(document.Stringify().c_str());
+                const auto original = file.Read();
+                LightSwitchConfig saved;
+                std::wstring error = L"previous error";
+                Assert::IsTrue(SaveLightSwitchSunTimes(file.path, expected, 500, 1210, saved, error) == SunTimesSaveResult::Superseded, name.c_str());
+                Assert::IsTrue(error.empty());
+                Assert::AreEqual(original, file.Read());
+            }
+        }
+
+        TEST_METHOD (SunTimesSaveDoesNotReplaceMalformedOrUnreadableSettings)
+        {
+            Apartment apartment;
+            TemporarySettings file;
+            const auto document = SunSettings();
+            const auto expected = ParseConfig(document);
+            LightSwitchConfig saved;
+            std::wstring error;
+            file.Write(L"not json");
+            Assert::IsTrue(SaveLightSwitchSunTimes(file.path, expected, 500, 1210, saved, error) == SunTimesSaveResult::Failed);
+            Assert::IsFalse(error.empty());
+            Assert::AreEqual("not json", file.Read().c_str());
+
+            file.Write(document.Stringify().c_str());
+            const auto original = file.Read();
+            wil::unique_hfile reader(CreateFileW(file.path.c_str(), GENERIC_READ, 0, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
+            Assert::IsTrue(static_cast<bool>(reader));
+            Assert::IsTrue(SaveLightSwitchSunTimes(file.path, expected, 500, 1210, saved, error) == SunTimesSaveResult::Failed);
+            Assert::IsFalse(error.empty());
+            reader.reset();
+            Assert::AreEqual(original, file.Read());
+        }
+
+        TEST_METHOD (SunTimesSaveReportsAReplacementFailureWithoutChangingTheFile)
+        {
+            Apartment apartment;
+            TemporarySettings file;
+            const auto document = SunSettings();
+            const auto expected = ParseConfig(document);
+            file.Write(document.Stringify().c_str());
+            const auto original = file.Read();
+            wil::unique_hfile reader(CreateFileW(file.path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
+            Assert::IsTrue(static_cast<bool>(reader));
+            LightSwitchConfig saved;
+            std::wstring error;
+            Assert::IsTrue(SaveLightSwitchSunTimes(file.path, expected, 500, 1210, saved, error) == SunTimesSaveResult::Failed);
+            Assert::IsFalse(error.empty());
+            reader.reset();
+            Assert::AreEqual(original, file.Read());
+            WIN32_FIND_DATAW entry{};
+            const auto leftover = FindFirstFileW((file.path + L".sun.*").c_str(), &entry);
+            if (leftover != INVALID_HANDLE_VALUE)
+                FindClose(leftover);
+            Assert::IsTrue(leftover == INVALID_HANDLE_VALUE);
         }
 
         TEST_METHOD (EffectiveSettingsIgnoreOnlyDerivedSunTimes)

--- a/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/SettingsTests.cpp
+++ b/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/SettingsTests.cpp
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include <CppUnitTest.h>
+#include "LightSwitchSettings.h"
+#include "TestSupport.h"
+#include <fstream>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace LightSwitchServiceUnitTests
+{
+    namespace
+    {
+        constexpr wchar_t ValidSettings[] = LR"({"name":"LightSwitch","version":"1.0","properties":{"scheduleMode":{"value":"FixedHours","retained":42},"changeSystem":{"value":true},"changeApps":{"value":false},"lightTime":{"value":480},"darkTime":{"value":1200},"futureProperty":{"value":"keep"}},"metadata":"retained"})";
+
+        struct TemporarySettings
+        {
+            std::wstring path;
+            TemporarySettings()
+            {
+                wchar_t directory[MAX_PATH]{};
+                wchar_t name[MAX_PATH]{};
+                Assert::IsTrue(GetTempPathW(MAX_PATH, directory) != 0);
+                Assert::IsTrue(GetTempFileNameW(directory, L"LSC", 0, name) != 0);
+                path = name;
+            }
+            ~TemporarySettings()
+            {
+                DeleteFileW(path.c_str());
+            }
+            void Write(const std::wstring& text)
+            {
+                std::ofstream stream(path.c_str(), std::ios::binary | std::ios::trunc);
+                stream << winrt::to_string(text);
+                stream.close();
+                Assert::IsFalse(stream.fail());
+            }
+        };
+    }
+
+    TEST_CLASS (SettingsTests)
+    {
+    public:
+        TEST_METHOD (ParsesExistingSettingsWithoutChangingTheSchema)
+        {
+            Apartment apartment;
+            LightSwitchConfig config;
+            std::wstring error;
+            Assert::IsTrue(TryParseLightSwitchConfig(json::JsonObject::Parse(ValidSettings), config, error));
+            Assert::IsTrue(config.scheduleMode == ScheduleMode::FixedHours);
+            Assert::IsTrue(config.changeSystem);
+            Assert::IsFalse(config.changeApps);
+            Assert::AreEqual(480, config.lightTime);
+            Assert::AreEqual(1200, config.darkTime);
+        }
+
+        TEST_METHOD (InvalidSettingsDoNotProduceAPartialConfiguration)
+        {
+            Apartment apartment;
+            auto document = json::JsonObject::Parse(ValidSettings);
+            document.GetNamedObject(L"properties").GetNamedObject(L"darkTime").SetNamedValue(L"value", json::value(1.5));
+            LightSwitchConfig config;
+            config.lightTime = 123;
+            std::wstring error;
+            Assert::IsFalse(TryParseLightSwitchConfig(document, config, error));
+            Assert::AreEqual(123, config.lightTime);
+            Assert::IsFalse(error.empty());
+            document.GetNamedObject(L"properties").GetNamedObject(L"scheduleMode").SetNamedValue(L"value", json::value(L"unknown"));
+            Assert::IsFalse(TryParseLightSwitchConfig(document, config, error));
+        }
+
+        TEST_METHOD (MissingThemeTargetsAreNotGuessed)
+        {
+            Apartment apartment;
+            auto document = json::JsonObject::Parse(ValidSettings);
+            document.GetNamedObject(L"properties").Remove(L"changeApps");
+            LightSwitchConfig config;
+            std::wstring error;
+            Assert::IsFalse(TryParseLightSwitchConfig(document, config, error));
+        }
+
+        TEST_METHOD (SchedulePatchRetainsUnrelatedFieldsAndCanBeReadBack)
+        {
+            Apartment apartment;
+            TemporarySettings file;
+            file.Write(ValidSettings);
+            LightSwitchConfig config;
+            std::wstring error;
+            Assert::IsTrue(TryPatchLightSwitchScheduleMode(file.path, ScheduleMode::Off, config, error), error.c_str());
+            Assert::IsTrue(config.scheduleMode == ScheduleMode::Off);
+            const auto saved = json::from_file(file.path);
+            Assert::IsTrue(saved.has_value());
+            Assert::AreEqual(L"retained", saved->GetNamedString(L"metadata").c_str());
+            const auto properties = saved->GetNamedObject(L"properties");
+            Assert::AreEqual(L"keep", properties.GetNamedObject(L"futureProperty").GetNamedString(L"value").c_str());
+            Assert::AreEqual(42.0, properties.GetNamedObject(L"scheduleMode").GetNamedNumber(L"retained"));
+            Assert::IsTrue(TryPatchLightSwitchScheduleMode(file.path, ScheduleMode::Off, config, error));
+            Assert::AreEqual(saved->Stringify().c_str(), json::from_file(file.path)->Stringify().c_str());
+        }
+
+        TEST_METHOD (MalformedSettingsAreNotReplacedByDefaults)
+        {
+            TemporarySettings file;
+            file.Write(L"not json");
+            LightSwitchConfig config;
+            std::wstring error;
+            Assert::IsFalse(TryPatchLightSwitchScheduleMode(file.path, ScheduleMode::Off, config, error));
+            std::ifstream input(file.path.c_str(), std::ios::binary);
+            const std::string remaining{ std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>() };
+            Assert::AreEqual("not json", remaining.c_str());
+        }
+
+        TEST_METHOD (EffectiveSettingsIgnoreOnlyDerivedSunTimes)
+        {
+            LightSwitchConfig left;
+            left.scheduleMode = ScheduleMode::SunsetToSunrise;
+            auto right = left;
+            ++right.lightTime;
+            Assert::IsTrue(HasSameEffectiveLightSwitchSettings(left, right));
+            ++right.sunrise_offset;
+            Assert::IsFalse(HasSameEffectiveLightSwitchSettings(left, right));
+            left.scheduleMode = ScheduleMode::FixedHours;
+            right = left;
+            ++right.lightTime;
+            Assert::IsFalse(HasSameEffectiveLightSwitchSettings(left, right));
+        }
+    };
+}

--- a/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/SettingsTests.cpp
+++ b/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/SettingsTests.cpp
@@ -4,8 +4,12 @@
 
 #include <CppUnitTest.h>
 #include "LightSwitchSettings.h"
+#include "LightSwitchStateManager.h"
 #include "TestSupport.h"
 #include <fstream>
+#include <future>
+#include <vector>
+#include <wil/resource.h>
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
@@ -37,12 +41,156 @@ namespace LightSwitchServiceUnitTests
                 stream.close();
                 Assert::IsFalse(stream.fail());
             }
+
+            std::string Read() const
+            {
+                std::ifstream stream(path.c_str(), std::ios::binary);
+                return { std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>() };
+            }
         };
     }
 
     TEST_CLASS (SettingsTests)
     {
     public:
+        TEST_METHOD (StartupDefaultsMatchSettingsUIAndAllowTheFirstHotkey)
+        {
+            Apartment apartment;
+            TemporarySettings file;
+            Assert::IsTrue(DeleteFileW(file.path.c_str()));
+            LightSwitchConfig config;
+            std::wstring error;
+            Assert::IsTrue(TryInitializeLightSwitchSettings(file.path, config, error), error.c_str());
+            Assert::IsTrue(config.scheduleMode == ScheduleMode::Off);
+            Assert::IsTrue(config.changeSystem);
+            Assert::IsTrue(config.changeApps);
+            Assert::AreEqual(480, config.lightTime);
+            Assert::AreEqual(1200, config.darkTime);
+            Assert::AreEqual(0, config.sunrise_offset);
+            Assert::AreEqual(0, config.sunset_offset);
+            Assert::AreEqual(L"0.0", config.latitude.c_str());
+            Assert::AreEqual(L"0.0", config.longitude.c_str());
+
+            const auto document = json::from_file(file.path);
+            Assert::IsTrue(document.has_value());
+            Assert::AreEqual(L"LightSwitch", document->GetNamedString(L"name").c_str());
+            Assert::IsFalse(document->GetNamedString(L"version").empty());
+            const auto properties = document->GetNamedObject(L"properties");
+            Assert::AreEqual(16u, properties.Size());
+            const auto hotkey = properties.GetNamedObject(L"toggle-theme-hotkey").GetNamedObject(L"value");
+            Assert::IsTrue(hotkey.GetNamedBoolean(L"win"));
+            Assert::IsTrue(hotkey.GetNamedBoolean(L"ctrl"));
+            Assert::IsTrue(hotkey.GetNamedBoolean(L"shift"));
+            Assert::IsFalse(hotkey.GetNamedBoolean(L"alt"));
+            Assert::AreEqual(68.0, hotkey.GetNamedNumber(L"code"));
+            Assert::IsFalse(properties.GetNamedObject(L"enableDarkModeProfile").GetNamedBoolean(L"value"));
+            Assert::IsFalse(properties.GetNamedObject(L"enableLightModeProfile").GetNamedBoolean(L"value"));
+            Assert::IsTrue(properties.GetNamedObject(L"darkModeProfile").GetNamedString(L"value").empty());
+            Assert::IsTrue(properties.GetNamedObject(L"lightModeProfile").GetNamedString(L"value").empty());
+            Assert::AreEqual(0.0, properties.GetNamedObject(L"darkModeProfileId").GetNamedNumber(L"value"));
+            Assert::AreEqual(0.0, properties.GetNamedObject(L"lightModeProfileId").GetNamedNumber(L"value"));
+
+            bool systemLight = true;
+            bool appsLight = true;
+            int writes = 0;
+            LightSwitchStateManagerDependencies dependencies;
+            dependencies.loadSettings = [&](LightSwitchConfig& loaded, std::wstring& loadError) {
+                const auto saved = json::from_file(file.path);
+                return saved && TryParseLightSwitchConfig(*saved, loaded, loadError);
+            };
+            dependencies.readTheme = [&](bool system, bool& light) -> LSTATUS {
+                light = system ? systemLight : appsLight;
+                return ERROR_SUCCESS;
+            };
+            dependencies.writeTheme = [&](bool system, bool light) -> LSTATUS {
+                (system ? systemLight : appsLight) = light;
+                ++writes;
+                return ERROR_SUCCESS;
+            };
+            dependencies.localTime = []() { return SYSTEMTIME{}; };
+            dependencies.readNightLight = []() { return false; };
+            dependencies.notifyThemeChanged = [](bool) {};
+            dependencies.updateSunTimes = [](const LightSwitchConfig&, const SYSTEMTIME&) { return std::pair{ 480, 1200 }; };
+            LightSwitchStateManager manager(std::move(dependencies));
+            manager.SyncInitialThemeState();
+            Assert::AreEqual(0, writes);
+            Assert::IsTrue(manager.ToggleTheme().success);
+            Assert::AreEqual(2, writes);
+            Assert::IsFalse(systemLight);
+            Assert::IsFalse(appsLight);
+        }
+
+        TEST_METHOD (StartupPreservesExistingSettingsIncludingUnknownFields)
+        {
+            TemporarySettings file;
+            file.Write(ValidSettings);
+            const auto original = file.Read();
+            LightSwitchConfig config;
+            std::wstring error;
+            Assert::IsTrue(TryInitializeLightSwitchSettings(file.path, config, error), error.c_str());
+            Assert::IsTrue(config.scheduleMode == ScheduleMode::FixedHours);
+            Assert::IsTrue(config.changeSystem);
+            Assert::IsFalse(config.changeApps);
+            Assert::AreEqual(original, file.Read());
+        }
+
+        TEST_METHOD (StartupDoesNotReplaceUnreadableSettings)
+        {
+            TemporarySettings file;
+            file.Write(ValidSettings);
+            const auto original = file.Read();
+            wil::unique_hfile locked(CreateFileW(file.path.c_str(), GENERIC_READ, 0, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
+            Assert::IsTrue(static_cast<bool>(locked));
+            LightSwitchConfig config;
+            config.lightTime = 123;
+            std::wstring error;
+            Assert::IsFalse(TryInitializeLightSwitchSettings(file.path, config, error));
+            Assert::IsFalse(error.empty());
+            Assert::AreEqual(123, config.lightTime);
+            locked.reset();
+            Assert::AreEqual(original, file.Read());
+        }
+
+        TEST_METHOD (StartupDoesNotTreatAMissingParentAsAMissingSettingsFile)
+        {
+            TemporarySettings file;
+            Assert::IsTrue(DeleteFileW(file.path.c_str()));
+            LightSwitchConfig config;
+            std::wstring error;
+            Assert::IsFalse(TryInitializeLightSwitchSettings(file.path + L"\\settings.json", config, error));
+            Assert::IsFalse(error.empty());
+            Assert::AreEqual(INVALID_FILE_ATTRIBUTES, GetFileAttributesW(file.path.c_str()));
+        }
+
+        TEST_METHOD (ConcurrentStartupPublishesACompleteSettingsFile)
+        {
+            Apartment apartment;
+            TemporarySettings file;
+            Assert::IsTrue(DeleteFileW(file.path.c_str()));
+            std::promise<void> start;
+            auto ready = start.get_future().share();
+            std::vector<std::future<bool>> operations;
+            for (int index = 0; index < 12; ++index)
+            {
+                operations.push_back(std::async(std::launch::async, [&, ready]() {
+                    ready.wait();
+                    LightSwitchConfig config;
+                    std::wstring error;
+                    return TryInitializeLightSwitchSettings(file.path, config, error) &&
+                           config.scheduleMode == ScheduleMode::Off && config.changeSystem && config.changeApps;
+                }));
+            }
+            start.set_value();
+            for (auto& operation : operations)
+                Assert::IsTrue(operation.get());
+            Assert::IsTrue(json::from_file(file.path).has_value());
+            WIN32_FIND_DATAW entry{};
+            const auto leftover = FindFirstFileW((file.path + L".init.*").c_str(), &entry);
+            if (leftover != INVALID_HANDLE_VALUE)
+                FindClose(leftover);
+            Assert::IsTrue(leftover == INVALID_HANDLE_VALUE);
+        }
+
         TEST_METHOD (ParsesExistingSettingsWithoutChangingTheSchema)
         {
             Apartment apartment;
@@ -79,6 +227,11 @@ namespace LightSwitchServiceUnitTests
             LightSwitchConfig config;
             std::wstring error;
             Assert::IsFalse(TryParseLightSwitchConfig(document, config, error));
+            TemporarySettings file;
+            file.Write(document.Stringify().c_str());
+            const auto original = file.Read();
+            Assert::IsFalse(TryInitializeLightSwitchSettings(file.path, config, error));
+            Assert::AreEqual(original, file.Read());
         }
 
         TEST_METHOD (SchedulePatchRetainsUnrelatedFieldsAndCanBeReadBack)
@@ -106,6 +259,8 @@ namespace LightSwitchServiceUnitTests
             file.Write(L"not json");
             LightSwitchConfig config;
             std::wstring error;
+            Assert::IsFalse(TryInitializeLightSwitchSettings(file.path, config, error));
+            Assert::AreEqual("not json", file.Read().c_str());
             Assert::IsFalse(TryPatchLightSwitchScheduleMode(file.path, ScheduleMode::Off, config, error));
             std::ifstream input(file.path.c_str(), std::ios::binary);
             const std::string remaining{ std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>() };

--- a/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/StateManagerTests.cpp
+++ b/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/StateManagerTests.cpp
@@ -5,6 +5,7 @@
 #include <CppUnitTest.h>
 #include "LightSwitchStateManager.h"
 #include <future>
+#include <iterator>
 #include <vector>
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
@@ -25,6 +26,7 @@ namespace LightSwitchServiceUnitTests
             bool failAppsWrite = false;
             int writes = 0;
             int settingsReads = 0;
+            int sunCalculations = 0;
             std::vector<bool> notifications;
             std::function<void(bool)> afterWrite;
 
@@ -71,6 +73,7 @@ namespace LightSwitchServiceUnitTests
                 dependencies.localTime = [this]() { return now; };
                 dependencies.notifyThemeChanged = [this](bool light) { notifications.push_back(light); };
                 dependencies.updateSunTimes = [this](const LightSwitchConfig&, const SYSTEMTIME&) {
+                    ++sunCalculations;
                     return std::pair{ config.lightTime, config.darkTime };
                 };
                 return dependencies;
@@ -149,6 +152,93 @@ namespace LightSwitchServiceUnitTests
             Assert::IsTrue(*environment.system);
         }
 
+        TEST_METHOD (ToggleAfterClockBoundaryStartsANewOverride)
+        {
+            for (const bool hadOverride : { false, true })
+            {
+                Environment environment;
+                environment.now.wHour = 19;
+                environment.now.wMinute = 59;
+                LightSwitchStateManager manager(environment.Dependencies());
+                Assert::IsTrue(manager.OnSettingsChanged().success);
+                if (hadOverride)
+                    Assert::IsTrue(manager.SetTheme(false).status.manualOverride);
+                else
+                    environment.system = environment.apps = false;
+
+                environment.now.wHour = 20;
+                environment.now.wMinute = 0;
+                const auto first = manager.ToggleTheme();
+                Assert::IsTrue(first.success);
+                Assert::IsTrue(first.status.manualOverride);
+                Assert::IsTrue(*first.status.systemLight);
+                Assert::IsTrue(*first.status.appsLight);
+                manager.OnTick();
+                Assert::IsTrue(manager.GetState().isManualOverride);
+                Assert::IsTrue(*environment.system);
+
+                const auto second = manager.ToggleTheme();
+                Assert::IsTrue(second.success);
+                Assert::IsFalse(second.status.manualOverride);
+                Assert::IsFalse(*second.status.systemLight);
+                Assert::IsFalse(*second.status.appsLight);
+            }
+        }
+
+        TEST_METHOD (ToggleToTheNewClockPlanDoesNotCancelTheFollowingToggle)
+        {
+            Environment environment;
+            environment.now.wHour = 19;
+            environment.now.wMinute = 59;
+            LightSwitchStateManager manager(environment.Dependencies());
+            Assert::IsTrue(manager.OnSettingsChanged().success);
+            environment.now.wHour = 20;
+            environment.now.wMinute = 0;
+            const auto first = manager.ToggleTheme();
+            Assert::IsTrue(first.success);
+            Assert::IsFalse(first.status.manualOverride);
+            Assert::IsFalse(*first.status.systemLight);
+            const auto second = manager.ToggleTheme();
+            Assert::IsTrue(second.success);
+            Assert::IsTrue(second.status.manualOverride);
+            Assert::IsTrue(*second.status.systemLight);
+            Assert::IsTrue(*second.status.appsLight);
+        }
+
+        TEST_METHOD (ToggleAfterSolarBoundaryAcrossMidnightUsesANewBaseline)
+        {
+            for (const bool hadOverride : { false, true })
+            {
+                Environment environment;
+                environment.config.scheduleMode = ScheduleMode::SunsetToSunrise;
+                environment.config.latitude = L"22";
+                environment.config.longitude = L"114";
+                environment.config.darkTime = 23 * 60 + 50;
+                environment.config.sunset_offset = 20;
+                environment.now.wHour = 23;
+                environment.now.wMinute = 59;
+                LightSwitchStateManager manager(environment.Dependencies());
+                Assert::IsTrue(manager.OnSettingsChanged().success);
+                if (hadOverride)
+                    Assert::IsTrue(manager.SetTheme(false).status.manualOverride);
+
+                ++environment.now.wDay;
+                environment.now.wHour = 0;
+                environment.now.wMinute = 10;
+                const auto first = manager.ToggleTheme();
+                Assert::IsTrue(first.success);
+                Assert::AreEqual(hadOverride, first.status.manualOverride);
+                Assert::AreEqual(hadOverride, *first.status.systemLight);
+                manager.OnTick();
+                Assert::AreEqual(hadOverride, manager.GetState().isManualOverride);
+                const auto second = manager.ToggleTheme();
+                Assert::IsTrue(second.success);
+                Assert::AreEqual(!hadOverride, second.status.manualOverride);
+                Assert::AreEqual(!hadOverride, *second.status.systemLight);
+                Assert::AreEqual(!hadOverride, *second.status.appsLight);
+            }
+        }
+
         TEST_METHOD (DuplicateSettingsNotificationDoesNotClearManualOverride)
         {
             Environment environment;
@@ -197,6 +287,101 @@ namespace LightSwitchServiceUnitTests
             Assert::IsTrue(manager.GetState().isManualOverride);
         }
 
+        TEST_METHOD (UnchangedSettingsPreserveExternalThemeBeforeMinuteDetection)
+        {
+            Environment environment;
+            LightSwitchStateManager manager(environment.Dependencies());
+            Assert::IsTrue(manager.OnSettingsChanged().success);
+            environment.system = environment.apps = false;
+            manager.GetStatusSnapshot();
+            const auto result = manager.OnSettingsChanged();
+            Assert::IsTrue(result.success);
+            Assert::IsTrue(result.status.manualOverride);
+            Assert::IsFalse(*result.status.systemLight);
+            Assert::IsFalse(*result.status.appsLight);
+            Assert::AreEqual(0, environment.writes);
+        }
+
+        TEST_METHOD (FailedSettingsCommandDoesNotConsumeAnExternalThemeChange)
+        {
+            Environment environment;
+            LightSwitchStateManager manager(environment.Dependencies());
+            Assert::IsTrue(manager.OnSettingsChanged().success);
+            environment.system = environment.apps = false;
+            environment.readableSettings = false;
+            Assert::IsFalse(manager.SetTheme(true).success);
+            environment.readableSettings = true;
+            const auto result = manager.OnSettingsChanged();
+            Assert::IsTrue(result.success);
+            Assert::IsTrue(result.status.manualOverride);
+            Assert::IsFalse(*result.status.systemLight);
+            Assert::AreEqual(0, environment.writes);
+        }
+
+        TEST_METHOD (UnchangedSettingsAtANaturalBoundaryApplyThePlan)
+        {
+            Environment environment;
+            environment.now.wHour = 19;
+            environment.now.wMinute = 59;
+            LightSwitchStateManager manager(environment.Dependencies());
+            Assert::IsTrue(manager.OnSettingsChanged().success);
+            environment.now.wHour = 20;
+            environment.now.wMinute = 0;
+            const auto result = manager.OnSettingsChanged();
+            Assert::IsTrue(result.success);
+            Assert::IsFalse(result.status.manualOverride);
+            Assert::IsFalse(*result.status.systemLight);
+            Assert::IsFalse(*result.status.appsLight);
+            Assert::AreEqual(2, environment.writes);
+            Assert::AreEqual(size_t{ 1 }, environment.notifications.size());
+        }
+
+        TEST_METHOD (MinuteDetectionDoesNotMistakeANaturalBoundaryForAnExternalEdit)
+        {
+            Environment environment;
+            environment.now.wHour = 19;
+            environment.now.wMinute = 59;
+            LightSwitchStateManager manager(environment.Dependencies());
+            manager.SyncInitialThemeState();
+            environment.now.wHour = 20;
+            environment.now.wMinute = 0;
+            manager.DetectExternalThemeChange();
+            Assert::IsFalse(manager.GetState().isManualOverride);
+            Assert::IsTrue(environment.notifications.empty());
+            manager.OnTick();
+            Assert::IsFalse(*environment.system);
+            Assert::AreEqual(size_t{ 1 }, environment.notifications.size());
+        }
+
+        TEST_METHOD (ARealSettingsChangeAppliesBeforePendingExternalThemeDetection)
+        {
+            Environment environment;
+            LightSwitchStateManager manager(environment.Dependencies());
+            Assert::IsTrue(manager.OnSettingsChanged().success);
+            environment.system = environment.apps = false;
+            environment.config.darkTime = 23 * 60;
+            const auto result = manager.OnSettingsChanged();
+            Assert::IsTrue(result.success);
+            Assert::IsFalse(result.status.manualOverride);
+            Assert::IsTrue(*result.status.systemLight);
+            Assert::IsTrue(*result.status.appsLight);
+        }
+
+        TEST_METHOD (ExternalChangesToUnselectedTargetsDoNotCreateAnOverride)
+        {
+            Environment environment;
+            environment.config.changeApps = false;
+            LightSwitchStateManager manager(environment.Dependencies());
+            Assert::IsTrue(manager.OnSettingsChanged().success);
+            environment.apps = false;
+            const auto result = manager.OnSettingsChanged();
+            Assert::IsTrue(result.success);
+            Assert::IsFalse(result.status.manualOverride);
+            Assert::IsTrue(*result.status.systemLight);
+            Assert::IsFalse(*result.status.appsLight);
+            Assert::AreEqual(0, environment.writes);
+        }
+
         TEST_METHOD (NightLightModeReadsTheActualStateBeforeApplyingAndIgnoresDuplicateNotifications)
         {
             Environment environment;
@@ -213,6 +398,167 @@ namespace LightSwitchServiceUnitTests
             manager.OnNightLightChange();
             Assert::IsFalse(manager.GetState().isManualOverride);
             Assert::IsTrue(*environment.system);
+        }
+
+        TEST_METHOD (ExplicitThemeAfterNightLightBoundarySurvivesDelayedNotification)
+        {
+            for (const bool initiallyOn : { false, true })
+            {
+                Environment environment;
+                environment.config.scheduleMode = ScheduleMode::FollowNightLight;
+                environment.nightLight = initiallyOn;
+                LightSwitchStateManager manager(environment.Dependencies());
+                Assert::IsTrue(manager.OnSettingsChanged().success);
+
+                // The boundary occurs before the command, but the observer is delayed.
+                environment.nightLight = !initiallyOn;
+                const auto result = manager.SetTheme(!initiallyOn);
+                Assert::IsTrue(result.success);
+                Assert::IsTrue(result.status.manualOverride);
+                manager.OnNightLightChange();
+                Assert::IsTrue(manager.GetState().isManualOverride);
+                Assert::AreEqual(!initiallyOn, *environment.system);
+                Assert::AreEqual(!initiallyOn, *environment.apps);
+
+                environment.nightLight = initiallyOn;
+                manager.OnNightLightChange();
+                Assert::IsFalse(manager.GetState().isManualOverride);
+            }
+        }
+
+        TEST_METHOD (ExplicitThemeSamplesNightLightAfterThemeWritesFinish)
+        {
+            Environment environment;
+            environment.config.scheduleMode = ScheduleMode::FollowNightLight;
+            LightSwitchStateManager manager(environment.Dependencies());
+            Assert::IsTrue(manager.OnSettingsChanged().success);
+            environment.system = environment.apps = false;
+            environment.afterWrite = [&](bool) { environment.nightLight = true; };
+            Assert::IsTrue(manager.SetTheme(true).status.manualOverride);
+            manager.OnNightLightChange();
+            Assert::IsTrue(manager.GetState().isManualOverride);
+            Assert::IsTrue(*environment.system);
+            Assert::IsTrue(*environment.apps);
+        }
+
+        TEST_METHOD (ToggleAfterNightLightBoundaryStartsANewOverride)
+        {
+            Environment environment;
+            environment.config.scheduleMode = ScheduleMode::FollowNightLight;
+            environment.nightLight = true;
+            LightSwitchStateManager manager(environment.Dependencies());
+            Assert::IsTrue(manager.OnSettingsChanged().success);
+            Assert::IsTrue(manager.SetTheme(true).status.manualOverride);
+            environment.nightLight = false;
+            const auto result = manager.ToggleTheme();
+            Assert::IsTrue(result.success);
+            Assert::IsTrue(result.status.manualOverride);
+            Assert::IsFalse(*result.status.systemLight);
+            manager.OnNightLightChange();
+            Assert::IsTrue(manager.GetState().isManualOverride);
+            Assert::IsFalse(*environment.system);
+
+            // With no further transition, the next toggle releases that override.
+            const auto release = manager.ToggleTheme();
+            Assert::IsTrue(release.success);
+            Assert::IsFalse(release.status.manualOverride);
+            Assert::IsTrue(*release.status.systemLight);
+        }
+
+        TEST_METHOD (ToggleToTheNewNightLightPlanDoesNotCancelTheFollowingToggle)
+        {
+            Environment environment;
+            environment.config.scheduleMode = ScheduleMode::FollowNightLight;
+            environment.nightLight = true;
+            LightSwitchStateManager manager(environment.Dependencies());
+            Assert::IsTrue(manager.OnSettingsChanged().success);
+            environment.nightLight = false;
+            const auto first = manager.ToggleTheme();
+            Assert::IsTrue(first.success);
+            Assert::IsFalse(first.status.manualOverride);
+            Assert::IsTrue(*first.status.systemLight);
+            manager.OnNightLightChange();
+            const auto second = manager.ToggleTheme();
+            Assert::IsTrue(second.success);
+            Assert::IsTrue(second.status.manualOverride);
+            Assert::IsFalse(*second.status.systemLight);
+            Assert::IsFalse(*second.status.appsLight);
+        }
+
+        TEST_METHOD (DuplicateNightLightNotificationPreservesAnExternalThemeChoice)
+        {
+            Environment environment;
+            environment.config.scheduleMode = ScheduleMode::FollowNightLight;
+            LightSwitchStateManager manager(environment.Dependencies());
+            Assert::IsTrue(manager.OnSettingsChanged().success);
+            environment.system = environment.apps = false;
+            manager.OnNightLightChange();
+            Assert::IsTrue(manager.GetState().isManualOverride);
+            Assert::IsFalse(*environment.system);
+            Assert::AreEqual(0, environment.writes);
+
+            environment.nightLight = true;
+            manager.OnNightLightChange();
+            Assert::IsFalse(manager.GetState().isManualOverride);
+            environment.nightLight = false;
+            manager.OnNightLightChange();
+            Assert::IsTrue(*environment.system);
+            Assert::IsTrue(*environment.apps);
+        }
+
+        TEST_METHOD (ExternalThemeDetectionUsesTheCurrentNightLightBaseline)
+        {
+            Environment environment;
+            environment.config.scheduleMode = ScheduleMode::FollowNightLight;
+            environment.nightLight = true;
+            environment.failSystemWrite = environment.failAppsWrite = true;
+            LightSwitchStateManager manager(environment.Dependencies());
+            Assert::IsFalse(manager.OnSettingsChanged().success);
+
+            // Windows recovers, Night Light changes, and an external editor chooses
+            // dark before the delayed Night Light callback acquires the state lock.
+            environment.failSystemWrite = environment.failAppsWrite = false;
+            environment.nightLight = false;
+            environment.system = environment.apps = false;
+            manager.DetectExternalThemeChange();
+            Assert::IsTrue(manager.GetState().isManualOverride);
+            manager.OnNightLightChange();
+            Assert::IsTrue(manager.GetState().isManualOverride);
+            Assert::IsFalse(*environment.system);
+            Assert::IsFalse(*environment.apps);
+            environment.nightLight = true;
+            manager.OnNightLightChange();
+            Assert::IsFalse(manager.GetState().isManualOverride);
+        }
+
+        TEST_METHOD (MinuteDetectionLeavesANightLightTransitionForTheObserver)
+        {
+            Environment environment;
+            environment.config.scheduleMode = ScheduleMode::FollowNightLight;
+            environment.nightLight = true;
+            LightSwitchStateManager manager(environment.Dependencies());
+            Assert::IsTrue(manager.OnSettingsChanged().success);
+            environment.nightLight = false;
+            manager.DetectExternalThemeChange();
+            Assert::IsFalse(manager.GetState().isManualOverride);
+            manager.OnNightLightChange();
+            Assert::IsFalse(manager.GetState().isManualOverride);
+            Assert::IsTrue(*environment.system);
+            Assert::IsTrue(*environment.apps);
+        }
+
+        TEST_METHOD (NightLightNotificationWithASettingsChangeAppliesTheNewPlan)
+        {
+            Environment environment;
+            environment.config.scheduleMode = ScheduleMode::FollowNightLight;
+            LightSwitchStateManager manager(environment.Dependencies());
+            Assert::IsTrue(manager.OnSettingsChanged().success);
+            environment.system = environment.apps = false;
+            environment.config.scheduleMode = ScheduleMode::FixedHours;
+            manager.OnNightLightChange();
+            Assert::IsFalse(manager.GetState().isManualOverride);
+            Assert::IsTrue(*environment.system);
+            Assert::IsTrue(*environment.apps);
         }
 
         TEST_METHOD (RepeatedOperationsRetainNewlyCalculatedSunBoundaries)
@@ -233,6 +579,215 @@ namespace LightSwitchServiceUnitTests
             Assert::IsTrue(manager.OnSettingsChanged().status.manualOverride);
             Assert::AreEqual(900, manager.GetState().effectiveLightMinutes);
             Assert::AreEqual(1, calculations);
+        }
+
+        TEST_METHOD (OverrideExpiresAcrossADayOfMissedBoundaries)
+        {
+            Environment environment;
+            environment.now.wHour = 21;
+            LightSwitchStateManager manager(environment.Dependencies());
+            manager.SyncInitialThemeState();
+            Assert::IsTrue(manager.SetTheme(true).status.manualOverride);
+            ++environment.now.wDay;
+            environment.now.wHour = 22;
+            manager.DetectExternalThemeChange();
+            manager.OnTick();
+            Assert::IsFalse(manager.GetState().isManualOverride);
+            Assert::IsFalse(*environment.system);
+            Assert::IsFalse(*environment.apps);
+        }
+
+        TEST_METHOD (MissedBoundariesIncludeMonthYearAndLeapDayTransitions)
+        {
+            const SYSTEMTIME previousDates[] = {
+                { 2026, 9, 0, 30, 21, 0, 0, 0 },
+                { 2026, 12, 0, 31, 21, 0, 0, 0 },
+                { 2028, 2, 0, 28, 21, 0, 0, 0 },
+                { 2028, 2, 0, 29, 21, 0, 0, 0 },
+            };
+            const SYSTEMTIME followingDates[] = {
+                { 2026, 10, 0, 1, 22, 0, 0, 0 },
+                { 2027, 1, 0, 1, 22, 0, 0, 0 },
+                { 2028, 2, 0, 29, 22, 0, 0, 0 },
+                { 2028, 3, 0, 1, 22, 0, 0, 0 },
+            };
+            for (size_t index = 0; index < std::size(previousDates); ++index)
+            {
+                Environment environment;
+                environment.now = previousDates[index];
+                LightSwitchStateManager manager(environment.Dependencies());
+                Assert::IsTrue(manager.SetTheme(true).status.manualOverride);
+                environment.now = followingDates[index];
+                manager.OnTick();
+                Assert::IsFalse(manager.GetState().isManualOverride);
+                Assert::IsFalse(*environment.system);
+            }
+        }
+
+        TEST_METHOD (BackwardClockAdjustmentPreservesOverrideAndRebasesNextBoundary)
+        {
+            Environment environment;
+            environment.now.wHour = 1;
+            environment.now.wMinute = 59;
+            LightSwitchStateManager manager(environment.Dependencies());
+            Assert::IsTrue(manager.SetTheme(true).status.manualOverride);
+            environment.now.wMinute = 0;
+            manager.DetectExternalThemeChange();
+            manager.OnTick();
+            Assert::IsTrue(manager.GetState().isManualOverride);
+            Assert::IsTrue(*environment.system);
+            environment.now.wHour = 8;
+            manager.OnTick();
+            Assert::IsFalse(manager.GetState().isManualOverride);
+        }
+
+        TEST_METHOD (MovingTheCalendarBackwardDoesNotInventAForwardBoundary)
+        {
+            Environment environment;
+            environment.now.wHour = 21;
+            LightSwitchStateManager manager(environment.Dependencies());
+            Assert::IsTrue(manager.SetTheme(true).status.manualOverride);
+            --environment.now.wDay;
+            environment.now.wHour = 22;
+            manager.OnTick();
+            Assert::IsTrue(manager.GetState().isManualOverride);
+            ++environment.now.wDay;
+            environment.now.wHour = 8;
+            manager.OnTick();
+            Assert::IsFalse(manager.GetState().isManualOverride);
+        }
+
+        TEST_METHOD (MidnightWithoutANewBoundaryDoesNotClearAnOverride)
+        {
+            Environment environment;
+            environment.now.wHour = 20;
+            LightSwitchStateManager manager(environment.Dependencies());
+            Assert::IsTrue(manager.SetTheme(true).status.manualOverride);
+            ++environment.now.wDay;
+            environment.now.wHour = 0;
+            manager.OnTick();
+            Assert::IsTrue(manager.GetState().isManualOverride);
+            environment.now.wHour = 8;
+            manager.OnTick();
+            Assert::IsFalse(manager.GetState().isManualOverride);
+        }
+
+        TEST_METHOD (AConfiguredMidnightBoundaryEndsAnOverride)
+        {
+            Environment environment;
+            environment.config.darkTime = 0;
+            environment.now.wHour = 23;
+            environment.now.wMinute = 59;
+            LightSwitchStateManager manager(environment.Dependencies());
+            Assert::IsTrue(manager.SetTheme(false).status.manualOverride);
+            ++environment.now.wDay;
+            environment.now.wHour = 0;
+            environment.now.wMinute = 0;
+            manager.OnTick();
+            Assert::IsFalse(manager.GetState().isManualOverride);
+            Assert::IsFalse(*environment.system);
+        }
+
+        TEST_METHOD (SunCacheUsesTheCompleteDate)
+        {
+            Environment environment;
+            environment.config.scheduleMode = ScheduleMode::SunsetToSunrise;
+            environment.config.latitude = L"22";
+            environment.config.longitude = L"114";
+            LightSwitchStateManager manager(environment.Dependencies());
+            manager.SyncInitialThemeState();
+            Assert::AreEqual(1, environment.sunCalculations);
+            manager.OnTick();
+            Assert::AreEqual(1, environment.sunCalculations);
+            ++environment.now.wMonth;
+            manager.OnTick();
+            Assert::AreEqual(2, environment.sunCalculations);
+            ++environment.now.wYear;
+            manager.OnTick();
+            Assert::AreEqual(3, environment.sunCalculations);
+        }
+
+        TEST_METHOD (SolarBoundariesUseTheirOwnDatesAcrossMidnight)
+        {
+            for (const bool hadRemainingBoundary : { false, true })
+            {
+                Environment environment;
+                environment.config.scheduleMode = ScheduleMode::SunsetToSunrise;
+                environment.config.latitude = L"22";
+                environment.config.longitude = L"114";
+                environment.config.darkTime = (hadRemainingBoundary ? 23 : 21) * 60;
+                environment.now.wHour = 22;
+                LightSwitchStateManager manager(environment.Dependencies());
+                Assert::IsTrue(manager.SetTheme(!hadRemainingBoundary).status.manualOverride);
+                ++environment.now.wDay;
+                environment.now.wHour = 0;
+                environment.config.darkTime = (hadRemainingBoundary ? 21 : 23) * 60;
+                manager.OnTick();
+                Assert::AreEqual(!hadRemainingBoundary, manager.GetState().isManualOverride);
+                Assert::AreEqual(2, environment.sunCalculations);
+            }
+        }
+
+        TEST_METHOD (SunsetOffsetPastMidnightExpiresAtTheNormalizedBoundary)
+        {
+            Environment environment;
+            environment.config.scheduleMode = ScheduleMode::SunsetToSunrise;
+            environment.config.latitude = L"22";
+            environment.config.longitude = L"114";
+            environment.config.darkTime = 21 * 60;
+            environment.config.sunset_offset = 4 * 60;
+            environment.now.wHour = 0;
+            environment.now.wMinute = 59;
+            LightSwitchStateManager manager(environment.Dependencies());
+            Assert::IsTrue(manager.SetTheme(false).status.manualOverride);
+            Assert::AreEqual(60, manager.GetState().effectiveDarkMinutes);
+            environment.now.wHour = 1;
+            environment.now.wMinute = 0;
+            manager.OnTick();
+            Assert::IsFalse(manager.GetState().isManualOverride);
+            Assert::IsFalse(*environment.system);
+        }
+
+        TEST_METHOD (SunriseOffsetBeforeMidnightExpiresAtTheNormalizedBoundary)
+        {
+            Environment environment;
+            environment.config.scheduleMode = ScheduleMode::SunsetToSunrise;
+            environment.config.latitude = L"22";
+            environment.config.longitude = L"114";
+            environment.config.lightTime = 0;
+            environment.config.sunrise_offset = -1;
+            environment.now.wHour = 23;
+            environment.now.wMinute = 58;
+            LightSwitchStateManager manager(environment.Dependencies());
+            Assert::IsTrue(manager.SetTheme(true).status.manualOverride);
+            Assert::AreEqual(1439, manager.GetState().effectiveLightMinutes);
+            environment.now.wMinute = 59;
+            manager.OnTick();
+            Assert::IsFalse(manager.GetState().isManualOverride);
+            Assert::IsTrue(*environment.system);
+        }
+
+        TEST_METHOD (InvalidDatesDoNotInventBoundariesOrSunCalculations)
+        {
+            Environment environment;
+            environment.now = SYSTEMTIME{};
+            environment.now.wHour = 1;
+            environment.now.wMinute = 59;
+            LightSwitchStateManager manager(environment.Dependencies());
+            Assert::IsTrue(manager.SetTheme(true).status.manualOverride);
+            environment.now.wMinute = 0;
+            manager.OnTick();
+            Assert::IsTrue(manager.GetState().isManualOverride);
+            environment.config.scheduleMode = ScheduleMode::SunsetToSunrise;
+            environment.config.latitude = L"22";
+            environment.config.longitude = L"114";
+            manager.OnTick();
+            Assert::AreEqual(0, environment.sunCalculations);
+            environment.now.wYear = 2026;
+            environment.now.wMonth = 9;
+            environment.now.wDay = 8;
+            manager.OnTick();
+            Assert::AreEqual(1, environment.sunCalculations);
         }
 
         TEST_METHOD (NoTargetsAndUnreadableThemesDoNotMutateWindows)
@@ -275,6 +830,14 @@ namespace LightSwitchServiceUnitTests
             Assert::AreEqual(L"THEME_WRITE_FAILED", result.errorCode.c_str());
             Assert::IsFalse(*result.status.systemLight);
             Assert::IsTrue(*result.status.appsLight);
+
+            // The service's partial write is not an external manual override.
+            environment.failAppsWrite = false;
+            const auto retry = manager.OnSettingsChanged();
+            Assert::IsTrue(retry.success);
+            Assert::IsFalse(retry.status.manualOverride);
+            Assert::IsFalse(*retry.status.systemLight);
+            Assert::IsFalse(*retry.status.appsLight);
         }
 
         TEST_METHOD (EachCommandUsesOneConfigurationSnapshot)

--- a/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/StateManagerTests.cpp
+++ b/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/StateManagerTests.cpp
@@ -22,6 +22,8 @@ namespace LightSwitchServiceUnitTests
             SYSTEMTIME now{};
             bool nightLight = false;
             bool readableSettings = true;
+            bool failSystemRead = false;
+            bool failAppsRead = false;
             bool failSystemWrite = false;
             bool failAppsWrite = false;
             int writes = 0;
@@ -55,7 +57,7 @@ namespace LightSwitchServiceUnitTests
                 };
                 dependencies.readTheme = [this](bool systemTarget, bool& light) -> LSTATUS {
                     const auto value = systemTarget ? system : apps;
-                    if (!value)
+                    if ((systemTarget ? failSystemRead : failAppsRead) || !value)
                         return ERROR_ACCESS_DENIED;
                     light = *value;
                     return ERROR_SUCCESS;
@@ -126,8 +128,10 @@ namespace LightSwitchServiceUnitTests
         {
             Environment environment;
             environment.now.wHour = 21;
-            environment.apps = false;
+            environment.system = environment.apps = false;
             LightSwitchStateManager manager(environment.Dependencies());
+            manager.SyncInitialThemeState();
+            environment.system = true;
             manager.DetectExternalThemeChange();
             Assert::IsTrue(manager.GetState().isManualOverride);
             const auto result = manager.ToggleTheme();
@@ -415,13 +419,17 @@ namespace LightSwitchServiceUnitTests
                 const auto result = manager.SetTheme(!initiallyOn);
                 Assert::IsTrue(result.success);
                 Assert::IsTrue(result.status.manualOverride);
+                manager.DetectExternalThemeChange();
+                manager.OnTick();
+                Assert::IsTrue(manager.OnSettingsChanged().status.manualOverride);
                 manager.OnNightLightChange();
                 Assert::IsTrue(manager.GetState().isManualOverride);
                 Assert::AreEqual(!initiallyOn, *environment.system);
                 Assert::AreEqual(!initiallyOn, *environment.apps);
 
                 environment.nightLight = initiallyOn;
-                manager.OnNightLightChange();
+                manager.DetectExternalThemeChange();
+                manager.OnTick();
                 Assert::IsFalse(manager.GetState().isManualOverride);
             }
         }
@@ -454,6 +462,9 @@ namespace LightSwitchServiceUnitTests
             Assert::IsTrue(result.success);
             Assert::IsTrue(result.status.manualOverride);
             Assert::IsFalse(*result.status.systemLight);
+            manager.DetectExternalThemeChange();
+            manager.OnTick();
+            Assert::IsTrue(manager.OnSettingsChanged().status.manualOverride);
             manager.OnNightLightChange();
             Assert::IsTrue(manager.GetState().isManualOverride);
             Assert::IsFalse(*environment.system);
@@ -508,27 +519,110 @@ namespace LightSwitchServiceUnitTests
 
         TEST_METHOD (ExternalThemeDetectionUsesTheCurrentNightLightBaseline)
         {
+            for (const bool settingsNotificationFirst : { false, true })
+            {
+                Environment environment;
+                environment.config.scheduleMode = ScheduleMode::FollowNightLight;
+                environment.nightLight = true;
+                environment.failSystemWrite = environment.failAppsWrite = true;
+                LightSwitchStateManager manager(environment.Dependencies());
+                Assert::IsFalse(manager.OnSettingsChanged().success);
+
+                // Windows recovers, Night Light changes, and an external editor chooses
+                // dark before the delayed Night Light callback acquires the state lock.
+                environment.failSystemWrite = environment.failAppsWrite = false;
+                environment.nightLight = false;
+                environment.system = environment.apps = false;
+                if (settingsNotificationFirst)
+                    Assert::IsTrue(manager.OnSettingsChanged().success);
+                else
+                {
+                    manager.DetectExternalThemeChange();
+                    manager.OnTick();
+                }
+                Assert::IsTrue(manager.GetState().isManualOverride);
+                Assert::IsTrue(manager.OnSettingsChanged().status.manualOverride);
+                manager.OnNightLightChange();
+                Assert::IsTrue(manager.GetState().isManualOverride);
+                Assert::IsFalse(*environment.system);
+                Assert::IsFalse(*environment.apps);
+                environment.nightLight = true;
+                manager.DetectExternalThemeChange();
+                manager.OnTick();
+                Assert::IsFalse(manager.GetState().isManualOverride);
+            }
+        }
+
+        TEST_METHOD (NightLightPlanRetriesAWriteFailureWithoutAnotherNotification)
+        {
             Environment environment;
             environment.config.scheduleMode = ScheduleMode::FollowNightLight;
             environment.nightLight = true;
             environment.failSystemWrite = environment.failAppsWrite = true;
             LightSwitchStateManager manager(environment.Dependencies());
             Assert::IsFalse(manager.OnSettingsChanged().success);
+            Assert::AreEqual(2, environment.writes);
 
-            // Windows recovers, Night Light changes, and an external editor chooses
-            // dark before the delayed Night Light callback acquires the state lock.
             environment.failSystemWrite = environment.failAppsWrite = false;
-            environment.nightLight = false;
-            environment.system = environment.apps = false;
+            ++environment.now.wMinute;
             manager.DetectExternalThemeChange();
-            Assert::IsTrue(manager.GetState().isManualOverride);
-            manager.OnNightLightChange();
-            Assert::IsTrue(manager.GetState().isManualOverride);
+            manager.OnTick();
+
+            Assert::IsFalse(manager.GetState().isManualOverride);
             Assert::IsFalse(*environment.system);
             Assert::IsFalse(*environment.apps);
-            environment.nightLight = true;
-            manager.OnNightLightChange();
-            Assert::IsFalse(manager.GetState().isManualOverride);
+            Assert::AreEqual(4, environment.writes);
+            Assert::AreEqual(size_t{ 1 }, environment.notifications.size());
+        }
+
+        TEST_METHOD (NightLightTransitionRecoversFromATemporarySettingsReadFailure)
+        {
+            for (const bool hadOverride : { false, true })
+            {
+                Environment environment;
+                environment.config.scheduleMode = ScheduleMode::FollowNightLight;
+                LightSwitchStateManager manager(environment.Dependencies());
+                manager.SyncInitialThemeState();
+                if (hadOverride)
+                    Assert::IsTrue(manager.SetTheme(false).status.manualOverride);
+
+                // An exclusive file lock need not produce a settings-change event.
+                environment.readableSettings = false;
+                environment.nightLight = true;
+                manager.OnNightLightChange();
+                Assert::IsFalse(manager.GetState().isNightLightActive);
+                environment.readableSettings = true;
+                ++environment.now.wMinute;
+                manager.DetectExternalThemeChange();
+                manager.OnTick();
+
+                Assert::IsTrue(manager.GetState().isNightLightActive);
+                Assert::IsFalse(manager.GetState().isManualOverride);
+                Assert::IsFalse(*environment.system);
+                Assert::IsFalse(*environment.apps);
+            }
+        }
+
+        TEST_METHOD (UnchangedSettingsReconcileAnUnreportedNightLightTransition)
+        {
+            for (const bool hadOverride : { false, true })
+            {
+                Environment environment;
+                environment.config.scheduleMode = ScheduleMode::FollowNightLight;
+                LightSwitchStateManager manager(environment.Dependencies());
+                manager.SyncInitialThemeState();
+                if (hadOverride)
+                    Assert::IsTrue(manager.SetTheme(false).status.manualOverride);
+
+                environment.nightLight = true;
+                const auto result = manager.OnSettingsChanged();
+
+                Assert::IsTrue(result.success);
+                Assert::IsTrue(manager.GetState().isNightLightActive);
+                Assert::IsFalse(result.status.manualOverride);
+                Assert::IsFalse(*result.status.systemLight);
+                Assert::IsFalse(*result.status.appsLight);
+            }
         }
 
         TEST_METHOD (MinuteDetectionLeavesANightLightTransitionForTheObserver)
@@ -819,6 +913,87 @@ namespace LightSwitchServiceUnitTests
             Assert::IsTrue(environment.notifications.empty());
         }
 
+        TEST_METHOD (RecoveringThemeAccessDoesNotInventAnExternalChange)
+        {
+            for (const bool appsInitiallyUnreadable : { false, true })
+            {
+                Environment environment;
+                environment.system = environment.apps = false;
+                environment.failSystemRead = true;
+                environment.failAppsRead = appsInitiallyUnreadable;
+                environment.failSystemWrite = environment.failAppsWrite = true;
+                LightSwitchStateManager manager(environment.Dependencies());
+                manager.SyncInitialThemeState();
+                Assert::AreEqual(2, environment.writes);
+
+                environment.failSystemRead = environment.failAppsRead = false;
+                environment.failSystemWrite = environment.failAppsWrite = false;
+                ++environment.now.wMinute;
+                manager.DetectExternalThemeChange();
+                manager.OnTick();
+
+                Assert::IsFalse(manager.GetState().isManualOverride);
+                Assert::IsTrue(*environment.system);
+                Assert::IsTrue(*environment.apps);
+                Assert::AreEqual(4, environment.writes);
+                Assert::AreEqual(size_t{ 1 }, environment.notifications.size());
+            }
+        }
+
+        TEST_METHOD (UnverifiedScheduledWritesAreNotLaterMistakenForExternalChanges)
+        {
+            Environment environment;
+            environment.config.scheduleMode = ScheduleMode::FollowNightLight;
+            LightSwitchStateManager manager(environment.Dependencies());
+            manager.SyncInitialThemeState();
+
+            environment.afterWrite = [&](bool) {
+                environment.failSystemRead = environment.failAppsRead = true;
+            };
+            environment.nightLight = true;
+            manager.OnNightLightChange();
+            Assert::IsFalse(*environment.system);
+            Assert::IsFalse(*environment.apps);
+            Assert::AreEqual(2, environment.writes);
+
+            environment.afterWrite = nullptr;
+            environment.failSystemRead = environment.failAppsRead = false;
+            environment.nightLight = false;
+            manager.DetectExternalThemeChange();
+            manager.OnTick();
+
+            Assert::IsFalse(manager.GetState().isManualOverride);
+            Assert::IsTrue(*environment.system);
+            Assert::IsTrue(*environment.apps);
+            Assert::AreEqual(4, environment.writes);
+        }
+
+        TEST_METHOD (UnverifiedToggleWritesDoNotInventAnExternalOverride)
+        {
+            Environment environment;
+            LightSwitchStateManager manager(environment.Dependencies());
+            manager.SyncInitialThemeState();
+
+            environment.afterWrite = [&](bool) {
+                environment.failSystemRead = environment.failAppsRead = true;
+            };
+            const auto result = manager.ToggleTheme();
+            Assert::IsFalse(result.success);
+            Assert::IsFalse(*environment.system);
+            Assert::IsFalse(*environment.apps);
+            Assert::AreEqual(2, environment.writes);
+
+            environment.afterWrite = nullptr;
+            environment.failSystemRead = environment.failAppsRead = false;
+            manager.DetectExternalThemeChange();
+            manager.OnTick();
+
+            Assert::IsFalse(manager.GetState().isManualOverride);
+            Assert::IsTrue(*environment.system);
+            Assert::IsTrue(*environment.apps);
+            Assert::AreEqual(4, environment.writes);
+        }
+
         TEST_METHOD (SettingsApplicationReportsAWriteFailure)
         {
             Environment environment;
@@ -833,6 +1008,8 @@ namespace LightSwitchServiceUnitTests
 
             // The service's partial write is not an external manual override.
             environment.failAppsWrite = false;
+            manager.DetectExternalThemeChange();
+            manager.OnTick();
             const auto retry = manager.OnSettingsChanged();
             Assert::IsTrue(retry.success);
             Assert::IsFalse(retry.status.manualOverride);

--- a/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/StateManagerTests.cpp
+++ b/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/StateManagerTests.cpp
@@ -1,0 +1,331 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include <CppUnitTest.h>
+#include "LightSwitchStateManager.h"
+#include <future>
+#include <vector>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace LightSwitchServiceUnitTests
+{
+    namespace
+    {
+        struct Environment
+        {
+            LightSwitchConfig config;
+            std::optional<bool> system = true;
+            std::optional<bool> apps = true;
+            SYSTEMTIME now{};
+            bool nightLight = false;
+            bool readableSettings = true;
+            bool failSystemWrite = false;
+            bool failAppsWrite = false;
+            int writes = 0;
+            int settingsReads = 0;
+            std::vector<bool> notifications;
+            std::function<void(bool)> afterWrite;
+
+            Environment()
+            {
+                config.changeSystem = true;
+                config.changeApps = true;
+                now.wYear = 2026;
+                now.wMonth = 9;
+                now.wDay = 8;
+                now.wHour = 12;
+            }
+
+            LightSwitchStateManagerDependencies Dependencies()
+            {
+                LightSwitchStateManagerDependencies dependencies;
+                dependencies.loadSettings = [this](LightSwitchConfig& value, std::wstring& error) {
+                    ++settingsReads;
+                    if (!readableSettings)
+                    {
+                        error = L"Settings are unavailable.";
+                        return false;
+                    }
+                    value = config;
+                    return true;
+                };
+                dependencies.readTheme = [this](bool systemTarget, bool& light) -> LSTATUS {
+                    const auto value = systemTarget ? system : apps;
+                    if (!value)
+                        return ERROR_ACCESS_DENIED;
+                    light = *value;
+                    return ERROR_SUCCESS;
+                };
+                dependencies.writeTheme = [this](bool systemTarget, bool light) -> LSTATUS {
+                    ++writes;
+                    if (systemTarget ? failSystemWrite : failAppsWrite)
+                        return ERROR_ACCESS_DENIED;
+                    (systemTarget ? system : apps) = light;
+                    if (afterWrite)
+                        afterWrite(systemTarget);
+                    return ERROR_SUCCESS;
+                };
+                dependencies.readNightLight = [this]() { return nightLight; };
+                dependencies.localTime = [this]() { return now; };
+                dependencies.notifyThemeChanged = [this](bool light) { notifications.push_back(light); };
+                dependencies.updateSunTimes = [this](const LightSwitchConfig&, const SYSTEMTIME&) {
+                    return std::pair{ config.lightTime, config.darkTime };
+                };
+                return dependencies;
+            }
+        };
+    }
+
+    TEST_CLASS (StateManagerTests)
+    {
+    public:
+        TEST_METHOD (ExplicitSetIsIdempotentAndHoldsUntilTheNextBoundary)
+        {
+            Environment environment;
+            LightSwitchStateManager manager(environment.Dependencies());
+            const auto first = manager.SetTheme(false);
+            Assert::IsTrue(first.success);
+            Assert::IsTrue(first.status.manualOverride);
+            Assert::AreEqual(2, environment.writes);
+            Assert::IsTrue(manager.SetTheme(false).success);
+            Assert::AreEqual(2, environment.writes);
+            Assert::AreEqual(size_t{ 1 }, environment.notifications.size());
+            environment.now.wMinute = 1;
+            manager.OnTick();
+            Assert::IsTrue(manager.GetState().isManualOverride);
+            Assert::IsFalse(*environment.system);
+            environment.now.wHour = 20;
+            environment.now.wMinute = 0;
+            manager.OnTick();
+            Assert::IsFalse(manager.GetState().isManualOverride);
+            Assert::IsFalse(*environment.system);
+        }
+
+        TEST_METHOD (SettingTheScheduledThemeDoesNotCancelTheNextToggle)
+        {
+            Environment environment;
+            environment.system = false;
+            environment.apps = false;
+            LightSwitchStateManager manager(environment.Dependencies());
+            const auto set = manager.SetTheme(true);
+            Assert::IsTrue(set.success);
+            Assert::IsFalse(set.status.manualOverride);
+            const auto toggle = manager.ToggleTheme();
+            Assert::IsTrue(toggle.success);
+            Assert::IsTrue(toggle.status.manualOverride);
+            Assert::IsFalse(*toggle.status.systemLight);
+            Assert::IsFalse(*toggle.status.appsLight);
+        }
+
+        TEST_METHOD (TogglePreservesLegacyMixedThemeTransition)
+        {
+            Environment environment;
+            environment.now.wHour = 21;
+            environment.apps = false;
+            LightSwitchStateManager manager(environment.Dependencies());
+            manager.DetectExternalThemeChange();
+            Assert::IsTrue(manager.GetState().isManualOverride);
+            const auto result = manager.ToggleTheme();
+            Assert::IsTrue(result.success);
+            Assert::IsFalse(result.status.manualOverride);
+            Assert::IsFalse(*result.status.systemLight);
+            Assert::IsFalse(*result.status.appsLight);
+        }
+
+        TEST_METHOD (ExplicitSetAtABoundaryUsesItsOwnTimeBaseline)
+        {
+            Environment environment;
+            environment.now.wHour = 19;
+            environment.now.wMinute = 59;
+            LightSwitchStateManager manager(environment.Dependencies());
+            manager.OnTick();
+            environment.now.wHour = 20;
+            environment.now.wMinute = 0;
+            Assert::IsTrue(manager.SetTheme(true).status.manualOverride);
+            manager.OnTick();
+            Assert::IsTrue(manager.GetState().isManualOverride);
+            Assert::IsTrue(*environment.system);
+        }
+
+        TEST_METHOD (DuplicateSettingsNotificationDoesNotClearManualOverride)
+        {
+            Environment environment;
+            LightSwitchStateManager manager(environment.Dependencies());
+            Assert::IsTrue(manager.SetTheme(false).success);
+            Assert::IsTrue(manager.OnSettingsChanged().success);
+            Assert::IsTrue(manager.GetState().isManualOverride);
+            Assert::IsFalse(*environment.system);
+        }
+
+        TEST_METHOD (SettingsReadBeforeDebounceDoesNotBecomeAManualOverride)
+        {
+            Environment environment;
+            environment.now.wHour = 11;
+            environment.now.wMinute = 59;
+            LightSwitchStateManager manager(environment.Dependencies());
+            manager.OnTick();
+
+            // The minute tick sees the new plan before the settings file watcher fires.
+            environment.config.darkTime = 11 * 60;
+            environment.now.wHour = 12;
+            environment.now.wMinute = 0;
+            manager.DetectExternalThemeChange();
+            Assert::IsFalse(manager.GetState().isManualOverride);
+            manager.OnTick();
+            Assert::IsFalse(*environment.system);
+            Assert::IsFalse(*environment.apps);
+
+            const auto result = manager.OnSettingsChanged();
+            Assert::IsTrue(result.success);
+            Assert::IsFalse(result.status.manualOverride);
+            Assert::IsFalse(*result.status.systemLight);
+            Assert::IsFalse(*result.status.appsLight);
+        }
+
+        TEST_METHOD (SunTimeCacheEchoDoesNotClearManualOverride)
+        {
+            Environment environment;
+            environment.config.scheduleMode = ScheduleMode::SunsetToSunrise;
+            environment.config.latitude = L"22";
+            environment.config.longitude = L"114";
+            LightSwitchStateManager manager(environment.Dependencies());
+            Assert::IsTrue(manager.SetTheme(false).success);
+            ++environment.config.lightTime;
+            Assert::IsTrue(manager.OnSettingsChanged().success);
+            Assert::IsTrue(manager.GetState().isManualOverride);
+        }
+
+        TEST_METHOD (NightLightModeReadsTheActualStateBeforeApplyingAndIgnoresDuplicateNotifications)
+        {
+            Environment environment;
+            environment.config.scheduleMode = ScheduleMode::FollowNightLight;
+            environment.nightLight = true;
+            LightSwitchStateManager manager(environment.Dependencies());
+            const auto initial = manager.OnSettingsChanged();
+            Assert::IsTrue(initial.success);
+            Assert::IsFalse(*initial.status.systemLight);
+            Assert::IsTrue(manager.SetTheme(true).status.manualOverride);
+            manager.OnNightLightChange();
+            Assert::IsTrue(manager.GetState().isManualOverride);
+            environment.nightLight = false;
+            manager.OnNightLightChange();
+            Assert::IsFalse(manager.GetState().isManualOverride);
+            Assert::IsTrue(*environment.system);
+        }
+
+        TEST_METHOD (RepeatedOperationsRetainNewlyCalculatedSunBoundaries)
+        {
+            Environment environment;
+            environment.config.scheduleMode = ScheduleMode::SunsetToSunrise;
+            environment.config.latitude = L"22";
+            environment.config.longitude = L"114";
+            int calculations = 0;
+            auto dependencies = environment.Dependencies();
+            dependencies.updateSunTimes = [&](const LightSwitchConfig&, const SYSTEMTIME&) {
+                ++calculations;
+                return std::pair{ 900, 1300 };
+            };
+            LightSwitchStateManager manager(std::move(dependencies));
+            Assert::IsTrue(manager.SetTheme(true).status.manualOverride);
+            Assert::IsTrue(manager.SetTheme(true).status.manualOverride);
+            Assert::IsTrue(manager.OnSettingsChanged().status.manualOverride);
+            Assert::AreEqual(900, manager.GetState().effectiveLightMinutes);
+            Assert::AreEqual(1, calculations);
+        }
+
+        TEST_METHOD (NoTargetsAndUnreadableThemesDoNotMutateWindows)
+        {
+            Environment environment;
+            environment.config.changeSystem = false;
+            environment.config.changeApps = false;
+            LightSwitchStateManager manager(environment.Dependencies());
+            Assert::AreEqual(L"NO_TARGETS", manager.SetTheme(false).errorCode.c_str());
+            Assert::AreEqual(L"NO_TARGETS", manager.ToggleTheme().errorCode.c_str());
+            Assert::AreEqual(0, environment.writes);
+            environment.config.changeSystem = true;
+            environment.system.reset();
+            Assert::AreEqual(L"THEME_READ_FAILED", manager.ToggleTheme().errorCode.c_str());
+            Assert::AreEqual(0, environment.writes);
+            Assert::IsFalse(manager.GetStatusSnapshot().systemLight.has_value());
+        }
+
+        TEST_METHOD (WriteFailureReportsTheActualPartialResult)
+        {
+            Environment environment;
+            environment.failAppsWrite = true;
+            LightSwitchStateManager manager(environment.Dependencies());
+            const auto result = manager.SetTheme(false);
+            Assert::IsFalse(result.success);
+            Assert::AreEqual(L"THEME_WRITE_FAILED", result.errorCode.c_str());
+            Assert::IsFalse(*result.status.systemLight);
+            Assert::IsTrue(*result.status.appsLight);
+            Assert::IsTrue(environment.notifications.empty());
+        }
+
+        TEST_METHOD (SettingsApplicationReportsAWriteFailure)
+        {
+            Environment environment;
+            environment.now.wHour = 21;
+            environment.failAppsWrite = true;
+            LightSwitchStateManager manager(environment.Dependencies());
+            const auto result = manager.OnSettingsChanged();
+            Assert::IsFalse(result.success);
+            Assert::AreEqual(L"THEME_WRITE_FAILED", result.errorCode.c_str());
+            Assert::IsFalse(*result.status.systemLight);
+            Assert::IsTrue(*result.status.appsLight);
+        }
+
+        TEST_METHOD (EachCommandUsesOneConfigurationSnapshot)
+        {
+            Environment environment;
+            environment.afterWrite = [&](bool system) {
+                if (system)
+                    environment.config.changeApps = false;
+            };
+            LightSwitchStateManager manager(environment.Dependencies());
+            const auto result = manager.SetTheme(false);
+            Assert::IsTrue(result.success);
+            Assert::IsTrue(result.status.config.changeApps);
+            Assert::IsFalse(*result.status.appsLight);
+        }
+
+        TEST_METHOD (StatusDoesNotReloadSettingsOrChangeThemes)
+        {
+            Environment environment;
+            LightSwitchStateManager manager(environment.Dependencies());
+            manager.OnSettingsChanged();
+            const auto reads = environment.settingsReads;
+            const auto writes = environment.writes;
+            manager.GetStatusSnapshot();
+            Assert::AreEqual(reads, environment.settingsReads);
+            Assert::AreEqual(writes, environment.writes);
+        }
+
+        TEST_METHOD (UnreadableSettingsFailWithoutChangingThemes)
+        {
+            Environment environment;
+            environment.readableSettings = false;
+            LightSwitchStateManager manager(environment.Dependencies());
+            Assert::AreEqual(L"SETTINGS_READ_FAILED", manager.SetTheme(false).errorCode.c_str());
+            Assert::IsFalse(manager.GetStatusSnapshot().configurationAvailable);
+            Assert::AreEqual(0, environment.writes);
+        }
+
+        TEST_METHOD (ConcurrentTogglesAreSerialized)
+        {
+            Environment environment;
+            environment.config.scheduleMode = ScheduleMode::Off;
+            LightSwitchStateManager manager(environment.Dependencies());
+            std::vector<std::future<ThemeCommandResult>> operations;
+            for (int index = 0; index < 12; ++index)
+                operations.push_back(std::async(std::launch::async, [&manager]() { return manager.ToggleTheme(); }));
+            for (auto& operation : operations)
+                Assert::IsTrue(operation.get().success);
+            Assert::AreEqual(24, environment.writes);
+            Assert::IsTrue(*environment.system);
+            Assert::IsTrue(*environment.apps);
+        }
+    };
+}

--- a/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/TestSupport.h
+++ b/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/TestSupport.h
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include <Windows.h>
+#include <roapi.h>
+#include <winrt/Windows.Data.Json.h>
+
+namespace LightSwitchServiceUnitTests
+{
+    class Apartment
+    {
+    public:
+        Apartment() : m_result(RoInitialize(RO_INIT_MULTITHREADED))
+        {
+            if (m_result != RPC_E_CHANGED_MODE)
+            {
+                winrt::check_hresult(m_result);
+            }
+        }
+        ~Apartment()
+        {
+            if (SUCCEEDED(m_result))
+            {
+                RoUninitialize();
+            }
+        }
+
+    private:
+        HRESULT m_result;
+    };
+
+    inline winrt::Windows::Data::Json::JsonObject TestState()
+    {
+        using namespace winrt::Windows::Data::Json;
+        JsonObject state;
+        state.SetNamedValue(L"systemTheme", JsonValue::CreateStringValue(L"light"));
+        state.SetNamedValue(L"appsTheme", JsonValue::CreateStringValue(L"unknown"));
+        state.SetNamedValue(L"changeSystem", JsonValue::CreateBooleanValue(true));
+        state.SetNamedValue(L"changeApps", JsonValue::CreateBooleanValue(false));
+        state.SetNamedValue(L"scheduleMode", JsonValue::CreateStringValue(L"Off"));
+        state.SetNamedValue(L"manualOverride", JsonValue::CreateBooleanValue(false));
+        return state;
+    }
+}

--- a/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/ThemeHelperTests.cpp
+++ b/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/ThemeHelperTests.cpp
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include <CppUnitTest.h>
+#include "ThemeHelper.h"
+#include <atomic>
+#include <string>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace LightSwitchServiceUnitTests
+{
+    namespace
+    {
+        struct TemporaryRegistryKey
+        {
+            HKEY key = nullptr;
+            std::wstring path;
+            TemporaryRegistryKey()
+            {
+                static std::atomic<unsigned long> sequence{ 0 };
+                path = L"Software\\Microsoft\\PowerToys\\LightSwitchUnitTests\\" + std::to_wstring(GetCurrentProcessId()) + L"-" + std::to_wstring(++sequence);
+                Assert::AreEqual<LSTATUS>(ERROR_SUCCESS, RegCreateKeyExW(HKEY_CURRENT_USER, path.c_str(), 0, nullptr, 0, KEY_QUERY_VALUE | KEY_SET_VALUE, nullptr, &key, nullptr));
+            }
+            ~TemporaryRegistryKey()
+            {
+                if (key)
+                    RegCloseKey(key);
+                RegDeleteTreeW(HKEY_CURRENT_USER, path.c_str());
+            }
+        };
+    }
+
+    TEST_CLASS (ThemeHelperTests)
+    {
+    public:
+        TEST_METHOD (ThemeValuesCanBeWrittenAndVerifiedWithoutBroadcasting)
+        {
+            TemporaryRegistryKey registry;
+            bool light = false;
+            Assert::AreEqual<LSTATUS>(ERROR_SUCCESS, LightSwitchThemeHelpers::WriteThemeValue(registry.key, L"Theme", true));
+            Assert::AreEqual<LSTATUS>(ERROR_SUCCESS, LightSwitchThemeHelpers::ReadThemeValue(registry.key, L"Theme", light));
+            Assert::IsTrue(light);
+            Assert::AreEqual<LSTATUS>(ERROR_SUCCESS, LightSwitchThemeHelpers::WriteThemeValue(registry.key, L"Theme", false));
+            Assert::AreEqual<LSTATUS>(ERROR_SUCCESS, LightSwitchThemeHelpers::ReadThemeValue(registry.key, L"Theme", light));
+            Assert::IsFalse(light);
+        }
+
+        TEST_METHOD (MissingValuesDoNotGuessLightOrModifyTheOutput)
+        {
+            TemporaryRegistryKey registry;
+            bool light = false;
+            Assert::AreEqual<LSTATUS>(ERROR_FILE_NOT_FOUND, LightSwitchThemeHelpers::ReadThemeValue(registry.key, L"Missing", light));
+            Assert::IsFalse(light);
+        }
+
+        TEST_METHOD (InvalidTypesAndValuesAreRejected)
+        {
+            TemporaryRegistryKey registry;
+            DWORD value = 2;
+            Assert::AreEqual<LSTATUS>(ERROR_SUCCESS, RegSetValueExW(registry.key, L"Theme", 0, REG_DWORD, reinterpret_cast<const BYTE*>(&value), sizeof(value)));
+            bool light = true;
+            Assert::AreEqual<LSTATUS>(ERROR_INVALID_DATA, LightSwitchThemeHelpers::ReadThemeValue(registry.key, L"Theme", light));
+            Assert::IsTrue(light);
+            const wchar_t text[] = L"light";
+            Assert::AreEqual<LSTATUS>(ERROR_SUCCESS, RegSetValueExW(registry.key, L"Theme", 0, REG_SZ, reinterpret_cast<const BYTE*>(text), sizeof(text)));
+            Assert::IsTrue(LightSwitchThemeHelpers::ReadThemeValue(registry.key, L"Theme", light) != ERROR_SUCCESS);
+        }
+
+        TEST_METHOD (ReadOnlyKeysReportWriteFailures)
+        {
+            TemporaryRegistryKey registry;
+            HKEY readOnly = nullptr;
+            Assert::AreEqual<LSTATUS>(ERROR_SUCCESS, RegOpenKeyExW(HKEY_CURRENT_USER, registry.path.c_str(), 0, KEY_QUERY_VALUE, &readOnly));
+            const auto result = LightSwitchThemeHelpers::WriteThemeValue(readOnly, L"Theme", true);
+            RegCloseKey(readOnly);
+            Assert::AreEqual<LSTATUS>(ERROR_ACCESS_DENIED, result);
+        }
+    };
+}

--- a/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/packages.config
+++ b/src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/packages.config
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.250303.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.260126.7" targetFramework="native" />
+</packages>

--- a/src/settings-ui/Settings.UI.UnitTests/LightSwitchSettingsWatcherTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/LightSwitchSettingsWatcherTests.cs
@@ -6,15 +6,112 @@ using System;
 using System.IO;
 using System.IO.Abstractions;
 using System.Runtime.InteropServices;
+using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.PowerToys.Settings.UI.Library.Interfaces;
 using Microsoft.PowerToys.Settings.UI.Views;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 
 namespace Microsoft.PowerToys.Settings.UI.UnitTests;
 
 [TestClass]
 public class LightSwitchSettingsWatcherTests
 {
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    [Timeout(15000)]
+    public async Task InitialSettingsReadIncludesReplacementsBeforeAndDuringInitializationAsync(bool replaceDuringRead)
+    {
+        var directory = Directory.CreateTempSubdirectory("PowerToys-LightSwitchInitialRead-");
+        try
+        {
+            var settingsPath = Path.Combine(directory.FullName, "settings.json");
+            var temporaryPath = Path.Combine(directory.FullName, "settings.json.cli.tmp");
+            var cachedSettings = new LightSwitchSettings();
+            cachedSettings.Properties.ScheduleMode.Value = "FixedHours";
+            cachedSettings.Properties.LightTime.Value = 497;
+            cachedSettings.Properties.DarkTime.Value = 1260;
+            File.WriteAllText(settingsPath, cachedSettings.ToJsonString());
+
+            var replacement = (LightSwitchSettings)cachedSettings.Clone();
+            replacement.Properties.ScheduleMode.Value = "Off";
+            File.WriteAllText(temporaryPath, replacement.ToJsonString());
+
+            var repository = new Mock<ISettingsRepository<LightSwitchSettings>>();
+            repository.SetupGet(r => r.SettingsConfig).Returns(() => cachedSettings);
+            repository.Setup(r => r.ReloadSettings()).Returns(() =>
+            {
+                if (replaceDuringRead)
+                {
+                    ReplaceSettingsFile(temporaryPath, settingsPath);
+                }
+
+                cachedSettings = JsonSerializer.Deserialize<LightSwitchSettings>(File.ReadAllText(settingsPath))
+                    ?? throw new InvalidDataException("The test settings could not be deserialized.");
+                return true;
+            });
+
+            if (!replaceDuringRead)
+            {
+                ReplaceSettingsFile(temporaryPath, settingsPath);
+            }
+
+            Assert.AreEqual("FixedHours", repository.Object.SettingsConfig.Properties.ScheduleMode.Value);
+            var changed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var initialization = LightSwitchPage.InitializeSettings(
+                new FileSystem(), settingsPath, repository.Object, () => changed.TrySetResult());
+            using var watcher = initialization.Watcher;
+
+            Assert.AreEqual("Off", initialization.Settings.Properties.ScheduleMode.Value);
+            Assert.AreEqual(497, initialization.Settings.Properties.LightTime.Value);
+            Assert.AreEqual(1260, initialization.Settings.Properties.DarkTime.Value);
+            repository.Verify(r => r.ReloadSettings(), Times.Once);
+
+            if (!replaceDuringRead)
+            {
+                File.WriteAllText(temporaryPath, replacement.ToJsonString());
+                ReplaceSettingsFile(temporaryPath, settingsPath);
+            }
+
+            // A replacement during the initial reload is observed because the
+            // production helper subscribes before reading the current snapshot.
+            await changed.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void InitialSettingsReadRetainsTheRepositoryFallbackWhenReloadFails()
+    {
+        var directory = Directory.CreateTempSubdirectory("PowerToys-LightSwitchReadFallback-");
+        try
+        {
+            var cachedSettings = new LightSwitchSettings();
+            cachedSettings.Properties.ScheduleMode.Value = "FixedHours";
+            var repository = new Mock<ISettingsRepository<LightSwitchSettings>>();
+            repository.SetupGet(r => r.SettingsConfig).Returns(cachedSettings);
+            repository.Setup(r => r.ReloadSettings()).Returns(false);
+
+            var initialization = LightSwitchPage.InitializeSettings(
+                new FileSystem(), Path.Combine(directory.FullName, "settings.json"), repository.Object, () => { });
+            using var watcher = initialization.Watcher;
+
+            Assert.AreSame(cachedSettings, initialization.Settings);
+            repository.Verify(r => r.ReloadSettings(), Times.Once);
+            Assert.IsTrue(watcher.EnableRaisingEvents);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
@@ -36,12 +133,7 @@ public class LightSwitchSettingsWatcherTests
 
             if (replaceFile)
             {
-                // Use the CLI's exact atomic replacement flags, after both files are closed.
-                const uint moveFileReplaceExisting = 0x1;
-                const uint moveFileWriteThrough = 0x8;
-                Assert.IsTrue(
-                    MoveFileExW(temporaryPath, settingsPath, moveFileReplaceExisting | moveFileWriteThrough),
-                    $"MoveFileExW failed: {Marshal.GetLastWin32Error()}");
+                ReplaceSettingsFile(temporaryPath, settingsPath);
             }
             else
             {
@@ -55,6 +147,16 @@ public class LightSwitchSettingsWatcherTests
         {
             directory.Delete(recursive: true);
         }
+    }
+
+    private static void ReplaceSettingsFile(string temporaryPath, string settingsPath)
+    {
+        // Use the CLI's exact atomic replacement flags, after both files are closed.
+        const uint moveFileReplaceExisting = 0x1;
+        const uint moveFileWriteThrough = 0x8;
+        Assert.IsTrue(
+            MoveFileExW(temporaryPath, settingsPath, moveFileReplaceExisting | moveFileWriteThrough),
+            $"MoveFileExW failed: {Marshal.GetLastWin32Error()}");
     }
 
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]

--- a/src/settings-ui/Settings.UI.UnitTests/LightSwitchSettingsWatcherTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/LightSwitchSettingsWatcherTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.IO.Abstractions;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Microsoft.PowerToys.Settings.UI.Views;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.PowerToys.Settings.UI.UnitTests;
+
+[TestClass]
+public class LightSwitchSettingsWatcherTests
+{
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    [Timeout(15000)]
+    public async Task SettingsWritesNotifyReloadAsync(bool replaceFile)
+    {
+        var directory = Directory.CreateTempSubdirectory("PowerToys-LightSwitchWatcher-");
+        try
+        {
+            var settingsPath = Path.Combine(directory.FullName, "settings.json");
+            var temporaryPath = Path.Combine(directory.FullName, "settings.json.cli.tmp");
+            const string updatedSettings = "{\"properties\":{\"scheduleMode\":{\"value\":\"Off\"}}}";
+            File.WriteAllText(settingsPath, "{\"properties\":{\"scheduleMode\":{\"value\":\"FixedHours\"}}}");
+            File.WriteAllText(temporaryPath, updatedSettings);
+
+            var changed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var watcher = LightSwitchPage.CreateSettingsWatcher(
+                new FileSystem(), settingsPath, () => changed.TrySetResult());
+
+            if (replaceFile)
+            {
+                // Use the CLI's exact atomic replacement flags, after both files are closed.
+                const uint moveFileReplaceExisting = 0x1;
+                const uint moveFileWriteThrough = 0x8;
+                Assert.IsTrue(
+                    MoveFileExW(temporaryPath, settingsPath, moveFileReplaceExisting | moveFileWriteThrough),
+                    $"MoveFileExW failed: {Marshal.GetLastWin32Error()}");
+            }
+            else
+            {
+                File.WriteAllText(settingsPath, updatedSettings);
+            }
+
+            await changed.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.AreEqual(updatedSettings, File.ReadAllText(settingsPath));
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool MoveFileExW(string existingFileName, string newFileName, uint flags);
+}

--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/LightSwitch.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/LightSwitch.cs
@@ -2,20 +2,204 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.PowerToys.Settings.UI.Library.Helpers;
 using Microsoft.PowerToys.Settings.UI.UnitTests.BackwardsCompatibility;
 using Microsoft.PowerToys.Settings.UI.UnitTests.Mocks;
 using Microsoft.PowerToys.Settings.UI.ViewModels;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PowerDisplay.Models;
+using Settings.UI.Library.Helpers;
 
 namespace ViewModelTests;
 
 [TestClass]
 public class LightSwitch
 {
+    [TestMethod]
+    [DataRow("FixedHours")]
+    [DataRow("Off")]
+    [DataRow("FollowNightLight")]
+    public void ModuleSettingsRefreshUpdatesTimesAndClearsSunMarkersWithoutSaving(string nextMode)
+    {
+        var messages = new List<string>();
+        using var viewModel = CreateViewModel(new LightSwitchSettings(), message =>
+        {
+            messages.Add(message);
+            return 0;
+        });
+        var city = new SearchLocation("Hong Kong", "China", 22.3, 114.2);
+        viewModel.SearchLocations.Add(city);
+        var notifications = new HashSet<string>();
+        viewModel.PropertyChanged += (_, e) => notifications.Add(e.PropertyName);
+
+        var sunSettings = new LightSwitchSettings();
+        sunSettings.Properties.ScheduleMode.Value = "SunsetToSunrise";
+        sunSettings.Properties.Latitude.Value = "22.3";
+        sunSettings.Properties.Longitude.Value = "114.2";
+        sunSettings.Properties.LightTime.Value = 367;
+        sunSettings.Properties.DarkTime.Value = 1105;
+        sunSettings.Properties.SunriseOffset.Value = 15;
+        sunSettings.Properties.SunsetOffset.Value = -20;
+        string savedSunSettings = sunSettings.ToJsonString();
+
+        viewModel.ModuleSettings = sunSettings;
+
+        Assert.AreEqual(savedSunSettings, sunSettings.ToJsonString());
+        Assert.AreEqual(TimeSpan.FromMinutes(367), viewModel.LightTimePickerValue);
+        Assert.AreEqual(TimeSpan.FromMinutes(1105), viewModel.DarkTimePickerValue);
+        Assert.AreEqual(TimeSpan.FromMinutes(382), viewModel.LightTimeTimeSpan);
+        Assert.AreEqual(TimeSpan.FromMinutes(1085), viewModel.DarkTimeTimeSpan);
+        Assert.AreEqual<TimeSpan?>(TimeSpan.FromMinutes(367), viewModel.SunriseTimeSpan);
+        Assert.AreEqual<TimeSpan?>(TimeSpan.FromMinutes(1105), viewModel.SunsetTimeSpan);
+        Assert.AreEqual(-367, viewModel.SunriseOffsetMin);
+        Assert.AreEqual(717, viewModel.SunriseOffsetMax);
+        Assert.AreEqual(-722, viewModel.SunsetOffsetMin);
+        Assert.AreEqual(334, viewModel.SunsetOffsetMax);
+        Assert.AreSame(city, viewModel.SelectedCity);
+        Assert.AreEqual(city.City, viewModel.SyncButtonInformation);
+        AssertTimeBindingsNotified(notifications);
+        Assert.IsTrue(notifications.Contains(nameof(viewModel.SyncButtonInformation)));
+
+        notifications.Clear();
+        var nextSettings = (LightSwitchSettings)sunSettings.Clone();
+        nextSettings.Properties.ScheduleMode.Value = nextMode;
+        nextSettings.Properties.LightTime.Value = 503;
+        nextSettings.Properties.DarkTime.Value = 1259;
+        string savedNextSettings = nextSettings.ToJsonString();
+
+        viewModel.ModuleSettings = nextSettings;
+
+        Assert.AreEqual(savedNextSettings, nextSettings.ToJsonString());
+        Assert.AreEqual(TimeSpan.FromMinutes(503), viewModel.LightTimePickerValue);
+        Assert.AreEqual(TimeSpan.FromMinutes(1259), viewModel.DarkTimePickerValue);
+        Assert.AreEqual(TimeSpan.FromMinutes(503), viewModel.LightTimeTimeSpan);
+        Assert.AreEqual(TimeSpan.FromMinutes(1259), viewModel.DarkTimeTimeSpan);
+        Assert.IsNull(viewModel.SunriseTimeSpan);
+        Assert.IsNull(viewModel.SunsetTimeSpan);
+        AssertTimeBindingsNotified(notifications);
+        Assert.AreEqual(0, messages.Count);
+    }
+
+    [TestMethod]
+    public void InitialSunScheduleDisplayCalculatesTodayWithoutChangingSavedTimes()
+    {
+        var settings = new LightSwitchSettings();
+        settings.Properties.ScheduleMode.Value = "SunsetToSunrise";
+        settings.Properties.Latitude.Value = "22.3";
+        settings.Properties.Longitude.Value = "114.2";
+        settings.Properties.LightTime.Value = 503;
+        settings.Properties.DarkTime.Value = 1259;
+        settings.Properties.SunriseOffset.Value = 15;
+        settings.Properties.SunsetOffset.Value = -20;
+        string savedSettings = settings.ToJsonString();
+        var messages = new List<string>();
+        using var viewModel = CreateViewModel(settings, message =>
+        {
+            messages.Add(message);
+            return 0;
+        });
+        viewModel.SearchLocations.Add(new SearchLocation("Hong Kong", "China", 22.3, 114.2));
+        var today = DateTime.Now;
+        var expected = SunCalc.CalculateSunriseSunset(22.3, 114.2, today.Year, today.Month, today.Day);
+        int expectedLightMinutes = (expected.SunriseHour * 60) + expected.SunriseMinute;
+        int expectedDarkMinutes = (expected.SunsetHour * 60) + expected.SunsetMinute;
+
+        viewModel.InitializeScheduleMode();
+        viewModel.ScheduleMode = viewModel.ScheduleMode;
+
+        Assert.AreEqual(savedSettings, settings.ToJsonString());
+        Assert.AreEqual<TimeSpan?>(TimeSpan.FromMinutes(expectedLightMinutes), viewModel.SunriseTimeSpan);
+        Assert.AreEqual<TimeSpan?>(TimeSpan.FromMinutes(expectedDarkMinutes), viewModel.SunsetTimeSpan);
+        Assert.AreEqual(TimeSpan.FromMinutes(expectedLightMinutes + 15), viewModel.LightTimeTimeSpan);
+        Assert.AreEqual(TimeSpan.FromMinutes(expectedDarkMinutes - 20), viewModel.DarkTimeTimeSpan);
+        Assert.AreEqual(-expectedLightMinutes, viewModel.SunriseOffsetMin);
+        Assert.AreEqual(1439 - expectedDarkMinutes, viewModel.SunsetOffsetMax);
+        Assert.AreEqual(TimeSpan.FromMinutes(503), viewModel.LightTimePickerValue);
+        Assert.AreEqual(TimeSpan.FromMinutes(1259), viewModel.DarkTimePickerValue);
+        Assert.AreEqual("Hong Kong", viewModel.SyncButtonInformation);
+        Assert.AreEqual(0, messages.Count);
+
+        var fixedSettings = (LightSwitchSettings)settings.Clone();
+        fixedSettings.Properties.ScheduleMode.Value = "FixedHours";
+        viewModel.ModuleSettings = fixedSettings;
+        viewModel.InitializeScheduleMode();
+
+        Assert.AreEqual(503, fixedSettings.Properties.LightTime.Value);
+        Assert.AreEqual(1259, fixedSettings.Properties.DarkTime.Value);
+        Assert.AreEqual(TimeSpan.FromMinutes(503), viewModel.LightTimeTimeSpan);
+        Assert.AreEqual(TimeSpan.FromMinutes(1259), viewModel.DarkTimeTimeSpan);
+        Assert.IsNull(viewModel.SunriseTimeSpan);
+        Assert.IsNull(viewModel.SunsetTimeSpan);
+        Assert.AreEqual(0, messages.Count);
+    }
+
+    [TestMethod]
+    public void ModuleSettingsRefreshIgnoresTwoWayControlFeedback()
+    {
+        var messages = new List<string>();
+        using var viewModel = CreateViewModel(new LightSwitchSettings(), message =>
+        {
+            messages.Add(message);
+            return 0;
+        });
+        var profile = new PowerDisplayProfile("Night", new List<ProfileMonitorSetting>()) { Id = 7 };
+        viewModel.AvailableProfiles.Add(profile);
+        var settings = new LightSwitchSettings();
+        settings.Properties.ScheduleMode.Value = "SunsetToSunrise";
+        settings.Properties.LightTime.Value = 367;
+        settings.Properties.DarkTime.Value = 1105;
+        settings.Properties.SunriseOffset.Value = 15;
+        settings.Properties.EnableDarkModeProfile.Value = true;
+        settings.Properties.DarkModeProfileId.Value = profile.Id;
+        string savedSettings = settings.ToJsonString();
+        bool replayControlValues = true;
+        viewModel.PropertyChanged += (_, e) =>
+        {
+            if (!replayControlValues)
+            {
+                return;
+            }
+
+            // Bound controls can report a clamped/previous value while receiving
+            // new bounds, time values, mode or profile selection.
+            switch (e.PropertyName)
+            {
+                case nameof(viewModel.SunriseOffsetMax):
+                    viewModel.SunriseOffset = 0;
+                    break;
+                case nameof(viewModel.LightTimePickerValue):
+                    viewModel.LightTimePickerValue = TimeSpan.FromHours(8);
+                    break;
+                case nameof(viewModel.DarkTimePickerValue):
+                    viewModel.DarkTimePickerValue = TimeSpan.FromHours(20);
+                    break;
+                case nameof(viewModel.ScheduleMode):
+                    viewModel.ScheduleMode = "FixedHours";
+                    break;
+                case nameof(viewModel.EnableDarkModeProfile):
+                    viewModel.EnableDarkModeProfile = false;
+                    break;
+                case nameof(viewModel.SelectedDarkModeProfile):
+                    viewModel.SelectedDarkModeProfile = null;
+                    break;
+            }
+        };
+
+        viewModel.ModuleSettings = settings;
+
+        Assert.AreEqual(savedSettings, settings.ToJsonString());
+        Assert.AreSame(profile, viewModel.SelectedDarkModeProfile);
+        Assert.AreEqual(0, messages.Count);
+
+        replayControlValues = false;
+        viewModel.SunriseOffset = 16;
+        Assert.AreEqual(16, settings.Properties.SunriseOffset.Value);
+    }
+
     [TestMethod]
     public void SuppressedProfileSelectionChange_DoesNotPersistTemporaryZero()
     {
@@ -57,6 +241,27 @@ public class LightSwitch
             generalSettingsRepository,
             settings,
             sendConfigMessage);
+    }
+
+    private static void AssertTimeBindingsNotified(HashSet<string> notifications)
+    {
+        string[] boundProperties =
+        [
+            nameof(LightSwitchViewModel.LightTimePickerValue),
+            nameof(LightSwitchViewModel.DarkTimePickerValue),
+            nameof(LightSwitchViewModel.LightTimeTimeSpan),
+            nameof(LightSwitchViewModel.DarkTimeTimeSpan),
+            nameof(LightSwitchViewModel.SunriseTimeSpan),
+            nameof(LightSwitchViewModel.SunsetTimeSpan),
+            nameof(LightSwitchViewModel.SunriseOffsetMin),
+            nameof(LightSwitchViewModel.SunriseOffsetMax),
+            nameof(LightSwitchViewModel.SunsetOffsetMin),
+            nameof(LightSwitchViewModel.SunsetOffsetMax),
+        ];
+        foreach (string property in boundProperties)
+        {
+            Assert.IsTrue(notifications.Contains(property), $"Missing change notification for {property}.");
+        }
     }
 
     private static void SetSuppression(LightSwitchViewModel viewModel, bool value)

--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/LightSwitch.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/LightSwitch.cs
@@ -4,7 +4,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
 using System.Reflection;
+using System.Text.Json;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.Library.Helpers;
 using Microsoft.PowerToys.Settings.UI.UnitTests.BackwardsCompatibility;
@@ -201,6 +204,257 @@ public class LightSwitch
     }
 
     [TestMethod]
+    [DataRow(-61)]
+    [DataRow(-1)]
+    [DataRow(1440)]
+    [DataRow(int.MinValue)]
+    [DataRow(int.MaxValue)]
+    public void InvalidStoredTimesRefreshAsUnsetPickersWithoutChangingTheSettings(int minutes)
+    {
+        var messages = new List<string>();
+        using var viewModel = CreateViewModel(new LightSwitchSettings(), message =>
+        {
+            messages.Add(message);
+            return 0;
+        });
+        var notifications = new HashSet<string>();
+        viewModel.PropertyChanged += (_, e) =>
+        {
+            notifications.Add(e.PropertyName);
+            if (e.PropertyName == nameof(viewModel.LightTimePickerValue))
+            {
+                Assert.AreEqual(TimeSpan.FromTicks(-1), viewModel.LightTimePickerValue);
+                viewModel.LightTimePickerValue = viewModel.LightTimePickerValue;
+            }
+            else if (e.PropertyName == nameof(viewModel.DarkTimePickerValue))
+            {
+                Assert.AreEqual(TimeSpan.FromTicks(-1), viewModel.DarkTimePickerValue);
+                viewModel.DarkTimePickerValue = viewModel.DarkTimePickerValue;
+            }
+        };
+        var settings = CreateSunSettings(minutes, minutes, 0, 0);
+        string original = settings.ToJsonString();
+
+        viewModel.ModuleSettings = settings;
+
+        Assert.IsTrue(notifications.Contains(nameof(viewModel.LightTimePickerValue)));
+        Assert.IsTrue(notifications.Contains(nameof(viewModel.DarkTimePickerValue)));
+        Assert.AreEqual(original, settings.ToJsonString());
+        Assert.AreEqual(0, messages.Count);
+    }
+
+    [TestMethod]
+    [DataRow(-61, -61)]
+    [DataRow(-61, 1080)]
+    [DataRow(360, -61)]
+    public void ApplyingLocationWithMissingSunTimesPreservesRawValuesAndUsesSafePickers(int lightMinutes, int darkMinutes)
+    {
+        var messages = new List<string>();
+        using var viewModel = CreateViewModel(CreateSunSettings(360, 1080, 15, -20), message =>
+        {
+            messages.Add(message);
+            return 0;
+        });
+        viewModel.PropertyChanged += (_, e) =>
+        {
+            // Replay the generated TwoWay feedback while refreshing both pickers.
+            if (e.PropertyName == nameof(viewModel.LightTimePickerValue))
+            {
+                viewModel.LightTimePickerValue = viewModel.LightTimePickerValue;
+            }
+            else if (e.PropertyName == nameof(viewModel.DarkTimePickerValue))
+            {
+                viewModel.DarkTimePickerValue = viewModel.DarkTimePickerValue;
+            }
+        };
+
+        viewModel.ApplyLocation(85, 0, lightMinutes, darkMinutes);
+
+        Assert.AreEqual(lightMinutes, viewModel.LightTime);
+        Assert.AreEqual(darkMinutes, viewModel.DarkTime);
+        Assert.AreEqual(lightMinutes < 0 ? TimeSpan.FromTicks(-1) : TimeSpan.FromMinutes(lightMinutes), viewModel.LightTimePickerValue);
+        Assert.AreEqual(darkMinutes < 0 ? TimeSpan.FromTicks(-1) : TimeSpan.FromMinutes(darkMinutes), viewModel.DarkTimePickerValue);
+        Assert.AreEqual(15, viewModel.SunriseOffset);
+        Assert.AreEqual(-20, viewModel.SunsetOffset);
+        AssertCompleteSavedSettings(viewModel, messages);
+    }
+
+    [TestMethod]
+    public void UnsetAndInvalidPickerFeedbackDoesNotWriteMidnightOrNotifyASave()
+    {
+        using var viewModel = CreateViewModel(CreateSunSettings(-61, 1080, 0, 0), _ => 0);
+        int notifications = 0;
+        viewModel.PropertyChanged += (_, _) => ++notifications;
+
+        foreach (var invalid in new[]
+        {
+            TimeSpan.FromTicks(-1),
+            TimeSpan.FromMinutes(-61),
+            TimeSpan.FromDays(1),
+            TimeSpan.FromHours(25),
+            TimeSpan.MinValue,
+            TimeSpan.MaxValue,
+        })
+        {
+            viewModel.LightTimePickerValue = invalid;
+            viewModel.DarkTimePickerValue = invalid;
+        }
+
+        Assert.AreEqual(-61, viewModel.LightTime);
+        Assert.AreEqual(1080, viewModel.DarkTime);
+        Assert.AreEqual(0, notifications, "Rejected picker feedback must not trigger the page's settings-save handler.");
+    }
+
+    [TestMethod]
+    [DataRow(0, 1439)]
+    [DataRow(437, 1259)]
+    public void ValidPickerEditsIncludeMidnightAndTheLastMinuteOfTheDay(int lightMinutes, int darkMinutes)
+    {
+        var settings = new LightSwitchSettings();
+        settings.Properties.ScheduleMode.Value = "FixedHours";
+        using var viewModel = CreateViewModel(settings, _ => 0);
+        var notifications = new HashSet<string>();
+        viewModel.PropertyChanged += (_, e) => notifications.Add(e.PropertyName);
+
+        viewModel.LightTimePickerValue = TimeSpan.FromMinutes(lightMinutes);
+        viewModel.DarkTimePickerValue = TimeSpan.FromMinutes(darkMinutes);
+
+        Assert.AreEqual(lightMinutes, settings.Properties.LightTime.Value);
+        Assert.AreEqual(darkMinutes, settings.Properties.DarkTime.Value);
+        Assert.AreEqual(TimeSpan.FromMinutes(lightMinutes), viewModel.LightTimePickerValue);
+        Assert.AreEqual(TimeSpan.FromMinutes(darkMinutes), viewModel.DarkTimePickerValue);
+        Assert.IsTrue(notifications.Contains(nameof(viewModel.LightTime)));
+        Assert.IsTrue(notifications.Contains(nameof(viewModel.DarkTime)));
+    }
+
+    [TestMethod]
+    public void ApplyingLocationPreservesValidOffsetsAndPublishesOneCompleteSnapshot()
+    {
+        var settings = CreateSunSettings(60, 180, 30, 0);
+        var messages = new List<string>();
+        using var viewModel = CreateViewModel(settings, message =>
+        {
+            messages.Add(message);
+            return 0;
+        });
+        viewModel.RefreshModuleSettings();
+        using var controls = new OffsetControlFeedback(viewModel);
+        int notifications = 0;
+        int pageSaves = 0;
+        viewModel.PropertyChanged += (_, _) =>
+        {
+            ++notifications;
+
+            // The page suppresses persistence while a complete source snapshot is
+            // being published to bindings; the location operation saves once later.
+            if (!viewModel.IsRefreshingModuleSettings)
+            {
+                ++pageSaves;
+            }
+
+            Assert.AreEqual("22.3", viewModel.Latitude);
+            Assert.AreEqual("114.2", viewModel.Longitude);
+            Assert.AreEqual(480, viewModel.LightTime);
+            Assert.AreEqual(1080, viewModel.DarkTime);
+            Assert.AreEqual<TimeSpan?>(TimeSpan.FromMinutes(480), viewModel.SunriseTimeSpan);
+            Assert.AreEqual<TimeSpan?>(TimeSpan.FromMinutes(1080), viewModel.SunsetTimeSpan);
+        };
+
+        viewModel.ApplyLocation(22.3, 114.2, 480, 1080);
+
+        Assert.IsTrue(notifications > 0);
+        Assert.AreEqual(0, pageSaves);
+        Assert.AreEqual(30, viewModel.SunriseOffset);
+        Assert.AreEqual(30, controls.SunriseValue);
+        Assert.AreEqual(0, viewModel.SunsetOffset);
+        AssertCompleteSavedSettings(viewModel, messages);
+
+        viewModel.ApplyLocation(22.3, 114.2, 480, 1080);
+        Assert.AreEqual(1, messages.Count, "An unchanged location must not send another settings save.");
+    }
+
+    [TestMethod]
+    [DataRow(-500, 0, 60, 120, -60, 0)]
+    [DataRow(500, 100, 600, 660, 159, 100)]
+    [DataRow(0, 100, 480, 1400, 0, 39)]
+    public void ApplyingLocationClampsOffsetsAgainstTheCompleteFinalRange(
+        int oldSunriseOffset, int oldSunsetOffset, int lightMinutes, int darkMinutes, int expectedSunriseOffset, int expectedSunsetOffset)
+    {
+        var messages = new List<string>();
+        using var viewModel = CreateViewModel(CreateSunSettings(600, 1200, oldSunriseOffset, oldSunsetOffset), message =>
+        {
+            messages.Add(message);
+            return 0;
+        });
+        viewModel.RefreshModuleSettings();
+        using var controls = new OffsetControlFeedback(viewModel);
+
+        viewModel.ApplyLocation(22.3, 114.2, lightMinutes, darkMinutes);
+
+        Assert.AreEqual(expectedSunriseOffset, viewModel.SunriseOffset);
+        Assert.AreEqual(expectedSunsetOffset, viewModel.SunsetOffset);
+        Assert.AreEqual(expectedSunriseOffset, controls.SunriseValue);
+        Assert.AreEqual(expectedSunsetOffset, controls.SunsetValue);
+        Assert.IsTrue(viewModel.SunriseOffset >= viewModel.SunriseOffsetMin && viewModel.SunriseOffset <= viewModel.SunriseOffsetMax);
+        Assert.IsTrue(viewModel.SunsetOffset >= viewModel.SunsetOffsetMin && viewModel.SunsetOffset <= viewModel.SunsetOffsetMax);
+        AssertCompleteSavedSettings(viewModel, messages);
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void ManualAndSelectedCityLocationsUseTheSameAtomicApplication(bool selectCity)
+    {
+        var messages = new List<string>();
+        using var viewModel = CreateViewModel(CreateSunSettings(60, 180, 30, 0), message =>
+        {
+            messages.Add(message);
+            return 0;
+        });
+
+        // Keep solar noon near local noon in every test machine's time zone.
+        // Near the equator the new sunrise stays later than the old 03:00 sunset.
+        var today = DateTime.Now;
+        double longitude = (((TimeZoneInfo.Local.GetUtcOffset(today).TotalHours * 15) + 540) % 360) - 180;
+        var city = new SearchLocation("Test city", "Test country", 1, longitude);
+        viewModel.SearchLocations.Add(city);
+        viewModel.RefreshModuleSettings();
+        using var controls = new OffsetControlFeedback(viewModel);
+        var expected = SunCalc.CalculateSunriseSunset(city.Latitude, city.Longitude, today.Year, today.Month, today.Day);
+        int lightMinutes = (expected.SunriseHour * 60) + expected.SunriseMinute;
+        int darkMinutes = (expected.SunsetHour * 60) + expected.SunsetMinute;
+        int pageSaves = 0;
+        viewModel.PropertyChanged += (_, _) =>
+        {
+            if (!viewModel.IsRefreshingModuleSettings)
+            {
+                ++pageSaves;
+            }
+
+            Assert.AreEqual(lightMinutes, viewModel.LightTime);
+            Assert.AreEqual(darkMinutes, viewModel.DarkTime);
+        };
+
+        if (selectCity)
+        {
+            viewModel.SelectedCity = city;
+        }
+        else
+        {
+            // This is the same entry point used by LocationDialog_PrimaryButtonClick.
+            viewModel.UpdateSunTimes(city.Latitude, city.Longitude);
+        }
+
+        Assert.AreEqual(0, pageSaves);
+        Assert.AreSame(city, viewModel.SelectedCity);
+        Assert.AreEqual(city.Latitude.ToString(CultureInfo.InvariantCulture), viewModel.Latitude);
+        Assert.AreEqual(city.Longitude.ToString(CultureInfo.InvariantCulture), viewModel.Longitude);
+        Assert.AreEqual(30, viewModel.SunriseOffset);
+        Assert.AreEqual(30, controls.SunriseValue);
+        AssertCompleteSavedSettings(viewModel, messages);
+    }
+
+    [TestMethod]
     public void SuppressedProfileSelectionChange_DoesNotPersistTemporaryZero()
     {
         var settings = new LightSwitchSettings();
@@ -227,6 +481,106 @@ public class LightSwitch
 
         Assert.AreEqual(7, settings.Properties.DarkModeProfileId.Value);
         Assert.AreEqual(0, messages.Count);
+    }
+
+    private static LightSwitchSettings CreateSunSettings(int lightMinutes, int darkMinutes, int sunriseOffset, int sunsetOffset)
+    {
+        var settings = new LightSwitchSettings();
+        settings.Properties.ScheduleMode.Value = "SunsetToSunrise";
+        settings.Properties.LightTime.Value = lightMinutes;
+        settings.Properties.DarkTime.Value = darkMinutes;
+        settings.Properties.SunriseOffset.Value = sunriseOffset;
+        settings.Properties.SunsetOffset.Value = sunsetOffset;
+        return settings;
+    }
+
+    private static void AssertCompleteSavedSettings(LightSwitchViewModel viewModel, List<string> messages)
+    {
+        Assert.AreEqual(1, messages.Count);
+        using var document = JsonDocument.Parse(messages[0]);
+        var saved = JsonSerializer.Deserialize<LightSwitchSettings>(document.RootElement.GetProperty("powertoys").GetProperty("LightSwitch"));
+        Assert.IsNotNull(saved);
+        Assert.AreEqual(viewModel.ModuleSettings.ToJsonString(), saved.ToJsonString());
+    }
+
+    // Models the generated x:Bind maximum/minimum/value assignments and synchronous
+    // NumberBox coercion callbacks while executing the production ViewModel unchanged.
+    private sealed class OffsetControlFeedback : IDisposable
+    {
+        private readonly LightSwitchViewModel viewModel;
+        private readonly OffsetControl sunrise;
+        private readonly OffsetControl sunset;
+
+        public OffsetControlFeedback(LightSwitchViewModel viewModel)
+        {
+            this.viewModel = viewModel;
+            sunrise = new OffsetControl(viewModel.SunriseOffsetMin, viewModel.SunriseOffsetMax, viewModel.SunriseOffset, value => viewModel.SunriseOffset = value);
+            sunset = new OffsetControl(viewModel.SunsetOffsetMin, viewModel.SunsetOffsetMax, viewModel.SunsetOffset, value => viewModel.SunsetOffset = value);
+            viewModel.PropertyChanged += OnPropertyChanged;
+        }
+
+        public int SunriseValue => sunrise.Value;
+
+        public int SunsetValue => sunset.Value;
+
+        public void Dispose() => viewModel.PropertyChanged -= OnPropertyChanged;
+
+        private void OnPropertyChanged(object sender, PropertyChangedEventArgs args)
+        {
+            switch (args.PropertyName)
+            {
+                case nameof(viewModel.SunriseOffsetMin):
+                    sunrise.SetMinimum(viewModel.SunriseOffsetMin);
+                    break;
+                case nameof(viewModel.SunriseOffsetMax):
+                    sunrise.SetMaximum(viewModel.SunriseOffsetMax);
+                    break;
+                case nameof(viewModel.SunriseOffset):
+                    sunrise.SetValue(viewModel.SunriseOffset);
+                    break;
+                case nameof(viewModel.SunsetOffsetMin):
+                    sunset.SetMinimum(viewModel.SunsetOffsetMin);
+                    break;
+                case nameof(viewModel.SunsetOffsetMax):
+                    sunset.SetMaximum(viewModel.SunsetOffsetMax);
+                    break;
+                case nameof(viewModel.SunsetOffset):
+                    sunset.SetValue(viewModel.SunsetOffset);
+                    break;
+            }
+        }
+
+        private sealed class OffsetControl(int initialMinimum, int initialMaximum, int initialValue, Action<int> writeBack)
+        {
+            private int minimum = initialMinimum;
+            private int maximum = initialMaximum;
+
+            public int Value { get; private set; } = initialValue;
+
+            public void SetMinimum(int value)
+            {
+                minimum = value;
+                maximum = Math.Max(maximum, minimum);
+                SetValue(Value);
+            }
+
+            public void SetMaximum(int value)
+            {
+                maximum = value;
+                minimum = Math.Min(minimum, maximum);
+                SetValue(Value);
+            }
+
+            public void SetValue(int value)
+            {
+                int previous = Value;
+                Value = Math.Clamp(value, minimum, maximum);
+                if (Value != previous)
+                {
+                    writeBack(Value);
+                }
+            }
+        }
     }
 
     private static LightSwitchViewModel CreateViewModel(

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/LightSwitchPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/LightSwitchPage.xaml.cs
@@ -14,6 +14,7 @@ using ManagedCommon;
 using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.Library.Helpers;
+using Microsoft.PowerToys.Settings.UI.Library.Interfaces;
 using Microsoft.PowerToys.Settings.UI.ViewModels;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
@@ -50,23 +51,21 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             this.generalSettingsRepository = SettingsRepository<GeneralSettings>.GetInstance(this.settingsUtils);
             this.moduleSettingsRepository = SettingsRepository<LightSwitchSettings>.GetInstance(this.settingsUtils);
 
-            // Get settings from JSON (or defaults if JSON missing)
-            var darkSettings = this.moduleSettingsRepository.SettingsConfig;
+            var settingsPath = this.settingsUtils.GetSettingsFilePath(this.appName);
+            this.dispatcherQueue = DispatcherQueue.GetForCurrentThread();
+            this.fileSystem = new FileSystem();
+
+            var initialization = InitializeSettings(
+                this.fileSystem, settingsPath, this.moduleSettingsRepository, OnSettingsChanged);
+            this.fileSystemWatcher = initialization.Watcher;
 
             // Pass them into the ViewModel
-            this.ViewModel = new LightSwitchViewModel(this.generalSettingsRepository, darkSettings, ShellPage.SendDefaultIPCMessage);
+            this.ViewModel = new LightSwitchViewModel(this.generalSettingsRepository, initialization.Settings, ShellPage.SendDefaultIPCMessage);
             this.ViewModel.PropertyChanged += ViewModel_PropertyChanged;
 
             this.LoadSettings(this.generalSettingsRepository, this.moduleSettingsRepository);
 
             DataContext = this.ViewModel;
-
-            var settingsPath = this.settingsUtils.GetSettingsFilePath(this.appName);
-
-            this.dispatcherQueue = DispatcherQueue.GetForCurrentThread();
-            this.fileSystem = new FileSystem();
-
-            this.fileSystemWatcher = CreateSettingsWatcher(this.fileSystem, settingsPath, OnSettingsChanged);
 
             this.InitializeComponent();
             Loaded += LightSwitchPage_Loaded;
@@ -76,6 +75,29 @@ namespace Microsoft.PowerToys.Settings.UI.Views
         public void RefreshEnabledState()
         {
             this.ViewModel.RefreshEnabledState();
+        }
+
+        internal static (IFileSystemWatcher Watcher, LightSwitchSettings Settings) InitializeSettings(
+            IFileSystem fileSystem,
+            string settingsPath,
+            ISettingsRepository<LightSwitchSettings> settingsRepository,
+            Action onChanged)
+        {
+            // Dashboard can have cached this repository before a CLI file replacement.
+            // Subscribe first so an edit during the initial read also triggers a reload.
+            var watcher = CreateSettingsWatcher(fileSystem, settingsPath, onChanged);
+            try
+            {
+                settingsRepository.ReloadSettings();
+
+                // Preserve the repository's cached/default fallback if reading fails.
+                return (watcher, settingsRepository.SettingsConfig);
+            }
+            catch
+            {
+                watcher.Dispose();
+                throw;
+            }
         }
 
         internal static IFileSystemWatcher CreateSettingsWatcher(IFileSystem fileSystem, string settingsPath, Action onChanged)
@@ -314,11 +336,15 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             this.dispatcherQueue.TryEnqueue(() =>
             {
                 this.suppressViewModelUpdates = true;
-
-                this.moduleSettingsRepository.ReloadSettings();
-                this.LoadSettings(this.generalSettingsRepository, this.moduleSettingsRepository);
-
-                this.suppressViewModelUpdates = false;
+                try
+                {
+                    this.moduleSettingsRepository.ReloadSettings();
+                    this.LoadSettings(this.generalSettingsRepository, this.moduleSettingsRepository);
+                }
+                finally
+                {
+                    this.suppressViewModelUpdates = false;
+                }
             });
         }
 

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/LightSwitchPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/LightSwitchPage.xaml.cs
@@ -66,16 +66,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             this.dispatcherQueue = DispatcherQueue.GetForCurrentThread();
             this.fileSystem = new FileSystem();
 
-            this.fileSystemWatcher = this.fileSystem.FileSystemWatcher.New();
-            this.fileSystemWatcher.Path = this.fileSystem.Path.GetDirectoryName(settingsPath);
-            this.fileSystemWatcher.Filter = this.fileSystem.Path.GetFileName(settingsPath);
-            this.fileSystemWatcher.NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.CreationTime;
-            this.fileSystemWatcher.Changed += Settings_Changed;
-
-            // CLI updates replace the settings file after checking the complete write.
-            this.fileSystemWatcher.Created += Settings_Changed;
-            this.fileSystemWatcher.Renamed += Settings_Changed;
-            this.fileSystemWatcher.EnableRaisingEvents = true;
+            this.fileSystemWatcher = CreateSettingsWatcher(this.fileSystem, settingsPath, OnSettingsChanged);
 
             this.InitializeComponent();
             Loaded += LightSwitchPage_Loaded;
@@ -85,6 +76,23 @@ namespace Microsoft.PowerToys.Settings.UI.Views
         public void RefreshEnabledState()
         {
             this.ViewModel.RefreshEnabledState();
+        }
+
+        internal static IFileSystemWatcher CreateSettingsWatcher(IFileSystem fileSystem, string settingsPath, Action onChanged)
+        {
+            var watcher = fileSystem.FileSystemWatcher.New();
+            watcher.Path = fileSystem.Path.GetDirectoryName(settingsPath);
+            watcher.Filter = fileSystem.Path.GetFileName(settingsPath);
+
+            // CLI saves replace the file. FileName enables the rename/create notifications.
+            watcher.NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.CreationTime | NotifyFilters.FileName;
+            watcher.Changed += SettingsChanged;
+            watcher.Created += SettingsChanged;
+            watcher.Renamed += SettingsChanged;
+            watcher.EnableRaisingEvents = true;
+            return watcher;
+
+            void SettingsChanged(object sender, FileSystemEventArgs e) => onChanged();
         }
 
         private async void LightSwitchPage_Loaded(object sender, RoutedEventArgs e)
@@ -301,7 +309,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             }
         }
 
-        private void Settings_Changed(object sender, FileSystemEventArgs e)
+        private void OnSettingsChanged()
         {
             this.dispatcherQueue.TryEnqueue(() =>
             {

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/LightSwitchPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/LightSwitchPage.xaml.cs
@@ -71,6 +71,10 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             this.fileSystemWatcher.Filter = this.fileSystem.Path.GetFileName(settingsPath);
             this.fileSystemWatcher.NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.CreationTime;
             this.fileSystemWatcher.Changed += Settings_Changed;
+
+            // CLI updates replace the settings file after checking the complete write.
+            this.fileSystemWatcher.Created += Settings_Changed;
+            this.fileSystemWatcher.Renamed += Settings_Changed;
             this.fileSystemWatcher.EnableRaisingEvents = true;
 
             this.InitializeComponent();

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/LightSwitchPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/LightSwitchPage.xaml.cs
@@ -235,22 +235,14 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             double latitude = this.LatitudeBox.Value;
             double longitude = this.LongitudeBox.Value;
 
-            // need to save the values
-            this.ViewModel.Latitude = latitude.ToString(CultureInfo.InvariantCulture);
-            this.ViewModel.Longitude = longitude.ToString(CultureInfo.InvariantCulture);
-            this.ViewModel.SyncButtonInformation = $"{this.ViewModel.Latitude}°, {this.ViewModel.Longitude}°";
-
-            var result = SunCalc.CalculateSunriseSunset(latitude, longitude, DateTime.Now.Year, DateTime.Now.Month, DateTime.Now.Day);
-
-            this.ViewModel.LightTime = (result.SunriseHour * 60) + result.SunriseMinute;
-            this.ViewModel.DarkTime = (result.SunsetHour * 60) + result.SunsetMinute;
+            this.ViewModel.UpdateSunTimes(latitude, longitude);
 
             this.SunriseModeChartState();
         }
 
         private void ViewModel_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
-            if (this.suppressViewModelUpdates)
+            if (this.suppressViewModelUpdates || this.ViewModel.IsRefreshingModuleSettings)
             {
                 return;
             }

--- a/src/settings-ui/Settings.UI/ViewModels/LightSwitchViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/LightSwitchViewModel.cs
@@ -61,8 +61,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 "FollowNightLight",
             };
 
-            // Check if PowerDisplay is enabled
-            CheckPowerDisplayEnabled();
+            IsPowerDisplayEnabled = GeneralSettingsConfig.Enabled.PowerDisplay;
         }
 
         public override Dictionary<string, HotkeySettings[]> GetAllHotkeySettings()
@@ -126,9 +125,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 {
                     _moduleSettings = value;
 
-                    OnPropertyChanged(nameof(ModuleSettings));
                     RefreshModuleSettings();
-                    RefreshEnabledState();
                 }
             }
         }
@@ -182,12 +179,14 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             get => ModuleSettings.Properties.ScheduleMode.Value;
             set
             {
-                var oldMode = ModuleSettings.Properties.ScheduleMode.Value;
-                if (ModuleSettings.Properties.ScheduleMode.Value != value)
+                if (_refreshingModuleSettings || ModuleSettings.Properties.ScheduleMode.Value == value)
                 {
-                    ModuleSettings.Properties.ScheduleMode.Value = value;
-                    OnPropertyChanged(nameof(ScheduleMode));
+                    return;
                 }
+
+                var oldMode = ModuleSettings.Properties.ScheduleMode.Value;
+                ModuleSettings.Properties.ScheduleMode.Value = value;
+                OnPropertyChanged(nameof(ScheduleMode));
 
                 if (ModuleSettings.Properties.ScheduleMode.Value == "FixedHours" && oldMode != "FixedHours")
                 {
@@ -219,7 +218,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             get => ModuleSettings.Properties.ChangeSystem.Value;
             set
             {
-                if (ModuleSettings.Properties.ChangeSystem.Value != value)
+                if (!_refreshingModuleSettings && ModuleSettings.Properties.ChangeSystem.Value != value)
                 {
                     ModuleSettings.Properties.ChangeSystem.Value = value;
                     NotifyPropertyChanged();
@@ -232,7 +231,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             get => ModuleSettings.Properties.ChangeApps.Value;
             set
             {
-                if (ModuleSettings.Properties.ChangeApps.Value != value)
+                if (!_refreshingModuleSettings && ModuleSettings.Properties.ChangeApps.Value != value)
                 {
                     ModuleSettings.Properties.ChangeApps.Value = value;
                     NotifyPropertyChanged();
@@ -245,7 +244,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             get => ModuleSettings.Properties.LightTime.Value;
             set
             {
-                if (ModuleSettings.Properties.LightTime.Value != value)
+                if (!_refreshingModuleSettings && ModuleSettings.Properties.LightTime.Value != value)
                 {
                     ModuleSettings.Properties.LightTime.Value = value;
                     NotifyPropertyChanged();
@@ -267,7 +266,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             get => ModuleSettings.Properties.DarkTime.Value;
             set
             {
-                if (ModuleSettings.Properties.DarkTime.Value != value)
+                if (!_refreshingModuleSettings && ModuleSettings.Properties.DarkTime.Value != value)
                 {
                     ModuleSettings.Properties.DarkTime.Value = value;
                     NotifyPropertyChanged();
@@ -289,7 +288,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             get => ModuleSettings.Properties.SunriseOffset.Value;
             set
             {
-                if (ModuleSettings.Properties.SunriseOffset.Value != value)
+                if (!_refreshingModuleSettings && ModuleSettings.Properties.SunriseOffset.Value != value)
                 {
                     ModuleSettings.Properties.SunriseOffset.Value = value;
                     OnPropertyChanged(nameof(LightTimeTimeSpan));
@@ -303,7 +302,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             get => ModuleSettings.Properties.SunsetOffset.Value;
             set
             {
-                if (ModuleSettings.Properties.SunsetOffset.Value != value)
+                if (!_refreshingModuleSettings && ModuleSettings.Properties.SunsetOffset.Value != value)
                 {
                     ModuleSettings.Properties.SunsetOffset.Value = value;
                     OnPropertyChanged(nameof(DarkTimeTimeSpan));
@@ -317,7 +316,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             get
             {
                 // Minimum: don't let adjusted sunrise go before 00:00
-                return -LightTime;
+                return -DisplayLightMinutes;
             }
         }
 
@@ -326,8 +325,8 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             get
             {
                 // Maximum: adjusted sunrise must stay before adjusted sunset
-                int adjustedSunset = DarkTime + SunsetOffset;
-                return Math.Max(0, adjustedSunset - LightTime - 1);
+                int adjustedSunset = DisplayDarkMinutes + SunsetOffset;
+                return Math.Max(0, adjustedSunset - DisplayLightMinutes - 1);
             }
         }
 
@@ -336,8 +335,8 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             get
             {
                 // Minimum: adjusted sunset must stay after adjusted sunrise
-                int adjustedSunrise = LightTime + SunriseOffset;
-                return Math.Min(0, adjustedSunrise - DarkTime + 1);
+                int adjustedSunrise = DisplayLightMinutes + SunriseOffset;
+                return Math.Min(0, adjustedSunrise - DisplayDarkMinutes + 1);
             }
         }
 
@@ -346,18 +345,26 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             get
             {
                 // Maximum: don't let adjusted sunset go past 23:59 (1439 minutes)
-                return 1439 - DarkTime;
+                return 1439 - DisplayDarkMinutes;
             }
         }
 
         // === Computed projections (OneWay bindings only) ===
+        private int DisplayLightMinutes => ScheduleMode == "SunsetToSunrise" && SunriseTimeSpan.HasValue
+            ? (int)SunriseTimeSpan.Value.TotalMinutes
+            : LightTime;
+
+        private int DisplayDarkMinutes => ScheduleMode == "SunsetToSunrise" && SunsetTimeSpan.HasValue
+            ? (int)SunsetTimeSpan.Value.TotalMinutes
+            : DarkTime;
+
         public TimeSpan LightTimeTimeSpan
         {
             get
             {
                 if (ScheduleMode == "SunsetToSunrise")
                 {
-                    return TimeSpan.FromMinutes(LightTime + SunriseOffset);
+                    return TimeSpan.FromMinutes(DisplayLightMinutes + SunriseOffset);
                 }
                 else
                 {
@@ -372,7 +379,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             {
                 if (ScheduleMode == "SunsetToSunrise")
                 {
-                    return TimeSpan.FromMinutes(DarkTime + SunsetOffset);
+                    return TimeSpan.FromMinutes(DisplayDarkMinutes + SunsetOffset);
                 }
                 else
                 {
@@ -391,6 +398,10 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 {
                     _sunriseTimeSpan = value;
                     NotifyPropertyChanged();
+                    OnPropertyChanged(nameof(LightTimeTimeSpan));
+                    OnPropertyChanged(nameof(SunriseOffsetMin));
+                    OnPropertyChanged(nameof(SunriseOffsetMax));
+                    OnPropertyChanged(nameof(SunsetOffsetMin));
                 }
             }
         }
@@ -404,6 +415,10 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 {
                     _sunsetTimeSpan = value;
                     NotifyPropertyChanged();
+                    OnPropertyChanged(nameof(DarkTimeTimeSpan));
+                    OnPropertyChanged(nameof(SunriseOffsetMax));
+                    OnPropertyChanged(nameof(SunsetOffsetMin));
+                    OnPropertyChanged(nameof(SunsetOffsetMax));
                 }
             }
         }
@@ -426,7 +441,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             get => ModuleSettings.Properties.Latitude.Value;
             set
             {
-                if (ModuleSettings.Properties.Latitude.Value != value)
+                if (!_refreshingModuleSettings && ModuleSettings.Properties.Latitude.Value != value)
                 {
                     ModuleSettings.Properties.Latitude.Value = value;
                     NotifyPropertyChanged();
@@ -439,7 +454,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             get => ModuleSettings.Properties.Longitude.Value;
             set
             {
-                if (ModuleSettings.Properties.Longitude.Value != value)
+                if (!_refreshingModuleSettings && ModuleSettings.Properties.Longitude.Value != value)
                 {
                     ModuleSettings.Properties.Longitude.Value = value;
                     NotifyPropertyChanged();
@@ -454,7 +469,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             get => _selectedSearchLocation;
             set
             {
-                if (_selectedSearchLocation != value)
+                if (!_refreshingModuleSettings && _selectedSearchLocation != value)
                 {
                     _selectedSearchLocation = value;
                     NotifyPropertyChanged();
@@ -553,7 +568,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
             set
             {
-                if (value != ModuleSettings.Properties.ToggleThemeHotkey.Value)
+                if (!_refreshingModuleSettings && value != ModuleSettings.Properties.ToggleThemeHotkey.Value)
                 {
                     if (value == null)
                     {
@@ -636,7 +651,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             get => ModuleSettings.Properties.EnableDarkModeProfile.Value;
             set
             {
-                if (ModuleSettings.Properties.EnableDarkModeProfile.Value != value)
+                if (!_refreshingModuleSettings && ModuleSettings.Properties.EnableDarkModeProfile.Value != value)
                 {
                     ModuleSettings.Properties.EnableDarkModeProfile.Value = value;
                     NotifyPropertyChanged();
@@ -651,7 +666,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             get => ModuleSettings.Properties.EnableLightModeProfile.Value;
             set
             {
-                if (ModuleSettings.Properties.EnableLightModeProfile.Value != value)
+                if (!_refreshingModuleSettings && ModuleSettings.Properties.EnableLightModeProfile.Value != value)
                 {
                     ModuleSettings.Properties.EnableLightModeProfile.Value = value;
                     NotifyPropertyChanged();
@@ -680,7 +695,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         /// </summary>
         private void SetSelectedProfile(ref PowerDisplayProfile? field, PowerDisplayProfile? value, bool isDarkMode, string propertyName)
         {
-            if (field == value)
+            if (_refreshingModuleSettings || field == value)
             {
                 return;
             }
@@ -817,17 +832,79 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
         public void RefreshModuleSettings()
         {
-            OnPropertyChanged(nameof(ChangeSystem));
-            OnPropertyChanged(nameof(ChangeApps));
-            OnPropertyChanged(nameof(LightTime));
-            OnPropertyChanged(nameof(DarkTime));
-            OnPropertyChanged(nameof(SunriseOffset));
-            OnPropertyChanged(nameof(SunsetOffset));
-            OnPropertyChanged(nameof(Latitude));
-            OnPropertyChanged(nameof(Longitude));
-            OnPropertyChanged(nameof(ScheduleMode));
-            OnPropertyChanged(nameof(EnableDarkModeProfile));
-            OnPropertyChanged(nameof(EnableLightModeProfile));
+            RefreshModuleSettings(calculateSunTimes: false);
+        }
+
+        private void RefreshModuleSettings(bool calculateSunTimes)
+        {
+            var wasRefreshing = _refreshingModuleSettings;
+            _refreshingModuleSettings = true;
+            try
+            {
+                // Reloaded values are authoritative. Updating TwoWay controls (in
+                // particular NumberBox bounds) must not write their old values back.
+                RefreshScheduleDisplay(calculateSunTimes);
+                OnPropertyChanged(nameof(ModuleSettings));
+                OnPropertyChanged(nameof(ChangeSystem));
+                OnPropertyChanged(nameof(ChangeApps));
+                OnPropertyChanged(nameof(LightTime));
+                OnPropertyChanged(nameof(DarkTime));
+                OnPropertyChanged(nameof(LightTimePickerValue));
+                OnPropertyChanged(nameof(DarkTimePickerValue));
+                OnPropertyChanged(nameof(LightTimeTimeSpan));
+                OnPropertyChanged(nameof(DarkTimeTimeSpan));
+                OnPropertyChanged(nameof(SunriseTimeSpan));
+                OnPropertyChanged(nameof(SunsetTimeSpan));
+                OnPropertyChanged(nameof(SunriseOffsetMin));
+                OnPropertyChanged(nameof(SunriseOffsetMax));
+                OnPropertyChanged(nameof(SunsetOffsetMin));
+                OnPropertyChanged(nameof(SunsetOffsetMax));
+                OnPropertyChanged(nameof(SunriseOffset));
+                OnPropertyChanged(nameof(SunsetOffset));
+                OnPropertyChanged(nameof(Latitude));
+                OnPropertyChanged(nameof(Longitude));
+                OnPropertyChanged(nameof(SelectedCity));
+                OnPropertyChanged(nameof(SyncButtonInformation));
+                OnPropertyChanged(nameof(ScheduleMode));
+                OnPropertyChanged(nameof(ToggleThemeActivationShortcut));
+                OnPropertyChanged(nameof(EnableDarkModeProfile));
+                OnPropertyChanged(nameof(EnableLightModeProfile));
+                SelectByStoredReference(isDarkMode: true);
+                SelectByStoredReference(isDarkMode: false);
+                RefreshEnabledState();
+            }
+            finally
+            {
+                _refreshingModuleSettings = wasRefreshing;
+            }
+        }
+
+        private void RefreshScheduleDisplay(bool calculateSunTimes)
+        {
+            bool sunSchedule = ScheduleMode == "SunsetToSunrise";
+            _sunriseTimeSpan = sunSchedule ? TimeSpan.FromMinutes(LightTime) : null;
+            _sunsetTimeSpan = sunSchedule ? TimeSpan.FromMinutes(DarkTime) : null;
+
+            _selectedSearchLocation = null;
+            if (double.TryParse(Latitude, NumberStyles.Float, CultureInfo.InvariantCulture, out double savedLat) &&
+                double.TryParse(Longitude, NumberStyles.Float, CultureInfo.InvariantCulture, out double savedLng))
+            {
+                _selectedSearchLocation = SearchLocations.FirstOrDefault(c =>
+                    Math.Abs(c.Latitude - savedLat) < 0.0001 &&
+                    Math.Abs(c.Longitude - savedLng) < 0.0001);
+
+                if (sunSchedule && calculateSunTimes)
+                {
+                    // Keep the initial preview current even when the module is off.
+                    // These display values must not replace the saved schedule times.
+                    var today = DateTime.Now;
+                    var sunTimes = SunCalc.CalculateSunriseSunset(savedLat, savedLng, today.Year, today.Month, today.Day);
+                    _sunriseTimeSpan = TimeSpan.FromMinutes((sunTimes.SunriseHour * 60) + sunTimes.SunriseMinute);
+                    _sunsetTimeSpan = TimeSpan.FromMinutes((sunTimes.SunsetHour * 60) + sunTimes.SunsetMinute);
+                }
+            }
+
+            _syncButtonInformation = _selectedSearchLocation?.City ?? $"{Latitude}°,{Longitude}°";
         }
 
         private void UpdateSunTimes(double latitude, double longitude, string city = "n/a")
@@ -852,35 +929,13 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
         public void InitializeScheduleMode()
         {
-            if (ScheduleMode == "SunsetToSunrise" &&
-                double.TryParse(Latitude, NumberStyles.Float, CultureInfo.InvariantCulture, out double savedLat) &&
-                double.TryParse(Longitude, NumberStyles.Float, CultureInfo.InvariantCulture, out double savedLng))
-            {
-                var match = SearchLocations.FirstOrDefault(c =>
-                    Math.Abs(c.Latitude - savedLat) < 0.0001 &&
-                    Math.Abs(c.Longitude - savedLng) < 0.0001);
-
-                if (match != null)
-                {
-                    SelectedCity = match;
-                }
-
-                SyncButtonInformation = SelectedCity != null
-                    ? SelectedCity.City
-                    : $"{Latitude}°,{Longitude}°";
-
-                double lat = double.Parse(ModuleSettings.Properties.Latitude.Value, CultureInfo.InvariantCulture);
-                double lon = double.Parse(ModuleSettings.Properties.Longitude.Value, CultureInfo.InvariantCulture);
-                UpdateSunTimes(lat, lon);
-
-                SunriseTimeSpan = TimeSpan.FromMinutes(LightTime);
-                SunsetTimeSpan = TimeSpan.FromMinutes(DarkTime);
-            }
+            RefreshModuleSettings(calculateSunTimes: true);
         }
 
         private bool _enabledStateIsGPOConfigured;
         private GpoRuleConfigured _enabledGpoRuleConfiguration;
         private LightSwitchSettings _moduleSettings;
+        private bool _refreshingModuleSettings;
         private bool _isEnabled;
         private TimeSpan? _sunriseTimeSpan;
         private TimeSpan? _sunsetTimeSpan;

--- a/src/settings-ui/Settings.UI/ViewModels/LightSwitchViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/LightSwitchViewModel.cs
@@ -130,6 +130,8 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
+        internal bool IsRefreshingModuleSettings => _refreshingModuleSettings;
+
         public bool IsEnabled
         {
             get => _isEnabled;
@@ -424,16 +426,33 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         }
 
         // === Picker values (TwoWay binding targets for TimePickers) ===
+        private static TimeSpan ToPickerTime(int minutes) =>
+            minutes is >= 0 and < 1440 ? TimeSpan.FromMinutes(minutes) : TimeSpan.FromTicks(-1);
+
         public TimeSpan LightTimePickerValue
         {
-            get => TimeSpan.FromMinutes(LightTime);
-            set => LightTime = (int)value.TotalMinutes;
+            // TimePicker only accepts -1 tick for an unset value. Keep missing sun
+            // times in settings without passing other negative durations to XAML.
+            get => ToPickerTime(LightTime);
+            set
+            {
+                if (value.Ticks >= 0 && value.Ticks < TimeSpan.TicksPerDay)
+                {
+                    LightTime = (int)value.TotalMinutes;
+                }
+            }
         }
 
         public TimeSpan DarkTimePickerValue
         {
-            get => TimeSpan.FromMinutes(DarkTime);
-            set => DarkTime = (int)value.TotalMinutes;
+            get => ToPickerTime(DarkTime);
+            set
+            {
+                if (value.Ticks >= 0 && value.Ticks < TimeSpan.TicksPerDay)
+                {
+                    DarkTime = (int)value.TotalMinutes;
+                }
+            }
         }
 
         public string Latitude
@@ -472,11 +491,14 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 if (!_refreshingModuleSettings && _selectedSearchLocation != value)
                 {
                     _selectedSearchLocation = value;
-                    NotifyPropertyChanged();
 
                     if (_selectedSearchLocation != null)
                     {
                         UpdateSunTimes(_selectedSearchLocation.Latitude, _selectedSearchLocation.Longitude, _selectedSearchLocation.City);
+                    }
+                    else
+                    {
+                        NotifyPropertyChanged();
                     }
                 }
             }
@@ -835,7 +857,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             RefreshModuleSettings(calculateSunTimes: false);
         }
 
-        private void RefreshModuleSettings(bool calculateSunTimes)
+        private void RefreshModuleSettings(bool calculateSunTimes, string? locationName = null)
         {
             var wasRefreshing = _refreshingModuleSettings;
             _refreshingModuleSettings = true;
@@ -844,6 +866,11 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 // Reloaded values are authoritative. Updating TwoWay controls (in
                 // particular NumberBox bounds) must not write their old values back.
                 RefreshScheduleDisplay(calculateSunTimes);
+                if (locationName != null)
+                {
+                    _syncButtonInformation = locationName;
+                }
+
                 OnPropertyChanged(nameof(ModuleSettings));
                 OnPropertyChanged(nameof(ChangeSystem));
                 OnPropertyChanged(nameof(ChangeApps));
@@ -907,24 +934,63 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             _syncButtonInformation = _selectedSearchLocation?.City ?? $"{Latitude}°,{Longitude}°";
         }
 
-        private void UpdateSunTimes(double latitude, double longitude, string city = "n/a")
+        public void UpdateSunTimes(double latitude, double longitude, string city = "n/a")
         {
+            var today = DateTime.Now;
             SunTimes result = SunCalc.CalculateSunriseSunset(
                 latitude,
                 longitude,
-                DateTime.Now.Year,
-                DateTime.Now.Month,
-                DateTime.Now.Day);
+                today.Year,
+                today.Month,
+                today.Day);
 
-            LightTime = (result.SunriseHour * 60) + result.SunriseMinute;
-            DarkTime = (result.SunsetHour * 60) + result.SunsetMinute;
-            Latitude = latitude.ToString(CultureInfo.InvariantCulture);
-            Longitude = longitude.ToString(CultureInfo.InvariantCulture);
+            ApplyLocation(latitude, longitude, (result.SunriseHour * 60) + result.SunriseMinute, (result.SunsetHour * 60) + result.SunsetMinute, city);
+        }
 
-            if (city != "n/a")
+        internal void ApplyLocation(double latitude, double longitude, int lightMinutes, int darkMinutes, string city = "n/a")
+        {
+            if (_refreshingModuleSettings)
             {
-                SyncButtonInformation = city;
+                return;
             }
+
+            var properties = ModuleSettings.Properties;
+            string latitudeText = latitude.ToString(CultureInfo.InvariantCulture);
+            string longitudeText = longitude.ToString(CultureInfo.InvariantCulture);
+            int sunriseOffset = properties.SunriseOffset.Value;
+            int sunsetOffset = properties.SunsetOffset.Value;
+
+            if (lightMinutes is >= 0 and < 1440 && darkMinutes is >= 0 and < 1440)
+            {
+                // Clamp against the complete new schedule, in the same order as the
+                // offset controls. Recheck sunset after a sunrise adjustment. Missing
+                // polar sun times retain the existing offsets rather than invent bounds.
+                sunsetOffset = ClampSunsetOffset(sunsetOffset, sunriseOffset);
+                sunriseOffset = (int)Math.Clamp((long)sunriseOffset, -lightMinutes, Math.Max(0L, (long)darkMinutes + sunsetOffset - lightMinutes - 1));
+                sunsetOffset = ClampSunsetOffset(sunsetOffset, sunriseOffset);
+            }
+
+            bool changed = properties.Latitude.Value != latitudeText || properties.Longitude.Value != longitudeText ||
+                properties.LightTime.Value != lightMinutes || properties.DarkTime.Value != darkMinutes ||
+                properties.SunriseOffset.Value != sunriseOffset || properties.SunsetOffset.Value != sunsetOffset;
+
+            // Publish all source values before any binding or persistence callback
+            // can observe the new location. A partial pair can clamp a valid offset.
+            properties.Latitude.Value = latitudeText;
+            properties.Longitude.Value = longitudeText;
+            properties.LightTime.Value = lightMinutes;
+            properties.DarkTime.Value = darkMinutes;
+            properties.SunriseOffset.Value = sunriseOffset;
+            properties.SunsetOffset.Value = sunsetOffset;
+            RefreshModuleSettings(calculateSunTimes: false, locationName: city == "n/a" ? null : city);
+
+            if (changed)
+            {
+                SaveSettings();
+            }
+
+            int ClampSunsetOffset(int value, int lightOffset) =>
+                (int)Math.Clamp((long)value, Math.Min(0L, (long)lightMinutes + lightOffset - darkMinutes + 1), 1439 - darkMinutes);
         }
 
         public void InitializeScheduleMode()

--- a/tools/CliShim/CliShimManifest.props
+++ b/tools/CliShim/CliShimManifest.props
@@ -16,6 +16,9 @@
     <CliShim Include="PowerToys.PowerDisplay.CLI">
       <RelativeTarget>../WinUI3Apps/PowerToys.PowerDisplay.Cli.exe</RelativeTarget>
     </CliShim>
+    <CliShim Include="PowerToys.LightSwitch.CLI">
+      <RelativeTarget>../PowerToys.LightSwitch.Cli.exe</RelativeTarget>
+    </CliShim>
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
## Summary of the Pull Request

Adds `PowerToys.LightSwitch.CLI.exe` for querying and controlling the running Light Switch service. Scripts can read status, set or toggle the configured theme targets, and enable or disable the existing schedule, with JSON output and documented exit codes.

Closes #49904.

## PR Checklist

- [x] Closes: #49904
- [ ] **Communication:** Discussed with core contributors.
- [x] **Tests:** Added/updated; all 152 module tests pass locally.
- [ ] **Localization:** CLI help and diagnostics are currently English.
- [x] **Dev docs:** Added/updated.
- [x] **New binaries:** Added to the solution, signing list, CLI shim manifest, and installer shim components.
- [ ] **Documentation updated:** External PowerToys documentation PR.

## Detailed Description of the Pull Request / Additional comments

- `src/modules/LightSwitch/LightSwitch.Cli/` adds `status`, `light`, `dark`, `toggle`, `schedule enable [--mode]`, and `schedule disable`. All commands support `--json`; help and version work without the service. Enabling a schedule from `Off` requires an explicit existing mode: `fixed-hours`, `sunset-to-sunrise`, or `follow-night-light`.
- `src/modules/LightSwitch/LightSwitchService/CliPipeServer.cpp` and `CliProtocol.cpp` implement bounded, versioned request/response IPC with session/user isolation, server identity checks in the client, timeouts, and shutdown handling. The CLI requires a running service and does not automatically retry mutations after an uncertain result.
- `src/modules/LightSwitch/LightSwitchService/LightSwitchStateManager.cpp` exposes serialized theme operations and status snapshots using the existing scheduling rules. `src/modules/LightSwitch/LightSwitchModuleInterface/dllmain.cpp` submits counted toggle requests to the service so theme writes and manual-override updates occur together. Theme access failures and partial changes are reported to callers.
- Schedule commands update the existing `scheduleMode` setting and complete the worker's settings handling before replying. Duplicate settings notifications preserve manual overrides, and settings loaded before a delayed notification are not mistaken for an external theme change. `src/settings-ui/Settings.UI/SettingsXAML/Views/LightSwitchPage.xaml.cs` also refreshes after settings-file replacement. Concurrent editors retain the existing whole-file save behavior.
- `tools/CliShim/CliShimManifest.props`, `installer/PowerToysSetupVNext/CliShims.wxs`, and `.pipelines/ESRPSigning_core.json` register deployment and signing. Usage, protocol behavior, and exit codes are documented in `doc/devdocs/modules/lightswitch-cli.md`.

## Validation Steps Performed

- x64 Debug builds passed for Runner, Settings UI, Light Switch service/module interface, CLI and test projects, and CLI shim. The service and native tests were rebuilt successfully after the final regression fix.
- 106 managed CLI tests passed in `src/modules/LightSwitch/Tests/LightSwitch.Cli.UnitTests/`.
- 46 native tests passed via `vstest.console.exe` in `src/modules/LightSwitch/Tests/LightSwitchService.UnitTests/`, including the regression for a minute tick loading settings before the debounced notification.
- Built shim smoke checks passed for JSON help, invalid-mode exit code 2, and unavailable-service JSON output with exit code 3.
- `git diff --check` passed.

Desktop theme/hotkey acceptance, ARM64/Release validation, and full installer acceptance remain pending. Settings UI's successful build reported an existing `CsWinRT1028` warning in `src/common/ManagedCommon/HotkeySettingsControlHook.cs`.