### PR TITLE
[Shortcut Guide] Restore keyboard tab order and accessible focus to shortcut items

### DIFF
--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/Controls/MainPaneControl.xaml
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/Controls/MainPaneControl.xaml
@@ -95,6 +95,7 @@
                 <NavigationView.Content>
                     <Frame
                         x:Name="ContentFrame"
+                        IsTabStop="False"
                         Background="{ThemeResource LayerFillColorDefaultBrush}"
                         BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                         BorderThickness="1,1,0,0"

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/Controls/ShortcutItemView.xaml
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/Controls/ShortcutItemView.xaml
@@ -7,7 +7,15 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:models="using:ShortcutGuide.Models"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    IsTabStop="True"
+    UseSystemFocusVisuals="True"
+    AutomationProperties.Name="{x:Bind Shortcut.Name, Mode=OneWay}">
+    <UserControl.ContextFlyout>
+        <MenuFlyout Opening="PinFlyout_Opening">
+            <MenuFlyoutItem x:Name="PinMenuItem" Click="Pin_Click" />
+        </MenuFlyout>
+    </UserControl.ContextFlyout>
     <Grid
         Padding="16,8,16,8"
         BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
@@ -16,11 +24,6 @@
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="160" />
         </Grid.ColumnDefinitions>
-        <Grid.ContextFlyout>
-            <MenuFlyout Opening="PinFlyout_Opening">
-                <MenuFlyoutItem x:Name="PinMenuItem" Click="Pin_Click" />
-            </MenuFlyout>
-        </Grid.ContextFlyout>
         <StackPanel
             Grid.Column="0"
             VerticalAlignment="Center"

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/Pages/ShortcutsPage.xaml
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/Pages/ShortcutsPage.xaml
@@ -43,7 +43,7 @@
             SubtitleTemplate="{StaticResource SubtitleTemplate}" />
     </Page.Resources>
     <Grid>
-        <ScrollViewer>
+        <ScrollViewer IsTabStop="False">
             <ItemsRepeater
                 x:Name="MainItemsRepeater"
                 Margin="0,0,0,24"


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Restores keyboard tab navigation and accessibility focus into the shortcut items list within Shortcut Guide.

Previously, pressing `Tab` repeatedly navigated through the search box, close button, and navigation rail, but then bypassed the shortcut items entirely, landing on an intermediate unnamed container (`InputSiteWindowClass` / `DesktopChildSiteBridge`) before looping back. This change ensures `Tab` cleanly enters the shortcut items list, displays system focus visuals, and announces shortcut item names via UI Automation.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #50031
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Verified passing via automated UI regression suite (see companion wintegrate CI run and recordings below)
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

### Problem & Root Cause
1. In `MainPaneControl.xaml` and `ShortcutsPage.xaml`, `ContentFrame` (`Frame`) and `ScrollViewer` acted as intermediate focus stops (`IsTabStop="True"` by default in WinUI 3) without providing direct accessible interactive content.
2. In `ShortcutItemView.xaml`, the root `UserControl` had `IsTabStop="False"` by default, lacked `UseSystemFocusVisuals="True"`, and did not define `AutomationProperties.Name`. Consequently, keyboard users could not tab into or select individual shortcut items.
3. The `MenuFlyout` was hosted on an internal `Grid` rather than on the interactive `UserControl`.

### Changes
- Marked `ContentFrame` ([`MainPaneControl.xaml#L98`](https://github.com/mangokingTW/PowerToys/blob/ff1dac981d70f489710a488da32df1de7bc0ff23/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/Controls/MainPaneControl.xaml#L98)) and `ScrollViewer` ([`ShortcutsPage.xaml#L46`](https://github.com/mangokingTW/PowerToys/blob/ff1dac981d70f489710a488da32df1de7bc0ff23/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/Pages/ShortcutsPage.xaml#L46)) with `IsTabStop="False"`.
- Set `IsTabStop="True"` and `UseSystemFocusVisuals="True"` on `ShortcutItemView`'s root `<UserControl>` ([`ShortcutItemView.xaml#L10-L12`](https://github.com/mangokingTW/PowerToys/blob/ff1dac981d70f489710a488da32df1de7bc0ff23/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/Controls/ShortcutItemView.xaml#L10-L12)).
- Added `AutomationProperties.Name="{x:Bind Shortcut.Name, Mode=OneWay}"` to `ShortcutItemView` ([`ShortcutItemView.xaml#L13`](https://github.com/mangokingTW/PowerToys/blob/ff1dac981d70f489710a488da32df1de7bc0ff23/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/Controls/ShortcutItemView.xaml#L13)).
- Moved `<MenuFlyout>` from `<Grid.ContextFlyout>` to `<UserControl.ContextFlyout>` ([`ShortcutItemView.xaml#L14-L18`](https://github.com/mangokingTW/PowerToys/blob/ff1dac981d70f489710a488da32df1de7bc0ff23/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/Controls/ShortcutItemView.xaml#L14-L18)).

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

### Visual Demonstration (Full Screen Desktop)

Both recordings capture the exact same keyboard Tab navigation test (`test_shortcut_guide_tab_order_reaches_shortcuts`): opening Shortcut Guide, navigating via Tab through SearchBox, Close button, and Navigation rail, then pressing Tab to enter the shortcut items list.

| Unpatched Baseline (focus trapped on unnamed container) | Patched Build (focus enters shortcut card with system visual) |
|:---:|:---:|
| ![Before: Tab 4 skips shortcut list](https://raw.githubusercontent.com/mangokingTW/PowerToys/2df2fa2b3433e5bbdb0fa610e70d7f87e24a9e65/before-unfixed.gif) | ![After: Tab 4 focuses shortcut item](https://raw.githubusercontent.com/mangokingTW/PowerToys/2df2fa2b3433e5bbdb0fa610e70d7f87e24a9e65/after-fixed.gif) |
| **Full Desktop Clip: 0.0s – 4.5s** of `session_recording.mp4`<br>From [Run 34329756473](https://github.com/mangokingTW/PowerToys/actions/runs/34329756473) ([`verification-artifacts-unpatched-baseline.zip`](https://github.com/mangokingTW/PowerToys/actions/runs/34329756473/artifacts/10095328962))<br>• **0.0s – 1.0s**: Window activated, initial focus on SearchBox<br>• **1.0s – 1.7s**: Content island focus routing<br>• **1.7s – 2.2s**: `Tab 1` ➡️ CloseButton, `Tab 2` ➡️ Navigation rail, `Tab 3` ➡️ Settings<br>• **2.2s**: `Tab 4` skips shortcut list entirely; focus trapped on unnamed container (`class='InputSiteWindowClass'`, ctype 50033) with zero focus visuals<br>• **2.2s – 4.5s**: 2.0s settling timeout expires; assertion fails (`AssertionError`) | **Full Desktop Clip: 0.0s – 2.3s** of `session_recording.mp4`<br>From [Run 34329756473](https://github.com/mangokingTW/PowerToys/actions/runs/34329756473) ([`verification-artifacts-patched-verification.zip`](https://github.com/mangokingTW/PowerToys/actions/runs/34329756473/artifacts/10095317398))<br>• **0.0s – 1.1s**: Window activated, initial focus on SearchBox<br>• **1.1s – 1.7s**: Content island focus routing<br>• **1.7s – 2.2s**: `Tab 1` ➡️ CloseButton, `Tab 2` ➡️ Navigation rail, `Tab 3` ➡️ Settings<br>• **2.2s**: `Tab 4` seamlessly enters shortcut list on `Open File Explorer` (`NamedContainerAutomationPeer`, ctype 50026) with visible system focus border<br>• **2.2s – 2.3s**: Focus firmly held on shortcut item; test passes cleanly |

### Automated UI Testing & Bug Verification

Verification was executed via an automated UI test harness running under [wintegrate](https://github.com/mangokingTW/wintegrate) on GitHub Actions CI (`windows-latest` Windows Server 2025 Datacenter). [wintegrate](https://github.com/mangokingTW/wintegrate) provides native Windows UI Automation tree inspection, focus queries, keyboard injection, and continuous full-screen video recordings during CI runs.

The complete test suite and CI workflow are maintained in companion fork PR [mangokingTW/PowerToys#6 (fix/shortcut-guide-tab-order-focus)](https://github.com/mangokingTW/PowerToys/pull/6):

- **CI Verification Run**: [Run 34329756473](https://github.com/mangokingTW/PowerToys/actions/runs/34329756473) (`windows-latest` runner)
- **Continuous Full-Screen Recordings & Artifacts**:
  - [`verification-artifacts-patched-verification.zip`](https://github.com/mangokingTW/PowerToys/actions/runs/34329756473/artifacts/10095317398) (All 9 tests passed; clean focus transition into shortcut cards)
  - [`verification-artifacts-unpatched-baseline.zip`](https://github.com/mangokingTW/PowerToys/actions/runs/34329756473/artifacts/10095328962) (Control tests passed; target keyboard navigation tests reproduced failure)

#### Target Bug Scenarios

| Test Scenario | Code Location | Baseline (Unpatched) | Patched Build | Result |
|---|---|---|---|---|
| **Tab 4: Shortcut Card Entry**<br>• Sequential Tab from header into shortcut list | [`test_shortcut_guide_tab_order.py#L225`](https://github.com/mangokingTW/PowerToys/blob/fix/shortcut-guide-tab-order-focus/src/modules/ShortcutGuide/Tests/ui-verification/test_shortcut_guide_tab_order.py#L225) | ❌ **Failed (`AssertionError`)**<br>Skipped list; trapped on unnamed container (`InputSiteWindowClass`, ctype 50033) | ✅ **Passed**<br>Lands on `Open File Explorer` (`ctype=50026`) with visible system focus border | Verified |
| **Tab from Settings Button into Shortcuts**<br>• Tab navigation from navigation footer into shortcut list | [`test_shortcut_guide_tab_order.py#L244`](https://github.com/mangokingTW/PowerToys/blob/fix/shortcut-guide-tab-order-focus/src/modules/ShortcutGuide/Tests/ui-verification/test_shortcut_guide_tab_order.py#L244) | ❌ **Failed (`AssertionError`)**<br>Skipped list; trapped on unnamed container (`InputSiteWindowClass`, ctype 50033) | ✅ **Passed**<br>Lands on `Open File Explorer` (`ctype=50026`) with visible system focus border | Verified |
| **Arrow Key Navigation Between Shortcut Cards**<br>• Down Arrow navigates sequentially between cards | [`test_shortcut_guide_tab_order.py#L272`](https://github.com/mangokingTW/PowerToys/blob/fix/shortcut-guide-tab-order-focus/src/modules/ShortcutGuide/Tests/ui-verification/test_shortcut_guide_tab_order.py#L272) | ❌ **Failed (`AssertionError`)**<br>Initial focus never reached first card; navigation aborted | ✅ **Passed**<br>Down Arrow moves focus from first card to subsequent card | Verified |

*(Reference Controls: Existing behaviors were validated as control baselines on both builds: Initial focus on SearchBox ([`#L139`](https://github.com/mangokingTW/PowerToys/blob/fix/shortcut-guide-tab-order-focus/src/modules/ShortcutGuide/Tests/ui-verification/test_shortcut_guide_tab_order.py#L139)), Tab to CloseButton ([`#L154`](https://github.com/mangokingTW/PowerToys/blob/fix/shortcut-guide-tab-order-focus/src/modules/ShortcutGuide/Tests/ui-verification/test_shortcut_guide_tab_order.py#L154)), Tab to Navigation rail ([`#L168`](https://github.com/mangokingTW/PowerToys/blob/fix/shortcut-guide-tab-order-focus/src/modules/ShortcutGuide/Tests/ui-verification/test_shortcut_guide_tab_order.py#L168)), Tab to Settings ([`#L184`](https://github.com/mangokingTW/PowerToys/blob/fix/shortcut-guide-tab-order-focus/src/modules/ShortcutGuide/Tests/ui-verification/test_shortcut_guide_tab_order.py#L184)), SearchBox query typing ([`#L200`](https://github.com/mangokingTW/PowerToys/blob/fix/shortcut-guide-tab-order-focus/src/modules/ShortcutGuide/Tests/ui-verification/test_shortcut_guide_tab_order.py#L200)), and Escape key dismissal ([`#L208`](https://github.com/mangokingTW/PowerToys/blob/fix/shortcut-guide-tab-order-focus/src/modules/ShortcutGuide/Tests/ui-verification/test_shortcut_guide_tab_order.py#L208)) passed 100% identically across both unpatched and patched environments).*

---

## Generative AI Disclosure

This pull request was developed with the assistance of Google Antigravity (Gemini Flash 3.8).
