### PR TITLE
[UITests][Workspaces] Add UI tests

### DIFF
--- a/.pipelines/tests/runUiTestAsUser.Tests.ps1
+++ b/.pipelines/tests/runUiTestAsUser.Tests.ps1
@@ -446,17 +446,44 @@ Describe 'runUiTestAsUser controller contracts without desktop work' {
 }
 
 Describe 'UI-test pipeline non-elevated dispatch' {
-    It 'fails infrastructure instead of using the DLL when the required executable is absent' {
+    It 'fails infrastructure instead of using the DLL when <Suite> is absent' -TestCases @(
+        @{ Suite = 'CropAndLock.UITests' }
+        @{ Suite = 'Workspaces.UITests.Next' }
+    ) {
+        param($Suite)
+
         $template = Get-Content (Join-Path $PSScriptRoot '..\v2\templates\job-test-project.yml') -Raw
-        $template | Should Match '\$nonElevatedSuites = @\(''CropAndLock.UITests''\)'
+        $declaration = [regex]::Match($template, '\$nonElevatedSuites = @\([^\r\n]*\)').Value
+        $declaration | Should Not BeNullOrEmpty
+        $nonElevatedSuites = @([regex]::Matches($declaration, "'([^']+)'") | ForEach-Object { $_.Groups[1].Value })
+        ($nonElevatedSuites -contains $Suite) | Should Be $true
         $dispatch = [regex]::Match($template, '(?ms)^ {10}if \(\$nonElevatedSuites -contains \$base\) \{.*?^ {10}\}').Value
         $dispatch | Should Not BeNullOrEmpty
-        $nonElevatedSuites = @('CropAndLock.UITests')
-        $base = 'CropAndLock.UITests'
+        $base = $Suite
         $exe = Join-Path $TestDrive "$base.exe"
         $dll = Join-Path $TestDrive "$base.dll"
         'not a test runner' | Set-Content -LiteralPath $dll
 
         { & ([scriptblock]::Create($dispatch)) } | Should Throw 'requires its staged executable for non-elevated dispatch'
+    }
+
+    It 'scopes Workspaces package and Quick Access signing to the selected suite' -TestCases @(
+        @{ Modules = @('Workspaces.UITests.Next'); AllModules = $false; Expected = $true }
+        @{ Modules = @('RegistryPreview.UITests'); AllModules = $false; Expected = $false }
+        @{ Modules = @(); AllModules = $true; Expected = $true }
+    ) {
+        param($Modules, $AllModules, $Expected)
+
+        $template = Get-Content (Join-Path $PSScriptRoot '..\v2\templates\job-test-project.yml') -Raw
+        $signing = [regex]::Match($template, '(?ms)^ {6}if \(\$allModules -or \$selectedModules -contains ''Workspaces\.UITests\.Next''\) \{.*?^ {6}\}').Value
+        $signing | Should Not BeNullOrEmpty
+        $selectedModules = $Modules
+        $allModules = $AllModules
+        $requiredPackages = @()
+        $requiredAuthenticodeFiles = @()
+        . ([scriptblock]::Create($signing))
+
+        ($requiredPackages -contains 'Workspaces.TestApp.msix') | Should Be $Expected
+        ($requiredAuthenticodeFiles -contains 'PowerToys.QuickAccess.exe') | Should Be $Expected
     }
 }

--- a/.pipelines/tests/runUiTestAsUser.Tests.ps1
+++ b/.pipelines/tests/runUiTestAsUser.Tests.ps1
@@ -469,6 +469,9 @@ Describe 'UI-test pipeline non-elevated dispatch' {
 
     It 'scopes Workspaces package and Quick Access signing to the selected suite' -TestCases @(
         @{ Modules = @('Workspaces.UITests.Next'); AllModules = $false; Expected = $true }
+        @{ Modules = @('Workspaces.Editor.UITests'); AllModules = $false; Expected = $false }
+        @{ Modules = @('Other.Workspaces.UITests.Next'); AllModules = $false; Expected = $false }
+        @{ Modules = @('Workspaces.UITests.Next.Other'); AllModules = $false; Expected = $false }
         @{ Modules = @('RegistryPreview.UITests'); AllModules = $false; Expected = $false }
         @{ Modules = @(); AllModules = $true; Expected = $true }
     ) {
@@ -485,5 +488,26 @@ Describe 'UI-test pipeline non-elevated dispatch' {
 
         ($requiredPackages -contains 'Workspaces.TestApp.msix') | Should Be $Expected
         ($requiredAuthenticodeFiles -contains 'PowerToys.QuickAccess.exe') | Should Be $Expected
+    }
+
+    It 'scopes Workspaces authenticated Settings IPC signing without changing other families' -TestCases @(
+        @{ Modules = @('Workspaces.UITests.Next'); AllModules = $false; Expected = $true }
+        @{ Modules = @('Workspaces.Editor.UITests'); AllModules = $false; Expected = $false }
+        @{ Modules = @('Other.Workspaces.UITests.Next'); AllModules = $false; Expected = $false }
+        @{ Modules = @('Workspaces.UITests.Next.Other'); AllModules = $false; Expected = $false }
+        @{ Modules = @('RegistryPreview.UITests'); AllModules = $false; Expected = $true }
+        @{ Modules = @('CropAndLock.UITests'); AllModules = $false; Expected = $true }
+        @{ Modules = @(); AllModules = $true; Expected = $true }
+    ) {
+        param($Modules, $AllModules, $Expected)
+
+        $template = Get-Content (Join-Path $PSScriptRoot '..\v2\templates\job-test-project.yml') -Raw
+        $selection = [regex]::Match($template, '(?m)^\s*\$requiresAuthenticatedSettingsIpc = [^\r\n]+').Value
+        $selection | Should Not BeNullOrEmpty
+        $selectedModules = $Modules
+        $allModules = $AllModules
+        . ([scriptblock]::Create($selection))
+
+        $requiresAuthenticatedSettingsIpc | Should Be $Expected
     }
 }

--- a/.pipelines/v2/templates/job-test-project.yml
+++ b/.pipelines/v2/templates/job-test-project.yml
@@ -217,7 +217,7 @@ jobs:
       $allModules = [string]::IsNullOrWhiteSpace($modulesRaw)
       $requiresModernContextMenu = '$(TestPlatform)' -ne 'x64Win10'
       $requiresPowerRename = $allModules -or @($selectedModules | Where-Object { $_ -match 'PowerRename' }).Count -gt 0
-      $requiresAuthenticatedSettingsIpc = $allModules -or @($selectedModules | Where-Object { $_ -match 'PowerRename|MouseUtils|PowerAccent|ColorPicker|Hosts|RegistryPreview|CropAndLock' }).Count -gt 0
+      $requiresAuthenticatedSettingsIpc = $allModules -or @($selectedModules | Where-Object { $_ -match 'PowerRename|MouseUtils|PowerAccent|ColorPicker|Hosts|RegistryPreview|CropAndLock|Workspaces' }).Count -gt 0
       $requiredPackages = @()
       $requiredAuthenticodeFiles = @()
       $certificateMarkerPath = "$(Agent.WorkFolder)\PowerToysUiTestState\SigningCertificates.txt"
@@ -232,6 +232,11 @@ jobs:
 
       if ($allModules -or @($selectedModules | Where-Object { $_ -match 'CropAndLock' }).Count -gt 0) {
         $requiredPackages += 'CropAndLock.TestApp.msix'
+      }
+
+      if ($allModules -or $selectedModules -contains 'Workspaces.UITests.Next') {
+        $requiredPackages += 'Workspaces.TestApp.msix'
+        $requiredAuthenticodeFiles += 'PowerToys.QuickAccess.exe'
       }
 
       if ($requiresAuthenticatedSettingsIpc) {
@@ -344,7 +349,7 @@ jobs:
       $resultsDir = "$(Common.TestResultsDirectory)"
       New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
 
-      $nonElevatedSuites = @('CropAndLock.UITests')
+      $nonElevatedSuites = @('CropAndLock.UITests', 'Workspaces.UITests.Next')
       $failed = 0
       foreach ($rc in ($entries | Sort-Object FullName -Unique)) {
         $base = $rc.Name -replace '\.runtimeconfig\.json$', ''

--- a/.pipelines/v2/templates/job-test-project.yml
+++ b/.pipelines/v2/templates/job-test-project.yml
@@ -217,7 +217,7 @@ jobs:
       $allModules = [string]::IsNullOrWhiteSpace($modulesRaw)
       $requiresModernContextMenu = '$(TestPlatform)' -ne 'x64Win10'
       $requiresPowerRename = $allModules -or @($selectedModules | Where-Object { $_ -match 'PowerRename' }).Count -gt 0
-      $requiresAuthenticatedSettingsIpc = $allModules -or @($selectedModules | Where-Object { $_ -match 'PowerRename|MouseUtils|PowerAccent|ColorPicker|Hosts|RegistryPreview|CropAndLock|Workspaces' }).Count -gt 0
+      $requiresAuthenticatedSettingsIpc = $allModules -or $selectedModules -contains 'Workspaces.UITests.Next' -or @($selectedModules | Where-Object { $_ -match 'PowerRename|MouseUtils|PowerAccent|ColorPicker|Hosts|RegistryPreview|CropAndLock' }).Count -gt 0
       $requiredPackages = @()
       $requiredAuthenticodeFiles = @()
       $certificateMarkerPath = "$(Agent.WorkFolder)\PowerToysUiTestState\SigningCertificates.txt"

--- a/PowerToys.slnx
+++ b/PowerToys.slnx
@@ -1208,6 +1208,14 @@
     <Project Path="src/modules/Workspaces/WorkspacesWindowArranger/WorkspacesWindowArranger.vcxproj" Id="37d07516-4185-43a4-924f-3c7a5d95ecf6" />
   </Folder>
   <Folder Name="/modules/Workspaces/Tests/">
+    <Project Path="src/modules/Workspaces/Tests/Workspaces.TestApp/Workspaces.TestApp.csproj">
+      <Platform Solution="*|ARM64" Project="ARM64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
+    <Project Path="src/modules/Workspaces/Tests/Workspaces.UITests.Next/Workspaces.UITests.Next.csproj">
+      <Platform Solution="*|ARM64" Project="ARM64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
     <Project Path="src/modules/Workspaces/WorkspacesEditorUITest/Workspaces.Editor.UITests.csproj">
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />

--- a/doc/devdocs/modules/workspaces.md
+++ b/doc/devdocs/modules/workspaces.md
@@ -17,6 +17,94 @@ Workspaces is a PowerToys module that allows users to save and restore window la
 - [Source code folder](https://github.com/microsoft/PowerToys/tree/main/src/modules/Workspaces)
 - [Issue tracker](https://github.com/microsoft/PowerToys/issues?q=is%3Aissue+label%3AWorkspaces)
 
+## UI tests
+
+`src\modules\Workspaces\Tests\Workspaces.UITests.Next` uses the winappcli-based
+`UITestAutomation.Next` harness. It runs through Visual Studio Test Explorer or
+the built Microsoft.Testing.Platform executable. Build the product runtime from
+the same branch as the tests, use an English-language, connected and unlocked
+desktop, and run Visual Studio/testhost **without elevation**. Keep an RDP
+connection open and avoid mouse/keyboard input while the UI cases execute.
+
+```powershell
+# Run from the repository root; use ARM64 instead of x64 when appropriate.
+tools\build\build.cmd -Path src\modules\Workspaces\Tests\Workspaces.UITests.Next -Platform x64 -Configuration Debug
+```
+
+The test-project reference builds `Workspaces.TestApp` and stages both an
+unpackaged fixture and `Workspaces.TestApp.msix`. The package is **unsigned by
+default**, so ordinary local builds do not require certificate installation.
+
+These two cases need the packaged fixture:
+
+- `CaptureIncludesPackagedUnpackagedAndMinimizedWindows`
+- `CommandLineArgumentsReachUnpackagedAndPackagedApps (True)`
+
+If the MSIX has no signature, or Windows rejects its certificate chain with
+`CERT_E_UNTRUSTEDROOT`, these cases report **Inconclusive/Skipped locally**, with
+the missing prerequisite and a pointer to this section. Package preparation is
+attempted before opening the capture overlay. Other cases, including the
+unpackaged command-line variant, remain enabled.
+
+CI and pipeline-like VM runs (`TF_BUILD=true` or a nonempty `platform` environment
+variable) are strict: missing signing is a **failure**, not a skip. Missing build
+outputs, malformed archives, hash/signature corruption, access errors, and other
+deployment/product failures also remain failures. The tests never sign packages,
+install trust, or change security policy automatically.
+
+### Optional packaged-fixture setup
+
+Running the packaged cases locally is straightforward, but it requires an
+explicit test-certificate trust setup. The Windows SDK's `signtool.exe` is needed;
+the repository signer locates it or uses the existing pinned SDK-tools mechanism.
+A disposable UI-test VM is preferable if you do not want test trust on a working
+machine.
+
+1. Build the test project **before** signing.
+2. From an **elevated PowerShell terminal using the same Windows account**, run
+   the existing signer below. This signs only `Workspaces.TestApp.msix` copies in
+   the selected test output tree and records the certificate for cleanup. It adds
+   a test trust anchor to the machine Root/TrustedPeople stores; do not use that
+   certificate for production signing.
+3. Run the two cases again from **non-elevated** Test Explorer.
+
+```powershell
+# Elevated PowerShell, repository root. Adjust platform/configuration as needed.
+$testRoot = (Resolve-Path .\x64\Debug\tests).Path
+$marker = Join-Path $env:LOCALAPPDATA 'PowerToysUiTestSigning\Workspaces-certificates.txt'
+
+.\.pipelines\signSparsePackages.ps1 `
+    -PackageRoot $testRoot `
+    -Include Workspaces.TestApp.msix `
+    -RequiredPackage Workspaces.TestApp.msix `
+    -CertificateMarkerPath $marker
+```
+
+Both the fixture project's output and the copy beside the UI-test runner are
+signed, so ordinary copy staging does not immediately replace the signed fixture
+with an unsigned one. A rebuild that regenerates the MSIX still requires signing
+again. A Windows error of `0x800B0100` means the package is unsigned;
+`0x800B0109` means the signing root is not trusted on the execution machine.
+
+When finished, remove the recorded test trust/private key from the same elevated
+account:
+
+```powershell
+$marker = Join-Path $env:LOCALAPPDATA 'PowerToysUiTestSigning\Workspaces-certificates.txt'
+.\.pipelines\removeTestSigningCertificates.ps1 -CertificateMarkerPath $marker
+```
+
+For VM execution, use the `ui-tests-local-vm` skill: sign on the build host with
+`-SkipLocalTrust`, export only the public certificate, and trust it in the guest
+instead. Release Runner/Settings/Quick Access authentication is a separate
+prerequisite: use matching signed product binaries or the existing CI companion
+signing setup. The package-only command above does not bypass product IPC
+authentication.
+
+The suite README documents the full checklist mapping, fixture ownership, and
+evidence/cleanup behavior:
+`src\modules\Workspaces\Tests\Workspaces.UITests.Next\README.md`.
+
 ## Implementation Details
 
 TODO: Add implementation details

--- a/src/common/UITestAutomation.Next.UnitTests/PackagedFixturePrerequisitesTests.cs
+++ b/src/common/UITestAutomation.Next.UnitTests/PackagedFixturePrerequisitesTests.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO.Compression;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Workspaces.UITests;
+
+namespace Microsoft.PowerToys.UITestAutomationNext.UnitTests;
+
+[TestClass]
+public sealed class PackagedFixturePrerequisitesTests
+{
+    [TestMethod]
+    public void UnsignedArchiveIsSkippedOnlyLocally()
+    {
+        WithArchive(hasSignature: false, path =>
+        {
+            var skipped = Assert.ThrowsExactly<AssertInconclusiveException>(
+                () => PackagedFixturePrerequisites.RequireSignature(path, isInPipeline: false));
+            StringAssert.Contains(skipped.Message, path);
+            StringAssert.Contains(skipped.Message, "doc\\devdocs\\modules\\workspaces.md");
+            Assert.ThrowsExactly<AssertFailedException>(
+                () => PackagedFixturePrerequisites.RequireSignature(path, isInPipeline: true));
+        });
+    }
+
+    [TestMethod]
+    public void SignatureMarkerDefersIntegrityAndTrustValidationToWindows()
+    {
+        WithArchive(hasSignature: true, path =>
+        {
+            PackagedFixturePrerequisites.RequireSignature(path, isInPipeline: false);
+            PackagedFixturePrerequisites.RequireSignature(path, isInPipeline: true);
+        });
+    }
+
+    [TestMethod]
+    [DataRow(PackagedFixturePrerequisites.NoSignature)]
+    [DataRow(PackagedFixturePrerequisites.UntrustedRoot)]
+    public void MissingSigningIsInconclusiveLocallyButFailsInPipeline(int errorCode)
+    {
+        var local = PackagedFixturePrerequisites.MissingSigningException("fixture.msix", errorCode, isInPipeline: false);
+        var pipeline = PackagedFixturePrerequisites.MissingSigningException("fixture.msix", errorCode, isInPipeline: true);
+
+        Assert.IsInstanceOfType<AssertInconclusiveException>(local);
+        Assert.IsInstanceOfType<AssertFailedException>(pipeline);
+    }
+
+    [TestMethod]
+    [DataRow(unchecked((int)0x80096010))]
+    [DataRow(unchecked((int)0x80070005))]
+    [DataRow(unchecked((int)0x80073CF6))]
+    public void CorruptSignaturesAndOtherDeploymentFailuresAreNotSetupSkips(int errorCode)
+    {
+        Assert.IsFalse(PackagedFixturePrerequisites.IsMissingSigning(errorCode));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+            () => PackagedFixturePrerequisites.MissingSigningException("fixture.msix", errorCode, isInPipeline: false));
+    }
+
+    [TestMethod]
+    public void MissingPackageIsAlwaysABuildFailure()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"Workspaces-absent-{Guid.NewGuid():N}.msix");
+        Assert.ThrowsExactly<AssertFailedException>(
+            () => PackagedFixturePrerequisites.RequireSignature(path, isInPipeline: false));
+        Assert.ThrowsExactly<AssertFailedException>(
+            () => PackagedFixturePrerequisites.RequireSignature(path, isInPipeline: true));
+    }
+
+    [TestMethod]
+    public void MalformedArchiveIsNeverSkipped()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(path, "not an MSIX archive");
+            Assert.ThrowsExactly<InvalidDataException>(
+                () => PackagedFixturePrerequisites.RequireSignature(path, isInPipeline: false));
+            Assert.ThrowsExactly<InvalidDataException>(
+                () => PackagedFixturePrerequisites.RequireSignature(path, isInPipeline: true));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    private static void WithArchive(bool hasSignature, Action<string> assertion)
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            using (var file = File.Open(path, FileMode.Create))
+            using (var archive = new ZipArchive(file, ZipArchiveMode.Create))
+            {
+                archive.CreateEntry("AppxManifest.xml");
+                if (hasSignature)
+                {
+                    archive.CreateEntry("AppxSignature.p7x");
+                }
+            }
+
+            assertion(path);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/src/common/UITestAutomation.Next.UnitTests/SettingsConfigHelperTests.cs
+++ b/src/common/UITestAutomation.Next.UnitTests/SettingsConfigHelperTests.cs
@@ -130,6 +130,36 @@ public class SettingsConfigHelperTests
     }
 
     [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void PreserveFileRestoresAbsenceWhenParentDirectoryIsMissing(bool createThenRemoveParent)
+    {
+        var root = CreateTemporaryDirectory();
+        var parent = Path.Combine(root, "module");
+        var path = Path.Combine(parent, "settings.json");
+
+        try
+        {
+            using (SettingsConfigHelper.PreserveFile(path))
+            {
+                if (createThenRemoveParent)
+                {
+                    Directory.CreateDirectory(parent);
+                    File.WriteAllText(path, "temporary");
+                    Directory.Delete(parent, recursive: true);
+                }
+            }
+
+            Assert.IsFalse(File.Exists(path));
+            Assert.IsFalse(Directory.Exists(parent), "Restoring absence should not create the parent directory.");
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [TestMethod]
     public void PreserveFirstRunSettingsRestoresExistingFiles()
     {
         var root = CreateTemporaryDirectory();

--- a/src/common/UITestAutomation.Next.UnitTests/UITestAutomation.Next.UnitTests.csproj
+++ b/src/common/UITestAutomation.Next.UnitTests/UITestAutomation.Next.UnitTests.csproj
@@ -22,5 +22,7 @@
   <ItemGroup>
     <ProjectReference Include="..\UITestAutomation.Next\UITestAutomation.Next.csproj" />
     <Compile Include="..\..\modules\EnvironmentVariables\EnvironmentVariables.UITests\TestState.cs" Link="EnvironmentVariables\TestState.cs" />
+    <Compile Include="..\..\modules\Workspaces\Tests\Workspaces.UITests.Next\WorkspacesDisplay.cs" Link="Workspaces\WorkspacesDisplay.cs" />
+    <Compile Include="..\..\modules\Workspaces\Tests\Workspaces.UITests.Next\PackagedFixturePrerequisites.cs" Link="Workspaces\PackagedFixturePrerequisites.cs" />
   </ItemGroup>
 </Project>

--- a/src/common/UITestAutomation.Next.UnitTests/WorkspacesDisplayTests.cs
+++ b/src/common/UITestAutomation.Next.UnitTests/WorkspacesDisplayTests.cs
@@ -1,0 +1,229 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Workspaces.UITests;
+using DisplayDeviceInfo = Microsoft.Workspaces.UITests.WorkspacesDisplay.DisplayDeviceInfo;
+using TargetDisplay = Microsoft.Workspaces.UITests.WorkspacesDisplay.TargetDisplay;
+
+namespace Microsoft.PowerToys.UITestAutomationNext.UnitTests;
+
+// Regression coverage for the product display-identity contract the Workspaces UI tests seed against.
+// These exercise the pure resolution helpers only (no live topology), so they run deterministically on any
+// host and CI, including where the host reports sparse/non-1 numbering, mixed DPI, or a numberless display.
+[TestClass]
+public sealed class WorkspacesDisplayTests
+{
+    private const uint Active = 0x1;
+    private const uint Inactive = 0x0;
+    private const uint Mirroring = 0x8;
+
+    [TestMethod]
+    public void ActiveDeviceYieldsNumberFromAdapterAndSplitDeviceId()
+    {
+        var devices = new[]
+        {
+            new DisplayDeviceInfo(
+                "\\\\.\\DISPLAY3\\Monitor0",
+                "\\\\?\\DISPLAY#GSM1388#4&125707d6&0&UID8388688#{e6f07b5f-ee97-4a90-b076-33f57bf4eaa7}",
+                Active),
+        };
+
+        var (number, id, instanceId) = WorkspacesDisplay.ResolveNumberAndId("\\\\.\\DISPLAY3", devices);
+
+        Assert.AreEqual(3, number);
+        Assert.AreEqual("GSM1388", id);
+        Assert.AreEqual("4&125707d6&0&UID8388688", instanceId);
+    }
+
+    [TestMethod]
+    public void FirstActiveNonMirroringDeviceIsSelected()
+    {
+        var devices = new[]
+        {
+            new DisplayDeviceInfo("\\\\.\\DISPLAY2\\Monitor0", "\\\\?\\DISPLAY#MIR#x#{g}", Active | Mirroring),
+            new DisplayDeviceInfo("\\\\.\\DISPLAY2\\Monitor0", "\\\\?\\DISPLAY#OFF#x#{g}", Inactive),
+            new DisplayDeviceInfo("\\\\.\\DISPLAY2\\Monitor0", "\\\\?\\DISPLAY#DELL0001#5&abcd&0&UID256#{g}", Active),
+        };
+
+        var (number, id, instanceId) = WorkspacesDisplay.ResolveNumberAndId("\\\\.\\DISPLAY2", devices);
+
+        Assert.AreEqual(2, number);
+        Assert.AreEqual("DELL0001", id);
+        Assert.AreEqual("5&abcd&0&UID256", instanceId);
+    }
+
+    [TestMethod]
+    public void NoActiveDeviceFallsBackToGdiDeviceName()
+    {
+        // Only inactive/mirroring devices -> product uses the GDI device name for both id and number.
+        var devices = new[]
+        {
+            new DisplayDeviceInfo("\\\\.\\DISPLAY5\\Monitor0", "\\\\?\\DISPLAY#MIR#x#{g}", Mirroring),
+        };
+
+        var (number, id, instanceId) = WorkspacesDisplay.ResolveNumberAndId("\\\\.\\DISPLAY5", devices);
+
+        Assert.AreEqual(5, number);
+        Assert.AreEqual("\\\\.\\DISPLAY5", id);
+        Assert.AreEqual(string.Empty, instanceId);
+    }
+
+    [TestMethod]
+    public void NumberlessDisplayIsRejectedWithActionableGuidance()
+    {
+        var exception = Assert.ThrowsExactly<InvalidOperationException>(
+            () => WorkspacesDisplay.ResolveNumberAndId("WinDisc", System.Array.Empty<DisplayDeviceInfo>()));
+
+        StringAssert.Contains(exception.Message, "WinDisc");
+        StringAssert.Contains(exception.Message, "Connect and unlock");
+    }
+
+    [TestMethod]
+    public void ActiveDeviceWithNumberlessAdapterIsRejected()
+    {
+        var devices = new[]
+        {
+            new DisplayDeviceInfo("WinDisc", "\\\\?\\DISPLAY#RDP#x#{g}", Active),
+        };
+
+        Assert.ThrowsExactly<InvalidOperationException>(
+            () => WorkspacesDisplay.ResolveNumberAndId("WinDisc", devices));
+    }
+
+    [TestMethod]
+    public void SplitDisplayDeviceIdMatchesProductExample()
+    {
+        var (id, instanceId) = WorkspacesDisplay.SplitDisplayDeviceId(
+            "\\\\?\\DISPLAY#GSM1388#4&125707d6&0&UID8388688#{e6f07b5f-ee97-4a90-b076-33f57bf4eaa7}");
+
+        Assert.AreEqual("GSM1388", id);
+        Assert.AreEqual("4&125707d6&0&UID8388688", instanceId);
+    }
+
+    [TestMethod]
+    public void SplitDisplayDeviceIdReturnsWholeStringWhenMalformed()
+    {
+        var (id, instanceId) = WorkspacesDisplay.SplitDisplayDeviceId("no-delimiters");
+
+        Assert.AreEqual("no-delimiters", id);
+        Assert.AreEqual(string.Empty, instanceId);
+    }
+
+    [TestMethod]
+    public void RemoveNonDigitsKeepsOnlyDigits()
+    {
+        Assert.AreEqual("12", WorkspacesDisplay.RemoveNonDigits("\\\\.\\DISPLAY12"));
+        Assert.AreEqual(string.Empty, WorkspacesDisplay.RemoveNonDigits("WinDisc"));
+    }
+
+    [TestMethod]
+    [DataRow(new[] { 3 }, 1)]
+    [DataRow(new[] { 1 }, 2)]
+    [DataRow(new[] { 1, 2 }, 3)]
+    [DataRow(new[] { 2, 15 }, 1)]
+    [DataRow(new[] { 1, 3, 11 }, 2)]
+    [DataRow(new int[0], 1)]
+    public void FirstUnusedNumberIsSmallestProvablyAbsent(int[] used, int expected)
+    {
+        Assert.AreEqual(expected, WorkspacesDisplay.FirstUnusedNumber(used));
+    }
+
+    [TestMethod]
+    public void DefaultPositionKeepsBaselineOnTypicalWorkArea()
+    {
+        // 1920x1040 logical work area at origin (0,0), 96 DPI -> historical baseline is preserved.
+        var target = MakeTarget(dpi: 96, monitorLeft: 0, monitorTop: 0, monitorRight: 1920, monitorBottom: 1080, workRight: 1920, workBottom: 1040);
+
+        var (x, y, width, height) = WorkspacesDisplay.DefaultApplicationPosition(target);
+
+        Assert.AreEqual(240, x);
+        Assert.AreEqual(220, y);
+        Assert.AreEqual(720, width);
+        Assert.AreEqual(460, height);
+    }
+
+    [TestMethod]
+    public void DefaultPositionScalesToLogicalWorkAreaAtHighDpi()
+    {
+        // 3840x2160 physical at 200% -> 1920x1080 logical; work area 1920x1040 logical -> baseline preserved.
+        var target = MakeTarget(dpi: 192, monitorLeft: 0, monitorTop: 0, monitorRight: 3840, monitorBottom: 2160, workRight: 3840, workBottom: 2080);
+
+        var (x, y, width, height) = WorkspacesDisplay.DefaultApplicationPosition(target);
+
+        Assert.AreEqual(240, x);
+        Assert.AreEqual(220, y);
+        Assert.AreEqual(720, width);
+        Assert.AreEqual(460, height);
+    }
+
+    [TestMethod]
+    public void DefaultPositionFitsInsideSmallWorkArea()
+    {
+        // 1024x600 logical work area cannot hold the baseline -> derived rect stays inside with padding.
+        var target = MakeTarget(dpi: 96, monitorLeft: 0, monitorTop: 0, monitorRight: 1024, monitorBottom: 600, workRight: 1024, workBottom: 600);
+
+        var (x, y, width, height) = WorkspacesDisplay.DefaultApplicationPosition(target);
+
+        Assert.IsTrue(x >= 0, $"x={x}");
+        Assert.IsTrue(y >= 0, $"y={y}");
+        Assert.IsTrue(width > 0 && height > 0, $"size={width}x{height}");
+        Assert.IsTrue(x + width <= 1024, $"right={x + width}");
+        Assert.IsTrue(y + height <= 600, $"bottom={y + height}");
+    }
+
+    [TestMethod]
+    public void DefaultPositionRejectsMissingDpi()
+    {
+        var target = MakeTarget(dpi: 0, monitorLeft: 0, monitorTop: 0, monitorRight: 1920, monitorBottom: 1080, workRight: 1920, workBottom: 1040);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() => WorkspacesDisplay.DefaultApplicationPosition(target));
+    }
+
+    [TestMethod]
+    public void DefaultPositionRejectsEmptyWorkArea()
+    {
+        var target = MakeTarget(dpi: 96, monitorLeft: 0, monitorTop: 0, monitorRight: 1920, monitorBottom: 1080, workRight: 0, workBottom: 0);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() => WorkspacesDisplay.DefaultApplicationPosition(target));
+    }
+
+    [TestMethod]
+    public void LogicalWorkAreaHonorsDpiAndOffset()
+    {
+        // Primary at 150% with a left/top taskbar offset. Logical = physical * 96 / dpi.
+        var target = MakeTarget(dpi: 144, monitorLeft: 0, monitorTop: 0, monitorRight: 2880, monitorBottom: 1620, workLeft: 96, workTop: 0, workRight: 2880, workBottom: 1560);
+
+        Assert.AreEqual(64, target.LogicalWorkLeft);   // 96 * 96 / 144
+        Assert.AreEqual(0, target.LogicalWorkTop);
+        Assert.AreEqual(1920, target.LogicalWorkRight); // 2880 * 96 / 144
+        Assert.AreEqual(1040, target.LogicalWorkBottom); // 1560 * 96 / 144
+    }
+
+    private static TargetDisplay MakeTarget(
+        uint dpi,
+        int monitorLeft,
+        int monitorTop,
+        int monitorRight,
+        int monitorBottom,
+        int workRight,
+        int workBottom,
+        int workLeft = 0,
+        int workTop = 0) =>
+        new(
+            "\\\\.\\DISPLAY1",
+            1,
+            "GSM1388",
+            "instance",
+            dpi,
+            monitorLeft,
+            monitorTop,
+            monitorRight,
+            monitorBottom,
+            workLeft,
+            workTop,
+            workRight,
+            workBottom,
+            true);
+}

--- a/src/common/UITestAutomation.Next/SettingsConfigHelper.cs
+++ b/src/common/UITestAutomation.Next/SettingsConfigHelper.cs
@@ -247,7 +247,14 @@ public static class SettingsConfigHelper
             }
             else
             {
-                File.Delete(path);
+                try
+                {
+                    File.Delete(path);
+                }
+                catch (DirectoryNotFoundException)
+                {
+                    // A missing parent already satisfies the snapshot's original file absence.
+                }
             }
         }
     }

--- a/src/modules/Workspaces/Tests/Workspaces.TestApp/AppxManifest.xml
+++ b/src/modules/Workspaces/Tests/Workspaces.TestApp/AppxManifest.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) Microsoft Corporation
+  The Microsoft Corporation licenses this file to you under the MIT license.
+  See the LICENSE file in the project root for more information.
+-->
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+         xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+         xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+         IgnorableNamespaces="uap rescap">
+  <Identity Name="Microsoft.PowerToys.Workspaces.TestApp"
+            ProcessorArchitecture="x64"
+            Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
+            Version="1.0.0.0" />
+  <Properties>
+    <DisplayName>Workspaces UI test app</DisplayName>
+    <PublisherDisplayName>Microsoft</PublisherDisplayName>
+    <Logo>Assets\StoreLogo.png</Logo>
+  </Properties>
+  <Resources>
+    <Resource Language="en-us" />
+  </Resources>
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.19041.0" MaxVersionTested="10.0.26100.0" />
+  </Dependencies>
+  <Applications>
+    <Application Id="App" Executable="Workspaces.TestApp.exe" EntryPoint="Windows.FullTrustApplication">
+      <uap:VisualElements DisplayName="Workspaces UI test app"
+                          Description="Deterministic packaged app for Workspaces UI tests"
+                          BackgroundColor="transparent"
+                          Square150x150Logo="Assets\Square150x150Logo.png"
+                          Square44x44Logo="Assets\Square44x44Logo.png" />
+    </Application>
+  </Applications>
+  <Capabilities>
+    <rescap:Capability Name="runFullTrust" />
+  </Capabilities>
+</Package>

--- a/src/modules/Workspaces/Tests/Workspaces.TestApp/BuildFixturePackage.ps1
+++ b/src/modules/Workspaces/Tests/Workspaces.TestApp/BuildFixturePackage.ps1
@@ -1,0 +1,89 @@
+# Copyright (c) Microsoft Corporation
+# The Microsoft Corporation licenses this file to you under the MIT license.
+# See the LICENSE file in the project root for more information.
+
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string] $BinaryDirectory,
+    [Parameter(Mandatory)]
+    [string] $StagingDirectory,
+    [Parameter(Mandatory)]
+    [ValidateSet('x64', 'ARM64')]
+    [string] $Platform
+)
+
+$ErrorActionPreference = 'Stop'
+$BinaryDirectory = [IO.Path]::GetFullPath($BinaryDirectory).TrimEnd('\')
+$StagingDirectory = [IO.Path]::GetFullPath($StagingDirectory).TrimEnd('\')
+$packagePath = Join-Path $BinaryDirectory 'Workspaces.TestApp.msix'
+
+$makeAppx = Get-Command makeappx.exe -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty Source
+if (-not $makeAppx) {
+    $hostArchitecture = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'arm64' } else { 'x64' }
+    $sdkTools = @(
+        "${env:ProgramFiles(x86)}\Windows Kits\10\bin\*\$hostArchitecture\makeappx.exe",
+        "$env:ProgramFiles\Windows Kits\10\bin\*\$hostArchitecture\makeappx.exe"
+    )
+    $makeAppx = Get-ChildItem -Path $sdkTools -ErrorAction SilentlyContinue |
+        Where-Object { $version = $null; [version]::TryParse($_.Directory.Parent.Name, [ref]$version) } |
+        Sort-Object { [version]$_.Directory.Parent.Name } -Descending |
+        Select-Object -First 1 -ExpandProperty FullName
+}
+if (-not $makeAppx) {
+    throw 'Windows SDK makeappx.exe is required to build the packaged Workspaces fixture.'
+}
+
+foreach ($file in @(
+    'Workspaces.TestApp.exe',
+    'Workspaces.TestApp.dll',
+    'Workspaces.TestApp.deps.json',
+    'Workspaces.TestApp.runtimeconfig.json',
+    'hostfxr.dll',
+    'hostpolicy.dll',
+    'coreclr.dll',
+    'System.Private.CoreLib.dll',
+    'System.Windows.Forms.dll'
+)) {
+    if (-not (Test-Path (Join-Path $BinaryDirectory $file) -PathType Leaf)) {
+        throw "Missing self-contained fixture build output: $file"
+    }
+}
+
+$runtimeConfig = Get-Content (Join-Path $BinaryDirectory 'Workspaces.TestApp.runtimeconfig.json') -Raw | ConvertFrom-Json
+if ($runtimeConfig.runtimeOptions.framework -or $runtimeConfig.runtimeOptions.frameworks) {
+    throw 'The packaged fixture must not depend on an ambient .NET installation.'
+}
+if ($StagingDirectory.Equals($BinaryDirectory, [StringComparison]::OrdinalIgnoreCase) -or
+    $StagingDirectory.StartsWith($BinaryDirectory + '\', [StringComparison]::OrdinalIgnoreCase) -or
+    $BinaryDirectory.StartsWith($StagingDirectory + '\', [StringComparison]::OrdinalIgnoreCase)) {
+    throw 'Package staging and binary directories must not overlap.'
+}
+
+if (Test-Path $StagingDirectory) {
+    Remove-Item $StagingDirectory -Recurse -Force
+}
+New-Item $StagingDirectory -ItemType Directory -Force | Out-Null
+try {
+    # Preserve the complete self-contained runtime, including native files and culture subfolders.
+    foreach ($file in Get-ChildItem $BinaryDirectory -File -Recurse | Where-Object { $_.Extension -notin '.pdb', '.msix' }) {
+        $relativePath = $file.FullName.Substring($BinaryDirectory.Length).TrimStart('\')
+        $destination = Join-Path $StagingDirectory $relativePath
+        New-Item (Split-Path $destination -Parent) -ItemType Directory -Force | Out-Null
+        Copy-Item $file.FullName $destination
+    }
+    [xml]$manifest = Get-Content (Join-Path $PSScriptRoot 'AppxManifest.xml') -Raw
+    $manifest.Package.Identity.SetAttribute('ProcessorArchitecture', $Platform.ToLowerInvariant())
+    $manifest.Save((Join-Path $StagingDirectory 'AppxManifest.xml'))
+
+    & $makeAppx pack /d $StagingDirectory /p $packagePath /o
+    if ($LASTEXITCODE -ne 0 -or -not (Test-Path $packagePath -PathType Leaf)) {
+        throw "makeappx failed to produce the Workspaces fixture (exit $LASTEXITCODE)."
+    }
+}
+finally {
+    Remove-Item $StagingDirectory -Recurse -Force
+}
+
+Write-Host "Created unsigned fixture package: $packagePath"

--- a/src/modules/Workspaces/Tests/Workspaces.TestApp/LaunchOptions.cs
+++ b/src/modules/Workspaces/Tests/Workspaces.TestApp/LaunchOptions.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Workspaces.TestApp
+{
+    internal sealed class LaunchOptions
+    {
+        internal string Title { get; private set; } = "Workspaces UI test app";
+
+        internal string Payload { get; private set; } = string.Empty;
+
+        internal string? WaitEventName { get; private set; }
+
+        internal string? StartedEventName { get; private set; }
+
+        internal string? ReadyEventName { get; private set; }
+
+        internal bool Minimized { get; private set; }
+
+        internal static LaunchOptions Parse(string[] args)
+        {
+            var options = new LaunchOptions();
+            for (int index = 0; index < args.Length; index++)
+            {
+                switch (args[index])
+                {
+                    case "--title":
+                        options.Title = ReadValue(args, ref index);
+                        break;
+                    case "--payload":
+                        options.Payload = ReadValue(args, ref index);
+                        break;
+                    case "--wait-event":
+                        options.WaitEventName = ReadEventName(args, ref index);
+                        break;
+                    case "--started-event":
+                        options.StartedEventName = ReadEventName(args, ref index);
+                        break;
+                    case "--ready-event":
+                        options.ReadyEventName = ReadEventName(args, ref index);
+                        break;
+                    case "--minimized":
+                        options.Minimized = true;
+                        break;
+                    default:
+                        throw new ArgumentException($"Unknown argument '{args[index]}'.");
+                }
+            }
+
+            return options;
+        }
+
+        private static string ReadValue(string[] args, ref int index)
+        {
+            string option = args[index];
+            if (index + 1 >= args.Length || args[index + 1].StartsWith("--", StringComparison.Ordinal))
+            {
+                throw new ArgumentException($"Missing value for '{option}'.");
+            }
+
+            return args[++index];
+        }
+
+        private static string ReadEventName(string[] args, ref int index)
+        {
+            string option = args[index];
+            string name = ReadValue(args, ref index);
+            string localName = name.StartsWith(@"Local\", StringComparison.Ordinal) ? name[6..] : name;
+            if (string.IsNullOrWhiteSpace(localName) || localName.Contains('\\'))
+            {
+                throw new ArgumentException($"'{option}' requires a local event name, optionally prefixed with 'Local\\'.");
+            }
+
+            return name;
+        }
+    }
+}

--- a/src/modules/Workspaces/Tests/Workspaces.TestApp/Program.cs
+++ b/src/modules/Workspaces/Tests/Workspaces.TestApp/Program.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.IO;
+using System.Threading;
+using System.Windows.Forms;
+
+namespace Microsoft.Workspaces.TestApp
+{
+    internal static class Program
+    {
+        [STAThread]
+        private static int Main(string[] args)
+        {
+            try
+            {
+                var options = LaunchOptions.Parse(args);
+                using var startedEvent = OpenEvent(options.StartedEventName);
+                startedEvent?.Set();
+
+                using var waitEvent = OpenEvent(options.WaitEventName);
+                using var readyEvent = OpenEvent(options.ReadyEventName);
+                if (waitEvent is not null && !waitEvent.WaitOne(TimeSpan.FromSeconds(120)))
+                {
+                    throw new TimeoutException($"Timed out after 120 seconds waiting for event '{options.WaitEventName}'.");
+                }
+
+                Application.SetUnhandledExceptionMode(UnhandledExceptionMode.ThrowException);
+                Application.SetHighDpiMode(HighDpiMode.PerMonitorV2);
+                Application.EnableVisualStyles();
+                Application.SetCompatibleTextRenderingDefault(false);
+
+                using var form = new WorkspacesForm(options.Title, options.Payload, options.Minimized);
+                form.Shown += (_, _) => readyEvent?.Set();
+                Application.Run(form);
+                return 0;
+            }
+            catch (Exception exception) when (exception is ArgumentException
+                or WaitHandleCannotBeOpenedException
+                or UnauthorizedAccessException
+                or IOException
+                or TimeoutException
+                or Win32Exception)
+            {
+                Console.Error.WriteLine($"Workspaces.TestApp: {exception.Message}");
+                return 1;
+            }
+        }
+
+        private static EventWaitHandle? OpenEvent(string? name)
+        {
+            return name is null ? null : EventWaitHandle.OpenExisting(name);
+        }
+    }
+}

--- a/src/modules/Workspaces/Tests/Workspaces.TestApp/Workspaces.TestApp.csproj
+++ b/src/modules/Workspaces/Tests/Workspaces.TestApp/Workspaces.TestApp.csproj
@@ -1,0 +1,65 @@
+<!--
+  Copyright (c) Microsoft Corporation
+  The Microsoft Corporation licenses this file to you under the MIT license.
+  See the LICENSE file in the project root for more information.
+-->
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(RepoRoot)src\Common.Dotnet.CsWinRT.props" />
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <AssemblyName>Workspaces.TestApp</AssemblyName>
+    <RootNamespace>Microsoft.Workspaces.TestApp</RootNamespace>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <RuntimeIdentifier>win-$([System.String]::Copy('$(Platform)').ToLowerInvariant())</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <UseAppHost>true</UseAppHost>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>false</IsTestProject>
+    <!-- Referenced only as a fixture artifact, never loaded into the test process. -->
+    <ShouldBeValidatedAsExecutableReference>false</ShouldBeValidatedAsExecutableReference>
+    <EnableMSTestRunner>false</EnableMSTestRunner>
+    <IsTestingPlatformApplication>false</IsTestingPlatformApplication>
+    <TestingPlatformDotNetTestSupport>false</TestingPlatformDotNetTestSupport>
+    <TestingPlatformDisableCustomTestTarget>true</TestingPlatformDisableCustomTestTarget>
+    <RunVSTest>false</RunVSTest>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <OutputPath>$(RepoRoot)$(Platform)\$(Configuration)\tests\Workspaces.TestApp\</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="$(RepoRoot)src\PackageIdentity\Images\*.png" Link="Assets\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <Target Name="BuildFixturePackage"
+          AfterTargets="Build"
+          DependsOnTargets="GetFixturePayload"
+          Condition="'$(DesignTimeBuild)' != 'true' and '$(_IsSkippedTestProject)' != 'true'"
+          Inputs="@(_FixturePayload);$(MSBuildProjectFullPath);$(MSBuildProjectDirectory)\AppxManifest.xml;$(MSBuildProjectDirectory)\BuildFixturePackage.ps1"
+          Outputs="$(TargetDir)Workspaces.TestApp.msix">
+    <Exec WorkingDirectory="$(MSBuildProjectDirectory)"
+          Command="powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File &quot;$(MSBuildProjectDirectory)\BuildFixturePackage.ps1&quot; -BinaryDirectory &quot;$(TargetDir).&quot; -StagingDirectory &quot;$(IntermediateOutputPath)Package&quot; -Platform &quot;$(Platform)&quot;" />
+    <ItemGroup>
+      <FileWrites Include="$(TargetDir)Workspaces.TestApp.msix" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="GetFixturePackage" DependsOnTargets="GetTargetPath" Returns="$(TargetDir)Workspaces.TestApp.msix">
+    <Error Condition="!Exists('$(TargetDir)Workspaces.TestApp.msix')" Text="The Workspaces fixture package was not built." />
+  </Target>
+
+  <Target Name="GetFixturePayload" DependsOnTargets="GetTargetPath" Returns="@(_FixturePayload)">
+    <Error Condition="!Exists('$(TargetPath)') or !Exists('$(TargetDir)$(AssemblyName).exe')" Text="The Workspaces fixture executable was not built." />
+    <ItemGroup>
+      <_FixturePayload Include="$(TargetDir)**\*" Exclude="$(TargetDir)**\*.msix;$(TargetDir)**\*.pdb" />
+      <_FixturePayload>
+        <RelativePath>%(_FixturePayload.RecursiveDir)%(_FixturePayload.Filename)%(_FixturePayload.Extension)</RelativePath>
+      </_FixturePayload>
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/modules/Workspaces/Tests/Workspaces.TestApp/WorkspacesForm.cs
+++ b/src/modules/Workspaces/Tests/Workspaces.TestApp/WorkspacesForm.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace Microsoft.Workspaces.TestApp
+{
+    internal sealed class WorkspacesForm : Form
+    {
+        internal WorkspacesForm(string title, string payload, bool minimized)
+        {
+            Text = title;
+            Name = "WorkspacesTestWindow";
+            StartPosition = FormStartPosition.Manual;
+            AutoScaleMode = AutoScaleMode.None;
+            FormBorderStyle = FormBorderStyle.Sizable;
+            Bounds = new Rectangle(100, 120, 640, 420);
+            WindowState = minimized ? FormWindowState.Minimized : FormWindowState.Normal;
+
+            var titleLabel = new Label
+            {
+                Name = "TitleLabel",
+                Text = title,
+                UseMnemonic = false,
+                AutoEllipsis = true,
+                Bounds = new Rectangle(20, 20, ClientSize.Width - 40, 44),
+                Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right,
+            };
+            var payloadLabel = new Label
+            {
+                Text = "Payload",
+                AutoSize = true,
+                Location = new Point(20, 84),
+            };
+            var payloadTextBox = new TextBox
+            {
+                Name = "PayloadTextBox",
+                AccessibleName = "Payload",
+                Text = payload,
+                ReadOnly = true,
+                Multiline = true,
+                WordWrap = false,
+                ScrollBars = ScrollBars.Both,
+                Bounds = new Rectangle(20, 110, ClientSize.Width - 40, ClientSize.Height - 130),
+                Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right,
+            };
+            Controls.AddRange([titleLabel, payloadLabel, payloadTextBox]);
+        }
+    }
+}

--- a/src/modules/Workspaces/Tests/Workspaces.TestApp/app.manifest
+++ b/src/modules/Workspaces/Tests/Workspaces.TestApp/app.manifest
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) Microsoft Corporation
+  The Microsoft Corporation licenses this file to you under the MIT license.
+  See the LICENSE file in the project root for more information.
+-->
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="Workspaces.TestApp.app" />
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/NativeMethods.cs
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/NativeMethods.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Microsoft.Workspaces.UITests
+{
+    internal static class NativeMethods
+    {
+        private const int AppModelErrorNoPackage = 15700;
+        private const int ErrorInsufficientBuffer = 122;
+
+        [DllImport("user32.dll")]
+        internal static extern uint GetDpiForWindow(IntPtr window);
+
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool IsIconic(IntPtr window);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        private static extern int GetPackageFullName(IntPtr process, ref uint length, StringBuilder? packageFullName);
+
+        internal static string? PackageFullName(int processId)
+        {
+            using var process = Process.GetProcessById(processId);
+            uint length = 0;
+            var result = GetPackageFullName(process.Handle, ref length, null);
+            if (result == AppModelErrorNoPackage)
+            {
+                return null;
+            }
+
+            if (result != ErrorInsufficientBuffer)
+            {
+                throw new Win32Exception(result, $"Could not read the package identity for PID {processId}.");
+            }
+
+            var name = new StringBuilder(checked((int)length));
+            result = GetPackageFullName(process.Handle, ref length, name);
+            if (result != 0)
+            {
+                throw new Win32Exception(result, $"Could not read the package identity for PID {processId}.");
+            }
+
+            return name.ToString();
+        }
+    }
+}

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/PackagedFixturePrerequisites.cs
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/PackagedFixturePrerequisites.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO.Compression;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Workspaces.UITests
+{
+    internal static class PackagedFixturePrerequisites
+    {
+        internal const int NoSignature = unchecked((int)0x800B0100);
+        internal const int UntrustedRoot = unchecked((int)0x800B0109);
+
+        internal static void RequireSignature(string path, bool isInPipeline)
+        {
+            Assert.IsTrue(File.Exists(path), $"The fixture package was not staged: '{path}'. Build Workspaces.UITests.Next first.");
+            using var archive = ZipFile.OpenRead(path);
+
+            // Detect the ordinary unsigned developer build cheaply. A present signature is NOT a trust
+            // decision: Windows still validates its integrity and certificate chain during deployment.
+            if (archive.GetEntry("AppxSignature.p7x") is null)
+            {
+                throw MissingSigningException(path, NoSignature, isInPipeline);
+            }
+        }
+
+        internal static bool IsMissingSigning(int errorCode) => errorCode is NoSignature or UntrustedRoot;
+
+        internal static Exception MissingSigningException(string path, int errorCode, bool isInPipeline)
+        {
+            if (!IsMissingSigning(errorCode))
+            {
+                throw new ArgumentOutOfRangeException(nameof(errorCode), errorCode, "Not a missing signing prerequisite.");
+            }
+
+            var reason = errorCode == NoSignature ? "has no digital signature" : "does not chain to a trusted certificate";
+            var message = $"The packaged Workspaces fixture '{path}' {reason} (0x{errorCode:X8}). " +
+                "See doc\\devdocs\\modules\\workspaces.md, 'Optional packaged-fixture setup', for signing, trust, and cleanup instructions. " +
+                "Rebuilding can replace signed packages; prepare signing again after rebuilding. " +
+                "The tests never install certificate trust automatically.";
+
+            if (isInPipeline)
+            {
+                return new AssertFailedException("CI/VM packaged coverage requires prepared signing. " + message);
+            }
+
+            return new AssertInconclusiveException("Packaged scenario skipped locally because signing setup is missing. " + message);
+        }
+    }
+}

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/PreviewSnapshot.cs
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/PreviewSnapshot.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
+using Microsoft.PowerToys.UITest.Next;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Workspaces.UITests
+{
+    internal sealed class PreviewSnapshot : IDisposable
+    {
+        private readonly Bitmap bitmap;
+
+        private PreviewSnapshot(Bitmap bitmap)
+        {
+            this.bitmap = bitmap;
+        }
+
+        internal static PreviewSnapshot Capture(TestContext context, Session editor, string label)
+        {
+            MouseHelper.MoveTo(0, 0);
+            var image = editor.Find<Element>(By.AccessibilityId("WorkspacePreviewImage"), 15_000);
+            Assert.IsTrue(image.Width > 0 && image.Height > 0, "The visible workspace preview has no geometry.");
+            var directory = context.TestRunResultsDirectory ?? throw new InvalidOperationException("No results directory is available.");
+            var framePath = Path.Combine(directory, $"{context.TestName}-{Guid.NewGuid():N}-frame.png");
+            var previewPath = Path.Combine(directory, $"{context.TestName}-{Guid.NewGuid():N}-{label}.png");
+            Directory.CreateDirectory(directory);
+            try
+            {
+                editor.ScreenshotVisibleWindow(framePath);
+                var bounds = WindowHelper.GetVisibleBounds(new IntPtr(editor.WindowHandle));
+                var rectangle = new Rectangle(image.X - bounds.Left, image.Y - bounds.Top, image.Width, image.Height);
+                using var frame = new Bitmap(framePath);
+                Assert.IsTrue(new Rectangle(0, 0, frame.Width, frame.Height).Contains(rectangle), "The preview is not entirely within the composed editor frame.");
+                var cropped = frame.Clone(rectangle, PixelFormat.Format32bppArgb);
+                cropped.Save(previewPath, ImageFormat.Png);
+                context.AddResultFile(previewPath);
+                return new PreviewSnapshot(cropped);
+            }
+            finally
+            {
+                File.Delete(framePath);
+            }
+        }
+
+        internal static void AssertChanged(TestContext context, Session editor, PreviewSnapshot before) =>
+            AssertDifference(context, editor, before, changed: true);
+
+        internal static void AssertRestored(TestContext context, Session editor, PreviewSnapshot before) =>
+            AssertDifference(context, editor, before, changed: false);
+
+        public void Dispose() => bitmap.Dispose();
+
+        private static void AssertDifference(TestContext context, Session editor, PreviewSnapshot before, bool changed)
+        {
+            var result = WaitHelper.WaitForStable(
+                () =>
+                {
+                    using var after = Capture(context, editor, changed ? "changed-preview" : "restored-preview");
+                    return before.ChangedFraction(after);
+                },
+                fraction => changed ? fraction >= 0.005 : fraction <= 0.001,
+                timeoutMS: 20_000,
+                requiredConsecutiveMatches: 2,
+                pollIntervalMS: 150);
+            Assert.IsTrue(
+                result.Succeeded,
+                $"The preview {(changed ? "did not materially change" : "did not return to its original pixels")}. Changed fraction: {result.LastObservation:P3}.");
+        }
+
+        private double ChangedFraction(PreviewSnapshot other)
+        {
+            var otherBitmap = other.bitmap;
+            Assert.AreEqual(bitmap.Size, otherBitmap.Size, "Preview dimensions changed during an application edit.");
+            var first = Pixels(bitmap);
+            var second = Pixels(otherBitmap);
+            var changed = 0;
+            for (var offset = 0; offset < first.Length; offset += 4)
+            {
+                var difference = Math.Abs(first[offset] - second[offset]) +
+                    Math.Abs(first[offset + 1] - second[offset + 1]) +
+                    Math.Abs(first[offset + 2] - second[offset + 2]);
+                if (difference > 48)
+                {
+                    changed++;
+                }
+            }
+
+            return changed / (double)(bitmap.Width * bitmap.Height);
+        }
+
+        private static byte[] Pixels(Bitmap image)
+        {
+            var pixels = new byte[checked(image.Width * image.Height * 4)];
+            var data = image.LockBits(new Rectangle(0, 0, image.Width, image.Height), ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
+            try
+            {
+                for (var row = 0; row < image.Height; row++)
+                {
+                    Marshal.Copy(IntPtr.Add(data.Scan0, row * data.Stride), pixels, row * image.Width * 4, image.Width * 4);
+                }
+            }
+            finally
+            {
+                image.UnlockBits(data);
+            }
+
+            return pixels;
+        }
+    }
+}

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/PreviewSnapshot.cs
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/PreviewSnapshot.cs
@@ -19,30 +19,22 @@ namespace Microsoft.Workspaces.UITests
             this.bitmap = bitmap;
         }
 
+        // Grab the current preview as a baseline: park the cursor once and attach the frame as a single
+        // piece of evidence. Callers keep the returned snapshot to compare against with
+        // AssertChanged/AssertRestored.
         internal static PreviewSnapshot Capture(TestContext context, Session editor, string label)
         {
             MouseHelper.MoveTo(0, 0);
-            var image = editor.Find<Element>(By.AccessibilityId("WorkspacePreviewImage"), 15_000);
-            Assert.IsTrue(image.Width > 0 && image.Height > 0, "The visible workspace preview has no geometry.");
-            var directory = context.TestRunResultsDirectory ?? throw new InvalidOperationException("No results directory is available.");
-            var framePath = Path.Combine(directory, $"{context.TestName}-{Guid.NewGuid():N}-frame.png");
-            var previewPath = Path.Combine(directory, $"{context.TestName}-{Guid.NewGuid():N}-{label}.png");
-            Directory.CreateDirectory(directory);
+            var snapshot = CaptureBitmap(context, editor);
             try
             {
-                editor.ScreenshotVisibleWindow(framePath);
-                var bounds = WindowHelper.GetVisibleBounds(new IntPtr(editor.WindowHandle));
-                var rectangle = new Rectangle(image.X - bounds.Left, image.Y - bounds.Top, image.Width, image.Height);
-                using var frame = new Bitmap(framePath);
-                Assert.IsTrue(new Rectangle(0, 0, frame.Width, frame.Height).Contains(rectangle), "The preview is not entirely within the composed editor frame.");
-                var cropped = frame.Clone(rectangle, PixelFormat.Format32bppArgb);
-                cropped.Save(previewPath, ImageFormat.Png);
-                context.AddResultFile(previewPath);
-                return new PreviewSnapshot(cropped);
+                snapshot.Attach(context, label);
+                return snapshot;
             }
-            finally
+            catch
             {
-                File.Delete(framePath);
+                snapshot.Dispose();
+                throw;
             }
         }
 
@@ -54,21 +46,99 @@ namespace Microsoft.Workspaces.UITests
 
         public void Dispose() => bitmap.Dispose();
 
+        // Capture the visible preview into an in-memory bitmap without attaching any evidence. The
+        // composed frame is written to a transient file only long enough to crop the preview region out
+        // of it, then deleted, so a long comparison loop never accumulates result files.
+        private static PreviewSnapshot CaptureBitmap(TestContext context, Session editor)
+        {
+            var image = editor.Find<Element>(By.AccessibilityId("WorkspacePreviewImage"), 15_000);
+            Assert.IsTrue(image.Width > 0 && image.Height > 0, "The visible workspace preview has no geometry.");
+            var directory = context.TestRunResultsDirectory ?? throw new InvalidOperationException("No results directory is available.");
+            Directory.CreateDirectory(directory);
+            var framePath = Path.Combine(directory, $"{context.TestName}-{Guid.NewGuid():N}-frame.png");
+            try
+            {
+                editor.ScreenshotVisibleWindow(framePath);
+                var bounds = WindowHelper.GetVisibleBounds(new IntPtr(editor.WindowHandle));
+                var rectangle = new Rectangle(image.X - bounds.Left, image.Y - bounds.Top, image.Width, image.Height);
+                using var frame = new Bitmap(framePath);
+                Assert.IsTrue(new Rectangle(0, 0, frame.Width, frame.Height).Contains(rectangle), "The preview is not entirely within the composed editor frame.");
+                return new PreviewSnapshot(frame.Clone(rectangle, PixelFormat.Format32bppArgb));
+            }
+            finally
+            {
+                File.Delete(framePath);
+            }
+        }
+
+        // Persist the in-memory bitmap as a TRX result file. Used for the baseline frame and for the
+        // single final frame retained by a comparison, so the attached evidence stays bounded.
+        private void Attach(TestContext context, string label)
+        {
+            var directory = context.TestRunResultsDirectory ?? throw new InvalidOperationException("No results directory is available.");
+            Directory.CreateDirectory(directory);
+            var previewPath = Path.Combine(directory, $"{context.TestName}-{Guid.NewGuid():N}-{label}.png");
+            bitmap.Save(previewPath, ImageFormat.Png);
+            context.AddResultFile(previewPath);
+        }
+
         private static void AssertDifference(TestContext context, Session editor, PreviewSnapshot before, bool changed)
         {
-            var result = WaitHelper.WaitForStable(
-                () =>
+            // Park the cursor once for the whole comparison rather than on every poll.
+            MouseHelper.MoveTo(0, 0);
+            var label = changed ? "changed-preview" : "restored-preview";
+            PreviewSnapshot? latest = null;
+            try
+            {
+                WaitHelper.StableWaitResult<double> result;
+                try
                 {
-                    using var after = Capture(context, editor, changed ? "changed-preview" : "restored-preview");
-                    return before.ChangedFraction(after);
-                },
-                fraction => changed ? fraction >= 0.005 : fraction <= 0.001,
-                timeoutMS: 20_000,
-                requiredConsecutiveMatches: 2,
-                pollIntervalMS: 150);
-            Assert.IsTrue(
-                result.Succeeded,
-                $"The preview {(changed ? "did not materially change" : "did not return to its original pixels")}. Changed fraction: {result.LastObservation:P3}.");
+                    result = WaitHelper.WaitForStable(
+                        () =>
+                        {
+                            var after = CaptureBitmap(context, editor);
+                            latest?.Dispose();
+                            latest = after;
+                            return before.ChangedFraction(after);
+                        },
+                        fraction => changed ? fraction >= 0.005 : fraction <= 0.001,
+                        timeoutMS: 20_000,
+                        requiredConsecutiveMatches: 2,
+                        pollIntervalMS: 150);
+                }
+                finally
+                {
+                    // Retain exactly one comparison frame (the final observation) alongside the baseline,
+                    // whether the wait succeeded, timed out, or a dimension mismatch propagated.
+                    TryAttach(context, latest, label);
+                }
+
+                Assert.IsTrue(
+                    result.Succeeded,
+                    $"The preview {(changed ? "did not materially change" : "did not return to its original pixels")}. Changed fraction: {result.LastObservation:P3}.");
+            }
+            finally
+            {
+                latest?.Dispose();
+            }
+        }
+
+        private static void TryAttach(TestContext context, PreviewSnapshot? snapshot, string label)
+        {
+            if (snapshot is null)
+            {
+                return;
+            }
+
+            try
+            {
+                snapshot.Attach(context, label);
+            }
+            catch (Exception error) when (error is IOException or UnauthorizedAccessException or ExternalException or InvalidOperationException)
+            {
+                // Evidence attachment is best-effort; it must never mask the comparison outcome.
+                context.WriteLine($"Could not attach the '{label}' preview evidence: {error.Message}");
+            }
         }
 
         private double ChangedFraction(PreviewSnapshot other)

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/README.md
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/README.md
@@ -54,18 +54,73 @@ serializes outstanding instances. Cancellation proves that a final pending app
 never started while an already-open HWND survives. Dismissal releases the gate
 after the UI closes and requires every configured app to appear and be positioned.
 
-Run in an unlocked, English-language **non-elevated** desktop. Use the local VM
-skill rather than a working desktop. No Visual Studio, Store access, third-party
-applications, or elevated fixture process is needed inside the guest. The test
-fixture is representative packaged/unpackaged desktop coverage, not a claim of
-compatibility testing every application named as an example in the issue.
+Run in an unlocked, English-language **non-elevated** desktop. No Visual Studio,
+Store access, third-party applications, or elevated fixture process is needed on
+the machine under test. The test fixture is representative packaged/unpackaged
+desktop coverage, not a claim of compatibility testing every application named as
+an example in the issue.
+
+Placement cases seed each application against the display Workspaces actually
+enumerates at launch: `WorkspacesDisplay` resolves the primary monitor to the
+product's GDI monitor **number**, effective DPI, and physical/logical work area
+(the same contract as `src\common\Display\DisplayUtils.cpp`), and the seed uses
+those real values plus a default rectangle kept inside the target work area. This
+replaces the previous fixed `monitor = 1` / `(240, 220, 720, 460)` assumption,
+which made the native launcher's live-monitor lookup miss and minimize the
+window when display 1 was absent. The fixed geometry/DPI assumptions could also
+produce incorrect placement on other display configurations.
+The class preflight fails fast with actionable guidance when the host cannot support real
+placement — for example a disconnected RDP session that reports only
+the numberless `WinDisc` pseudo-display — instead of a ~96s minimized-placement
+assertion timeout, and before any window is opened or state is mutated.
+
+### Running on the host via Visual Studio Test Explorer
+
+These tests can run directly on a developer machine, not only inside the local VM.
+Requirements for a host run:
+
+- A **connected, unlocked, interactive** desktop in an **English** display
+  language. A disconnected/locked RDP session (`WinDisc` primary) is rejected up
+  front by the placement preflight.
+- **Non-elevated** Test Explorer / `testhost`. The suite asserts it is not
+  elevated and drives the real standard-user Settings/Runner scope; do not launch
+  Visual Studio "as administrator".
+- Build the project (and its `Workspaces.TestApp` fixture) with the repository
+  script for the platform under test, then let Test Explorer discover the
+  `Microsoft.Testing.Platform` executable. Make sure the build selected in Test
+  Explorer matches the bits you intend to exercise.
+- Build the **product runtime from the same branch** too. Building the UI-test
+  project does not rebuild Runner, Settings, or Workspaces Editor. Stale editor
+  binaries can lack the automation identifiers used by the suite. When staging
+  binaries elsewhere, keep the complete runtime/dependency set, including
+  `PowerToys.WorkspacesEditor.dll.config` and the launcher UI configuration;
+  copying a lone editor DLL is not a supported deployment.
+- **Do not touch the mouse or keyboard** while a case runs — the tests move the
+  real cursor and rely on foreground ownership.
+- Settings, workspace storage, temporary snapshots, desktop shortcuts, and
+  generated icons are journaled before each run and restored afterwards, so a run
+  does not lose your existing Workspaces data. Cleanup stops only the fixture and
+  Workspaces module processes it owns, never unrelated apps.
+
+The **unpackaged** placement/launch/cancel cases can use matching local Debug
+product builds without signing the fixture. The two **packaged** cases report
+Inconclusive/Skipped locally when the fixture is unsigned or its root certificate
+is untrusted. CI and pipeline-like VM runs remain strict, and malformed packages,
+corrupt signatures, missing files, and unrelated deployment failures are never
+converted into skips. Package preparation happens before opening the capture
+overlay. The tests never add host certificate trust automatically.
+
+For the optional host signing/trust command and cleanup instructions, see
+`doc\devdocs\modules\workspaces.md`, **Optional packaged-fixture setup**. Do not
+claim full packaged coverage on an unsigned host. Authenticated **Release**
+Runner/Settings IPC is a separate prerequisite and remains unchanged.
 
 The full suite needs a signed/trusted `Workspaces.TestApp.msix`. Release
 Runner/Settings must have matching versions and valid Microsoft-named signatures.
 Quick Access has its own authenticated pipe, so `PowerToys.QuickAccess.exe` must
 also satisfy that contract. The existing CI companion/package-signing step covers
-all three executables and the fixture. The suite is dispatched through the shared
-limited-token UI-test runner, not through an elevated test host.
+all three executables and the fixture. In CI the suite is dispatched through the
+shared limited-token UI-test runner, not through an elevated test host.
 
 ## Checklist coverage
 
@@ -129,6 +184,20 @@ missing; build with the repository script, not `dotnet build`, because the share
 harness has COM references. Build `ARM64` as well before CI. The project reference
 builds the matching fixture and stages its complete self-contained payload under
 `Fixture`, plus `Workspaces.TestApp.msix` beside the MTP test executable.
+
+On a connected, unlocked, non-elevated host you can run the unpackaged cases from
+Visual Studio Test Explorer, or directly against the built executable:
+
+```powershell
+$tests = (Resolve-Path .\x64\Debug\tests\Workspaces.UITests.Next\net10.0-windows10.0.26100.0).Path
+& "$tests\Workspaces.UITests.Next.exe" `
+    --filter "FullyQualifiedName~CancelLaunchStopsPendingAppsAndPreservesOpenedWindows" `
+    --report-trx --results-directory .\TestResults
+```
+
+The placement preflight rejects a disconnected/locked (`WinDisc`) desktop with
+actionable guidance before touching any state. Packaged-fixture and Release-IPC
+cases still need the signed artifacts below; run those in the VM or CI.
 
 Sign the staged payload before packaging it for a VM. Use the existing signer
 without adding trust to the build host:

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/README.md
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/README.md
@@ -1,0 +1,166 @@
+# Workspaces UI tests
+
+End-to-end coverage for [#40682](https://github.com/microsoft/PowerToys/issues/40682),
+using `Microsoft.PowerToys.UITest.Next` and the repository-pinned winappcli.
+The legacy `WorkspacesEditorUITest` project is retained unchanged.
+
+## Test design
+
+The suite uses the real Settings/Runner scope with only Workspaces enabled.
+Runner and Settings are reused within the class; every case closes the previous
+editor/launcher/fixture processes and starts with independent workspace data.
+Settings, workspace storage, temporary snapshots, desktop shortcuts, and generated
+shortcut icons are journaled and restored after the owning processes stop.
+Failure screenshots, recordings, product logs, editor UIA trees, and workspace
+JSON are collected before cleanup removes the diagnostic windows.
+
+Settings lifecycle tests drive the real switch and observe Runner persistence and
+shortcut behavior. They never repair rejected IPC by writing the enabled map or
+restarting Runner. Shortcut tests read the live control, and the customization
+case captures a new chord through the real shortcut dialog. The Quick Access
+case opens the Runner-owned flyout through its show event, then invokes its
+Workspaces tile; it does not substitute direct editor activation for the tile.
+
+Saved-file assertions complement UI assertions rather than replacing them.
+Capture reads the native snapshot and compares fixture identity, package identity,
+window geometry, and minimized state. Launch cases observe actual fixture windows,
+their Workspaces placement stamp, geometry/state, received arguments, and process
+identity. Search checks exact inclusion and exclusion; sorting checks order and a
+real editor close/reopen. Preview tests compare composed pixels from the visible
+preview before/after editing and require removal/add-back to restore the original
+image. They do not use OS-specific golden screenshots or assert geometry on
+off-screen application rows.
+
+The product changes are automation identifiers only: the workspace-card container
+identity (its name, so a card stays addressable after the list re-projects its
+items), sort and window-position selectors, the preview image, and the launch
+progress/state indicators.
+
+## Fixtures and prerequisites
+
+`..\Workspaces.TestApp` builds one deterministic, resizable Windows Forms app as
+both a self-contained unpackaged payload and a **full MSIX**. The test package is
+`Microsoft.PowerToys.Workspaces.TestApp`, with application ID `App`. It is installed
+for the current user, and its HWND's actual package identity is checked. Cleanup
+stops only fixture processes matching the owned executable paths and removes the
+owned package registration.
+
+The fixture supports `--title`, `--payload`, `--minimized`, and existing local
+`--started-event`, `--wait-event`, and `--ready-event` handles. Startup gates hold
+the first window until the test releases it; no sleeps stand in for app readiness.
+Launch-progress/cancellation cases use ordered application IDs and same-executable
+pending instances because the native launcher iterates an ID-ordered map and
+serializes outstanding instances. Cancellation proves that a final pending app
+never started while an already-open HWND survives. Dismissal releases the gate
+after the UI closes and requires every configured app to appear and be positioned.
+
+Run in an unlocked, English-language **non-elevated** desktop. Use the local VM
+skill rather than a working desktop. No Visual Studio, Store access, third-party
+applications, or elevated fixture process is needed inside the guest. The test
+fixture is representative packaged/unpackaged desktop coverage, not a claim of
+compatibility testing every application named as an example in the issue.
+
+The full suite needs a signed/trusted `Workspaces.TestApp.msix`. Release
+Runner/Settings must have matching versions and valid Microsoft-named signatures.
+Quick Access has its own authenticated pipe, so `PowerToys.QuickAccess.exe` must
+also satisfy that contract. The existing CI companion/package-signing step covers
+all three executables and the fixture. The suite is dispatched through the shared
+limited-token UI-test runner, not through an elevated test host.
+
+## Checklist coverage
+
+| Item | Automated scenario or explicit boundary |
+| --- | --- |
+| 1 | `SettingsLaunchButtonOpensEditor` |
+| 2 | `QuickAccessLaunchesEditor` |
+| 3 | `ActivationShortcutOpensEditor`; `CustomizedShortcutReachesRunnerAndReplacesTheOldChord` |
+| 4 | `DisabledModuleRejectsShortcutUntilReenabled` |
+| 5 | `CaptureIncludesPackagedUnpackagedAndMinimizedWindows`, including an app opened after Create Workspace; elevated capture remains manual |
+| 6 | `CaptureIncludesPackagedUnpackagedAndMinimizedWindows` compares actual window bounds and minimized-monitor bounds |
+| 7 | Manual: capture a genuinely elevated app with elevated PowerToys |
+| 8 | `CaptureIncludesPackagedUnpackagedAndMinimizedWindows` saves and verifies the new list entry and stored application IDs |
+| 9 | `CancelCaptureLeavesWorkspaceListAndStorageUnchanged`; `CancellingCapturedWorkspaceDiscardsIt` |
+| 10 | `SearchFiltersByWorkspaceAndApplicationNames` |
+| 11 | `SortOrderPersistsAcrossEditorRestart`, all three sort orders |
+| 12 | `SortOrderPersistsAcrossEditorRestart` |
+| 13 | `DeleteRemovesOnlyTheSelectedWorkspace` |
+| 14 | `WorkspaceCardAndEditMenuOpenEditingPage`, menu case |
+| 15 | `WorkspaceCardAndEditMenuOpenEditingPage`, card case |
+| 16 | `RemoveAndAddBackUpdatePreviewAndSavedApplicationList` |
+| 17 | `RemoveAndAddBackUpdatePreviewAndSavedApplicationList` |
+| 18 | `WindowStateChangesUpdatePreviewAndPersist`, minimized case |
+| 19 | `WindowStateChangesUpdatePreviewAndPersist`, maximized case |
+| 20 | `NameArgumentsAdminAndGeometryEditsPersist` checks the available administrator preference; actual elevated activation is manual |
+| 21 | `NameArgumentsAdminAndGeometryEditsPersist`; `CommandLineArgumentsReachUnpackagedAndPackagedApps` |
+| 22 | `NameArgumentsAdminAndGeometryEditsPersist` compares preview changes after changing all four position fields |
+| 23 | `NameArgumentsAdminAndGeometryEditsPersist` |
+| 24 | Save assertions throughout; `CancelAndBreadcrumbDiscardUnsavedEdits`; `CancellingCapturedWorkspaceDiscardsIt` |
+| 25 | `CancelAndBreadcrumbDiscardUnsavedEdits`, breadcrumb case |
+| 26 | `DesktopShortcutTracksFilePresenceAndLaunchesWorkspace` |
+| 27 | `DesktopShortcutTracksFilePresenceAndLaunchesWorkspace`, including externally deleting the shortcut |
+| 28 | `LaunchAndEditCaptureAddsWindowsToTheExistingWorkspace` |
+| 29 | `LaunchFromEditorRestoresWindowPlacement`, normal/minimized/maximized cases |
+| 30 | `DesktopShortcutTracksFilePresenceAndLaunchesWorkspace` activates the actual `.lnk` through the Windows Shell |
+| 31 | `LauncherDisplaysLaunchingLaunchedAndFailedStates` |
+| 32 | `CancelLaunchStopsPendingAppsAndPreservesOpenedWindows` |
+| 33 | `DismissClosesProgressWhileApplicationsContinueLaunching` |
+| 34 | Capture and launch cases use the real unpackaged fixture |
+| 35 | Manual: UAC and genuinely elevated unpackaged launch |
+| 36 | `CommandLineArgumentsReachUnpackagedAndPackagedApps`, unpackaged case |
+| 37 | Capture and launch cases use the registered full-MSIX fixture |
+| 38 | Manual: UAC and genuinely elevated packaged launch |
+| 39 | `CommandLineArgumentsReachUnpackagedAndPackagedApps`, packaged case |
+| 40 | Manual: physically connect a second monitor after capture, including mixed DPI |
+| 41 | Manual hot-plug matrix; `MissingSavedMonitorUsesTheRemainingDisplay` separately covers replay of a saved, unavailable monitor |
+
+`MoveExistingWindowsReusesTheOriginalProcessAndWindow` additionally checks the
+current editor's move-existing-windows option without accepting duplicate launches.
+Manual boundaries are documented here, not represented by ignored/inconclusive
+tests that would make a full CI run appear complete.
+
+## Build and run
+
+```powershell
+tools\build\build.cmd -Path src\modules\Workspaces\Tests\Workspaces.UITests.Next -Platform x64 -Configuration Debug
+```
+
+Use a targeted `dotnet restore` when introducing the project or when assets are
+missing; build with the repository script, not `dotnet build`, because the shared
+harness has COM references. Build `ARM64` as well before CI. The project reference
+builds the matching fixture and stages its complete self-contained payload under
+`Fixture`, plus `Workspaces.TestApp.msix` beside the MTP test executable.
+
+Sign the staged payload before packaging it for a VM. Use the existing signer
+without adding trust to the build host:
+
+```powershell
+$tests = (Resolve-Path .\x64\Debug\tests\Workspaces.UITests.Next\net10.0-windows10.0.26100.0).Path
+$runtime = 'C:\PowerToysUiTestPayload\Product'
+$certificate = 'C:\PowerToysUiTestPayload\workspaces-test-signing.cer'
+
+.\.pipelines\signSparsePackages.ps1 `
+    -PackageRoot $tests, $runtime `
+    -Include Workspaces.TestApp.msix `
+    -RequiredAuthenticodeFile PowerToys.exe, PowerToys.Settings.exe, PowerToys.QuickAccess.exe `
+    -SkipLocalTrust -ExportCertificatePath $certificate
+```
+
+Import only the exported public certificate into the isolated guest's machine
+Root/TrustedPeople stores using the existing administrator control channel. Never
+create trust from the test executable. Repeat signing after a build/restage
+replaces signed files, and remove session-added guest trust after validation.
+
+Inside the prepared VM, the executable can run directly:
+
+```powershell
+.\Workspaces.UITests.Next.exe --report-trx --results-directory .\TestResults
+```
+
+For the first focused iteration, use
+`--filter "FullyQualifiedName~SettingsLaunchButtonOpensEditor"`.
+Follow the `ui-tests-local-vm` skill for hash-addressed payload staging, desktop
+preflight, durable evidence, and complete Windows 10/Windows 11 runs under both
+Default and Constrained profiles. Narrow filters are not full-suite sign-off.
+The `ui-tests-pipeline-ci` skill then queues the pushed revision with
+`uiTestModules=[Workspaces.UITests.Next]` and verifies the terminal results for
+every requested platform.

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/TestAppFixture.cs
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/TestAppFixture.cs
@@ -1,0 +1,229 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Microsoft.PowerToys.UITest.Next;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.ApplicationModel;
+using Windows.Management.Deployment;
+
+namespace Microsoft.Workspaces.UITests
+{
+    internal sealed class TestAppFixture : IDisposable
+    {
+        internal const string DefaultTitle = "Workspaces UI test app";
+        private const string PackageName = "Microsoft.PowerToys.Workspaces.TestApp";
+        private const string Publisher = "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US";
+        private readonly PackageManager packageManager = new();
+        private Package? package;
+        private bool ownsRegistration;
+        private global::Windows.Foundation.IAsyncOperationWithProgress<DeploymentResult, DeploymentProgress>? installationOperation;
+        private Task<DeploymentResult>? installation;
+
+        internal string ExecutablePath { get; } = Path.Combine(AppContext.BaseDirectory, "Fixture", "Workspaces.TestApp.exe");
+
+        internal string PackageFullName => package?.Id.FullName ?? throw new InvalidOperationException("The packaged fixture has not been installed.");
+
+        internal string AppUserModelId => package is not null
+            ? $"{package.Id.FamilyName}!App"
+            : throw new InvalidOperationException("The packaged fixture has not been installed.");
+
+        internal string PackagedExecutablePath => package is not null
+            ? Path.Combine(package.InstalledLocation.Path, "Workspaces.TestApp.exe")
+            : throw new InvalidOperationException("The packaged fixture has not been installed.");
+
+        internal Session OpenUnpackaged(string title, TestContext context, string payload = "")
+        {
+            Assert.IsTrue(File.Exists(ExecutablePath), $"The unpackaged fixture was not staged: {ExecutablePath}");
+            context.WriteLine($"[{DateTime.UtcNow:HH:mm:ss.fff}] Starting unpackaged fixture '{title}'.");
+            var start = new ProcessStartInfo(ExecutablePath)
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            start.ArgumentList.Add("--title");
+            start.ArgumentList.Add(title);
+            start.ArgumentList.Add("--payload");
+            start.ArgumentList.Add(payload);
+            using var process = Process.Start(start) ?? throw new InvalidOperationException("Could not start the unpackaged fixture.");
+            Assert.IsFalse(ElevationHelper.IsProcessElevated(process.Id), "The fixture must start non-elevated.");
+            Assert.IsNull(NativeMethods.PackageFullName(process.Id), "The unpackaged fixture unexpectedly has package identity.");
+            return WaitForWindow(title);
+        }
+
+        internal Session OpenPackaged(TestContext context)
+        {
+            EnsurePackage(context);
+            var entries = package!.GetAppListEntriesAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(20)).GetAwaiter().GetResult();
+            var application = entries.Single(entry => entry.AppUserModelId == AppUserModelId);
+            context.WriteLine($"[{DateTime.UtcNow:HH:mm:ss.fff}] Activating packaged fixture '{AppUserModelId}'.");
+            Assert.IsTrue(
+                application.LaunchAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(30)).GetAwaiter().GetResult(),
+                "Windows did not activate the packaged fixture.");
+            var window = WaitForWindow(DefaultTitle);
+            Assert.AreEqual(PackageFullName, NativeMethods.PackageFullName(window.ProcessId), "The fixture window must have the installed package identity.");
+            Assert.IsFalse(window.IsElevated, "The packaged fixture must run non-elevated.");
+            return window;
+        }
+
+        internal Session WaitForWindow(string title, int timeoutMS = 45_000)
+        {
+            var ready = WaitHelper.WaitForStable(
+                () => FindWindow(title),
+                window => window is not null,
+                timeoutMS,
+                requiredConsecutiveMatches: 3,
+                pollIntervalMS: 150);
+            Assert.IsTrue(ready.Succeeded, $"Fixture window '{title}' did not appear. Owned PIDs: {string.Join(", ", ProcessIds())}.");
+            var match = ready.LastObservation!;
+            var session = WindowsFinder.WaitForWindowByApp(
+                match.ProcessId.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                window => window.Hwnd == match.Hwnd,
+                timeoutMS: 5_000);
+            Assert.IsNotNull(session, $"The ready fixture HWND disappeared: {match}.");
+            return session;
+        }
+
+        internal WindowsFinder.WindowInfo? FindWindow(string title)
+        {
+            var ids = ProcessIds();
+            return WindowsFinder.ListAll().SingleOrDefault(window => ids.Contains(window.ProcessId) && window.Title == title);
+        }
+
+        internal IReadOnlyList<int> ProcessIds()
+        {
+            var ids = new List<int>();
+            foreach (var process in Process.GetProcessesByName("Workspaces.TestApp"))
+            {
+                using (process)
+                {
+                    try
+                    {
+                        if (process.HasExited)
+                        {
+                            continue;
+                        }
+
+                        var path = process.MainModule?.FileName;
+                        if (string.Equals(path, ExecutablePath, StringComparison.OrdinalIgnoreCase) ||
+                            (package is not null && string.Equals(path, PackagedExecutablePath, StringComparison.OrdinalIgnoreCase)))
+                        {
+                            ids.Add(process.Id);
+                        }
+                    }
+                    catch (InvalidOperationException) when (process.HasExited)
+                    {
+                    }
+                    catch (Win32Exception) when (process.HasExited)
+                    {
+                    }
+                }
+            }
+
+            return ids;
+        }
+
+        internal void CloseAll()
+        {
+            foreach (var id in ProcessIds())
+            {
+                Process process;
+                try
+                {
+                    process = Process.GetProcessById(id);
+                }
+                catch (ArgumentException)
+                {
+                    continue;
+                }
+
+                using (process)
+                {
+                    var windows = WindowControl.EnumerateProcessWindows([id]);
+                    foreach (var window in windows)
+                    {
+                        Assert.IsTrue(WindowControl.TryCloseWindow(window.Hwnd.ToInt64()), $"Could not close fixture HWND {window.Hwnd}.");
+                    }
+
+                    if (!process.WaitForExit(windows.Count == 0 ? 0 : 5_000))
+                    {
+                        process.Kill(entireProcessTree: true);
+                        Assert.IsTrue(process.WaitForExit(10_000), $"The test-owned fixture PID {id} did not exit.");
+                    }
+                }
+            }
+
+            Assert.HasCount(0, ProcessIds(), "A test-owned fixture process survived cleanup.");
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                CloseAll();
+            }
+            finally
+            {
+                if (installation is { IsCompleted: false })
+                {
+                    installationOperation!.Cancel();
+                    try
+                    {
+                        installation.WaitAsync(TimeSpan.FromSeconds(30)).GetAwaiter().GetResult();
+                    }
+                    catch (OperationCanceledException)
+                    {
+                    }
+                }
+
+                if (ownsRegistration)
+                {
+                    foreach (var registered in RegisteredPackages())
+                    {
+                        Assert.AreEqual(Publisher, registered.Id.Publisher, "Refusing to remove an unrelated package.");
+                        var removed = packageManager.RemovePackageAsync(registered.Id.FullName)
+                            .AsTask().WaitAsync(TimeSpan.FromSeconds(90)).GetAwaiter().GetResult();
+                        Assert.IsNull(removed.ExtendedErrorCode, $"Could not remove the fixture package: {removed.ErrorText}");
+                    }
+
+                    Assert.HasCount(0, RegisteredPackages(), "The fixture package remained registered after cleanup.");
+                    ownsRegistration = false;
+                    package = null;
+                }
+            }
+        }
+
+        private void EnsurePackage(TestContext context)
+        {
+            if (package is not null)
+            {
+                return;
+            }
+
+            var packagePath = Path.Combine(AppContext.BaseDirectory, "Workspaces.TestApp.msix");
+            Assert.IsTrue(File.Exists(packagePath), $"The signed fixture package was not staged: {packagePath}");
+            Assert.HasCount(0, RegisteredPackages(), "A previous fixture package is still registered; remove it before starting a new suite.");
+            context.WriteLine($"[{DateTime.UtcNow:HH:mm:ss.fff}] Installing the signed fixture for the current user: {packagePath}");
+            ownsRegistration = true;
+            installationOperation = packageManager.AddPackageAsync(new Uri(packagePath), [], DeploymentOptions.None);
+            installation = installationOperation.AsTask();
+            var deployment = installation.WaitAsync(TimeSpan.FromSeconds(90)).GetAwaiter().GetResult();
+            Assert.IsNull(
+                deployment.ExtendedErrorCode,
+                $"Fixture deployment failed: {deployment.ErrorText}. Activity: {deployment.ActivityId}. " +
+                "Stage a package signed by the shared UI-test signing setup and trust its public certificate in the test VM.");
+            package = RegisteredPackages().Single();
+            Assert.AreEqual(Publisher, package.Id.Publisher, "Unexpected fixture publisher.");
+            Assert.AreEqual(
+                RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant(),
+                package.Id.Architecture.ToString().ToLowerInvariant(),
+                "Fixture architecture must match the test host.");
+        }
+
+        private Package[] RegisteredPackages() =>
+            packageManager.FindPackagesForUser(string.Empty).Where(candidate => candidate.Id.Name == PackageName).ToArray();
+    }
+}

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/TestAppFixture.cs
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/TestAppFixture.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Workspaces.UITests
 
         internal Session OpenPackaged(TestContext context)
         {
-            EnsurePackage(context);
+            PreparePackage(context);
             var entries = package!.GetAppListEntriesAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(20)).GetAwaiter().GetResult();
             var application = entries.Single(entry => entry.AppUserModelId == AppUserModelId);
             context.WriteLine($"[{DateTime.UtcNow:HH:mm:ss.fff}] Activating packaged fixture '{AppUserModelId}'.");
@@ -196,7 +196,7 @@ namespace Microsoft.Workspaces.UITests
             }
         }
 
-        private void EnsurePackage(TestContext context)
+        internal void PreparePackage(TestContext context)
         {
             if (package is not null)
             {
@@ -204,13 +204,28 @@ namespace Microsoft.Workspaces.UITests
             }
 
             var packagePath = Path.Combine(AppContext.BaseDirectory, "Workspaces.TestApp.msix");
-            Assert.IsTrue(File.Exists(packagePath), $"The signed fixture package was not staged: {packagePath}");
+            PackagedFixturePrerequisites.RequireSignature(packagePath, EnvironmentConfig.IsInPipeline);
             Assert.HasCount(0, RegisteredPackages(), "A previous fixture package is still registered; remove it before starting a new suite.");
             context.WriteLine($"[{DateTime.UtcNow:HH:mm:ss.fff}] Installing the signed fixture for the current user: {packagePath}");
             ownsRegistration = true;
-            installationOperation = packageManager.AddPackageAsync(new Uri(packagePath), [], DeploymentOptions.None);
-            installation = installationOperation.AsTask();
-            var deployment = installation.WaitAsync(TimeSpan.FromSeconds(90)).GetAwaiter().GetResult();
+            DeploymentResult deployment;
+            try
+            {
+                installationOperation = packageManager.AddPackageAsync(new Uri(packagePath), [], DeploymentOptions.None);
+                installation = installationOperation.AsTask();
+                deployment = installation.WaitAsync(TimeSpan.FromSeconds(90)).GetAwaiter().GetResult();
+            }
+            catch (COMException error) when (PackagedFixturePrerequisites.IsMissingSigning(error.HResult))
+            {
+                throw PackagedFixturePrerequisites.MissingSigningException(packagePath, error.HResult, EnvironmentConfig.IsInPipeline);
+            }
+
+            if (deployment.ExtendedErrorCode is { } deploymentError &&
+                PackagedFixturePrerequisites.IsMissingSigning(deploymentError.HResult))
+            {
+                throw PackagedFixturePrerequisites.MissingSigningException(packagePath, deploymentError.HResult, EnvironmentConfig.IsInPipeline);
+            }
+
             Assert.IsNull(
                 deployment.ExtendedErrorCode,
                 $"Fixture deployment failed: {deployment.ErrorText}. Activity: {deployment.ActivityId}. " +

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspaceCaptureTests.cs
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspaceCaptureTests.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Workspaces.UITests
         [TestMethod]
         public void CaptureIncludesPackagedUnpackagedAndMinimizedWindows()
         {
+            State.Fixture.PreparePackage(TestContext);
             var firstTitle = State.Prefix + "-normal";
             var minimizedTitle = State.Prefix + "-minimized";
             var first = State.Fixture.OpenUnpackaged(firstTitle, TestContext);

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspaceCaptureTests.cs
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspaceCaptureTests.cs
@@ -1,0 +1,128 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json.Nodes;
+using Microsoft.PowerToys.UITest.Next;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Workspaces.UITests
+{
+    public sealed partial class WorkspacesTests
+    {
+        [TestMethod]
+        public void CaptureIncludesPackagedUnpackagedAndMinimizedWindows()
+        {
+            var firstTitle = State.Prefix + "-normal";
+            var minimizedTitle = State.Prefix + "-minimized";
+            var first = State.Fixture.OpenUnpackaged(firstTitle, TestContext);
+            var firstBounds = NormalizedOuterBounds(new IntPtr(first.WindowHandle));
+            var minimized = State.Fixture.OpenUnpackaged(minimizedTitle, TestContext);
+            WindowHelper.MinimizeWindow(new IntPtr(minimized.WindowHandle));
+            Assert.IsTrue(
+                WaitHelper.WaitForStable(
+                    () => NativeMethods.IsIconic(new IntPtr(minimized.WindowHandle)),
+                    value => value,
+                    10_000,
+                    requiredConsecutiveMatches: 2).Succeeded,
+                "The minimized fixture did not establish its capture precondition.");
+
+            OpenEditor();
+            var capture = StartCapture();
+            State.Fixture.OpenPackaged(TestContext);
+            var captured = Capture(capture);
+            var apps = captured["applications"]!.AsArray();
+            var normalApp = AppByTitle(apps, firstTitle);
+            var minimizedApp = AppByTitle(apps, minimizedTitle);
+            var packagedApp = AppByTitle(apps, TestAppFixture.DefaultTitle);
+
+            Assert.AreEqual(State.Fixture.ExecutablePath, WorkspaceTestState.Text(normalApp, "application-path"), true);
+            Assert.AreEqual(string.Empty, WorkspaceTestState.Text(normalApp, "package-full-name"), "The unpackaged app must not acquire package identity.");
+            Assert.IsFalse(normalApp["is-elevated"]!.GetValue<bool>(), "The non-elevated fixture was captured as administrator.");
+            Assert.IsFalse(normalApp["minimized"]!.GetValue<bool>());
+            Assert.IsFalse(normalApp["maximized"]!.GetValue<bool>());
+            AssertPosition(normalApp["position"]!, firstBounds.X, firstBounds.Y, firstBounds.Width, firstBounds.Height);
+            Assert.IsTrue(minimizedApp["minimized"]!.GetValue<bool>(), "The minimized fixture lost its captured state.");
+            Assert.IsFalse(minimizedApp["is-elevated"]!.GetValue<bool>());
+            Assert.AreEqual(State.Fixture.PackageFullName, WorkspaceTestState.Text(packagedApp, "package-full-name"), "The app opened after Create Workspace was not captured with its package identity.");
+            Assert.AreEqual(State.Fixture.AppUserModelId, WorkspaceTestState.Text(packagedApp, "app-user-model-id"));
+
+            var monitorNumber = minimizedApp["monitor"]!.GetValue<int>();
+            var monitor = captured["monitor-configuration"]!.AsArray().Single(node => node!["monitor-number"]!.GetValue<int>() == monitorNumber)!;
+            var minimizedBounds = monitor["monitor-rect-dpi-unaware"]!;
+            AssertPosition(
+                minimizedApp["position"]!,
+                minimizedBounds["left"]!.GetValue<int>(),
+                minimizedBounds["top"]!.GetValue<int>(),
+                minimizedBounds["width"]!.GetValue<int>(),
+                minimizedBounds["height"]!.GetValue<int>());
+
+            var name = State.Prefix + "-captured";
+            State.TrackShortcut(name);
+            Editor.Find<TextBox>(By.AccessibilityId("EditNameTextBox")).SetText(name);
+            SaveWorkspace();
+            AssertWorkspaceNames(name);
+            var saved = WorkspaceTestState.ReadProjects().Single()!.AsObject();
+            Assert.AreEqual(name, WorkspaceTestState.Text(saved, "name"));
+            var savedApps = saved["applications"]!.AsArray();
+            foreach (var title in new[] { firstTitle, minimizedTitle, TestAppFixture.DefaultTitle })
+            {
+                var app = AppByTitle(savedApps, title);
+                Assert.IsTrue(Guid.TryParse(WorkspaceTestState.Text(app, "id"), out _), $"Saved application '{title}' needs a stable ID.");
+            }
+        }
+
+        [TestMethod]
+        public void CancelCaptureLeavesWorkspaceListAndStorageUnchanged()
+        {
+            var project = SeedOneWorkspace();
+            var name = WorkspaceTestState.Text(project, "name");
+            var original = File.ReadAllBytes(WorkspaceTestState.WorkspacesPath);
+            OpenEditor();
+            var capture = StartCapture();
+            Step("Cancelling the capture before taking a snapshot.");
+            capture.Find<Button>(By.AccessibilityId("CancelButton"), 15_000).Invoke(msPostAction: 0);
+            Assert.IsTrue(
+                WaitHelper.WaitForStable(
+                    () => WindowsFinder.ListByApp(EditorProcess).Any(window => window.Hwnd == capture.WindowHandle),
+                    visible => !visible,
+                    10_000,
+                    requiredConsecutiveMatches: 2).Succeeded,
+                "The cancelled capture window remained visible.");
+            Assert.IsTrue(Editor.Has(By.AccessibilityId("NewProjectButton"), 15_000));
+            AssertWorkspaceNames(name);
+            CollectionAssert.AreEqual(original, File.ReadAllBytes(WorkspaceTestState.WorkspacesPath), "Cancelling capture changed the stored workspaces.");
+            Assert.IsFalse(File.Exists(WorkspaceTestState.TemporaryPath), "Cancelling before Capture unexpectedly created a snapshot.");
+        }
+
+        [TestMethod]
+        public void CancellingCapturedWorkspaceDiscardsIt()
+        {
+            State.Fixture.OpenUnpackaged(State.Prefix + "-capture-cancel", TestContext);
+            var original = File.ReadAllBytes(WorkspaceTestState.WorkspacesPath);
+            OpenEditor();
+            Capture(StartCapture());
+            Step("Discarding the newly captured workspace.");
+            Editor.Find<Button>(By.AccessibilityId("CancelButton")).Invoke(msPostAction: 0);
+            Assert.IsTrue(Editor.Has(By.AccessibilityId("NewProjectButton"), 15_000));
+            AssertWorkspaceNames();
+            CollectionAssert.AreEqual(original, File.ReadAllBytes(WorkspaceTestState.WorkspacesPath), "Cancelling the new workspace persisted it.");
+            Assert.IsFalse(File.Exists(WorkspaceTestState.TemporaryPath), "The discarded temporary snapshot was not removed.");
+        }
+
+        private static JsonObject AppByTitle(JsonArray apps, string title)
+        {
+            var matches = apps.Where(app => app is not null && WorkspaceTestState.Text(app, "title") == title).ToArray();
+            Assert.HasCount(1, matches, $"Expected exactly one captured window titled '{title}'. Actual: {apps}");
+            return matches[0]!.AsObject();
+        }
+
+        private static void AssertPosition(JsonNode position, int x, int y, int width, int height)
+        {
+            Assert.AreEqual(x, position["X"]!.GetValue<int>(), 2, $"Unexpected X coordinate: {position}");
+            Assert.AreEqual(y, position["Y"]!.GetValue<int>(), 2, $"Unexpected Y coordinate: {position}");
+            Assert.AreEqual(width, position["width"]!.GetValue<int>(), 2, $"Unexpected width: {position}");
+            Assert.AreEqual(height, position["height"]!.GetValue<int>(), 2, $"Unexpected height: {position}");
+        }
+    }
+}

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspaceEditingTests.cs
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspaceEditingTests.cs
@@ -142,7 +142,9 @@ namespace Microsoft.Workspaces.UITests
             AssertWorkspaceNames(name);
             EditWorkspace(name);
             row = ExpandApplication("Primary fixture");
-            Assert.AreEqual("240", row.Find<TextBox>(By.AccessibilityId("LeftTextBox")).Value);
+            Assert.AreEqual(
+                project["applications"]!.AsArray()[0]!["position"]!["X"]!.GetValue<int>().ToString(System.Globalization.CultureInfo.InvariantCulture),
+                row.Find<TextBox>(By.AccessibilityId("LeftTextBox")).Value);
             Assert.AreEqual(
                 WorkspaceTestState.Text(project["applications"]!.AsArray()[0]!, "command-line-arguments"),
                 row.Find<TextBox>(By.AccessibilityId("CommandLineTextBox")).Value);
@@ -154,7 +156,7 @@ namespace Microsoft.Workspaces.UITests
             var first = State.Application("Primary fixture", State.Prefix + "-first");
             var second = State.Application("Secondary fixture", State.Prefix + "-second");
             second["position"] = WorkspaceTestState.Position(1080, 550, 560, 390);
-            var project = State.Project("applications", SettingsWindow(), first, second);
+            var project = State.Project("applications", first, second);
             State.WriteProjects(project);
             OpenEditor();
             EditWorkspace(WorkspaceTestState.Text(project, "name"));
@@ -205,16 +207,16 @@ namespace Microsoft.Workspaces.UITests
         private JsonObject SeedOneWorkspace()
         {
             var app = State.Application("Primary fixture", State.Prefix + "-app");
-            var project = State.Project("workspace", SettingsWindow(), app);
+            var project = State.Project("workspace", app);
             State.WriteProjects(project);
             return project;
         }
 
         private JsonObject[] SeedSearchWorkspaces()
         {
-            var atlas = State.Project("Atlas", SettingsWindow(), State.Application("Browser fixture", "browser"));
-            var zenith = State.Project("Zenith", SettingsWindow(), State.Application("Editor fixture", "editor"));
-            var mesa = State.Project("Mesa", SettingsWindow(), State.Application("Editor fixture", "editor-two"));
+            var atlas = State.Project("Atlas", State.Application("Browser fixture", "browser"));
+            var zenith = State.Project("Zenith", State.Application("Editor fixture", "editor"));
+            var mesa = State.Project("Mesa", State.Application("Editor fixture", "editor-two"));
             atlas["creation-time"] = 2_000;
             zenith["creation-time"] = 1_000;
             mesa["creation-time"] = 3_000;

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspaceEditingTests.cs
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspaceEditingTests.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Workspaces.UITests
             var first = State.Application("Primary fixture", State.Prefix + "-first");
             var second = State.Application("Secondary fixture", State.Prefix + "-second");
             second["position"] = WorkspaceTestState.Position(1080, 550, 560, 390);
-            var project = State.Project("applications", new IntPtr(Session.WindowHandle), first, second);
+            var project = State.Project("applications", SettingsWindow(), first, second);
             State.WriteProjects(project);
             OpenEditor();
             EditWorkspace(WorkspaceTestState.Text(project, "name"));
@@ -205,16 +205,16 @@ namespace Microsoft.Workspaces.UITests
         private JsonObject SeedOneWorkspace()
         {
             var app = State.Application("Primary fixture", State.Prefix + "-app");
-            var project = State.Project("workspace", new IntPtr(Session.WindowHandle), app);
+            var project = State.Project("workspace", SettingsWindow(), app);
             State.WriteProjects(project);
             return project;
         }
 
         private JsonObject[] SeedSearchWorkspaces()
         {
-            var atlas = State.Project("Atlas", new IntPtr(Session.WindowHandle), State.Application("Browser fixture", "browser"));
-            var zenith = State.Project("Zenith", new IntPtr(Session.WindowHandle), State.Application("Editor fixture", "editor"));
-            var mesa = State.Project("Mesa", new IntPtr(Session.WindowHandle), State.Application("Editor fixture", "editor-two"));
+            var atlas = State.Project("Atlas", SettingsWindow(), State.Application("Browser fixture", "browser"));
+            var zenith = State.Project("Zenith", SettingsWindow(), State.Application("Editor fixture", "editor"));
+            var mesa = State.Project("Mesa", SettingsWindow(), State.Application("Editor fixture", "editor-two"));
             atlas["creation-time"] = 2_000;
             zenith["creation-time"] = 1_000;
             mesa["creation-time"] = 3_000;

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspaceEditingTests.cs
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspaceEditingTests.cs
@@ -1,0 +1,287 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json.Nodes;
+using Microsoft.PowerToys.UITest.Next;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Workspaces.UITests
+{
+    public sealed partial class WorkspacesTests
+    {
+        [TestMethod]
+        public void SearchFiltersByWorkspaceAndApplicationNames()
+        {
+            var projects = SeedSearchWorkspaces();
+            var names = projects.Select(project => WorkspaceTestState.Text(project, "name")).ToArray();
+            OpenEditor();
+            AssertWorkspaceNames(names);
+            Search("aTlAs");
+            AssertWorkspaceNames(names[0]);
+            Search("editor fixture");
+            AssertWorkspaceNames(names[1], names[2]);
+            Search("no matching workspace or application");
+            AssertWorkspaceNames();
+            Search(string.Empty);
+            AssertWorkspaceNames(names);
+            Assert.AreEqual(3, WorkspaceTestState.ReadProjects().Count, "Searching changed the saved workspaces.");
+        }
+
+        [TestMethod]
+        [DataRow("Last launched", 0)]
+        [DataRow("Created", 1)]
+        [DataRow("Name", 2)]
+        public void SortOrderPersistsAcrossEditorRestart(string order, int index)
+        {
+            var projects = SeedSearchWorkspaces();
+            var names = projects.Select(project => WorkspaceTestState.Text(project, "name")).ToArray();
+            string[] expected = index switch
+            {
+                0 => [names[1], names[2], names[0]],
+                1 => [names[2], names[0], names[1]],
+                2 => names.Order(StringComparer.Ordinal).ToArray(),
+                _ => throw new ArgumentOutOfRangeException(nameof(index)),
+            };
+            OpenEditor();
+            SelectCombo(Editor.Find<ComboBox>(By.AccessibilityId("WorkspaceSortComboBox")), order, EditorProcess);
+            AssertWorkspaceOrder(expected);
+            Assert.AreEqual(index, WorkspaceTestState.ReadObject(WorkspaceTestState.SettingsPath)["properties"]!["sortby"]!.GetValue<int>());
+            CloseEditor();
+            OpenEditor();
+            Assert.AreEqual(order, Editor.Find<ComboBox>(By.AccessibilityId("WorkspaceSortComboBox")).SelectedText);
+            AssertWorkspaceOrder(expected);
+        }
+
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public void WorkspaceCardAndEditMenuOpenEditingPage(bool useMenu)
+        {
+            var project = SeedOneWorkspace();
+            var original = File.ReadAllBytes(WorkspaceTestState.WorkspacesPath);
+            OpenEditor();
+            EditWorkspace(WorkspaceTestState.Text(project, "name"), useMenu);
+            Assert.IsTrue(Editor.Find<Button>(By.AccessibilityId("SaveButton")).IsEnabled);
+            Assert.IsTrue(Editor.Find<Button>(By.AccessibilityId("CancelButton")).IsEnabled);
+            CollectionAssert.AreEqual(original, File.ReadAllBytes(WorkspaceTestState.WorkspacesPath), "Opening the editing page changed stored data.");
+        }
+
+        [TestMethod]
+        public void DeleteRemovesOnlyTheSelectedWorkspace()
+        {
+            var projects = SeedSearchWorkspaces();
+            var names = projects.Select(project => WorkspaceTestState.Text(project, "name")).ToArray();
+            OpenEditor();
+            AssertWorkspaceNames(names);
+            OpenWorkspaceMenu(WaitForCard(names[1]));
+            Step("Deleting the selected workspace.");
+            Microsoft.PowerToys.UITest.Next.Session.FromProcess(EditorProcess)
+                .Find<Button>(By.Name("Remove"), 10_000).Invoke(msPostAction: 0);
+            AssertWorkspaceNames(names[0], names[2]);
+            CollectionAssert.AreEquivalent(
+                new[] { WorkspaceTestState.Text(projects[0], "id"), WorkspaceTestState.Text(projects[2], "id") },
+                WorkspaceTestState.ReadProjects().Select(project => WorkspaceTestState.Text(project!, "id")).ToArray(),
+                "Deleting a workspace removed the wrong stored project.");
+        }
+
+        [TestMethod]
+        public void NameArgumentsAdminAndGeometryEditsPersist()
+        {
+            var project = SeedOneWorkspace();
+            var id = WorkspaceTestState.Text(project, "id");
+            var newName = State.Prefix + "-renamed";
+            var arguments = $"--title \"{State.Prefix}-edited\" --payload \"argument with spaces\"";
+            State.TrackShortcut(newName);
+            OpenEditor();
+            EditWorkspace(WorkspaceTestState.Text(project, "name"));
+            var row = ExpandApplication("Primary fixture");
+            Step("Editing application arguments, administrator preference, and all four position fields.");
+            row.Find<TextBox>(By.AccessibilityId("CommandLineTextBox")).SetText(arguments);
+            SetCheck(row.Find<CheckBox>(By.Name("Launch as")), true);
+            using var before = PreviewSnapshot.Capture(TestContext, Editor, "before-position");
+            row.Find<TextBox>(By.AccessibilityId("LeftTextBox")).SetText("420");
+            row.Find<TextBox>(By.AccessibilityId("TopTextBox")).SetText("310");
+            row.Find<TextBox>(By.AccessibilityId("WidthTextBox")).SetText("810");
+            row.Find<TextBox>(By.AccessibilityId("HeightTextBox")).SetText("510");
+            PreviewSnapshot.AssertChanged(TestContext, Editor, before);
+            Editor.Find<TextBox>(By.AccessibilityId("EditNameTextBox")).SetText(newName);
+            SaveWorkspace();
+            var saved = WorkspaceTestState.WaitForProject(id, value => WorkspaceTestState.Text(value, "name") == newName);
+            var app = saved["applications"]!.AsArray().Single()!;
+            Assert.AreEqual(arguments, WorkspaceTestState.Text(app, "command-line-arguments"));
+            Assert.IsTrue(app["is-elevated"]!.GetValue<bool>(), "The administrator launch preference was not saved.");
+            AssertPosition(app["position"]!, 420, 310, 810, 510);
+            AssertWorkspaceNames(newName);
+            EditWorkspace(newName);
+            row = ExpandApplication("Primary fixture");
+            Assert.AreEqual(arguments, row.Find<TextBox>(By.AccessibilityId("CommandLineTextBox")).Value);
+            Assert.IsTrue(row.Find<CheckBox>(By.Name("Launch as")).IsChecked);
+            Assert.AreEqual("420", row.Find<TextBox>(By.AccessibilityId("LeftTextBox")).Value);
+            Assert.AreEqual("310", row.Find<TextBox>(By.AccessibilityId("TopTextBox")).Value);
+            Assert.AreEqual("810", row.Find<TextBox>(By.AccessibilityId("WidthTextBox")).Value);
+            Assert.AreEqual("510", row.Find<TextBox>(By.AccessibilityId("HeightTextBox")).Value);
+        }
+
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public void CancelAndBreadcrumbDiscardUnsavedEdits(bool useBreadcrumb)
+        {
+            var project = SeedOneWorkspace();
+            var name = WorkspaceTestState.Text(project, "name");
+            var original = File.ReadAllBytes(WorkspaceTestState.WorkspacesPath);
+            OpenEditor();
+            EditWorkspace(name);
+            var row = ExpandApplication("Primary fixture");
+            row.Find<TextBox>(By.AccessibilityId("LeftTextBox")).SetText("600");
+            row.Find<TextBox>(By.AccessibilityId("CommandLineTextBox")).SetText("--payload discarded");
+            Editor.Find<TextBox>(By.AccessibilityId("EditNameTextBox")).SetText(State.Prefix + "-discarded");
+            CancelEditing(useBreadcrumb);
+            CollectionAssert.AreEqual(original, File.ReadAllBytes(WorkspaceTestState.WorkspacesPath), "Discarding edits changed stored workspace data.");
+            AssertWorkspaceNames(name);
+            EditWorkspace(name);
+            row = ExpandApplication("Primary fixture");
+            Assert.AreEqual("240", row.Find<TextBox>(By.AccessibilityId("LeftTextBox")).Value);
+            Assert.AreEqual(
+                WorkspaceTestState.Text(project["applications"]!.AsArray()[0]!, "command-line-arguments"),
+                row.Find<TextBox>(By.AccessibilityId("CommandLineTextBox")).Value);
+        }
+
+        [TestMethod]
+        public void RemoveAndAddBackUpdatePreviewAndSavedApplicationList()
+        {
+            var first = State.Application("Primary fixture", State.Prefix + "-first");
+            var second = State.Application("Secondary fixture", State.Prefix + "-second");
+            second["position"] = WorkspaceTestState.Position(1080, 550, 560, 390);
+            var project = State.Project("applications", new IntPtr(Session.WindowHandle), first, second);
+            State.WriteProjects(project);
+            OpenEditor();
+            EditWorkspace(WorkspaceTestState.Text(project, "name"));
+            using var before = PreviewSnapshot.Capture(TestContext, Editor, "both-applications");
+            ToggleApplicationInclusion("Primary fixture");
+            Assert.IsFalse(Editor.Find(By.AccessibilityId("Primary fixture")).IsEnabled, "The removed application remained editable.");
+            PreviewSnapshot.AssertChanged(TestContext, Editor, before);
+            ToggleApplicationInclusion("Primary fixture");
+            Assert.IsTrue(Editor.Find(By.AccessibilityId("Primary fixture")).IsEnabled, "Add back did not restore the application.");
+            PreviewSnapshot.AssertRestored(TestContext, Editor, before);
+            ToggleApplicationInclusion("Primary fixture");
+            SaveWorkspace();
+            var saved = WorkspaceTestState.WaitForProject(
+                WorkspaceTestState.Text(project, "id"),
+                value => value["applications"]!.AsArray().Count == 1);
+            Assert.AreEqual("Secondary fixture", WorkspaceTestState.Text(saved["applications"]!.AsArray().Single()!, "application"));
+            EditWorkspace(WorkspaceTestState.Text(project, "name"));
+            Assert.IsFalse(Editor.Has(By.AccessibilityId("Primary fixture"), 500), "The excluded application reappeared after reopening.");
+            Assert.IsTrue(Editor.Has(By.AccessibilityId("Secondary fixture"), 5_000));
+        }
+
+        [TestMethod]
+        [DataRow("Minimized", true, false)]
+        [DataRow("Maximized", false, true)]
+        public void WindowStateChangesUpdatePreviewAndPersist(string selected, bool minimized, bool maximized)
+        {
+            var project = SeedOneWorkspace();
+            OpenEditor();
+            EditWorkspace(WorkspaceTestState.Text(project, "name"));
+            var row = ExpandApplication("Primary fixture");
+            using var before = PreviewSnapshot.Capture(TestContext, Editor, "custom-position");
+            SelectCombo(row.Find<ComboBox>(By.AccessibilityId("WindowPositionComboBox")), selected, EditorProcess);
+            Assert.IsFalse(row.Find<TextBox>(By.AccessibilityId("LeftTextBox")).IsEnabled, "Custom coordinates stayed editable for a minimized/maximized app.");
+            PreviewSnapshot.AssertChanged(TestContext, Editor, before);
+            SaveWorkspace();
+            var saved = WorkspaceTestState.ReadProject(WorkspaceTestState.Text(project, "id"));
+            var app = saved["applications"]!.AsArray().Single()!;
+            Assert.AreEqual(minimized, app["minimized"]!.GetValue<bool>());
+            Assert.AreEqual(maximized, app["maximized"]!.GetValue<bool>());
+            EditWorkspace(WorkspaceTestState.Text(project, "name"));
+            row = ExpandApplication("Primary fixture");
+            Assert.AreEqual(selected, row.Find<ComboBox>(By.AccessibilityId("WindowPositionComboBox")).SelectedText);
+            SelectCombo(row.Find<ComboBox>(By.AccessibilityId("WindowPositionComboBox")), "Custom", EditorProcess);
+            Assert.IsTrue(row.Find<TextBox>(By.AccessibilityId("LeftTextBox")).IsEnabled);
+            PreviewSnapshot.AssertRestored(TestContext, Editor, before);
+        }
+
+        private JsonObject SeedOneWorkspace()
+        {
+            var app = State.Application("Primary fixture", State.Prefix + "-app");
+            var project = State.Project("workspace", new IntPtr(Session.WindowHandle), app);
+            State.WriteProjects(project);
+            return project;
+        }
+
+        private JsonObject[] SeedSearchWorkspaces()
+        {
+            var atlas = State.Project("Atlas", new IntPtr(Session.WindowHandle), State.Application("Browser fixture", "browser"));
+            var zenith = State.Project("Zenith", new IntPtr(Session.WindowHandle), State.Application("Editor fixture", "editor"));
+            var mesa = State.Project("Mesa", new IntPtr(Session.WindowHandle), State.Application("Editor fixture", "editor-two"));
+            atlas["creation-time"] = 2_000;
+            zenith["creation-time"] = 1_000;
+            mesa["creation-time"] = 3_000;
+            atlas["last-launched-time"] = 1_000;
+            zenith["last-launched-time"] = 3_000;
+            mesa["last-launched-time"] = 2_000;
+            State.WriteProjects(atlas, zenith, mesa);
+            return [atlas, zenith, mesa];
+        }
+
+        private void AssertWorkspaceOrder(string[] expected)
+        {
+            var result = WaitHelper.WaitForStable(WorkspaceNames, actual => actual is not null && actual.SequenceEqual(expected), 15_000, requiredConsecutiveMatches: 2);
+            Assert.IsTrue(result.Succeeded, $"Expected order [{string.Join(", ", expected)}], observed [{string.Join(", ", result.LastObservation ?? [])}].");
+        }
+
+        private void SelectCombo(ComboBox combo, string item, string processName)
+        {
+            Step($"Selecting '{item}'.");
+            if (combo.SelectedText == item)
+            {
+                return;
+            }
+
+            Editor.EnsureForeground();
+            combo.Invoke(msPostAction: 0);
+            var process = Microsoft.PowerToys.UITest.Next.Session.FromProcess(processName);
+
+            // WPF surfaces each open ComboBox item twice (once beneath the ComboBox, once in the popup
+            // host) at an identical rectangle. Collapse those duplicate peers by their on-screen bounds so
+            // a genuinely ambiguous match (two different items) still fails, then activate the single
+            // remaining selection.
+            var options = process.FindAll<Element>(By.Name(item), 15_000)
+                .Where(option => option.Name.Equals(item, StringComparison.OrdinalIgnoreCase) && option.ControlType == "ListItem")
+                .GroupBy(option => (option.X, option.Y, option.Width, option.Height))
+                .ToArray();
+            Assert.HasCount(1, options, $"The '{item}' selection item was not uniquely addressable.");
+            options[0].First().Click(msPostAction: 0);
+            Assert.IsTrue(combo.WaitForValue(item, timeoutMS: 10_000), $"The selection did not change to '{item}'.");
+        }
+
+        private void SetCheck(CheckBox checkBox, bool value)
+        {
+            Step($"Setting '{checkBox.Name}' to {value}.");
+            Assert.IsTrue(checkBox.IsEnabled, $"'{checkBox.Name}' is not available.");
+            if (checkBox.IsChecked != value)
+            {
+                checkBox.Invoke(msPostAction: 0);
+            }
+
+            Assert.IsTrue(checkBox.WaitForProperty("ToggleState", value ? "On" : "Off", 10_000));
+        }
+
+        private void ToggleApplicationInclusion(string name)
+        {
+            Step($"Removing or adding back '{name}'.");
+            Editor.Find(By.AccessibilityId(name)).Find<Button>(By.Name("Remove")).Invoke(msPostAction: 0);
+        }
+
+        private void CancelEditing(bool useBreadcrumb = false)
+        {
+            Step(useBreadcrumb ? "Discarding edits through the Workspaces breadcrumb." : "Cancelling workspace edits.");
+            var button = useBreadcrumb
+                ? Editor.Find<Button>(By.Name("Workspaces"))
+                : Editor.Find<Button>(By.AccessibilityId("CancelButton"));
+            button.Invoke(msPostAction: 0);
+            Assert.IsTrue(Editor.Has(By.AccessibilityId("NewProjectButton"), 15_000), "Discard did not return to the workspace list.");
+        }
+    }
+}

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspaceLaunchingTests.cs
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspaceLaunchingTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Workspaces.UITests
             var app = State.Application("Placement fixture", title);
             app["minimized"] = minimized;
             app["maximized"] = maximized;
-            var project = State.Project("launch", new IntPtr(Session.WindowHandle), app);
+            var project = State.Project("launch", SettingsWindow(), app);
             State.WriteProjects(project);
             OpenEditor();
             LaunchWorkspace(WorkspaceTestState.Text(project, "name"));
@@ -54,7 +54,7 @@ namespace Microsoft.Workspaces.UITests
                 app["app-user-model-id"] = State.Fixture.AppUserModelId;
             }
 
-            var project = State.Project("arguments", new IntPtr(Session.WindowHandle), app);
+            var project = State.Project("arguments", SettingsWindow(), app);
             State.WriteProjects(project);
             OpenEditor();
             EditWorkspace(WorkspaceTestState.Text(project, "name"));
@@ -77,7 +77,7 @@ namespace Microsoft.Workspaces.UITests
         {
             var title = State.Prefix + "-shortcut";
             var app = State.Application("Shortcut fixture", title);
-            var project = State.Project("shortcut", new IntPtr(Session.WindowHandle), app);
+            var project = State.Project("shortcut", SettingsWindow(), app);
             State.WriteProjects(project);
             var name = WorkspaceTestState.Text(project, "name");
             var shortcut = WorkspaceTestState.ShortcutPath(name);
@@ -130,7 +130,7 @@ namespace Microsoft.Workspaces.UITests
             var originalTitle = State.Prefix + "-original";
             var addedTitle = State.Prefix + "-added";
             var app = State.Application("Workspaces.TestApp", originalTitle);
-            var project = State.Project("launch-edit", new IntPtr(Session.WindowHandle), app);
+            var project = State.Project("launch-edit", SettingsWindow(), app);
             State.WriteProjects(project);
             var name = WorkspaceTestState.Text(project, "name");
             OpenEditor();
@@ -162,7 +162,7 @@ namespace Microsoft.Workspaces.UITests
             var title = State.Prefix + "-reuse";
             var original = State.Fixture.OpenUnpackaged(title, TestContext);
             var app = State.Application("Existing fixture", title);
-            var project = State.Project("reuse", new IntPtr(Session.WindowHandle), app);
+            var project = State.Project("reuse", SettingsWindow(), app);
             State.WriteProjects(project);
             OpenEditor();
             EditWorkspace(WorkspaceTestState.Text(project, "name"));
@@ -184,7 +184,7 @@ namespace Microsoft.Workspaces.UITests
             var app = State.Application("Topology fixture", title);
             var missingNumber = MonitorInfo.Count + 10;
             app["monitor"] = missingNumber;
-            var project = State.Project("topology", new IntPtr(Session.WindowHandle), app);
+            var project = State.Project("topology", SettingsWindow(), app);
             var missingMonitor = project["monitor-configuration"]!.AsArray()[0]!.DeepClone();
             missingMonitor["monitor-number"] = missingNumber;
             missingMonitor["id"] = "Disconnected test monitor";
@@ -210,7 +210,7 @@ namespace Microsoft.Workspaces.UITests
             var missing = State.Application("Missing fixture", "missing", path: Path.Combine(Path.GetTempPath(), State.Prefix + "-missing.exe"));
             var applications = new List<JsonObject> { first, missing };
             applications.AddRange(PendingApplications(10, $@"Local\{State.Prefix}-progress-gate"));
-            var project = State.Project("progress", new IntPtr(Session.WindowHandle), applications.ToArray());
+            var project = State.Project("progress", SettingsWindow(), applications.ToArray());
             State.WriteProjects(project);
             OpenEditor();
             LaunchWorkspace(WorkspaceTestState.Text(project, "name"));
@@ -238,7 +238,7 @@ namespace Microsoft.Workspaces.UITests
             var first = State.Application("Opened fixture", firstTitle);
             var applications = new List<JsonObject> { first };
             applications.AddRange(PendingApplications(16, gateName, startedName, tailName));
-            var project = State.Project("cancel-launch", new IntPtr(Session.WindowHandle), applications.ToArray());
+            var project = State.Project("cancel-launch", SettingsWindow(), applications.ToArray());
             State.WriteProjects(project);
             OpenEditor();
             LaunchWorkspace(WorkspaceTestState.Text(project, "name"));
@@ -265,7 +265,7 @@ namespace Microsoft.Workspaces.UITests
             using var gate = new EventWaitHandle(false, EventResetMode.ManualReset, gateName);
             using var started = new EventWaitHandle(false, EventResetMode.ManualReset, startedName);
             var applications = PendingApplications(8, gateName, startedName).ToArray();
-            var project = State.Project("dismiss", new IntPtr(Session.WindowHandle), applications);
+            var project = State.Project("dismiss", SettingsWindow(), applications);
             State.WriteProjects(project);
             OpenEditor();
             LaunchWorkspace(WorkspaceTestState.Text(project, "name"));

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspaceLaunchingTests.cs
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspaceLaunchingTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Workspaces.UITests
             var app = State.Application("Placement fixture", title);
             app["minimized"] = minimized;
             app["maximized"] = maximized;
-            var project = State.Project("launch", SettingsWindow(), app);
+            var project = State.Project("launch", app);
             State.WriteProjects(project);
             OpenEditor();
             LaunchWorkspace(WorkspaceTestState.Text(project, "name"));
@@ -54,7 +54,7 @@ namespace Microsoft.Workspaces.UITests
                 app["app-user-model-id"] = State.Fixture.AppUserModelId;
             }
 
-            var project = State.Project("arguments", SettingsWindow(), app);
+            var project = State.Project("arguments", app);
             State.WriteProjects(project);
             OpenEditor();
             EditWorkspace(WorkspaceTestState.Text(project, "name"));
@@ -77,7 +77,7 @@ namespace Microsoft.Workspaces.UITests
         {
             var title = State.Prefix + "-shortcut";
             var app = State.Application("Shortcut fixture", title);
-            var project = State.Project("shortcut", SettingsWindow(), app);
+            var project = State.Project("shortcut", app);
             State.WriteProjects(project);
             var name = WorkspaceTestState.Text(project, "name");
             var shortcut = WorkspaceTestState.ShortcutPath(name);
@@ -130,7 +130,7 @@ namespace Microsoft.Workspaces.UITests
             var originalTitle = State.Prefix + "-original";
             var addedTitle = State.Prefix + "-added";
             var app = State.Application("Workspaces.TestApp", originalTitle);
-            var project = State.Project("launch-edit", SettingsWindow(), app);
+            var project = State.Project("launch-edit", app);
             State.WriteProjects(project);
             var name = WorkspaceTestState.Text(project, "name");
             OpenEditor();
@@ -162,7 +162,7 @@ namespace Microsoft.Workspaces.UITests
             var title = State.Prefix + "-reuse";
             var original = State.Fixture.OpenUnpackaged(title, TestContext);
             var app = State.Application("Existing fixture", title);
-            var project = State.Project("reuse", SettingsWindow(), app);
+            var project = State.Project("reuse", app);
             State.WriteProjects(project);
             OpenEditor();
             EditWorkspace(WorkspaceTestState.Text(project, "name"));
@@ -182,9 +182,9 @@ namespace Microsoft.Workspaces.UITests
         {
             var title = State.Prefix + "-missing-monitor";
             var app = State.Application("Topology fixture", title);
-            var missingNumber = MonitorInfo.Count + 10;
+            var missingNumber = WorkspacesDisplay.FirstUnusedNumber(WorkspacesDisplay.ConnectedMonitorNumbers());
             app["monitor"] = missingNumber;
-            var project = State.Project("topology", SettingsWindow(), app);
+            var project = State.Project("topology", app);
             var missingMonitor = project["monitor-configuration"]!.AsArray()[0]!.DeepClone();
             missingMonitor["monitor-number"] = missingNumber;
             missingMonitor["id"] = "Disconnected test monitor";
@@ -210,7 +210,7 @@ namespace Microsoft.Workspaces.UITests
             var missing = State.Application("Missing fixture", "missing", path: Path.Combine(Path.GetTempPath(), State.Prefix + "-missing.exe"));
             var applications = new List<JsonObject> { first, missing };
             applications.AddRange(PendingApplications(10, $@"Local\{State.Prefix}-progress-gate"));
-            var project = State.Project("progress", SettingsWindow(), applications.ToArray());
+            var project = State.Project("progress", applications.ToArray());
             State.WriteProjects(project);
             OpenEditor();
             LaunchWorkspace(WorkspaceTestState.Text(project, "name"));
@@ -243,7 +243,7 @@ namespace Microsoft.Workspaces.UITests
             var first = State.Application("Opened fixture", firstTitle);
             var applications = new List<JsonObject> { first };
             applications.AddRange(PendingApplications(16, gateName, startedName, tailName));
-            var project = State.Project("cancel-launch", SettingsWindow(), applications.ToArray());
+            var project = State.Project("cancel-launch", applications.ToArray());
             State.WriteProjects(project);
             OpenEditor();
             LaunchWorkspace(WorkspaceTestState.Text(project, "name"));
@@ -270,7 +270,7 @@ namespace Microsoft.Workspaces.UITests
             using var gate = new EventWaitHandle(false, EventResetMode.ManualReset, gateName);
             using var started = new EventWaitHandle(false, EventResetMode.ManualReset, startedName);
             var applications = PendingApplications(8, gateName, startedName).ToArray();
-            var project = State.Project("dismiss", SettingsWindow(), applications);
+            var project = State.Project("dismiss", applications);
             State.WriteProjects(project);
             OpenEditor();
             LaunchWorkspace(WorkspaceTestState.Text(project, "name"));

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspaceLaunchingTests.cs
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspaceLaunchingTests.cs
@@ -218,6 +218,11 @@ namespace Microsoft.Workspaces.UITests
             AssertPositioned(window, first);
             var progress = LauncherWindow();
             AssertLaunchGlyph(progress, "Ready fixture", "\uF78C");
+
+            // The missing app has no executable on disk, so it reaches Failed. Failed and the "\uEF2C"
+            // fallback share a glyph, but a still-pending app (Waiting/Launched) has Loading == true and
+            // hides its glyph behind the progress ring, and Canceled cannot occur before the Cancel below.
+            // A displayed "\uEF2C" here therefore uniquely proves the Failed state without a product hook.
             AssertLaunchGlyph(progress, "Missing fixture", "\uEF2C");
             var loading = progress.Find(By.AccessibilityId("LaunchProgress_Pending fixture 01"), 15_000);
             Assert.IsTrue(loading.Displayed, "The not-yet-ready application did not show its launching indicator.");

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspaceLaunchingTests.cs
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspaceLaunchingTests.cs
@@ -1,0 +1,416 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text.Json.Nodes;
+using Microsoft.PowerToys.UITest.Next;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Workspaces.UITests
+{
+    public sealed partial class WorkspacesTests
+    {
+        [TestMethod]
+        [DataRow(false, false)]
+        [DataRow(true, false)]
+        [DataRow(false, true)]
+        public void LaunchFromEditorRestoresWindowPlacement(bool minimized, bool maximized)
+        {
+            var title = State.Prefix + "-placement";
+            var app = State.Application("Placement fixture", title);
+            app["minimized"] = minimized;
+            app["maximized"] = maximized;
+            var project = State.Project("launch", new IntPtr(Session.WindowHandle), app);
+            State.WriteProjects(project);
+            OpenEditor();
+            LaunchWorkspace(WorkspaceTestState.Text(project, "name"));
+            var window = State.Fixture.WaitForWindow(title);
+            AssertPositioned(window, app);
+            WaitForLaunchCompletion(project);
+            Assert.AreEqual(1, State.Fixture.ProcessIds().Count, "Launching one application created unexpected fixture processes.");
+        }
+
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public void CommandLineArgumentsReachUnpackagedAndPackagedApps(bool packaged)
+        {
+            if (packaged)
+            {
+                State.Fixture.OpenPackaged(TestContext);
+                State.Fixture.CloseAll();
+            }
+
+            var title = State.Prefix + "-arguments";
+            var app = State.Application(
+                "Argument fixture",
+                title,
+                path: packaged ? State.Fixture.PackagedExecutablePath : State.Fixture.ExecutablePath);
+            if (packaged)
+            {
+                app["package-full-name"] = State.Fixture.PackageFullName;
+                app["app-user-model-id"] = State.Fixture.AppUserModelId;
+            }
+
+            var project = State.Project("arguments", new IntPtr(Session.WindowHandle), app);
+            State.WriteProjects(project);
+            OpenEditor();
+            EditWorkspace(WorkspaceTestState.Text(project, "name"));
+            const string payload = "Workspaces argument with spaces";
+            var arguments = $"--title \"{title}\" --payload \"{payload}\"";
+            ExpandApplication("Argument fixture").Find<TextBox>(By.AccessibilityId("CommandLineTextBox")).SetText(arguments);
+            SaveWorkspace();
+            var saved = WorkspaceTestState.ReadProject(WorkspaceTestState.Text(project, "id"));
+            Assert.AreEqual(arguments, WorkspaceTestState.Text(saved["applications"]!.AsArray().Single()!, "command-line-arguments"));
+            LaunchWorkspace(WorkspaceTestState.Text(project, "name"));
+            var window = State.Fixture.WaitForWindow(title);
+            Assert.AreEqual(payload, window.Find<TextBox>(By.AccessibilityId("PayloadTextBox"), 15_000).Value, "The launched application did not receive the saved command line.");
+            Assert.AreEqual(packaged ? State.Fixture.PackageFullName : null, NativeMethods.PackageFullName(window.ProcessId));
+            AssertPositioned(window, app);
+            WaitForLaunchCompletion(project);
+        }
+
+        [TestMethod]
+        public void DesktopShortcutTracksFilePresenceAndLaunchesWorkspace()
+        {
+            var title = State.Prefix + "-shortcut";
+            var app = State.Application("Shortcut fixture", title);
+            var project = State.Project("shortcut", new IntPtr(Session.WindowHandle), app);
+            State.WriteProjects(project);
+            var name = WorkspaceTestState.Text(project, "name");
+            var shortcut = WorkspaceTestState.ShortcutPath(name);
+            OpenEditor();
+            EditWorkspace(name);
+            var checkBox = Editor.Find<CheckBox>(By.Name("Create desktop shortcut"));
+            Assert.IsFalse(checkBox.IsChecked, "A missing desktop shortcut should be shown as unchecked.");
+            SetCheck(checkBox, true);
+            SaveWorkspace();
+            Assert.IsTrue(
+                WaitHelper.WaitForStable(() => File.Exists(shortcut), exists => exists, 15_000, requiredConsecutiveMatches: 2).Succeeded,
+                "Save did not create the desktop shortcut.");
+
+            // Read the created .lnk through the Windows Script Host shell. StorageFile.GetFileFromPathAsync
+            // refuses desktop shortcuts on some images ("Access is denied ... system or hidden"), while the
+            // WScript.Shell shortcut object reads the target and arguments the Shell actually stored.
+            var (target, shortcutArguments) = ReadShortcutTargetAndArguments(shortcut);
+            Assert.AreEqual(
+                Path.Combine(Path.GetDirectoryName(SessionHelper.GetExecutablePath(PowerToysModule.Workspaces))!, "PowerToys.WorkspacesLauncher.exe"),
+                target,
+                true,
+                "The shortcut does not target the Workspaces launcher.");
+            StringAssert.Contains(shortcutArguments, WorkspaceTestState.Text(project, "id"), "The shortcut targets the wrong workspace.");
+
+            Step("Launching the actual desktop .lnk through the Windows Shell.");
+            using var launch = Process.Start(new ProcessStartInfo(shortcut) { UseShellExecute = true });
+            var window = State.Fixture.WaitForWindow(title);
+            AssertPositioned(window, app);
+            WaitForLaunchCompletion(project);
+
+            EditWorkspace(name);
+            Assert.IsTrue(Editor.Find<CheckBox>(By.Name("Create desktop shortcut")).IsChecked, "The existing desktop shortcut was not recognized.");
+            CancelEditing();
+            File.Delete(shortcut);
+            EditWorkspace(name);
+            Assert.IsFalse(Editor.Find<CheckBox>(By.Name("Create desktop shortcut")).IsChecked, "The checkbox did not notice an externally removed shortcut.");
+            SetCheck(Editor.Find<CheckBox>(By.Name("Create desktop shortcut")), true);
+            SaveWorkspace();
+            Assert.IsTrue(File.Exists(shortcut), "The shortcut was not recreated.");
+            EditWorkspace(name);
+            SetCheck(Editor.Find<CheckBox>(By.Name("Create desktop shortcut")), false);
+            SaveWorkspace();
+            Assert.IsFalse(File.Exists(shortcut), "Unchecking the option did not remove the desktop shortcut.");
+            Assert.IsFalse(WorkspaceTestState.ReadProject(WorkspaceTestState.Text(project, "id"))["is-shortcut-needed"]!.GetValue<bool>());
+        }
+
+        [TestMethod]
+        public void LaunchAndEditCaptureAddsWindowsToTheExistingWorkspace()
+        {
+            var originalTitle = State.Prefix + "-original";
+            var addedTitle = State.Prefix + "-added";
+            var app = State.Application("Workspaces.TestApp", originalTitle);
+            var project = State.Project("launch-edit", new IntPtr(Session.WindowHandle), app);
+            State.WriteProjects(project);
+            var name = WorkspaceTestState.Text(project, "name");
+            OpenEditor();
+            EditWorkspace(name);
+            Step("Launching the saved workspace from Launch and Edit.");
+            Editor.Find<Button>(By.AccessibilityId("LaunchEditButton")).Invoke(msPostAction: 0);
+            var original = State.Fixture.WaitForWindow(originalTitle);
+            AssertPositioned(original, app);
+            var capture = WaitForCaptureWindow();
+            State.Fixture.OpenUnpackaged(addedTitle, TestContext);
+            Capture(capture, addedTitle);
+            Assert.IsTrue(Editor.Find<Button>(By.AccessibilityId("RevertButton")).IsEnabled, "Launch and Edit did not expose its revert action.");
+            SaveWorkspace();
+            var saved = WorkspaceTestState.WaitForProject(
+                WorkspaceTestState.Text(project, "id"),
+                value => value["applications"]!.AsArray().Any(application => WorkspaceTestState.Text(application!, "title") == addedTitle));
+            Assert.AreEqual(1, WorkspaceTestState.ReadProjects().Count, "Launch and Edit created a second workspace instead of updating the existing one.");
+            Assert.AreEqual(name, WorkspaceTestState.Text(saved, "name"));
+            Assert.AreEqual(
+                Guid.Parse(WorkspaceTestState.Text(app, "id")),
+                Guid.Parse(WorkspaceTestState.Text(AppByTitle(saved["applications"]!.AsArray(), originalTitle), "id")),
+                "Recapture did not retain the identity of the originally launched application.");
+            AppByTitle(saved["applications"]!.AsArray(), addedTitle);
+        }
+
+        [TestMethod]
+        public void MoveExistingWindowsReusesTheOriginalProcessAndWindow()
+        {
+            var title = State.Prefix + "-reuse";
+            var original = State.Fixture.OpenUnpackaged(title, TestContext);
+            var app = State.Application("Existing fixture", title);
+            var project = State.Project("reuse", new IntPtr(Session.WindowHandle), app);
+            State.WriteProjects(project);
+            OpenEditor();
+            EditWorkspace(WorkspaceTestState.Text(project, "name"));
+            SetCheck(Editor.Find<CheckBox>(By.Name("Move existing windows")), true);
+            SaveWorkspace();
+            LaunchWorkspace(WorkspaceTestState.Text(project, "name"));
+            AssertPositioned(original, app);
+            WaitForLaunchCompletion(project);
+            CollectionAssert.AreEqual(new[] { original.ProcessId }, State.Fixture.ProcessIds().ToArray(), "Move existing windows launched a duplicate application.");
+            var reused = State.Fixture.FindWindow(title);
+            Assert.IsNotNull(reused, "Move existing windows closed the original window.");
+            Assert.AreEqual(original.WindowHandle, reused.Hwnd, "Move existing windows replaced the existing HWND.");
+        }
+
+        [TestMethod]
+        public void MissingSavedMonitorUsesTheRemainingDisplay()
+        {
+            var title = State.Prefix + "-missing-monitor";
+            var app = State.Application("Topology fixture", title);
+            var missingNumber = MonitorInfo.Count + 10;
+            app["monitor"] = missingNumber;
+            var project = State.Project("topology", new IntPtr(Session.WindowHandle), app);
+            var missingMonitor = project["monitor-configuration"]!.AsArray()[0]!.DeepClone();
+            missingMonitor["monitor-number"] = missingNumber;
+            missingMonitor["id"] = "Disconnected test monitor";
+            project["monitor-configuration"]!.AsArray().Add(missingMonitor);
+            State.WriteProjects(project);
+            OpenEditor();
+            LaunchWorkspace(WorkspaceTestState.Text(project, "name"));
+            var window = State.Fixture.WaitForWindow(title);
+            var fallback = app.DeepClone().AsObject();
+            fallback["minimized"] = true;
+            AssertPositioned(window, fallback);
+            Assert.IsTrue(MonitorInfo.GetFromWindow(new IntPtr(window.WindowHandle)).IsPrimary, "The missing-monitor fallback did not use the remaining primary display.");
+            WaitForLaunchCompletion(project);
+            TestContext.WriteLine("This exercises replay of a saved disconnected monitor, not physical monitor hot-plugging or mixed-DPI hardware.");
+        }
+
+        [TestMethod]
+        public void LauncherDisplaysLaunchingLaunchedAndFailedStates()
+        {
+            using var gate = new EventWaitHandle(false, EventResetMode.ManualReset, $@"Local\{State.Prefix}-progress-gate");
+            var firstTitle = State.Prefix + "-launched";
+            var first = State.Application("Ready fixture", firstTitle);
+            var missing = State.Application("Missing fixture", "missing", path: Path.Combine(Path.GetTempPath(), State.Prefix + "-missing.exe"));
+            var applications = new List<JsonObject> { first, missing };
+            applications.AddRange(PendingApplications(10, $@"Local\{State.Prefix}-progress-gate"));
+            var project = State.Project("progress", new IntPtr(Session.WindowHandle), applications.ToArray());
+            State.WriteProjects(project);
+            OpenEditor();
+            LaunchWorkspace(WorkspaceTestState.Text(project, "name"));
+            var window = State.Fixture.WaitForWindow(firstTitle);
+            AssertPositioned(window, first);
+            var progress = LauncherWindow();
+            AssertLaunchGlyph(progress, "Ready fixture", "\uF78C");
+            AssertLaunchGlyph(progress, "Missing fixture", "\uEF2C");
+            var loading = progress.Find(By.AccessibilityId("LaunchProgress_Pending fixture 01"), 15_000);
+            Assert.IsTrue(loading.Displayed, "The not-yet-ready application did not show its launching indicator.");
+            Assert.IsNull(State.Fixture.FindWindow(State.Prefix + "-pending-01"), "The gated fixture unexpectedly created a window.");
+            progress.Find<Button>(By.AccessibilityId("CancelButton")).Invoke(msPostAction: 0);
+        }
+
+        [TestMethod]
+        public void CancelLaunchStopsPendingAppsAndPreservesOpenedWindows()
+        {
+            var gateName = $@"Local\{State.Prefix}-cancel-gate";
+            var startedName = $@"Local\{State.Prefix}-first-started";
+            var tailName = $@"Local\{State.Prefix}-tail-started";
+            using var gate = new EventWaitHandle(false, EventResetMode.ManualReset, gateName);
+            using var started = new EventWaitHandle(false, EventResetMode.ManualReset, startedName);
+            using var tailStarted = new EventWaitHandle(false, EventResetMode.ManualReset, tailName);
+            var firstTitle = State.Prefix + "-opened";
+            var first = State.Application("Opened fixture", firstTitle);
+            var applications = new List<JsonObject> { first };
+            applications.AddRange(PendingApplications(16, gateName, startedName, tailName));
+            var project = State.Project("cancel-launch", new IntPtr(Session.WindowHandle), applications.ToArray());
+            State.WriteProjects(project);
+            OpenEditor();
+            LaunchWorkspace(WorkspaceTestState.Text(project, "name"));
+            var opened = State.Fixture.WaitForWindow(firstTitle);
+            AssertPositioned(opened, first);
+            Assert.IsTrue(started.WaitOne(20_000), "The blocking fixture never reached its startup gate.");
+            Assert.IsFalse(tailStarted.WaitOne(0), "The final fixture started before the cancellation precondition was established.");
+            Step("Cancelling the launch with one window open and more applications pending.");
+            var progress = LauncherWindow();
+            progress.Find<Button>(By.AccessibilityId("CancelButton"), 15_000).Invoke(msPostAction: 0);
+            Assert.IsTrue(WaitForProcess(LauncherUiProcess, false), "Cancel launch did not close the progress UI.");
+            Assert.IsTrue(WaitForProcess(LauncherProcess, false, 45_000), "Cancel launch did not stop the launch engine.");
+            Assert.IsFalse(tailStarted.WaitOne(0), "Cancel launch still started an application that was pending.");
+            var remaining = State.Fixture.FindWindow(firstTitle);
+            Assert.IsNotNull(remaining, "Cancel launch closed an already-open application.");
+            Assert.AreEqual(opened.WindowHandle, remaining.Hwnd, "Cancel launch replaced an already-open application.");
+        }
+
+        [TestMethod]
+        public void DismissClosesProgressWhileApplicationsContinueLaunching()
+        {
+            var gateName = $@"Local\{State.Prefix}-dismiss-gate";
+            var startedName = $@"Local\{State.Prefix}-dismiss-started";
+            using var gate = new EventWaitHandle(false, EventResetMode.ManualReset, gateName);
+            using var started = new EventWaitHandle(false, EventResetMode.ManualReset, startedName);
+            var applications = PendingApplications(8, gateName, startedName).ToArray();
+            var project = State.Project("dismiss", new IntPtr(Session.WindowHandle), applications);
+            State.WriteProjects(project);
+            OpenEditor();
+            LaunchWorkspace(WorkspaceTestState.Text(project, "name"));
+            Assert.IsTrue(started.WaitOne(20_000), "The fixture did not reach its startup gate.");
+            var progress = LauncherWindow();
+            Step("Dismissing progress without cancelling the pending launch.");
+            progress.Find<Button>(By.AccessibilityId("DismissButton"), 15_000).Invoke(msPostAction: 0);
+            Assert.IsTrue(WaitForProcess(LauncherUiProcess, false), "Dismiss did not close the progress UI.");
+            Assert.IsTrue(WaitForProcess(LauncherProcess, true, 5_000), "Dismiss cancelled the launch engine.");
+            Step("Releasing the application startup gate after the progress UI has closed.");
+            gate.Set();
+            foreach (var app in applications)
+            {
+                var window = State.Fixture.WaitForWindow(WorkspaceTestState.Text(app, "title"), 60_000);
+                AssertPositioned(window, app);
+            }
+
+            WaitForLaunchCompletion(project);
+            Assert.AreEqual(applications.Length, State.Fixture.ProcessIds().Count, "Dismiss did not allow every configured app to launch.");
+        }
+
+        private void LaunchWorkspace(string name)
+        {
+            var card = WaitForCard(name);
+            var launch = LaunchButtonsForCard(card);
+            if (launch.Length != 1)
+            {
+                // The Launch button is a card descendant, so its automation peer can be missing after the
+                // list re-projected its items (e.g. right after a save). Re-render the list once from a
+                // fresh editor to restore live descendant peers, then reacquire the button.
+                Step("Re-rendering the workspace list to restore the card's Launch button.");
+                CloseEditor();
+                OpenEditor();
+                card = WaitForCard(name);
+                launch = LaunchButtonsForCard(card);
+            }
+
+            Assert.HasCount(1, launch, "The workspace Launch button was not uniquely addressable.");
+            Step($"Launching workspace '{name}' from its editor card.");
+            launch[0].Invoke(msPostAction: 0);
+        }
+
+        private Button[] LaunchButtonsForCard(WorkspaceCard card) =>
+            [.. Editor.FindAll<Button>(By.Name("Launch"), 5_000)
+                .Where(button => button.Name == "Launch" && button.Y >= card.Y && button.Y <= card.Y + card.Height)];
+
+        private static (string Target, string Arguments) ReadShortcutTargetAndArguments(string path)
+        {
+            var shellType = Type.GetTypeFromProgID("WScript.Shell") ?? throw new InvalidOperationException("WScript.Shell is not registered.");
+            dynamic shell = Activator.CreateInstance(shellType)!;
+            try
+            {
+                dynamic link = shell.CreateShortcut(path);
+                try
+                {
+                    return ((string)link.TargetPath, (string)link.Arguments);
+                }
+                finally
+                {
+                    Marshal.FinalReleaseComObject(link);
+                }
+            }
+            finally
+            {
+                Marshal.FinalReleaseComObject(shell);
+            }
+        }
+
+        private Session LauncherWindow()
+        {
+            var progress = WindowsFinder.WaitForWindowByApp(LauncherUiProcess, window => window.Width > 200 && window.Height > 100, 30_000);
+            Assert.IsNotNull(progress, "The launcher progress window did not appear.");
+            Assert.IsTrue(progress.Has(By.AccessibilityId("CancelButton"), 15_000), "The progress window did not become interactive.");
+            return progress;
+        }
+
+        private void AssertLaunchGlyph(Session progress, string application, string expected)
+        {
+            Step($"Reading the launch state of '{application}'.");
+            var result = WaitHelper.WaitForStable(
+                () =>
+                {
+                    var state = progress.FindAll<Element>(By.AccessibilityId("LaunchState_" + application), 0).SingleOrDefault();
+                    return state is not null && state.Displayed ? state.GetValue() : string.Empty;
+                },
+                glyph => glyph == expected,
+                15_000,
+                requiredConsecutiveMatches: 2);
+            Assert.IsTrue(result.Succeeded, $"'{application}' did not show the expected launch state glyph. Actual: '{result.LastObservation}'.");
+        }
+
+        private IEnumerable<JsonObject> PendingApplications(int count, string gate, string? firstStarted = null, string? lastStarted = null)
+        {
+            for (var index = 1; index <= count; index++)
+            {
+                var title = $"{State.Prefix}-pending-{index:00}";
+                var started = index == 1 ? firstStarted : index == count ? lastStarted : null;
+                var arguments = $"--title \"{title}\" --wait-event \"{gate}\"";
+                if (started is not null)
+                {
+                    arguments += $" --started-event \"{started}\"";
+                }
+
+                yield return State.Application($"Pending fixture {index:00}", title, arguments);
+            }
+        }
+
+        private static void WaitForLaunchCompletion(JsonObject project)
+        {
+            Assert.IsTrue(WaitForProcess(LauncherProcess, false, 60_000), "The workspace launch did not finish.");
+            WorkspaceTestState.WaitForProject(
+                WorkspaceTestState.Text(project, "id"),
+                value => value["last-launched-time"]!.GetValue<long>() > 0);
+        }
+
+        private static void AssertPositioned(Session window, JsonObject application)
+        {
+            var handle = new IntPtr(window.WindowHandle);
+            var minimized = application["minimized"]!.GetValue<bool>();
+            var maximized = application["maximized"]!.GetValue<bool>();
+            var target = application["position"]!;
+            var result = WaitHelper.WaitForStable(
+                () =>
+                {
+                    var stamped = WindowHelper.GetWindowPropertyValue(handle, "PowerToys_LaunchedByWorkspaces") != 0;
+                    if (minimized || maximized)
+                    {
+                        return stamped && NativeMethods.IsIconic(handle) == minimized && WindowHelper.IsWindowMaximized(handle) == maximized;
+                    }
+
+                    var bounds = NormalizedOuterBounds(handle);
+                    return stamped && !NativeMethods.IsIconic(handle) && !WindowHelper.IsWindowMaximized(handle) &&
+                        Math.Abs(bounds.X - target["X"]!.GetValue<int>()) <= 2 &&
+                        Math.Abs(bounds.Y - target["Y"]!.GetValue<int>()) <= 2 &&
+                        Math.Abs(bounds.Width - target["width"]!.GetValue<int>()) <= 2 &&
+                        Math.Abs(bounds.Height - target["height"]!.GetValue<int>()) <= 2;
+                },
+                match => match,
+                60_000,
+                requiredConsecutiveMatches: 3,
+                pollIntervalMS: 150);
+            Assert.IsTrue(
+                result.Succeeded,
+                $"Workspaces did not place '{window.WindowTitle}' as configured: {application}. " +
+                $"Actual bounds: {WindowHelper.GetWindowBounds(handle)}, minimized: {NativeMethods.IsIconic(handle)}, maximized: {WindowHelper.IsWindowMaximized(handle)}.");
+        }
+    }
+}

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspaceSettingsTests.cs
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspaceSettingsTests.cs
@@ -1,0 +1,170 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Text.Json;
+using Microsoft.PowerToys.UITest.Next;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Workspaces.UITests
+{
+    public sealed partial class WorkspacesTests
+    {
+        [TestMethod]
+        public void SettingsLaunchButtonOpensEditor()
+        {
+            Assert.IsTrue(ModuleToggle().IsOn, "Workspaces should start enabled.");
+            OpenEditor();
+            AssertWorkspaceNames();
+        }
+
+        [TestMethod]
+        public void QuickAccessLaunchesEditor()
+        {
+            var runners = Process.GetProcessesByName("PowerToys");
+            int runnerId;
+            try
+            {
+                Assert.HasCount(1, runners, "Expected one Runner to own Quick Access.");
+                runnerId = runners[0].Id;
+            }
+            finally
+            {
+                foreach (var runner in runners)
+                {
+                    runner.Dispose();
+                }
+            }
+
+            Step("Showing the Runner-owned Quick Access flyout.");
+            Assert.IsTrue(
+                NamedEventHelper.WaitAndSignal($@"Local\PowerToysQuickAccess_{runnerId}_Show", 30_000),
+                "The Runner did not expose its Quick Access show event.");
+            var quickAccess = WindowsFinder.WaitForWindowByApp("PowerToys.QuickAccess", window => window.Width > 200 && window.Height > 100, 30_000);
+            Assert.IsNotNull(quickAccess, "Quick Access did not appear.");
+            Step("Invoking the Workspaces tile in Quick Access.");
+            quickAccess.Find<Button>(By.Name("Workspaces"), 20_000).Invoke(msPostAction: 0);
+            AttachEditor();
+        }
+
+        [TestMethod]
+        public void ActivationShortcutOpensEditor()
+        {
+            ActivateWithShortcut(ReadActivationShortcut());
+        }
+
+        [TestMethod]
+        public void CustomizedShortcutReachesRunnerAndReplacesTheOldChord()
+        {
+            var original = ReadActivationShortcut();
+            var letter = original.Contains(Key.K) ? Key.J : Key.K;
+            Key[] replacement = [Key.LWin, Key.Ctrl, Key.Shift, letter];
+            Step("Opening the activation-shortcut editor.");
+            Session.Find<Element>(By.AccessibilityId("WorkspacesActivationShortcut"))
+                .Find<Button>(By.AccessibilityId("EditButton")).Invoke(msPostAction: 0);
+            var settings = Microsoft.PowerToys.UITest.Next.Session.FromProcess("PowerToys.Settings");
+            Assert.IsTrue(settings.Has(By.AccessibilityId("PrimaryButton"), 15_000), "The shortcut dialog did not open.");
+            Session.EnsureForeground();
+            Assert.IsTrue(
+                WindowControl.WaitForForeground(new IntPtr(Session.WindowHandle), 10_000),
+                $"Settings did not acquire foreground for shortcut capture: {WindowControl.GetForegroundWindowInfo()}.");
+            Step("Entering the replacement shortcut.");
+            KeyboardHelper.SendKeys(replacement);
+            Assert.IsTrue(
+                settings.WaitFor(() => settings.FindAll<Element>(By.Name(letter.ToString()), 0).Any(element => element.Name == letter.ToString()), 15_000),
+                "The shortcut dialog did not display the replacement key.");
+            var save = settings.Find<Button>(By.AccessibilityId("PrimaryButton"));
+            Assert.IsTrue(save.IsEnabled, "The replacement shortcut was rejected.");
+            save.Invoke(msPostAction: 0);
+            Assert.IsTrue(save.WaitForGone(15_000), "The shortcut dialog did not close.");
+            CollectionAssert.AreEquivalent(replacement, ReadActivationShortcut(), "Settings did not display the saved shortcut.");
+            ActivateWithShortcut(replacement);
+            CloseEditor();
+            KeyboardHelper.SendKeys(original);
+            Assert.IsNull(
+                WindowsFinder.WaitForWindowByApp(EditorProcess, window => window.Width > 400 && window.Height > 300, 5_000),
+                "The previous shortcut remained registered after customization.");
+        }
+
+        [TestMethod]
+        public void DisabledModuleRejectsShortcutUntilReenabled()
+        {
+            var shortcut = ReadActivationShortcut();
+            ActivateWithShortcut(shortcut);
+            CloseEditor();
+            var toggle = ModuleToggle();
+            try
+            {
+                Step("Disabling Workspaces through the real Settings switch.");
+                toggle.Invoke(msPostAction: 0);
+                Assert.IsTrue(toggle.WaitForProperty("ToggleState", "Off", 15_000), "The Settings switch did not turn off.");
+                WaitForModuleEnabled(false);
+                Assert.IsFalse(Session.Find<Element>(By.AccessibilityId("WorkspacesLaunchEditorButtonControl")).IsEnabled, "The launch action remained enabled.");
+
+                Step("Sending the previously working shortcut while Workspaces is disabled.");
+                KeyboardHelper.SendKeys(shortcut);
+                var forbidden = WindowsFinder.WaitForWindowByApp(EditorProcess, window => window.Width > 400 && window.Height > 300, 5_000);
+                Assert.IsNull(forbidden, "Disabled Workspaces still opened from its activation shortcut.");
+            }
+            finally
+            {
+                if (!toggle.IsOn)
+                {
+                    Step("Restoring Workspaces through Settings.");
+                    toggle.Invoke(msPostAction: 0);
+                    Assert.IsTrue(toggle.WaitForProperty("ToggleState", "On", 15_000), "Could not restore the module's enabled state.");
+                    WaitForModuleEnabled(true);
+                }
+            }
+
+            ActivateWithShortcut(shortcut);
+        }
+
+        private static void WaitForModuleEnabled(bool expected)
+        {
+            var path = Path.Combine(SettingsConfigHelper.PowerToysSettingsRoot, "settings.json");
+            var result = WaitHelper.WaitForStable(
+                () => WorkspaceTestState.ReadObject(path)["enabled"]!["Workspaces"]!.GetValue<bool>(),
+                enabled => enabled == expected,
+                15_000,
+                requiredConsecutiveMatches: 2,
+                shouldRetryException: error => error is IOException or JsonException);
+            Assert.IsTrue(result.Succeeded, $"The Runner did not persist the Settings command enabling Workspaces={expected}. Last error: {result.LastException?.Message}");
+        }
+
+        private Key[] ReadActivationShortcut()
+        {
+            var card = Session.Find<Element>(By.AccessibilityId("WorkspacesActivationShortcut"), 15_000);
+            var text = card.Find<Button>(By.AccessibilityId("EditButton"), 15_000).HelpText;
+            Assert.IsFalse(string.IsNullOrWhiteSpace(text), "The activation shortcut has no accessible HelpText.");
+            Step($"Reading the current activation shortcut: {text}");
+            return text.Split(['+', ' '], StringSplitOptions.RemoveEmptyEntries).Select(part => part.ToUpperInvariant() switch
+            {
+                "WIN" or "WINDOWS" => Key.LWin,
+                "CTRL" or "CONTROL" => Key.Ctrl,
+                "SHIFT" => Key.Shift,
+                "ALT" => Key.Alt,
+                var key when key.Length == 1 && key[0] is >= 'A' and <= 'Z' => Enum.Parse<Key>(key),
+                _ => throw new InvalidOperationException($"Unsupported shortcut token '{part}' in '{text}'."),
+            }).ToArray();
+        }
+
+        private void ActivateWithShortcut(Key[] shortcut)
+        {
+            for (var attempt = 0; attempt < 3; attempt++)
+            {
+                Step($"Sending the activation shortcut, attempt {attempt + 1}.");
+                KeyboardHelper.SendKeys(shortcut);
+                var window = WindowsFinder.WaitForWindowByApp(EditorProcess, candidate => candidate.Width > 400 && candidate.Height > 300, 5_000);
+                if (window is not null)
+                {
+                    AttachEditor();
+                    return;
+                }
+            }
+
+            Assert.Fail("The activation shortcut did not open Workspaces Editor.");
+        }
+    }
+}

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspaceSettingsTests.cs
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspaceSettingsTests.cs
@@ -61,13 +61,13 @@ namespace Microsoft.Workspaces.UITests
             var letter = original.Contains(Key.K) ? Key.J : Key.K;
             Key[] replacement = [Key.LWin, Key.Ctrl, Key.Shift, letter];
             Step("Opening the activation-shortcut editor.");
-            Session.Find<Element>(By.AccessibilityId("WorkspacesActivationShortcut"))
+            SettingsUi.Find<Element>(By.AccessibilityId("WorkspacesActivationShortcut"))
                 .Find<Button>(By.AccessibilityId("EditButton")).Invoke(msPostAction: 0);
-            var settings = Microsoft.PowerToys.UITest.Next.Session.FromProcess("PowerToys.Settings");
+            var settings = SettingsUi;
             Assert.IsTrue(settings.Has(By.AccessibilityId("PrimaryButton"), 15_000), "The shortcut dialog did not open.");
-            Session.EnsureForeground();
+            SettingsUi.EnsureForeground();
             Assert.IsTrue(
-                WindowControl.WaitForForeground(new IntPtr(Session.WindowHandle), 10_000),
+                WindowControl.WaitForForeground(SettingsWindow(), 10_000),
                 $"Settings did not acquire foreground for shortcut capture: {WindowControl.GetForegroundWindowInfo()}.");
             Step("Entering the replacement shortcut.");
             KeyboardHelper.SendKeys(replacement);
@@ -100,7 +100,7 @@ namespace Microsoft.Workspaces.UITests
                 toggle.Invoke(msPostAction: 0);
                 Assert.IsTrue(toggle.WaitForProperty("ToggleState", "Off", 15_000), "The Settings switch did not turn off.");
                 WaitForModuleEnabled(false);
-                Assert.IsFalse(Session.Find<Element>(By.AccessibilityId("WorkspacesLaunchEditorButtonControl")).IsEnabled, "The launch action remained enabled.");
+                Assert.IsFalse(SettingsUi.Find<Element>(By.AccessibilityId("WorkspacesLaunchEditorButtonControl")).IsEnabled, "The launch action remained enabled.");
 
                 Step("Sending the previously working shortcut while Workspaces is disabled.");
                 KeyboardHelper.SendKeys(shortcut);
@@ -135,7 +135,7 @@ namespace Microsoft.Workspaces.UITests
 
         private Key[] ReadActivationShortcut()
         {
-            var card = Session.Find<Element>(By.AccessibilityId("WorkspacesActivationShortcut"), 15_000);
+            var card = SettingsUi.Find<Element>(By.AccessibilityId("WorkspacesActivationShortcut"), 15_000);
             var text = card.Find<Button>(By.AccessibilityId("EditButton"), 15_000).HelpText;
             Assert.IsFalse(string.IsNullOrWhiteSpace(text), "The activation shortcut has no accessible HelpText.");
             Step($"Reading the current activation shortcut: {text}");

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspaceTestState.cs
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspaceTestState.cs
@@ -70,8 +70,11 @@ namespace Microsoft.Workspaces.UITests
         {
             Prefix = $"PTUITest-{Guid.NewGuid():N}";
             applicationIndex = 0;
-            File.Delete(TemporaryPath);
+
+            // WriteProjects creates the Workspaces directory; run it first so deleting a leftover
+            // temporary snapshot cannot throw DirectoryNotFoundException on a fresh profile.
             WriteProjects();
+            File.Delete(TemporaryPath);
         }
 
         internal JsonObject Application(string name, string title, string? arguments = null, string? path = null)

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspaceTestState.cs
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspaceTestState.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Workspaces.UITests
         private readonly List<IDisposable> snapshots = [];
         private readonly HashSet<string> trackedFiles = new(StringComparer.OrdinalIgnoreCase);
         private int applicationIndex;
+        private WorkspacesDisplay.TargetDisplay? target;
 
         internal WorkspaceTestState()
         {
@@ -34,6 +35,17 @@ namespace Microsoft.Workspaces.UITests
         internal TestAppFixture Fixture { get; } = new();
 
         internal string Prefix { get; private set; } = string.Empty;
+
+        // The connected display Workspaces will actually enumerate at launch (the primary monitor resolved to
+        // the product's number/DPI/geometry contract). Seeding uses its real values so a launched fixture is
+        // placed rather than falling into the native missing-monitor minimize path.
+        internal WorkspacesDisplay.TargetDisplay Target =>
+            target ?? throw new InvalidOperationException("The target display has not been resolved. Call ResolveTarget first.");
+
+        // Fail fast with actionable guidance when the host cannot support real placement (e.g. a disconnected
+        // or locked RDP session that only reports the numberless 'WinDisc' pseudo-display), before any window
+        // is opened or seeded.
+        internal void ResolveTarget() => target = WorkspacesDisplay.GetPrimaryTarget();
 
         internal void PrepareSettings()
         {
@@ -80,6 +92,7 @@ namespace Microsoft.Workspaces.UITests
         internal JsonObject Application(string name, string title, string? arguments = null, string? path = null)
         {
             applicationIndex++;
+            var (x, y, width, height) = WorkspacesDisplay.DefaultApplicationPosition(Target);
             return new JsonObject
             {
                 // Deterministic, ordering-stable application IDs. The value keeps its ascending index in
@@ -100,22 +113,23 @@ namespace Microsoft.Workspaces.UITests
                 ["can-launch-elevated"] = true,
                 ["minimized"] = false,
                 ["maximized"] = false,
-                ["position"] = Position(240, 220, 720, 460),
-                ["monitor"] = 1,
+                ["position"] = Position(x, y, width, height),
+
+                // The GDI monitor number the product will resolve for the target display. Assuming 1 here
+                // makes moveWindow fail its live-monitor lookup and minimize the window whenever the primary
+                // is not DISPLAY1.
+                ["monitor"] = Target.Number,
                 ["version"] = "1",
             };
         }
 
-        internal JsonObject Project(string suffix, IntPtr settingsWindow, params JsonObject[] applications)
+        internal JsonObject Project(string suffix, params JsonObject[] applications)
         {
             var name = $"{Prefix}-{suffix}";
             var id = Guid.NewGuid().ToString("B");
             Preserve(Path.Combine(DirectoryPath, "WorkspacesIcons", id + ".ico"));
             TrackShortcut(name);
-            var monitor = MonitorInfo.GetPrimary() ?? throw new InvalidOperationException("No primary monitor is available.");
-            var dpi = NativeMethods.GetDpiForWindow(settingsWindow);
-            Assert.IsTrue(dpi > 0, "The Settings window did not report a usable DPI.");
-            var scale = dpi / 96.0;
+            var display = Target;
             return new JsonObject
             {
                 ["id"] = id,
@@ -128,16 +142,16 @@ namespace Microsoft.Workspaces.UITests
                 {
                     new JsonObject
                     {
-                        ["id"] = monitor.DeviceName,
-                        ["instance-id"] = string.Empty,
-                        ["monitor-number"] = 1,
-                        ["dpi"] = dpi,
-                        ["monitor-rect-dpi-aware"] = MonitorRectangle(monitor.Left, monitor.Top, monitor.Width, monitor.Height),
+                        ["id"] = display.Id,
+                        ["instance-id"] = display.InstanceId,
+                        ["monitor-number"] = display.Number,
+                        ["dpi"] = (int)display.Dpi,
+                        ["monitor-rect-dpi-aware"] = MonitorRectangle(display.MonitorLeft, display.MonitorTop, display.MonitorWidth, display.MonitorHeight),
                         ["monitor-rect-dpi-unaware"] = MonitorRectangle(
-                            (int)Math.Round(monitor.Left / scale),
-                            (int)Math.Round(monitor.Top / scale),
-                            (int)Math.Round(monitor.Width / scale),
-                            (int)Math.Round(monitor.Height / scale)),
+                            display.LogicalMonitorLeft,
+                            display.LogicalMonitorTop,
+                            display.LogicalMonitorRight - display.LogicalMonitorLeft,
+                            display.LogicalMonitorBottom - display.LogicalMonitorTop),
                     },
                 },
                 ["applications"] = new JsonArray(applications.Select(application => application.DeepClone()).ToArray()),

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspaceTestState.cs
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspaceTestState.cs
@@ -1,0 +1,237 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.PowerToys.UITest.Next;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Workspaces.UITests
+{
+    internal sealed class WorkspaceTestState : IDisposable
+    {
+        private readonly List<IDisposable> snapshots = [];
+        private readonly HashSet<string> trackedFiles = new(StringComparer.OrdinalIgnoreCase);
+        private int applicationIndex;
+
+        internal WorkspaceTestState()
+        {
+            Preserve(SettingsPath);
+            Preserve(WorkspacesPath);
+            Preserve(TemporaryPath);
+        }
+
+        internal static string DirectoryPath => Path.Combine(SettingsConfigHelper.PowerToysSettingsRoot, "Workspaces");
+
+        internal static string SettingsPath => Path.Combine(DirectoryPath, "settings.json");
+
+        internal static string WorkspacesPath => Path.Combine(DirectoryPath, "workspaces.json");
+
+        internal static string TemporaryPath => Path.Combine(DirectoryPath, "temp-workspaces.json");
+
+        internal TestAppFixture Fixture { get; } = new();
+
+        internal string Prefix { get; private set; } = string.Empty;
+
+        internal void PrepareSettings()
+        {
+            Directory.CreateDirectory(DirectoryPath);
+            File.WriteAllText(SettingsPath, """
+                {
+                  "name": "Workspaces",
+                  "version": "0.0.1",
+                  "properties": {
+                    "hotkey": {
+                      "value": {
+                        "win": true,
+                        "ctrl": true,
+                        "shift": true,
+                        "alt": false,
+                        "code": 87,
+                        "key": "W"
+                      }
+                    },
+                    "sortby": 0
+                  }
+                }
+                """);
+
+            // UITestBase has already journaled the global settings before this pre-launch hook.
+            var globalPath = Path.Combine(SettingsConfigHelper.PowerToysSettingsRoot, "settings.json");
+            var global = ReadObject(globalPath);
+            global["enable_quick_access"] = true;
+            global["run_elevated"] = false;
+            File.WriteAllText(globalPath, global.ToJsonString());
+        }
+
+        internal void Reset()
+        {
+            Prefix = $"PTUITest-{Guid.NewGuid():N}";
+            applicationIndex = 0;
+            File.Delete(TemporaryPath);
+            WriteProjects();
+        }
+
+        internal JsonObject Application(string name, string title, string? arguments = null, string? path = null)
+        {
+            applicationIndex++;
+            return new JsonObject
+            {
+                // Deterministic, ordering-stable application IDs. The value keeps its ascending index in
+                // the final GUID group so the native launcher's ID-keyed std::map iterates in a predictable
+                // order, and pins a non-zero first group so neither 8-byte half of the GUID is all zero:
+                // WorkspacesWindowProperties::GetGuidFromHwnd treats a zero half as "unstamped" and returns
+                // an empty ID, which would break Launch-and-Edit identity round-tripping for a window whose
+                // saved ID had a zero half.
+                ["id"] = $"{{00000001-0000-0000-0000-{applicationIndex.ToString("x12", CultureInfo.InvariantCulture)}}}",
+                ["application"] = name,
+                ["application-path"] = path ?? Fixture.ExecutablePath,
+                ["package-full-name"] = string.Empty,
+                ["app-user-model-id"] = string.Empty,
+                ["pwa-app-id"] = string.Empty,
+                ["title"] = title,
+                ["command-line-arguments"] = arguments ?? $"--title \"{title}\"",
+                ["is-elevated"] = false,
+                ["can-launch-elevated"] = true,
+                ["minimized"] = false,
+                ["maximized"] = false,
+                ["position"] = Position(240, 220, 720, 460),
+                ["monitor"] = 1,
+                ["version"] = "1",
+            };
+        }
+
+        internal JsonObject Project(string suffix, IntPtr settingsWindow, params JsonObject[] applications)
+        {
+            var name = $"{Prefix}-{suffix}";
+            var id = Guid.NewGuid().ToString("B");
+            Preserve(Path.Combine(DirectoryPath, "WorkspacesIcons", id + ".ico"));
+            TrackShortcut(name);
+            var monitor = MonitorInfo.GetPrimary() ?? throw new InvalidOperationException("No primary monitor is available.");
+            var dpi = NativeMethods.GetDpiForWindow(settingsWindow);
+            Assert.IsTrue(dpi > 0, "The Settings window did not report a usable DPI.");
+            var scale = dpi / 96.0;
+            return new JsonObject
+            {
+                ["id"] = id,
+                ["name"] = name,
+                ["creation-time"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds() - 3600,
+                ["last-launched-time"] = 0,
+                ["is-shortcut-needed"] = false,
+                ["move-existing-windows"] = false,
+                ["monitor-configuration"] = new JsonArray
+                {
+                    new JsonObject
+                    {
+                        ["id"] = monitor.DeviceName,
+                        ["instance-id"] = string.Empty,
+                        ["monitor-number"] = 1,
+                        ["dpi"] = dpi,
+                        ["monitor-rect-dpi-aware"] = MonitorRectangle(monitor.Left, monitor.Top, monitor.Width, monitor.Height),
+                        ["monitor-rect-dpi-unaware"] = MonitorRectangle(
+                            (int)Math.Round(monitor.Left / scale),
+                            (int)Math.Round(monitor.Top / scale),
+                            (int)Math.Round(monitor.Width / scale),
+                            (int)Math.Round(monitor.Height / scale)),
+                    },
+                },
+                ["applications"] = new JsonArray(applications.Select(application => application.DeepClone()).ToArray()),
+            };
+        }
+
+        internal static JsonObject Position(int x, int y, int width, int height) => new()
+        {
+            ["X"] = x,
+            ["Y"] = y,
+            ["width"] = width,
+            ["height"] = height,
+        };
+
+        internal void WriteProjects(params JsonObject[] projects)
+        {
+            Directory.CreateDirectory(DirectoryPath);
+            var root = new JsonObject
+            {
+                ["workspaces"] = new JsonArray(projects.Select(project => project.DeepClone()).ToArray()),
+            };
+            File.WriteAllText(WorkspacesPath, root.ToJsonString());
+        }
+
+        internal void TrackShortcut(string name) => Preserve(ShortcutPath(name));
+
+        internal static string ShortcutPath(string name) => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory), name + ".lnk");
+
+        internal static JsonObject ReadObject(string path) =>
+            JsonNode.Parse(File.ReadAllText(path))?.AsObject() ?? throw new InvalidDataException($"No JSON object was read from '{path}'.");
+
+        internal static JsonArray ReadProjects() =>
+            ReadObject(WorkspacesPath)["workspaces"]?.AsArray() ?? throw new InvalidDataException("The workspaces array is missing.");
+
+        internal static JsonObject ReadProject(string id) =>
+            ReadProjects().Select(node => node!.AsObject()).Single(project => Text(project, "id") == id);
+
+        internal static string Text(JsonNode node, string property) =>
+            node[property]?.GetValue<string>() ?? throw new InvalidDataException($"Required string '{property}' is missing.");
+
+        internal static JsonObject WaitForProject(string id, Func<JsonObject, bool> predicate)
+        {
+            var result = WaitHelper.WaitForStable(
+                () => ReadProjects().Select(node => node!.AsObject()).SingleOrDefault(project => Text(project, "id") == id),
+                project => project is not null && predicate(project),
+                timeoutMS: 15_000,
+                requiredConsecutiveMatches: 2,
+                shouldRetryException: error => error is IOException or JsonException);
+            Assert.IsTrue(
+                result.Succeeded,
+                $"Workspace '{id}' did not persist the expected state. Last: {result.LastObservation}; error: {result.LastException?.Message}");
+            return result.LastObservation!;
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Fixture.Dispose();
+            }
+            finally
+            {
+                List<Exception> errors = [];
+                foreach (var snapshot in snapshots.AsEnumerable().Reverse())
+                {
+                    try
+                    {
+                        snapshot.Dispose();
+                    }
+                    catch (Exception error) when (error is IOException or UnauthorizedAccessException)
+                    {
+                        errors.Add(error);
+                    }
+                }
+
+                snapshots.Clear();
+                if (errors.Count > 0)
+                {
+                    throw new AggregateException("Could not restore the Workspaces test files.", errors);
+                }
+            }
+        }
+
+        private static JsonObject MonitorRectangle(int left, int top, int width, int height) => new()
+        {
+            ["top"] = top,
+            ["left"] = left,
+            ["width"] = width,
+            ["height"] = height,
+        };
+
+        private void Preserve(string path)
+        {
+            if (trackedFiles.Add(path))
+            {
+                snapshots.Add(SettingsConfigHelper.PreserveFile(path));
+            }
+        }
+    }
+}

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/Workspaces.UITests.Next.csproj
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/Workspaces.UITests.Next.csproj
@@ -1,0 +1,46 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(RepoRoot)src\Common.Dotnet.CsWinRT.props" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <RootNamespace>Microsoft.Workspaces.UITests</RootNamespace>
+    <AssemblyName>Workspaces.UITests.Next</AssemblyName>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <RunVSTest>false</RunVSTest>
+    <OutputPath>$(RepoRoot)$(Platform)\$(Configuration)\tests\Workspaces.UITests.Next\</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest" />
+    <ProjectReference Include="..\..\..\..\common\UITestAutomation.Next\UITestAutomation.Next.csproj" />
+    <ProjectReference Include="..\Workspaces.TestApp\Workspaces.TestApp.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <Target Name="StageFixture" AfterTargets="Build" Condition="'$(DesignTimeBuild)' != 'true' and '$(_IsSkippedTestProject)' != 'true'">
+    <MSBuild Projects="$(MSBuildProjectDirectory)\..\Workspaces.TestApp\Workspaces.TestApp.csproj"
+             Targets="GetFixturePackage"
+             Properties="Configuration=$(Configuration);Platform=$(Platform)">
+      <Output TaskParameter="TargetOutputs" ItemName="_WorkspacesFixturePackage" />
+    </MSBuild>
+    <MSBuild Projects="$(MSBuildProjectDirectory)\..\Workspaces.TestApp\Workspaces.TestApp.csproj"
+             Targets="GetFixturePayload"
+             Properties="Configuration=$(Configuration);Platform=$(Platform)">
+      <Output TaskParameter="TargetOutputs" ItemName="_WorkspacesFixtureFile" />
+    </MSBuild>
+    <Copy SourceFiles="@(_WorkspacesFixturePackage)" DestinationFolder="$(TargetDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(_WorkspacesFixtureFile)"
+          DestinationFiles="@(_WorkspacesFixtureFile->'$(TargetDir)Fixture\%(RelativePath)')"
+          SkipUnchangedFiles="true" />
+    <ItemGroup>
+      <FileWrites Include="$(TargetDir)Workspaces.TestApp.msix;@(_WorkspacesFixtureFile->'$(TargetDir)Fixture\%(RelativePath)')" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspacesDisplay.cs
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspacesDisplay.cs
@@ -1,0 +1,280 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Runtime.InteropServices;
+using Microsoft.PowerToys.UITest.Next;
+
+namespace Microsoft.Workspaces.UITests
+{
+    // Match DisplayUtils::GetDisplays rather than inventing monitor 1. A missing live monitor number
+    // makes Workspaces minimize the app instead of restoring its requested placement.
+    internal static class WorkspacesDisplay
+    {
+        private const uint DisplayDeviceActive = 0x1;
+        private const uint DisplayDeviceMirroringDriver = 0x8;
+        private const uint EddGetDeviceInterfaceName = 0x1;
+        private const uint MonitorDefaultToPrimary = 0x1;
+        private const int MdtEffectiveDpi = 0;
+
+        // One connected display resolved to the product's identity/geometry contract. Rectangles are the
+        // physical (DPI-aware) virtual-screen pixels read from a per-monitor-DPI-aware host; the logical
+        // work-area helpers divide by the effective scale to reach the DPI-unaware coordinates Workspaces
+        // persists and restores.
+        internal sealed record TargetDisplay(
+            string DeviceName,
+            int Number,
+            string Id,
+            string InstanceId,
+            uint Dpi,
+            int MonitorLeft,
+            int MonitorTop,
+            int MonitorRight,
+            int MonitorBottom,
+            int WorkLeft,
+            int WorkTop,
+            int WorkRight,
+            int WorkBottom,
+            bool IsPrimary)
+        {
+            internal int MonitorWidth => MonitorRight - MonitorLeft;
+
+            internal int MonitorHeight => MonitorBottom - MonitorTop;
+
+            internal int LogicalMonitorLeft => Logical(MonitorLeft);
+
+            internal int LogicalMonitorTop => Logical(MonitorTop);
+
+            internal int LogicalMonitorRight => Logical(MonitorRight);
+
+            internal int LogicalMonitorBottom => Logical(MonitorBottom);
+
+            internal int LogicalWorkLeft => Logical(WorkLeft);
+
+            internal int LogicalWorkTop => Logical(WorkTop);
+
+            internal int LogicalWorkRight => Logical(WorkRight);
+
+            internal int LogicalWorkBottom => Logical(WorkBottom);
+
+            // Physical pixel -> DPI-unaware/logical coordinate (logical = physical * 96 / dpi), matching
+            // WindowUtils::GetWindowRect (DPIAware::InverseConvert) so seeded positions round-trip.
+            internal int Logical(int physical) => (int)Math.Round(physical * 96.0 / Dpi);
+        }
+
+        // A single row of EnumDisplayDevicesW output, reduced to the fields DisplayUtils reads.
+        internal readonly record struct DisplayDeviceInfo(string DeviceName, string DeviceId, uint StateFlags);
+
+        // Resolve the display containing the primary monitor to the product's identity/geometry. Throws an
+        // actionable InvalidOperationException when the host has no usable display (a disconnected
+        // RDP session), so the suite fails fast with guidance instead of a ~96s minimized-placement timeout.
+        internal static TargetDisplay GetPrimaryTarget()
+        {
+            var primary = MonitorInfo.GetPrimary()
+                ?? throw new InvalidOperationException(UnsupportedDesktopMessage("<none>"));
+            var (number, id, instanceId) = ResolveNumberAndId(primary.DeviceName, EnumerateDevices(primary.DeviceName));
+            var dpi = PrimaryDpi();
+            return new TargetDisplay(
+                primary.DeviceName,
+                number,
+                id,
+                instanceId,
+                dpi,
+                primary.Left,
+                primary.Top,
+                primary.Right,
+                primary.Bottom,
+                primary.WorkLeft,
+                primary.WorkTop,
+                primary.WorkRight,
+                primary.WorkBottom,
+                primary.IsPrimary);
+        }
+
+        // Do not silently ignore an unresolvable display when choosing a genuinely absent monitor number.
+        internal static IReadOnlyList<int> ConnectedMonitorNumbers()
+        {
+            var numbers = new List<int>();
+            foreach (var monitor in MonitorInfo.GetAll())
+            {
+                numbers.Add(ResolveNumberAndId(monitor.DeviceName, EnumerateDevices(monitor.DeviceName)).Number);
+            }
+
+            return numbers;
+        }
+
+        // The smallest positive integer not present in the live topology. Provably absent even when real
+        // displays are sparsely or highly numbered (e.g. only DISPLAY3 -> 1; DISPLAY1+DISPLAY2 -> 3).
+        internal static int FirstUnusedNumber(IEnumerable<int> used)
+        {
+            var reserved = new HashSet<int>(used);
+            var candidate = 1;
+            while (reserved.Contains(candidate))
+            {
+                candidate++;
+            }
+
+            return candidate;
+        }
+
+        // A default application rectangle in the target's DPI-unaware coordinates, kept inside its work area
+        // so the placement is not clamped by Windows on small monitors. On a typical work area whose logical
+        // origin is (0,0) this preserves the historical (240, 220, 720, 460) baseline the editor field
+        // assertions rely on; it only shrinks/offsets when the work area cannot contain it.
+        internal static (int X, int Y, int Width, int Height) DefaultApplicationPosition(TargetDisplay target)
+        {
+            const int desiredX = 240;
+            const int desiredY = 220;
+            const int desiredWidth = 720;
+            const int desiredHeight = 460;
+            const int padding = 40;
+
+            if (target.Dpi == 0)
+            {
+                throw new InvalidOperationException($"Display '{target.DeviceName}' has no usable DPI.");
+            }
+
+            var workLeft = target.LogicalWorkLeft;
+            var workTop = target.LogicalWorkTop;
+            var workWidth = target.LogicalWorkRight - workLeft;
+            var workHeight = target.LogicalWorkBottom - workTop;
+            if (workWidth <= 0 || workHeight <= 0)
+            {
+                throw new InvalidOperationException($"Display '{target.DeviceName}' has no usable work area or DPI.");
+            }
+
+            var width = Math.Clamp(desiredWidth, 1, Math.Max(1, workWidth - (2 * padding)));
+            var height = Math.Clamp(desiredHeight, 1, Math.Max(1, workHeight - (2 * padding)));
+            var x = workLeft + Math.Clamp(desiredX, Math.Min(padding, Math.Max(0, workWidth - width)), Math.Max(0, workWidth - width));
+            var y = workTop + Math.Clamp(desiredY, Math.Min(padding, Math.Max(0, workHeight - height)), Math.Max(0, workHeight - height));
+            return (x, y, width, height);
+        }
+
+        // Mirror of DisplayUtils::GetDisplays' per-monitor identity resolution: prefer the first active,
+        // non-mirroring display device (its adapter name yields the number, its interface DeviceID the
+        // id/instance-id); otherwise fall back to the GDI device name. Throws when no digits are present.
+        internal static (int Number, string Id, string InstanceId) ResolveNumberAndId(string gdiDeviceName, IEnumerable<DisplayDeviceInfo> devices)
+        {
+            ArgumentNullException.ThrowIfNull(devices);
+            foreach (var device in devices)
+            {
+                var active = (device.StateFlags & DisplayDeviceActive) == DisplayDeviceActive;
+                var mirroring = (device.StateFlags & DisplayDeviceMirroringDriver) != 0;
+                if (active && !mirroring)
+                {
+                    var (id, instanceId) = SplitDisplayDeviceId(device.DeviceId);
+                    return (ParseNumber(TrimToAdapter(device.DeviceName), gdiDeviceName), id, instanceId);
+                }
+            }
+
+            // No proper device: use the display name as the id and its digits as the number, as the product does.
+            return (ParseNumber(gdiDeviceName, gdiDeviceName), gdiDeviceName, string.Empty);
+        }
+
+        // Mirror of DisplayUtils::SplitDisplayDeviceId.
+        // \\?\DISPLAY#GSM1388#4&125707d6&0&UID8388688#{guid} -> (GSM1388, 4&125707d6&0&UID8388688)
+        internal static (string Id, string InstanceId) SplitDisplayDeviceId(string deviceId)
+        {
+            ArgumentNullException.ThrowIfNull(deviceId);
+            var nameStart = deviceId.IndexOf('#', StringComparison.Ordinal);
+            var uidStart = nameStart < 0 ? -1 : deviceId.IndexOf('#', nameStart + 1);
+            var uidEnd = uidStart < 0 ? -1 : deviceId.IndexOf('#', uidStart + 1);
+            if (nameStart < 0 || uidStart < 0 || uidEnd < 0)
+            {
+                return (deviceId, string.Empty);
+            }
+
+            return (deviceId.Substring(nameStart + 1, uidStart - nameStart - 1), deviceId.Substring(uidStart + 1, uidEnd - uidStart - 1));
+        }
+
+        internal static string RemoveNonDigits(string input)
+        {
+            ArgumentNullException.ThrowIfNull(input);
+            return new string(input.Where(char.IsDigit).ToArray());
+        }
+
+        private static string TrimToAdapter(string deviceName)
+        {
+            // \\.\DISPLAY1\Monitor0 -> \\.\DISPLAY1 (substring before the last backslash), matching the product.
+            var lastBackslash = deviceName.LastIndexOf('\\');
+            return lastBackslash > 0 ? deviceName[..lastBackslash] : deviceName;
+        }
+
+        private static int ParseNumber(string source, string gdiDeviceName)
+        {
+            var digits = RemoveNonDigits(source);
+            if (digits.Length > 0 && int.TryParse(digits, NumberStyles.Integer, CultureInfo.InvariantCulture, out var number))
+            {
+                return number;
+            }
+
+            throw new InvalidOperationException(UnsupportedDesktopMessage(gdiDeviceName));
+        }
+
+        private static string UnsupportedDesktopMessage(string deviceName) =>
+            $"Workspaces UI tests need a connected display to validate window placement, but '{deviceName}' has no GDI monitor number. " +
+            "A disconnected RDP session can expose the numberless 'WinDisc' pseudo-display, causing Workspaces to use its minimized-window fallback. " +
+            "Connect and unlock the desktop (physical or RDP), keep it connected during the run, and use non-elevated Test Explorer.";
+
+        private static IEnumerable<DisplayDeviceInfo> EnumerateDevices(string gdiDeviceName)
+        {
+            var device = new DISPLAY_DEVICE { Cb = Marshal.SizeOf<DISPLAY_DEVICE>() };
+            uint index = 0;
+            while (EnumDisplayDevicesW(gdiDeviceName, index, ref device, EddGetDeviceInterfaceName))
+            {
+                yield return new DisplayDeviceInfo(device.DeviceName, device.DeviceID, device.StateFlags);
+                index++;
+                device = new DISPLAY_DEVICE { Cb = Marshal.SizeOf<DISPLAY_DEVICE>() };
+            }
+        }
+
+        private static uint PrimaryDpi()
+        {
+            var monitor = MonitorFromPoint(default, MonitorDefaultToPrimary);
+            if (monitor == IntPtr.Zero || GetDpiForMonitor(monitor, MdtEffectiveDpi, out var dpiX, out _) != 0 || dpiX == 0)
+            {
+                throw new InvalidOperationException("Could not read the effective DPI of the primary monitor.");
+            }
+
+            return dpiX;
+        }
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool EnumDisplayDevicesW(string? lpDevice, uint iDevNum, ref DISPLAY_DEVICE lpDisplayDevice, uint dwFlags);
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr MonitorFromPoint(POINT pt, uint dwFlags);
+
+        [DllImport("shcore.dll")]
+        private static extern int GetDpiForMonitor(IntPtr monitor, int dpiType, out uint dpiX, out uint dpiY);
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct POINT
+        {
+            public int X;
+            public int Y;
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        private struct DISPLAY_DEVICE
+        {
+            public int Cb;
+
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+            public string DeviceName;
+
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+            public string DeviceString;
+
+            public uint StateFlags;
+
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+            public string DeviceID;
+
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+            public string DeviceKey;
+        }
+    }
+}

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspacesTests.cs
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspacesTests.cs
@@ -54,6 +54,15 @@ namespace Microsoft.Workspaces.UITests
         // toggles survive the swap — winappcli re-resolves the live window on every call.
         private Session SettingsUi => settingsUi ??= Microsoft.PowerToys.UITest.Next.Session.FromProcess(SettingsProcess, timeoutMS: 30_000);
 
+        [ClassInitialize]
+        public static void ValidateDesktop(TestContext context)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            Assert.IsFalse(ElevationHelper.IsProcessElevated(Environment.ProcessId), "Run Test Explorer and the Workspaces UI tests without elevation.");
+            var target = WorkspacesDisplay.GetPrimaryTarget();
+            context.WriteLine($"Workspaces placement target: {target.DeviceName}, monitor {target.Number}, DPI {target.Dpi}.");
+        }
+
         protected override void PrepareTestState()
         {
             StopModuleProcesses();
@@ -65,6 +74,9 @@ namespace Microsoft.Workspaces.UITests
         public void PrepareWorkspace()
         {
             Assert.IsFalse(ElevationHelper.IsProcessElevated(Environment.ProcessId), "Run the Workspaces suite in a standard-user desktop.");
+
+            // Refresh the topology between cases; the class preflight runs before base initialization.
+            State.ResolveTarget();
             StopModuleProcesses();
             State.Fixture.CloseAll();
             State.Reset();
@@ -101,6 +113,11 @@ namespace Microsoft.Workspaces.UITests
         [ClassCleanup(ClassCleanupBehavior.EndOfClass)]
         public static void RestoreWorkspaceState()
         {
+            if (state is null)
+            {
+                return;
+            }
+
             try
             {
                 StopModuleProcesses();

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspacesTests.cs
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspacesTests.cs
@@ -1,0 +1,456 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.PowerToys.UITest.Next;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Workspaces.UITests
+{
+    [TestClass]
+    [TestCategory("Workspaces")]
+    [DoNotParallelize]
+    public sealed partial class WorkspacesTests : UITestBase
+    {
+        private const string EditorProcess = "PowerToys.WorkspacesEditor";
+        private const string LauncherProcess = "PowerToys.WorkspacesLauncher";
+        private const string LauncherUiProcess = "PowerToys.WorkspacesLauncherUI";
+        private static readonly string[] ModuleProcesses =
+        [
+            LauncherProcess,
+            "PowerToys.WorkspacesWindowArranger",
+            LauncherUiProcess,
+            "PowerToys.WorkspacesSnapshotTool",
+            EditorProcess,
+        ];
+        private static WorkspaceTestState? state;
+        private Session? editor;
+
+        public WorkspacesTests()
+            : base(PowerToysModule.PowerToysSettings, enableModules: ["Workspaces"])
+        {
+        }
+
+        protected override bool ReuseScopeAcrossTests => true;
+
+        protected override IReadOnlyList<string> StaleProcessNames =>
+            [.. base.StaleProcessNames, .. ModuleProcesses, "PowerToys.QuickAccess"];
+
+        private static WorkspaceTestState State => state ?? throw new InvalidOperationException("Workspaces test state has not been prepared.");
+
+        private Session Editor => editor ?? throw new InvalidOperationException("The editor has not been opened.");
+
+        protected override void PrepareTestState()
+        {
+            StopModuleProcesses();
+            state ??= new WorkspaceTestState();
+            State.PrepareSettings();
+        }
+
+        [TestInitialize]
+        public void PrepareWorkspace()
+        {
+            Assert.IsFalse(ElevationHelper.IsProcessElevated(Environment.ProcessId), "Run the Workspaces suite in a standard-user desktop.");
+            StopModuleProcesses();
+            State.Fixture.CloseAll();
+            State.Reset();
+            NavigateToSettings();
+        }
+
+        [TestCleanup]
+        public async Task CleanUpWorkspace()
+        {
+            try
+            {
+                await CaptureFailureArtifactsBeforeCleanupAsync();
+                if (TestContext.CurrentTestOutcome != UnitTestOutcome.Passed)
+                {
+                    AttachDiagnostics();
+                }
+            }
+            finally
+            {
+                try
+                {
+                    StopModuleProcesses();
+                }
+                finally
+                {
+                    State.Fixture.CloseAll();
+                }
+            }
+        }
+
+        [ClassCleanup(ClassCleanupBehavior.EndOfClass)]
+        public static void RestoreWorkspaceState()
+        {
+            try
+            {
+                StopModuleProcesses();
+                StopSharedScope();
+            }
+            finally
+            {
+                state?.Dispose();
+                state = null;
+            }
+        }
+
+        private void NavigateToSettings()
+        {
+            Step("Navigating to Workspaces Settings.");
+            if (!Session.Has(By.AccessibilityId("WorkspacesNavItem"), 500))
+            {
+                Session.Find<NavigationViewItem>(By.AccessibilityId("WindowingAndLayoutsNavItem"), 15_000).Invoke(msPostAction: 0);
+            }
+
+            Session.Find<NavigationViewItem>(By.AccessibilityId("WorkspacesNavItem"), 15_000).Invoke(msPostAction: 0);
+            Assert.IsTrue(Session.Has(By.AccessibilityId("WorkspacesLaunchEditorButtonControl"), 15_000), "The Workspaces Settings page did not become ready.");
+        }
+
+        private ToggleSwitch ModuleToggle() =>
+            Session.Find<Element>(By.AccessibilityId("WorkspacesEnableToggleControlHeaderText"), 15_000)
+                .Find<ToggleSwitch>(By.Name("Workspaces"), 15_000);
+
+        private void OpenEditor()
+        {
+            Step("Clicking Open editor in Settings.");
+            var launch = Session.Find<Element>(By.AccessibilityId("WorkspacesLaunchEditorButtonControl"), 15_000);
+            Assert.IsTrue(launch.Displayed && launch.Width > 0 && launch.Height > 0, "The launch card is not visible.");
+            Session.EnsureForeground();
+            Assert.IsTrue(
+                WindowControl.WaitForForeground(new IntPtr(Session.WindowHandle), 10_000),
+                $"Settings did not acquire foreground for the launch card: {WindowControl.GetForegroundWindowInfo()}.");
+            // SettingsCard exposes a Button role but no InvokePattern; its pointer command is the user action.
+            launch.Click(msPostAction: 0);
+            AttachEditor();
+        }
+
+        private void AttachEditor()
+        {
+            editor = WindowsFinder.WaitForWindowByApp(EditorProcess, window => window.Width > 400 && window.Height > 300, 45_000);
+            Assert.IsNotNull(editor, "Workspaces Editor did not open.");
+            Assert.IsFalse(editor.IsElevated, "Workspaces Editor must run at the test user's integrity level.");
+            WindowHelper.MaximizeWindow(new IntPtr(editor.WindowHandle));
+            Assert.IsTrue(editor.Has(By.AccessibilityId("NewProjectButton"), 20_000), "The editor did not present its workspace list.");
+        }
+
+        private void CloseEditor()
+        {
+            Step("Closing Workspaces Editor and waiting for its process to exit.");
+            Assert.IsTrue(WindowControl.TryCloseWindow(Editor.WindowHandle), "Could not close the editor window.");
+            Assert.IsTrue(WaitForProcess(EditorProcess, false), "The editor process did not exit after closing its window.");
+            editor = null;
+        }
+
+        private void EditWorkspace(string name, bool useMenu = false)
+        {
+            var card = WaitForCard(name);
+            if (useMenu)
+            {
+                OpenWorkspaceMenu(card);
+                var process = Microsoft.PowerToys.UITest.Next.Session.FromProcess(EditorProcess);
+                var buttons = process.FindAll<Button>(By.Name("Edit"), 10_000).Where(button => button.Name == "Edit").ToArray();
+                var menuButton = buttons.Single(button => button.Width > 0 && button.Width < 300);
+                Step("Invoking the workspace's Edit menu command.");
+                menuButton.Invoke(msPostAction: 0);
+            }
+            else
+            {
+                Step($"Invoking the workspace card '{name}'.");
+                OpenCardForEditing(card);
+            }
+
+            Assert.IsTrue(Editor.Has(By.AccessibilityId("EditNameTextBox"), 15_000), "The editing page did not open.");
+            Assert.AreEqual(name, Editor.Find<TextBox>(By.AccessibilityId("EditNameTextBox")).Value);
+        }
+
+        // Open a workspace's editing page with a real mouse click on the card's name region. The whole
+        // card is the Edit button, and its left name area never overlaps the Launch/More buttons on the
+        // right. WPF drops the cards' descendant automation peers after the list re-projects its items
+        // (a save, sort, or filter), so a UIA invoke on the descendant Edit button is unreliable; the item
+        // container keeps correct on-screen bounds, so a physical click on it always reaches the button.
+        private void OpenCardForEditing(WorkspaceCard card)
+        {
+            Editor.EnsureForeground();
+            Assert.IsTrue(
+                WindowControl.WaitForForeground(new IntPtr(Editor.WindowHandle), 10_000),
+                $"The editor did not acquire foreground to open a workspace card: {WindowControl.GetForegroundWindowInfo()}.");
+            var x = card.X + Math.Clamp(card.Width / 8, 24, 120);
+            var y = card.Y + (card.Height / 2);
+            MouseHelper.MoveTo(x, y);
+            Thread.Sleep(50);
+            MouseHelper.LeftClick();
+            Thread.Sleep(200);
+        }
+
+        private void OpenWorkspaceMenu(WorkspaceCard card)
+        {
+            Step("Opening the workspace actions menu.");
+
+            // Scope the More button to the target card by its on-screen row so the correct card's menu
+            // opens even when several cards are present. This relies on live descendant peers, so it is
+            // only used on a freshly rendered list (before any save/sort/filter re-projects the items).
+            var more = Editor.FindAll<Button>(By.AccessibilityId("MoreButton"), 10_000)
+                .Where(button => button.Y >= card.Y && button.Y <= card.Y + card.Height)
+                .ToArray();
+            Assert.HasCount(1, more, "The workspace actions button was not uniquely addressable.");
+            more[0].Invoke(msPostAction: 0);
+            Assert.IsTrue(
+                // The delete command's accessible name is the localized Resources.Delete, which reads "Remove".
+                Microsoft.PowerToys.UITest.Next.Session.FromProcess(EditorProcess).Has<Button>(By.Name("Remove"), 10_000),
+                "The workspace actions menu did not open.");
+        }
+
+        private void Search(string term)
+        {
+            Step($"Searching workspaces for '{term}'.");
+            Editor.Find<TextBox>(By.AccessibilityId("SearchTextBox"), 15_000).SetText(term);
+        }
+
+        // Reproduce the product's snapshot geometry contract (workspaces-common WindowUtils::GetWindowRect):
+        // take the raw Win32 GetWindowRect (outer window, including invisible resize borders) and convert
+        // it to DPI-normalized/logical coordinates with DPIAware::InverseConvert (logical = physical * 96 / dpi).
+        // This is the rectangle Workspaces persists and later restores via PlacementHelper::SizeWindowToRect,
+        // so both capture and launch assertions must compare against it. DWM extended-frame bounds
+        // (WindowHelper.GetVisibleBounds) are only correct for composed preview pixels, not saved placement.
+        private static (int X, int Y, int Width, int Height) NormalizedOuterBounds(IntPtr handle)
+        {
+            var (left, top, right, bottom) = WindowHelper.GetWindowBounds(handle);
+            var dpi = NativeMethods.GetDpiForWindow(handle);
+            Assert.IsTrue(dpi > 0, $"Could not read DPI for fixture HWND {handle}.");
+
+            var scale = 96f / dpi;
+            var originX = left * scale;
+            var originY = top * scale;
+            var width = (right - left) * scale;
+            var height = (bottom - top) * scale;
+            var x = (int)Math.Round(originX);
+            var y = (int)Math.Round(originY);
+            return (x, y, (int)Math.Round(originX + width) - x, (int)Math.Round(originY + height) - y);
+        }
+
+        private WorkspaceCard[] WorkspaceCards()
+        {
+            // Read each workspace card from its container's AutomationId (bound to the workspace name via
+            // the ItemsControl item-container style in MainPage.xaml) plus its on-screen bounds. WPF drops
+            // the cards' descendant automation peers after a filter/sort/save re-projects the ItemsControl
+            // source, but the item container itself stays in the tree with correct bounds, so it is the one
+            // handle on a workspace's identity and location that survives every re-projection.
+            var found = new List<WorkspaceCard>();
+
+            void Walk(JsonElement element)
+            {
+                if (element.TryGetProperty("automationId", out var idProperty) &&
+                    idProperty.GetString() is { } id &&
+                    id.StartsWith(State.Prefix, StringComparison.Ordinal))
+                {
+                    found.Add(new WorkspaceCard(
+                        id,
+                        element.TryGetProperty("x", out var xp) ? xp.GetInt32() : 0,
+                        element.TryGetProperty("y", out var yp) ? yp.GetInt32() : 0,
+                        element.TryGetProperty("width", out var wp) ? wp.GetInt32() : 0,
+                        element.TryGetProperty("height", out var hp) ? hp.GetInt32() : 0));
+                }
+
+                if (element.TryGetProperty("children", out var children) && children.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var child in children.EnumerateArray())
+                    {
+                        Walk(child);
+                    }
+                }
+            }
+
+            var tree = Editor.Inspect(depth: 10);
+            if (tree.TryGetProperty("windows", out var windows) && windows.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var window in windows.EnumerateArray())
+                {
+                    if (window.TryGetProperty("elements", out var elements) && elements.ValueKind == JsonValueKind.Array)
+                    {
+                        foreach (var element in elements.EnumerateArray())
+                        {
+                            Walk(element);
+                        }
+                    }
+                }
+            }
+
+            return [.. found.OrderBy(card => card.Y)];
+        }
+
+        private string[] WorkspaceNames() => WorkspaceCards().Select(card => card.Name).ToArray();
+
+        private WorkspaceCard WaitForCard(string name)
+        {
+            var result = WaitHelper.WaitForStable(
+                () => WorkspaceCards().Where(card => card.Name == name).ToArray(),
+                cards => cards is { Length: 1 } && cards[0].Width > 0 && cards[0].Height > 0,
+                timeoutMS: 15_000,
+                requiredConsecutiveMatches: 2,
+                pollIntervalMS: 200);
+            Assert.IsTrue(result.Succeeded, $"The workspace card '{name}' did not become uniquely addressable.");
+            return result.LastObservation![0];
+        }
+
+        private readonly record struct WorkspaceCard(string Name, int X, int Y, int Width, int Height);
+
+        private void AssertWorkspaceNames(params string[] expected)
+        {
+            var ready = WaitHelper.WaitForStable(
+                WorkspaceNames,
+                actual => actual is not null && actual.Order(StringComparer.Ordinal).SequenceEqual(expected.Order(StringComparer.Ordinal)),
+                timeoutMS: 15_000,
+                requiredConsecutiveMatches: 2,
+                pollIntervalMS: 150);
+            Assert.IsTrue(
+                ready.Succeeded,
+                $"Expected workspaces [{string.Join(", ", expected)}], observed [{string.Join(", ", ready.LastObservation ?? [])}].");
+        }
+
+        private Element ExpandApplication(string name)
+        {
+            Step($"Expanding application '{name}'.");
+            var row = Editor.Find<Element>(By.AccessibilityId(name), 15_000);
+            if (!string.Equals(row.GetProperty("ExpandCollapseState"), "Expanded", StringComparison.OrdinalIgnoreCase))
+            {
+                row.Invoke(msPostAction: 0);
+            }
+
+            Assert.IsTrue(row.Find<TextBox>(By.AccessibilityId("CommandLineTextBox"), 15_000).IsEnabled, "Application details did not expand.");
+            return row;
+        }
+
+        private void SaveWorkspace()
+        {
+            Step("Saving the workspace.");
+            var save = Editor.Find<Button>(By.AccessibilityId("SaveButton"), 15_000);
+            Assert.IsTrue(save.IsEnabled, "The workspace cannot be saved.");
+            save.Invoke(msPostAction: 0);
+            Assert.IsTrue(Editor.Has(By.AccessibilityId("NewProjectButton"), 15_000), "Save did not return to the workspace list.");
+        }
+
+        private Session StartCapture()
+        {
+            Step("Creating a workspace from the current desktop.");
+            Editor.Find<Button>(By.AccessibilityId("NewProjectButton"), 15_000).Invoke(msPostAction: 0);
+            return WaitForCaptureWindow();
+        }
+
+        private Session WaitForCaptureWindow()
+        {
+            var capture = WindowsFinder.WaitForWindowByApp(
+                EditorProcess,
+                window => window.Hwnd != Editor.WindowHandle && window.Title == "Snapshot Creator",
+                60_000);
+            Assert.IsNotNull(capture, "The snapshot control window did not appear.");
+            Assert.IsTrue(capture.Has(By.AccessibilityId("SnapshotButton"), 15_000), "The snapshot window is not ready.");
+            return capture;
+        }
+
+        private JsonObject Capture(Session capture, string? expectedAddedTitle = null)
+        {
+            var previousId = File.Exists(WorkspaceTestState.TemporaryPath)
+                ? WorkspaceTestState.Text(WorkspaceTestState.ReadObject(WorkspaceTestState.TemporaryPath), "id")
+                : null;
+            Step("Capturing the desktop.");
+            capture.Find<Button>(By.AccessibilityId("SnapshotButton"), 15_000).Invoke(msPostAction: 0);
+            Assert.IsTrue(Editor.Has(By.AccessibilityId("EditNameTextBox"), 45_000), "The captured workspace did not open in the editing page.");
+            WindowHelper.MaximizeWindow(new IntPtr(Editor.WindowHandle));
+
+            // Recapture keeps the old editing page visible while the snapshot tool runs. Require the new
+            // snapshot's identity/content, then the editor's own completed-recapture state before saving.
+            var result = WaitHelper.WaitForStable(
+                () => File.Exists(WorkspaceTestState.TemporaryPath)
+                    ? WorkspaceTestState.ReadObject(WorkspaceTestState.TemporaryPath)
+                    : null,
+                snapshot => snapshot is not null &&
+                    WorkspaceTestState.Text(snapshot, "id") != previousId &&
+                    snapshot["applications"] is JsonArray { Count: > 0 } apps &&
+                    (expectedAddedTitle is null || apps.Any(app => WorkspaceTestState.Text(app!, "title") == expectedAddedTitle)),
+                timeoutMS: 30_000,
+                requiredConsecutiveMatches: 2,
+                pollIntervalMS: 300,
+                shouldRetryException: error => error is IOException or JsonException);
+            Assert.IsTrue(result.Succeeded, $"A fresh snapshot containing '{expectedAddedTitle ?? "the captured applications"}' was not written.");
+            if (expectedAddedTitle is not null)
+            {
+                Assert.IsTrue(
+                    Editor.Find<Button>(By.AccessibilityId("RevertButton"), 15_000).WaitForProperty("IsEnabled", "True", 30_000),
+                    "The editor did not finish applying the recaptured workspace.");
+            }
+
+            return result.LastObservation!;
+        }
+
+        private static bool WaitForProcess(string name, bool expected, int timeoutMS = 20_000)
+        {
+            return WaitHelper.WaitForStable(
+                () =>
+                {
+                    var processes = Process.GetProcessesByName(name);
+                    try
+                    {
+                        return processes.Length > 0;
+                    }
+                    finally
+                    {
+                        foreach (var process in processes)
+                        {
+                            process.Dispose();
+                        }
+                    }
+                },
+                running => running == expected,
+                timeoutMS,
+                requiredConsecutiveMatches: 3,
+                pollIntervalMS: 150).Succeeded;
+        }
+
+        private static void StopModuleProcesses()
+        {
+            foreach (var name in ModuleProcesses)
+            {
+                Assert.IsTrue(WindowControl.TryKillProcessTreeByNameAndWait(name, 15_000), $"Could not stop test-owned {name}.");
+            }
+        }
+
+        private void Step(string message) => TestContext.WriteLine($"[{DateTime.UtcNow:HH:mm:ss.fff}] {message}");
+
+        private void AttachDiagnostics()
+        {
+            try
+            {
+                var directory = TestContext.TestRunResultsDirectory ?? throw new InvalidOperationException("No test results directory is available.");
+                Directory.CreateDirectory(directory);
+                foreach (var path in new[] { WorkspaceTestState.WorkspacesPath, WorkspaceTestState.TemporaryPath, WorkspaceTestState.SettingsPath })
+                {
+                    if (File.Exists(path))
+                    {
+                        var copy = Path.Combine(directory, $"{TestContext.TestName}-{Guid.NewGuid():N}-{Path.GetFileName(path)}");
+                        File.Copy(path, copy);
+                        TestContext.AddResultFile(copy);
+                    }
+                }
+
+                if (editor is not null && WaitForProcess(EditorProcess, true, 500))
+                {
+                    var tree = Path.Combine(directory, $"{TestContext.TestName}-{Guid.NewGuid():N}-editor.json");
+                    File.WriteAllText(tree, editor.Inspect(depth: 20).GetRawText());
+                    TestContext.AddResultFile(tree);
+                }
+
+                Step($"Foreground: {WindowControl.GetForegroundWindowInfo()}");
+            }
+            catch (Exception error) when (error is IOException or UnauthorizedAccessException or InvalidOperationException or AssertFailedException or Win32Exception or JsonException or TimeoutException)
+            {
+                TestContext.WriteLine($"Could not attach supplementary Workspaces diagnostics: {error.Message}");
+            }
+        }
+    }
+}

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspacesTests.cs
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspacesTests.cs
@@ -75,6 +75,8 @@ namespace Microsoft.Workspaces.UITests
         [TestCleanup]
         public async Task CleanUpWorkspace()
         {
+            // MSTest appends cleanup errors to the original failure and fails passing tests on leaks.
+            // Capture evidence first; fixture cleanup must still run if stopping module processes fails.
             try
             {
                 await CaptureFailureArtifactsBeforeCleanupAsync();
@@ -102,6 +104,8 @@ namespace Microsoft.Workspaces.UITests
             try
             {
                 StopModuleProcesses();
+
+                // Defensive and idempotent: stop before file restoration even if inherited cleanup already ran.
                 StopSharedScope();
             }
             finally

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspacesTests.cs
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/WorkspacesTests.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Workspaces.UITests
         private const string EditorProcess = "PowerToys.WorkspacesEditor";
         private const string LauncherProcess = "PowerToys.WorkspacesLauncher";
         private const string LauncherUiProcess = "PowerToys.WorkspacesLauncherUI";
+        private const string SettingsProcess = "PowerToys.Settings";
         private static readonly string[] ModuleProcesses =
         [
             LauncherProcess,
@@ -29,6 +30,7 @@ namespace Microsoft.Workspaces.UITests
         ];
         private static WorkspaceTestState? state;
         private Session? editor;
+        private Session? settingsUi;
 
         public WorkspacesTests()
             : base(PowerToysModule.PowerToysSettings, enableModules: ["Workspaces"])
@@ -44,6 +46,14 @@ namespace Microsoft.Workspaces.UITests
 
         private Session Editor => editor ?? throw new InvalidOperationException("The editor has not been opened.");
 
+        // The PowerToys.Settings process can replace its top-level window while it finishes initializing:
+        // the HWND the base Session bound to at launch is destroyed and a fresh one is created (observed in
+        // CI as a still-initializing "PowerToys Settings (Not Responding)" window with a new handle). A
+        // window-scoped session pinned to the original HWND then fails every lookup with "Window HWND ...
+        // not found". Route Settings UIA reads through a process-scoped session (-a) so navigation and
+        // toggles survive the swap — winappcli re-resolves the live window on every call.
+        private Session SettingsUi => settingsUi ??= Microsoft.PowerToys.UITest.Next.Session.FromProcess(SettingsProcess, timeoutMS: 30_000);
+
         protected override void PrepareTestState()
         {
             StopModuleProcesses();
@@ -58,6 +68,7 @@ namespace Microsoft.Workspaces.UITests
             StopModuleProcesses();
             State.Fixture.CloseAll();
             State.Reset();
+            settingsUi = null;
             NavigateToSettings();
         }
 
@@ -103,27 +114,51 @@ namespace Microsoft.Workspaces.UITests
         private void NavigateToSettings()
         {
             Step("Navigating to Workspaces Settings.");
-            if (!Session.Has(By.AccessibilityId("WorkspacesNavItem"), 500))
+
+            // Wait out any startup window replacement before driving the UI, so navigation runs against the
+            // window Settings actually settles on rather than the transient handle it was launched with.
+            _ = SettingsWindow();
+
+            if (!SettingsUi.Has(By.AccessibilityId("WorkspacesNavItem"), 500))
             {
-                Session.Find<NavigationViewItem>(By.AccessibilityId("WindowingAndLayoutsNavItem"), 15_000).Invoke(msPostAction: 0);
+                SettingsUi.Find<NavigationViewItem>(By.AccessibilityId("WindowingAndLayoutsNavItem"), 15_000).Invoke(msPostAction: 0);
             }
 
-            Session.Find<NavigationViewItem>(By.AccessibilityId("WorkspacesNavItem"), 15_000).Invoke(msPostAction: 0);
-            Assert.IsTrue(Session.Has(By.AccessibilityId("WorkspacesLaunchEditorButtonControl"), 15_000), "The Workspaces Settings page did not become ready.");
+            SettingsUi.Find<NavigationViewItem>(By.AccessibilityId("WorkspacesNavItem"), 15_000).Invoke(msPostAction: 0);
+            Assert.IsTrue(SettingsUi.Has(By.AccessibilityId("WorkspacesLaunchEditorButtonControl"), 15_000), "The Workspaces Settings page did not become ready.");
+        }
+
+        // Freshly resolve the current PowerToys.Settings main window for the few physical operations that
+        // need a real handle (foreground gating, coordinate clicks, and DPI seeding for fixture placement).
+        // requiredConsecutiveMatches guards against reading a handle that startup is about to replace.
+        private IntPtr SettingsWindow()
+        {
+            var result = WaitHelper.WaitForStable(
+                () => WindowsFinder.ListByApp(SettingsProcess)
+                    .Where(window => window.ClassName == "WinUIDesktopWin32WindowClass" && window.Width > 400 && window.Height > 300)
+                    .OrderByDescending(window => (long)window.Width * window.Height)
+                    .Select(window => (long?)window.Hwnd)
+                    .FirstOrDefault(),
+                hwnd => hwnd is > 0,
+                timeoutMS: 30_000,
+                requiredConsecutiveMatches: 2,
+                pollIntervalMS: 200);
+            Assert.IsTrue(result.Succeeded && result.LastObservation is > 0, "The PowerToys Settings window did not stabilize.");
+            return new IntPtr(result.LastObservation!.Value);
         }
 
         private ToggleSwitch ModuleToggle() =>
-            Session.Find<Element>(By.AccessibilityId("WorkspacesEnableToggleControlHeaderText"), 15_000)
+            SettingsUi.Find<Element>(By.AccessibilityId("WorkspacesEnableToggleControlHeaderText"), 15_000)
                 .Find<ToggleSwitch>(By.Name("Workspaces"), 15_000);
 
         private void OpenEditor()
         {
             Step("Clicking Open editor in Settings.");
-            var launch = Session.Find<Element>(By.AccessibilityId("WorkspacesLaunchEditorButtonControl"), 15_000);
+            var launch = SettingsUi.Find<Element>(By.AccessibilityId("WorkspacesLaunchEditorButtonControl"), 15_000);
             Assert.IsTrue(launch.Displayed && launch.Width > 0 && launch.Height > 0, "The launch card is not visible.");
-            Session.EnsureForeground();
+            SettingsUi.EnsureForeground();
             Assert.IsTrue(
-                WindowControl.WaitForForeground(new IntPtr(Session.WindowHandle), 10_000),
+                WindowControl.WaitForForeground(SettingsWindow(), 10_000),
                 $"Settings did not acquire foreground for the launch card: {WindowControl.GetForegroundWindowInfo()}.");
             // SettingsCard exposes a Button role but no InvokePattern; its pointer command is the user action.
             launch.Click(msPostAction: 0);
@@ -162,7 +197,7 @@ namespace Microsoft.Workspaces.UITests
             else
             {
                 Step($"Invoking the workspace card '{name}'.");
-                OpenCardForEditing(card);
+                OpenCardForEditing(name);
             }
 
             Assert.IsTrue(Editor.Has(By.AccessibilityId("EditNameTextBox"), 15_000), "The editing page did not open.");
@@ -174,18 +209,50 @@ namespace Microsoft.Workspaces.UITests
         // right. WPF drops the cards' descendant automation peers after the list re-projects its items
         // (a save, sort, or filter), so a UIA invoke on the descendant Edit button is unreliable; the item
         // container keeps correct on-screen bounds, so a physical click on it always reaches the button.
-        private void OpenCardForEditing(WorkspaceCard card)
+        // A single physical click can still be silently dropped while the editor is settling foreground /
+        // z-order right after it opens (observed in CI), so retry a bounded number of times: re-acquire the
+        // card by name (its bounds survive re-projection), click, and stop the moment the editing page's
+        // ready signal (EditNameTextBox) appears. Only click while the workspace list is still active, so a
+        // retry can never land a click on the editing page itself — this stays idempotent, never a longer
+        // arbitrary sleep.
+        private void OpenCardForEditing(string name)
         {
-            Editor.EnsureForeground();
-            Assert.IsTrue(
-                WindowControl.WaitForForeground(new IntPtr(Editor.WindowHandle), 10_000),
-                $"The editor did not acquire foreground to open a workspace card: {WindowControl.GetForegroundWindowInfo()}.");
-            var x = card.X + Math.Clamp(card.Width / 8, 24, 120);
-            var y = card.Y + (card.Height / 2);
-            MouseHelper.MoveTo(x, y);
-            Thread.Sleep(50);
-            MouseHelper.LeftClick();
-            Thread.Sleep(200);
+            const int maxAttempts = 4;
+            for (var attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                if (Editor.Has(By.AccessibilityId("EditNameTextBox"), 500))
+                {
+                    return;
+                }
+
+                if (!Editor.Has(By.AccessibilityId("NewProjectButton"), 500))
+                {
+                    // The list page is gone but the editing page has not rendered yet: a prior click
+                    // registered and the page is transitioning. Wait for the ready signal, do not re-click.
+                    if (Editor.Has(By.AccessibilityId("EditNameTextBox"), 3_000))
+                    {
+                        return;
+                    }
+
+                    continue;
+                }
+
+                var card = WaitForCard(name);
+                Editor.EnsureForeground();
+                Assert.IsTrue(
+                    WindowControl.WaitForForeground(new IntPtr(Editor.WindowHandle), 10_000),
+                    $"The editor did not acquire foreground to open a workspace card: {WindowControl.GetForegroundWindowInfo()}.");
+                var x = card.X + Math.Clamp(card.Width / 8, 24, 120);
+                var y = card.Y + (card.Height / 2);
+                Step($"Clicking the workspace card '{name}' (attempt {attempt}).");
+                MouseHelper.MoveTo(x, y);
+                Thread.Sleep(50);
+                MouseHelper.LeftClick();
+                if (Editor.Has(By.AccessibilityId("EditNameTextBox"), 3_000))
+                {
+                    return;
+                }
+            }
         }
 
         private void OpenWorkspaceMenu(WorkspaceCard card)

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/app.manifest
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/app.manifest
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
   <assemblyIdentity version="1.0.0.0" name="Workspaces.UITests.Next.app" />
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />

--- a/src/modules/Workspaces/Tests/Workspaces.UITests.Next/app.manifest
+++ b/src/modules/Workspaces/Tests/Workspaces.UITests.Next/app.manifest
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="Workspaces.UITests.Next.app" />
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/src/modules/Workspaces/WorkspacesEditor/MainPage.xaml
+++ b/src/modules/Workspaces/WorkspacesEditor/MainPage.xaml
@@ -111,7 +111,10 @@
                 VerticalAlignment="Center"
                 Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                 Text="{x:Static props:Resources.SortBy}" />
-            <ComboBox MinWidth="140" SelectedIndex="{Binding OrderByIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+            <ComboBox
+                MinWidth="140"
+                AutomationProperties.AutomationId="WorkspaceSortComboBox"
+                SelectedIndex="{Binding OrderByIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
                 <ComboBoxItem Content="{x:Static props:Resources.LastLaunched}" />
                 <ComboBoxItem Content="{x:Static props:Resources.Created}" />
                 <ComboBoxItem Content="{x:Static props:Resources.Name}" />
@@ -138,6 +141,11 @@
                 x:Name="WorkspacesItemsControl"
                 Margin="24,0,24,24"
                 ItemsSource="{Binding WorkspacesView, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
+                <ItemsControl.ItemContainerStyle>
+                    <Style TargetType="ContentPresenter">
+                        <Setter Property="AutomationProperties.AutomationId" Value="{Binding Name, Mode=OneWay}" />
+                    </Style>
+                </ItemsControl.ItemContainerStyle>
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
                         <StackPanel

--- a/src/modules/Workspaces/WorkspacesEditor/WorkspacesEditorPage.xaml
+++ b/src/modules/Workspaces/WorkspacesEditor/WorkspacesEditorPage.xaml
@@ -144,6 +144,7 @@
                             <ComboBox
                                 Margin="12,0,0,0"
                                 VerticalAlignment="Center"
+                                AutomationProperties.AutomationId="WindowPositionComboBox"
                                 SelectedIndex="{Binding PositionComboboxIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
                                 <ComboBoxItem Content="{x:Static props:Resources.Custom}" />
                                 <ComboBoxItem Content="{x:Static props:Resources.Maximized}" />
@@ -297,6 +298,7 @@
                     Width="{Binding PreviewImageWidth, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
                     Height="200"
                     Margin="2"
+                    AutomationProperties.AutomationId="WorkspacePreviewImage"
                     DockPanel.Dock="Top"
                     Source="{Binding PreviewImage, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
                     Stretch="Fill" />

--- a/src/modules/Workspaces/WorkspacesLauncherUI/StatusWindow.xaml
+++ b/src/modules/Workspaces/WorkspacesLauncherUI/StatusWindow.xaml
@@ -61,6 +61,7 @@
                                     Margin="10"
                                     HorizontalAlignment="Center"
                                     VerticalAlignment="Center"
+                                    AutomationProperties.AutomationId="{Binding Name, StringFormat='LaunchProgress_{0}'}"
                                     IsIndeterminate="True"
                                     Visibility="{Binding Loading, Mode=OneWay, Converter={StaticResource BoolToVis}, UpdateSourceTrigger=PropertyChanged}" />
                                 <TextBlock
@@ -70,6 +71,7 @@
                                     Margin="10"
                                     HorizontalAlignment="Center"
                                     VerticalAlignment="Center"
+                                    AutomationProperties.AutomationId="{Binding Name, StringFormat='LaunchState_{0}'}"
                                     FontFamily="{DynamicResource SymbolThemeFontFamily}"
                                     FontSize="20"
                                     Foreground="{Binding StateColor}"


### PR DESCRIPTION
## Summary of the Pull Request

Add `Workspaces.UITests.Next` with 33 end-to-end UI test cases based on the manual checklist in #40682. The suite uses `Microsoft.PowerToys.UITest.Next` and winappcli, with deterministic unpackaged and full-MSIX fixtures instead of relying on installed third-party applications.

The legacy `WorkspacesEditorUITest` project remains unchanged.

## PR Checklist

- [ ] **Communication:** Awaiting maintainer review.
- [x] Closes: https://github.com/microsoft/PowerToys/issues/40682
- [x] **Tests:** Added/updated and passing, including the complete local VM matrix and UI Test Automation CI.
- [x] **Dev docs:** Added build, setup, fixture, and checklist-coverage documentation.
- [x] **New binaries:** Test-only runner and fixture projects are registered in the solution and staged/signed in the UI-test pipeline.

N/A: new shipping binaries, production installer/signing entries, localization changes, and public user-documentation changes. Product UI changes only add automation identifiers.

## Detailed Description of the Pull Request / Additional comments

- Add `src\modules\Workspaces\Tests\Workspaces.UITests.Next` covering Settings and Quick Access activation, shortcut customization and disable/enable behavior, capture/cancellation, search and sorting, workspace/application editing, preview updates, desktop shortcuts, launch progress/cancellation/dismissal, command-line arguments, and window placement.
- Add `src\modules\Workspaces\Tests\Workspaces.TestApp`, a self-contained Windows Forms fixture available as both an unpackaged executable and a full MSIX. Tests verify actual package/process identity and received arguments. Named startup gates make pending-launch scenarios controllable without depending on arbitrary application startup delays.
- Pair UI assertions with persisted workspace data, native window geometry/state, and composed preview pixels. Preserve and restore test-owned settings, files, shortcuts, and package registrations, and capture failure evidence before teardown.
- Add stable automation identifiers in the editor and launcher XAML, including workspace-card containers whose descendant automation peers can disappear after WPF list updates. Use process-scoped Settings automation to tolerate startup window replacement, and bounded, state-aware retries for card activation.
- Register the projects in `PowerToys.slnx` and update `.pipelines\v2\templates\job-test-project.yml` to reuse the existing package/companion signing and standard-user dispatch mechanisms. Tests continue to exercise real Settings-to-Runner behavior; there is no authentication bypass or settings-file/restart fallback.
- Fix `src\common\UITestAutomation.Next\SettingsConfigHelper.cs` so restoring an originally absent file also succeeds when its parent directory does not exist. Add regression cases for a never-created parent and a parent removed during the preservation scope.

The suite README maps all 41 checklist items to automated coverage or an explicit manual boundary. Actual elevated/UAC workflows and physical monitor hot-plug/mixed-DPI scenarios remain manual; they are not hidden behind ignored or inconclusive tests. Saved-topology replay is covered separately. This PR is related to #40682 rather than automatically closing the remaining manual coverage.

## Validation Steps Performed

| Validation | Result |
| --- | --- |
| Test and fixture builds | x64 and ARM64 passed |
| `SettingsConfigHelperTests` | 9/9 passed, including both new regression cases |
| UI-test dispatch/signing contract tests | 5/5 passed |
| Full local UI suite: Windows 10 and Windows 11, Default profile (4 vCPU / 8 GB) | 33/33 on each OS |
| Full local UI suite: Windows 10 and Windows 11, Constrained profile (1 vCPU / 4 GB) | 33/33 on each OS |
| UI Test Automation CI: Windows 10 x64, Windows 11 x64, and ARM64; machine and per-user installation modes | 198/198 passed across all six legs |

Final CI completed successfully with no failed, skipped, or not-executed selected tests. CI-discovered card-click and Settings-window timing issues were fixed and revalidated locally before the successful CI run.

<img width="857" height="683" alt="image" src="https://github.com/user-attachments/assets/efa56cb0-9053-41fe-bb2a-76c08080d37b" />

