### PR TITLE
[Peek] Fix title bar button being focused on start up, and fix scrolling and interaction in interactive previewers

### DIFF
--- a/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml
+++ b/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml
@@ -24,6 +24,14 @@
             <KeyboardAccelerator Key="Up" Invoked="PreviousNavigationInvoked" />
             <KeyboardAccelerator Key="Right" Invoked="NextNavigationInvoked" />
             <KeyboardAccelerator Key="Down" Invoked="NextNavigationInvoked" />
+            <KeyboardAccelerator
+                Key="Left"
+                Invoked="PreviousNavigationInvoked"
+                Modifiers="Menu" />
+            <KeyboardAccelerator
+                Key="Right"
+                Invoked="NextNavigationInvoked"
+                Modifiers="Menu" />
             <KeyboardAccelerator Key="Escape" Invoked="CloseInvoked" />
             <KeyboardAccelerator
                 Key="W"

--- a/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml.cs
+++ b/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml.cs
@@ -408,22 +408,22 @@ namespace Peek.UI
         private IntPtr LowLevelKeyboardHookCallback(int nCode, IntPtr wParam, IntPtr lParam)
         {
             const int WM_KEYDOWN = 0x0100;
+            const int WM_SYSKEYDOWN = 0x0104;
             const uint VK_W = 0x57;
             const uint VK_ESCAPE = 0x1B;
             const uint VK_LEFT = 0x25;
-            const uint VK_UP = 0x26;
             const uint VK_RIGHT = 0x27;
-            const uint VK_DOWN = 0x28;
             const int VK_CONTROL = 0x11;
             const int VK_ALT = 0x12;
             const int VK_SHIFT = 0x10;
             const int VK_LWIN = 0x5B;
             const int VK_RWIN = 0x5C;
             const int KEY_PRESSED_MASK = 0x8000;
+            const uint LLKHF_ALTDOWN = 0x20;
 
             try
             {
-                if (nCode >= 0 && wParam == (IntPtr)WM_KEYDOWN && lParam != IntPtr.Zero)
+                if (nCode >= 0 && (wParam == (IntPtr)WM_KEYDOWN || wParam == (IntPtr)WM_SYSKEYDOWN) && lParam != IntPtr.Zero)
                 {
                     // Only handle when our window is in the foreground (cheap check before marshaling)
                     var foreground = Windows.Win32.PInvoke_PeekUI.GetForegroundWindow();
@@ -434,16 +434,16 @@ namespace Peek.UI
 
                     var hookStruct = Marshal.PtrToStructure<NativeMethods.KBDLLHOOKSTRUCT>(lParam);
 
-                    // Fast-path: skip keys we never handle
-                    if (hookStruct.vkCode != VK_W && hookStruct.vkCode != VK_ESCAPE &&
-                        hookStruct.vkCode != VK_LEFT && hookStruct.vkCode != VK_RIGHT &&
-                        hookStruct.vkCode != VK_UP && hookStruct.vkCode != VK_DOWN)
+                    // Fast-path: skip keys we never handle. Only intercept Ctrl+W, Escape, and Alt+Left/Right
+                    // so that normal arrow keys and other inputs reach focused preview controls (e.g. WebView2).
+                    if (hookStruct.vkCode is not VK_W and not VK_ESCAPE and not VK_LEFT and not VK_RIGHT)
                     {
                         return NativeMethods.CallNextHookEx(_keyboardHookHandle, nCode, wParam, lParam);
                     }
 
                     bool ctrlPressed = (NativeMethods.GetAsyncKeyState(VK_CONTROL) & KEY_PRESSED_MASK) != 0;
-                    bool altPressed = (NativeMethods.GetAsyncKeyState(VK_ALT) & KEY_PRESSED_MASK) != 0;
+                    bool altPressed = (hookStruct.flags & LLKHF_ALTDOWN) != 0 ||
+                                      (NativeMethods.GetAsyncKeyState(VK_ALT) & KEY_PRESSED_MASK) != 0;
                     bool shiftPressed = (NativeMethods.GetAsyncKeyState(VK_SHIFT) & KEY_PRESSED_MASK) != 0;
                     bool winPressed = (NativeMethods.GetAsyncKeyState(VK_LWIN) & KEY_PRESSED_MASK) != 0 ||
                                       (NativeMethods.GetAsyncKeyState(VK_RWIN) & KEY_PRESSED_MASK) != 0;
@@ -475,28 +475,14 @@ namespace Peek.UI
                             }
                         });
                     }
-                    else if (!ctrlPressed && !altPressed && !shiftPressed && !winPressed && hookStruct.vkCode == VK_LEFT)
+                    else if (!ctrlPressed && altPressed && !shiftPressed && !winPressed && hookStruct.vkCode == VK_LEFT)
                     {
                         if (ViewModel.DisplayItemCount > 1)
                         {
                             handled = DispatcherQueue.TryEnqueue(() => ViewModel.AttemptPreviousNavigation());
                         }
                     }
-                    else if (!ctrlPressed && !altPressed && !shiftPressed && !winPressed && hookStruct.vkCode == VK_RIGHT)
-                    {
-                        if (ViewModel.DisplayItemCount > 1)
-                        {
-                            handled = DispatcherQueue.TryEnqueue(() => ViewModel.AttemptNextNavigation());
-                        }
-                    }
-                    else if (!ctrlPressed && !altPressed && !shiftPressed && !winPressed && hookStruct.vkCode == VK_UP)
-                    {
-                        if (ViewModel.DisplayItemCount > 1)
-                        {
-                            handled = DispatcherQueue.TryEnqueue(() => ViewModel.AttemptPreviousNavigation());
-                        }
-                    }
-                    else if (!ctrlPressed && !altPressed && !shiftPressed && !winPressed && hookStruct.vkCode == VK_DOWN)
+                    else if (!ctrlPressed && altPressed && !shiftPressed && !winPressed && hookStruct.vkCode == VK_RIGHT)
                     {
                         if (ViewModel.DisplayItemCount > 1)
                         {

--- a/src/modules/peek/Peek.UI/PeekXAML/Views/TitleBar.xaml
+++ b/src/modules/peek/Peek.UI/PeekXAML/Views/TitleBar.xaml
@@ -64,6 +64,18 @@
             </Grid>
         </Grid>
 
+        <!--
+            Prevent a title bar button from being focused on startup. Prevents Space
+            accidentally activating a button when the app is launched.
+        -->
+        <ContentControl
+            x:Name="FocusSink"
+            Width="0"
+            Height="0"
+            AutomationProperties.AccessibilityView="Raw"
+            IsTabStop="True"
+            UseSystemFocusVisuals="False" />
+
         <Button
             x:Name="LaunchAppButton"
             Grid.Column="2"


### PR DESCRIPTION
## Summary of the Pull Request
This fixes two focus-related issues in Peek:

1. One of the title bar buttons would be focused when Peek opened. This was because WinUI will focus the first tab-able control when displaying the window. This was usually the "Pin" button:

<img width="563" height="106" alt="image" src="https://github.com/user-attachments/assets/c8275d03-ac65-47a0-9a3b-0d2f5a7671fb" />

Unfortunately, the activation hotkey for Peek is <kbd>Space</kbd> and it is very easy to double-press a key or accidentally press it while viewing media. This would result in users accidentally pinning the window size or opening the file in the default viewer.

2. A [recent fix](#48293) added a low-level keyboard hook to handle <kbd>Ctrl</kbd>+<kbd>W</kbd> and <kbd>Escape</kbd> everywhere in Peek, to ensure that users could always close the window using the keyboard. Unfortunately, the arrow keys were also added to the handler and the file navigation events were directly tied to these key presses. This broke scrolling and text navigation in previewers, such as when viewing PDFs, interacting with text documents, navigating ZIP archives and so on.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #49805
- [x] Closes: #50471
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

### 1. Title bar focus issue
I added a focus trap to the title bar, which is non-interactive and does not announce accessibility events. As this is a tab stop, it captures focus when the window opens instead of the **Open in default viewer** or **Pin** buttons.

### 2. Arrow key handling
I've removed arrow keys on their own from the low-level keyboard handler. This restores scrolling and other interactions when the client area of the window has focus. I added <kbd>Alt</kbd>+<kbd>Left</kbd> and <kbd>Alt</kbd>+<kbd>Right</kbd> as Previous/Next file shortcuts which work everywhere, including when the client area has focus.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
(Manual testing only.)

- Confirmed that both <kbd>Ctrl</kbd>+<kbd>W</kbd> and <kbd>Escape</kbd> still correctly close the Peek window.
- Opened a variety of image, video and music files to ensure the focus issue was solved and pressing <kbd>Space</kbd> would not perform an action without intentionally tabbing to a control.
- Opened a markdown file and a text document to confirm that keyboard scrolling and text selection was fixed.
- Opened PDF and HTML files to confirm keyboard scrolling was restored in these previewers, too.
- Tabbed through each of the previewers to confirm that the title bar controls were still accessible via the keyboard.
- Used the new <kbd>Alt</kbd>+<kbd>Left</kbd> and <kbd>Alt</kbd>+<kbd>Right</kbd> shortcuts to navigate while focused on the client area in multiple different previewers, including non-interactive and interactive ones.

## Screenshots and video

No control focused on startup:
<img width="525" height="87" alt="image" src="https://github.com/user-attachments/assets/a9d17d67-66b6-47c4-934e-ea83852ecc37" />

Interacting with previewer:
https://github.com/user-attachments/assets/95b25034-6193-4305-9f9c-e9321539e696



