### PR TITLE
feat(mwb): improve handling of unexpected settings-sync callers

### DIFF
--- a/src/modules/MouseWithoutBorders/App/Class/IClipboardHelper.cs
+++ b/src/modules/MouseWithoutBorders/App/Class/IClipboardHelper.cs
@@ -17,6 +17,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 
+using Microsoft.PowerToys.Settings.UI.Library.Utilities;
 using Microsoft.VisualStudio.Threading;
 using MouseWithoutBorders.Core;
 using Newtonsoft.Json;
@@ -179,7 +180,7 @@ WellKnownSidType.AuthenticatedUserSid, null);
                 PipeAccessRights.ReadWrite | PipeAccessRights.CreateNewInstance,
                 AccessControlType.Allow));
 
-            _ = Task.Factory.StartNew(
+            _ = Task.Run(
                 async () =>
                 {
                     try
@@ -206,9 +207,76 @@ WellKnownSidType.AuthenticatedUserSid, null);
 #endif
                     }
                 },
-                cancellationToken,
-                TaskCreationOptions.None,
-                TaskScheduler.Default);
+                cancellationToken);
+
+            return default(T);
+        }
+
+        public static T StartVerifiedIpcServer(
+            string pipeName,
+            SecurityIdentifier allowedUser,
+            Func<NamedPipeServerStream, string> verifyClientConnection,
+            CancellationToken cancellationToken)
+        {
+            return StartVerifiedIpcServer(pipeName, allowedUser, verifyClientConnection, null, cancellationToken);
+        }
+
+        internal static T StartVerifiedIpcServer(
+            string pipeName,
+            SecurityIdentifier allowedUser,
+            Func<NamedPipeServerStream, string> verifyClientConnection,
+            Action<Exception> serverErrorObserver,
+            CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(verifyClientConnection);
+
+            _ = Task.Run(
+                async () =>
+                {
+                    while (!cancellationToken.IsCancellationRequested)
+                    {
+                        try
+                        {
+                            using var serverChannel = RestrictedNamedPipeServer.Create(pipeName, allowedUser);
+                            await serverChannel.WaitForConnectionAsync(cancellationToken);
+
+                            var rejectionReason = verifyClientConnection(serverChannel);
+                            if (!string.IsNullOrEmpty(rejectionReason))
+                            {
+#if !MM_HELPER
+                                Logger.Log($"Rejected Settings IPC client: {rejectionReason}");
+#endif
+                                if (serverChannel.IsConnected)
+                                {
+                                    serverChannel.Disconnect();
+                                }
+
+                                continue;
+                            }
+
+                            var taskRpc = JsonRpc.Attach(serverChannel, new T());
+                            await taskRpc.Completion;
+                        }
+                        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                        {
+                            break;
+                        }
+                        catch (Exception e)
+                        {
+                            serverErrorObserver?.Invoke(e);
+#if MM_HELPER
+                            _ = e;
+#else
+                            Logger.Log(e);
+#endif
+                            if (!cancellationToken.IsCancellationRequested)
+                            {
+                                await Task.Delay(250);
+                            }
+                        }
+                    }
+                },
+                cancellationToken);
 
             return default(T);
         }

--- a/src/modules/MouseWithoutBorders/App/Class/IClipboardHelper.cs
+++ b/src/modules/MouseWithoutBorders/App/Class/IClipboardHelper.cs
@@ -251,6 +251,7 @@ WellKnownSidType.AuthenticatedUserSid, null);
                                     serverChannel.Disconnect();
                                 }
 
+                                await Task.Delay(250, cancellationToken);
                                 continue;
                             }
 

--- a/src/modules/MouseWithoutBorders/App/Class/Program.cs
+++ b/src/modules/MouseWithoutBorders/App/Class/Program.cs
@@ -12,6 +12,7 @@
 // </history>
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing.Printing;
@@ -19,6 +20,7 @@ using System.Globalization;
 using System.IO;
 using System.IO.Pipes;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Security.Authentication.ExtendedProtection;
 using System.Security.Principal;
 using System.ServiceProcess;
@@ -376,10 +378,101 @@ namespace MouseWithoutBorders.Class
 
         internal static void StartSettingSyncThread()
         {
-            var serverTaskCancellationSource = new CancellationTokenSource();
-            CancellationToken cancellationToken = serverTaskCancellationSource.Token;
+            using var currentIdentity = WindowsIdentity.GetCurrent();
+            var processUserSid = currentIdentity.User;
+            if (processUserSid == null)
+            {
+                Logger.Log("Settings IPC v2 cannot determine the process user SID.");
+                return;
+            }
 
-            IpcChannel<SettingsSyncHelper>.StartIpcServer("MouseWithoutBorders/SettingsSync", cancellationToken);
+            var sessionId = Process.GetCurrentProcess().SessionId;
+            SecurityIdentifier currentUserSid;
+            try
+            {
+                currentUserSid = ResolveSettingsIpcUserSid(processUserSid, sessionId, GetInteractiveSessionUserSid);
+            }
+            catch (Exception e)
+            {
+                Logger.Log($"Settings IPC v2 cannot determine the interactive user SID: {e}");
+                return;
+            }
+
+            try
+            {
+                GrantSettingsIpcProcessQueryAccessIfNeeded(
+                    processUserSid,
+                    currentUserSid,
+                    MouseWithoutBordersIpc.GrantCurrentProcessQueryAccess);
+            }
+            catch (Exception e)
+            {
+                Logger.Log($"Settings IPC v2 cannot grant process query access to the interactive user: {e}");
+                return;
+            }
+
+            IpcChannel<SettingsSyncHelper>.StartVerifiedIpcServer(
+                MouseWithoutBordersIpc.GetSettingsSyncPipeName(sessionId),
+                currentUserSid,
+                stream => NamedPipePeerVerification.TryVerifyClient(
+                    stream,
+                    MouseWithoutBordersIpc.SettingsExecutableFileName,
+                    currentUserSid.Value,
+                    sessionId,
+                    out var rejectionReason)
+                    ? string.Empty
+                    : rejectionReason,
+                CancellationToken.None);
+        }
+
+        internal static SecurityIdentifier ResolveSettingsIpcUserSid(
+            SecurityIdentifier processUserSid,
+            int sessionId,
+            Func<int, SecurityIdentifier> interactiveUserSidResolver)
+        {
+            ArgumentNullException.ThrowIfNull(processUserSid);
+            ArgumentNullException.ThrowIfNull(interactiveUserSidResolver);
+
+            return processUserSid.IsWellKnown(WellKnownSidType.LocalSystemSid)
+                ? interactiveUserSidResolver(sessionId) ?? throw new InvalidOperationException("The interactive session has no user SID.")
+                : processUserSid;
+        }
+
+        internal static void GrantSettingsIpcProcessQueryAccessIfNeeded(
+            SecurityIdentifier processUserSid,
+            SecurityIdentifier interactiveUserSid,
+            Action<SecurityIdentifier> grantAccess)
+        {
+            ArgumentNullException.ThrowIfNull(processUserSid);
+            ArgumentNullException.ThrowIfNull(interactiveUserSid);
+            ArgumentNullException.ThrowIfNull(grantAccess);
+
+            if (processUserSid.IsWellKnown(WellKnownSidType.LocalSystemSid))
+            {
+                grantAccess(interactiveUserSid);
+            }
+        }
+
+        private static SecurityIdentifier GetInteractiveSessionUserSid(int sessionId)
+        {
+            IntPtr userToken = IntPtr.Zero;
+            try
+            {
+                if (NativeMethods.WTSQueryUserToken(unchecked((uint)sessionId), ref userToken) == 0)
+                {
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                }
+
+                using var interactiveIdentity = new WindowsIdentity(userToken);
+                return interactiveIdentity.User ?? throw new InvalidOperationException("The interactive session token has no user SID.");
+            }
+            finally
+            {
+                if (userToken != IntPtr.Zero)
+                {
+                    _ = NativeMethods.CloseHandle(userToken);
+                }
+            }
         }
 
         internal static void StartInputCallbackThread()

--- a/src/modules/MouseWithoutBorders/MouseWithoutBorders.UnitTests/IpcSerializationCompatibilityTests.cs
+++ b/src/modules/MouseWithoutBorders/MouseWithoutBorders.UnitTests/IpcSerializationCompatibilityTests.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MouseWithoutBorders.Class;
+using Newtonsoft.Json;
+
+namespace MouseWithoutBorders.UnitTests;
+
+[TestClass]
+public sealed class IpcSerializationCompatibilityTests
+{
+    [TestMethod]
+    public void SettingsSyncPayloadKeepsExistingJsonShape()
+    {
+        var contract = typeof(Program).GetNestedType("ISettingsSyncHelper", BindingFlags.NonPublic);
+        var stateType = contract!.GetNestedType("MachineSocketState");
+        var state = Activator.CreateInstance(stateType!);
+        stateType!.GetField("Name")!.SetValue(state, "PC");
+        stateType.GetField("Status")!.SetValue(state, Enum.ToObject(stateType.GetField("Status")!.FieldType, 9));
+
+        Assert.AreEqual("""{"Name":"PC","Status":9}""", JsonConvert.SerializeObject(state));
+    }
+}

--- a/src/modules/MouseWithoutBorders/MouseWithoutBorders.UnitTests/SettingsIpcIdentityTests.cs
+++ b/src/modules/MouseWithoutBorders/MouseWithoutBorders.UnitTests/SettingsIpcIdentityTests.cs
@@ -1,0 +1,272 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Pipes;
+using System.Security.Principal;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.PowerToys.Settings.UI.Library.Utilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MouseWithoutBorders.Class;
+
+namespace MouseWithoutBorders.UnitTests;
+
+[TestClass]
+public sealed class SettingsIpcIdentityTests
+{
+    [TestMethod]
+    public void CurrentUserProcessUsesItsOwnSid()
+    {
+        using var identity = WindowsIdentity.GetCurrent();
+        var processSid = identity.User!;
+        var resolverCalled = false;
+
+        var result = Program.ResolveSettingsIpcUserSid(
+            processSid,
+            42,
+            _ =>
+            {
+                resolverCalled = true;
+                return processSid;
+            });
+
+        Assert.AreEqual(processSid, result);
+        Assert.IsFalse(resolverCalled);
+    }
+
+    [TestMethod]
+    public void SystemProcessUsesInteractiveSessionSid()
+    {
+        var systemSid = new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null);
+        var interactiveSid = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null);
+        var resolvedSessionId = -1;
+
+        var result = Program.ResolveSettingsIpcUserSid(
+            systemSid,
+            42,
+            sessionId =>
+            {
+                resolvedSessionId = sessionId;
+                return interactiveSid;
+            });
+
+        Assert.AreEqual(interactiveSid, result);
+        Assert.AreEqual(42, resolvedSessionId);
+    }
+
+    [TestMethod]
+    public void SystemProcessGrantsInteractiveUserQueryAccess()
+    {
+        var systemSid = new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null);
+        var interactiveSid = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null);
+        SecurityIdentifier? grantedSid = null;
+
+        Program.GrantSettingsIpcProcessQueryAccessIfNeeded(systemSid, interactiveSid, sid => grantedSid = sid);
+
+        Assert.AreEqual(interactiveSid, grantedSid);
+    }
+
+    [TestMethod]
+    public void UserProcessKeepsItsExistingProcessDacl()
+    {
+        var userSid = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null);
+        var grantCount = 0;
+
+        Program.GrantSettingsIpcProcessQueryAccessIfNeeded(userSid, userSid, _ => grantCount++);
+
+        Assert.AreEqual(0, grantCount);
+    }
+
+    [TestMethod]
+    public void MissingVerifierIsRejectedBeforeListenerStarts()
+    {
+        using var identity = WindowsIdentity.GetCurrent();
+
+        Assert.ThrowsException<ArgumentNullException>(() =>
+            IpcChannel<TestRpcTarget>.StartVerifiedIpcServer(
+                $"PowerToys.MWB.v2.UnitTest.{Guid.NewGuid():N}",
+                identity.User!,
+                null!,
+                CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task ProductionVerifiedServerAcceptsReconnect()
+    {
+        var pipeName = $"PowerToys.MWB.v2.UnitTest.{Environment.ProcessId}.{Guid.NewGuid():N}";
+        using var identity = WindowsIdentity.GetCurrent();
+        using var cancellation = new CancellationTokenSource();
+        var executablePath = GetCurrentExecutablePath();
+        var sessionId = Process.GetCurrentProcess().SessionId;
+
+        TestRpcTarget.Reset();
+        IpcChannel<TestRpcTarget>.StartVerifiedIpcServer(
+            pipeName,
+            identity.User!,
+            stream => VerifyCurrentProcessClient(stream, Path.GetFileName(executablePath), identity.User!.Value, sessionId),
+            cancellation.Token);
+
+        for (var attempt = 0; attempt < 2; attempt++)
+        {
+            await using var client = await ConnectVerifiedClientAsync(
+                pipeName,
+                Path.GetFileName(executablePath),
+                identity.User!.Value,
+                sessionId);
+            Assert.IsTrue(client.IsConnected);
+            Assert.IsTrue(SpinWait.SpinUntil(() => TestRpcTarget.InstanceCount == attempt + 1, TimeSpan.FromSeconds(5)));
+        }
+
+        cancellation.Cancel();
+    }
+
+    [TestMethod]
+    public async Task RejectedClientDoesNotDispatchBeforeVerification()
+    {
+        var pipeName = $"PowerToys.MWB.v2.UnitTest.{Environment.ProcessId}.{Guid.NewGuid():N}";
+        using var identity = WindowsIdentity.GetCurrent();
+        using var cancellation = new CancellationTokenSource();
+        var executablePath = GetCurrentExecutablePath();
+        var sessionId = Process.GetCurrentProcess().SessionId;
+        var verifyCallCount = 0;
+
+        TestRpcTarget.Reset();
+        IpcChannel<TestRpcTarget>.StartVerifiedIpcServer(
+            pipeName,
+            identity.User!,
+            stream =>
+            {
+                var verifyAttempt = Interlocked.Increment(ref verifyCallCount);
+                return verifyAttempt == 1
+                    ? "blocked-for-test"
+                    : VerifyCurrentProcessClient(stream, Path.GetFileName(executablePath), identity.User!.Value, sessionId);
+            },
+            cancellation.Token);
+
+        await using (var rejectedClient = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous))
+        {
+            await rejectedClient.ConnectAsync(5000);
+            Assert.IsTrue(SpinWait.SpinUntil(() => Volatile.Read(ref verifyCallCount) == 1, TimeSpan.FromSeconds(5)));
+            Assert.AreEqual(0, TestRpcTarget.InstanceCount);
+        }
+
+        await using var acceptedClient = await ConnectVerifiedClientAsync(
+            pipeName,
+            Path.GetFileName(executablePath),
+            identity.User!.Value,
+            sessionId);
+        Assert.IsTrue(SpinWait.SpinUntil(() => TestRpcTarget.InstanceCount == 1, TimeSpan.FromSeconds(5)));
+        Assert.AreEqual(2, Volatile.Read(ref verifyCallCount));
+        cancellation.Cancel();
+    }
+
+    [TestMethod]
+    public async Task ProductionServerRecoversAfterPipeNameBecomesAvailable()
+    {
+        var pipeName = $"PowerToys.MWB.v2.UnitTest.{Environment.ProcessId}.{Guid.NewGuid():N}";
+        using var identity = WindowsIdentity.GetCurrent();
+        using var cancellation = new CancellationTokenSource();
+        var executablePath = GetCurrentExecutablePath();
+        var sessionId = Process.GetCurrentProcess().SessionId;
+        var initialCreationFailure = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using (var occupyingServer = RestrictedNamedPipeServer.Create(pipeName, identity.User!))
+        {
+            IpcChannel<TestRpcTarget>.StartVerifiedIpcServer(
+                pipeName,
+                identity.User!,
+                stream => VerifyCurrentProcessClient(stream, Path.GetFileName(executablePath), identity.User!.Value, sessionId),
+                _ => initialCreationFailure.TrySetResult(),
+                cancellation.Token);
+            await initialCreationFailure.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+
+        await using var client = await ConnectVerifiedClientAsync(
+            pipeName,
+            Path.GetFileName(executablePath),
+            identity.User!.Value,
+            sessionId);
+
+        Assert.IsTrue(client.IsConnected);
+        cancellation.Cancel();
+    }
+
+    private static async Task<NamedPipeClientStream> ConnectVerifiedClientAsync(
+        string pipeName,
+        string expectedServerFileName,
+        string expectedUserSid,
+        int expectedSessionId)
+    {
+        var stream = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+        try
+        {
+            await stream.ConnectAsync(5000);
+            if (!NamedPipePeerVerification.TryVerifyServer(
+                    stream,
+                    expectedServerFileName,
+                    expectedUserSid,
+                    expectedSessionId,
+                    allowLocalSystem: false,
+                    out var rejectionReason))
+            {
+                throw new UnauthorizedAccessException($"Rejected named pipe server: {rejectionReason}");
+            }
+
+            return stream;
+        }
+        catch
+        {
+            await stream.DisposeAsync();
+            throw;
+        }
+    }
+
+    private static string VerifyCurrentProcessClient(
+        NamedPipeServerStream stream,
+        string expectedClientFileName,
+        string expectedUserSid,
+        int expectedSessionId)
+    {
+        return NamedPipePeerVerification.TryVerifyClient(
+            stream,
+            expectedClientFileName,
+            expectedUserSid,
+            expectedSessionId,
+            out var rejectionReason)
+            ? string.Empty
+            : rejectionReason;
+    }
+
+    private static string GetCurrentExecutablePath()
+    {
+        return Process.GetCurrentProcess().MainModule?.FileName
+            ?? Environment.ProcessPath
+            ?? throw new InvalidOperationException("The current process has no executable path.");
+    }
+
+    private sealed class TestRpcTarget
+    {
+        private static int _instanceCount;
+
+        public TestRpcTarget()
+        {
+            Interlocked.Increment(ref _instanceCount);
+        }
+
+        public static int InstanceCount => Volatile.Read(ref _instanceCount);
+
+        public static void Reset()
+        {
+            Interlocked.Exchange(ref _instanceCount, 0);
+        }
+
+        public void Ping()
+        {
+        }
+    }
+}

--- a/src/settings-ui/Settings.UI.Library/Utilities/MouseWithoutBordersIpc.cs
+++ b/src/settings-ui/Settings.UI.Library/Utilities/MouseWithoutBordersIpc.cs
@@ -1,0 +1,209 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel;
+using System.IO.Pipes;
+using System.Runtime.InteropServices;
+using System.Security.Principal;
+
+using Microsoft.Win32.SafeHandles;
+
+#pragma warning disable SA1402 // Mouse Without Borders IPC helpers stay together intentionally.
+
+namespace Microsoft.PowerToys.Settings.UI.Library.Utilities
+{
+    public static class MouseWithoutBordersIpc
+    {
+        public const string SettingsSyncProtocol = "PowerToys.MouseWithoutBorders.v2.SettingsSync";
+        public const string SettingsExecutableFileName = "PowerToys.Settings.exe";
+        public const string MouseWithoutBordersExecutableFileName = "PowerToys.MouseWithoutBorders.exe";
+
+        public static string GetSettingsSyncPipeName(int sessionId)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(sessionId);
+
+            return $"{SettingsSyncProtocol}.Session.{sessionId}";
+        }
+
+        public static void GrantCurrentProcessQueryAccess(SecurityIdentifier allowedUser)
+        {
+            ArgumentNullException.ThrowIfNull(allowedUser);
+
+            using var processToken = OpenCurrentProcessTokenForDaclUpdate();
+            SetKernelObjectDacl(
+                processToken.DangerousGetHandle(),
+                $"D:P(A;;0x{MouseWithoutBordersIpcNativeMethods.TokenQuery:X};;;{allowedUser.Value})(A;;GA;;;SY)(A;;GA;;;BA)");
+            SetKernelObjectDacl(
+                MouseWithoutBordersIpcNativeMethods.GetCurrentProcess(),
+                $"D:P(A;;0x{MouseWithoutBordersIpcNativeMethods.ProcessQueryLimitedInformation:X};;;{allowedUser.Value})(A;;GA;;;SY)(A;;GA;;;BA)");
+        }
+
+        private static SafeAccessTokenHandle OpenCurrentProcessTokenForDaclUpdate()
+        {
+            if (!MouseWithoutBordersIpcNativeMethods.OpenCurrentProcessToken(
+                    MouseWithoutBordersIpcNativeMethods.GetCurrentProcess(),
+                    MouseWithoutBordersIpcNativeMethods.TokenQuery | MouseWithoutBordersIpcNativeMethods.ReadControl | MouseWithoutBordersIpcNativeMethods.WriteDac,
+                    out var processToken))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            return processToken;
+        }
+
+        private static void SetKernelObjectDacl(IntPtr handle, string sddl)
+        {
+            if (!MouseWithoutBordersIpcNativeMethods.ConvertStringSecurityDescriptorToSecurityDescriptor(
+                    sddl,
+                    MouseWithoutBordersIpcNativeMethods.SddlRevision1,
+                    out var securityDescriptor,
+                    out _))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            try
+            {
+                if (!MouseWithoutBordersIpcNativeMethods.SetKernelObjectSecurity(
+                        handle,
+                        MouseWithoutBordersIpcNativeMethods.DaclSecurityInformation,
+                        securityDescriptor))
+                {
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                }
+            }
+            finally
+            {
+                MouseWithoutBordersIpcNativeMethods.LocalFree(securityDescriptor);
+            }
+        }
+    }
+
+    public static class RestrictedNamedPipeServer
+    {
+        public static NamedPipeServerStream Create(string pipeName, SecurityIdentifier allowedUser)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(pipeName);
+            ArgumentNullException.ThrowIfNull(allowedUser);
+
+            var systemSid = new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null);
+            var sddl = $"D:P(A;;GA;;;{allowedUser.Value})";
+            if (!allowedUser.Equals(systemSid))
+            {
+                sddl += $"(A;;GA;;;{systemSid.Value})";
+            }
+
+            if (!MouseWithoutBordersIpcNativeMethods.ConvertStringSecurityDescriptorToSecurityDescriptor(
+                    sddl,
+                    MouseWithoutBordersIpcNativeMethods.SddlRevision1,
+                    out var securityDescriptor,
+                    out _))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            try
+            {
+                var securityAttributes = new MouseWithoutBordersIpcNativeMethods.SecurityAttributes
+                {
+                    Length = Marshal.SizeOf<MouseWithoutBordersIpcNativeMethods.SecurityAttributes>(),
+                    SecurityDescriptor = securityDescriptor,
+                    InheritHandle = false,
+                };
+
+                var handle = MouseWithoutBordersIpcNativeMethods.CreateNamedPipe(
+                    $@"\\.\pipe\{pipeName}",
+                    MouseWithoutBordersIpcNativeMethods.PipeAccessDuplex | MouseWithoutBordersIpcNativeMethods.FileFlagOverlapped | MouseWithoutBordersIpcNativeMethods.FileFlagFirstPipeInstance,
+                    MouseWithoutBordersIpcNativeMethods.PipeTypeByte | MouseWithoutBordersIpcNativeMethods.PipeReadModeByte | MouseWithoutBordersIpcNativeMethods.PipeWait | MouseWithoutBordersIpcNativeMethods.PipeRejectRemoteClients,
+                    1,
+                    4096,
+                    4096,
+                    0,
+                    ref securityAttributes);
+
+                if (handle.IsInvalid)
+                {
+                    var error = Marshal.GetLastWin32Error();
+                    handle.Dispose();
+                    throw new Win32Exception(error);
+                }
+
+                return new NamedPipeServerStream(PipeDirection.InOut, true, false, handle);
+            }
+            finally
+            {
+                MouseWithoutBordersIpcNativeMethods.LocalFree(securityDescriptor);
+            }
+        }
+    }
+
+    internal static class MouseWithoutBordersIpcNativeMethods
+    {
+        internal const uint ProcessQueryLimitedInformation = 0x1000;
+        internal const uint TokenQuery = 0x0008;
+        internal const uint ReadControl = 0x00020000;
+        internal const uint WriteDac = 0x00040000;
+        internal const uint PipeAccessDuplex = 0x00000003;
+        internal const uint FileFlagFirstPipeInstance = 0x00080000;
+        internal const uint FileFlagOverlapped = 0x40000000;
+        internal const uint PipeTypeByte = 0x00000000;
+        internal const uint PipeReadModeByte = 0x00000000;
+        internal const uint PipeWait = 0x00000000;
+        internal const uint PipeRejectRemoteClients = 0x00000008;
+        internal const uint SddlRevision1 = 1;
+        internal const uint DaclSecurityInformation = 0x00000004;
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct SecurityAttributes
+        {
+            internal int Length;
+            internal IntPtr SecurityDescriptor;
+
+            [MarshalAs(UnmanagedType.Bool)]
+            internal bool InheritHandle;
+        }
+
+        [DllImport("kernel32.dll", EntryPoint = "CreateNamedPipeW", CharSet = CharSet.Unicode, SetLastError = true)]
+        internal static extern SafePipeHandle CreateNamedPipe(
+            string name,
+            uint openMode,
+            uint pipeMode,
+            uint maxInstances,
+            uint outBufferSize,
+            uint inBufferSize,
+            uint defaultTimeout,
+            ref SecurityAttributes securityAttributes);
+
+        [DllImport("advapi32.dll", EntryPoint = "ConvertStringSecurityDescriptorToSecurityDescriptorW", CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool ConvertStringSecurityDescriptorToSecurityDescriptor(
+            string stringSecurityDescriptor,
+            uint stringSdRevision,
+            out IntPtr securityDescriptor,
+            out uint securityDescriptorSize);
+
+        [DllImport("kernel32.dll")]
+        internal static extern IntPtr LocalFree(IntPtr memory);
+
+        [DllImport("kernel32.dll")]
+        internal static extern IntPtr GetCurrentProcess();
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool SetKernelObjectSecurity(
+            IntPtr handle,
+            uint securityInformation,
+            IntPtr securityDescriptor);
+
+        [DllImport("advapi32.dll", EntryPoint = "OpenProcessToken", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool OpenCurrentProcessToken(
+            IntPtr processHandle,
+            uint desiredAccess,
+            out SafeAccessTokenHandle tokenHandle);
+    }
+}
+
+#pragma warning restore SA1402

--- a/src/settings-ui/Settings.UI.Library/Utilities/NamedPipePeerVerification.cs
+++ b/src/settings-ui/Settings.UI.Library/Utilities/NamedPipePeerVerification.cs
@@ -1,0 +1,718 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.IO.Pipes;
+using System.Reflection.PortableExecutable;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Principal;
+
+using Microsoft.Win32.SafeHandles;
+
+namespace Microsoft.PowerToys.Settings.UI.Library.Utilities
+{
+    public static class NamedPipePeerVerification
+    {
+        public static bool TryVerifyClient(
+            NamedPipeServerStream stream,
+            string expectedExeName,
+            string intendedUserSid,
+            int intendedSessionId,
+            out string rejectionReason)
+        {
+            ArgumentNullException.ThrowIfNull(stream);
+            ValidateExpectedPeer(expectedExeName, intendedUserSid);
+
+            if (!stream.IsConnected)
+            {
+                rejectionReason = "pipe-not-connected";
+                return false;
+            }
+
+            if (!NativeMethods.GetNamedPipeClientProcessId(stream.SafePipeHandle, out var processId))
+            {
+                rejectionReason = "client-pid-unavailable";
+                return false;
+            }
+
+            return TryVerifyPeerProcess(
+                processId,
+                expectedExeName,
+                intendedUserSid,
+                intendedSessionId,
+                allowLocalSystem: false,
+                out rejectionReason);
+        }
+
+        public static bool TryVerifyServer(
+            NamedPipeClientStream stream,
+            string expectedExeName,
+            string intendedUserSid,
+            int intendedSessionId,
+            bool allowLocalSystem,
+            out string rejectionReason)
+        {
+            ArgumentNullException.ThrowIfNull(stream);
+            ValidateExpectedPeer(expectedExeName, intendedUserSid);
+
+            if (!stream.IsConnected)
+            {
+                rejectionReason = "pipe-not-connected";
+                return false;
+            }
+
+            if (!NativeMethods.GetNamedPipeServerProcessId(stream.SafePipeHandle, out var processId))
+            {
+                rejectionReason = "server-pid-unavailable";
+                return false;
+            }
+
+            return TryVerifyPeerProcess(
+                processId,
+                expectedExeName,
+                intendedUserSid,
+                intendedSessionId,
+                allowLocalSystem,
+                out rejectionReason);
+        }
+
+        private static void ValidateExpectedPeer(string expectedExeName, string intendedUserSid)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(expectedExeName);
+            ArgumentException.ThrowIfNullOrWhiteSpace(intendedUserSid);
+
+            if (!string.Equals(Path.GetFileName(expectedExeName), expectedExeName, StringComparison.Ordinal))
+            {
+                throw new ArgumentException("The expected executable name must not include a directory path.", nameof(expectedExeName));
+            }
+        }
+
+        private static bool TryVerifyPeerProcess(
+            uint processId,
+            string expectedExeName,
+            string intendedUserSid,
+            int intendedSessionId,
+            bool allowLocalSystem,
+            out string rejectionReason)
+        {
+            try
+            {
+                using var processHandle = NativeMethods.OpenProcess(NativeMethods.ProcessQueryLimitedInformation, false, processId);
+                if (processHandle.IsInvalid)
+                {
+                    rejectionReason = "identity-unavailable";
+                    return false;
+                }
+
+                // Hold the process handle through the full check so the PID cannot be reused mid-verification.
+                if (!NativeMethods.GetProcessTimes(processHandle, out var creationTime, out _, out _, out _))
+                {
+                    rejectionReason = "identity-unavailable";
+                    return false;
+                }
+
+                if (creationTime.ToLong() == 0)
+                {
+                    rejectionReason = "invalid-process-instance";
+                    return false;
+                }
+
+                if (!NativeMethods.ProcessIdToSessionId(processId, out var actualSessionId))
+                {
+                    rejectionReason = "identity-unavailable";
+                    return false;
+                }
+
+                var actualImagePath = NativeMethods.GetProcessImagePath(processHandle);
+                var ownImagePath = Environment.ProcessPath ?? throw new InvalidOperationException("The current process has no executable path.");
+
+                if (!NativeMethods.OpenProcessToken(processHandle, NativeMethods.TokenQuery, out var tokenHandle))
+                {
+                    rejectionReason = "identity-unavailable";
+                    return false;
+                }
+
+                string actualUserSid;
+                using (tokenHandle)
+                using (var identity = new WindowsIdentity(tokenHandle.DangerousGetHandle()))
+                {
+                    actualUserSid = identity.User?.Value ?? throw new InvalidOperationException("The process token has no user SID.");
+                }
+
+                if (unchecked((int)actualSessionId) != intendedSessionId)
+                {
+                    rejectionReason = "wrong-session";
+                    return false;
+                }
+
+                var isLocalSystem = string.Equals(
+                    actualUserSid,
+                    new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null).Value,
+                    StringComparison.OrdinalIgnoreCase);
+                if (!string.Equals(actualUserSid, intendedUserSid, StringComparison.OrdinalIgnoreCase) &&
+                    !(allowLocalSystem && isLocalSystem))
+                {
+                    rejectionReason = "wrong-user";
+                    return false;
+                }
+
+                if (!TryVerifyPeerExecutableIdentity(
+                        actualImagePath,
+                        expectedExeName,
+                        out var actualFullPath,
+                        out rejectionReason))
+                {
+                    return false;
+                }
+
+                if (!MeetsSigningPolicy(ownImagePath, actualFullPath))
+                {
+                    rejectionReason = "untrusted-signature";
+                    return false;
+                }
+
+                rejectionReason = string.Empty;
+                return true;
+            }
+            catch (Win32Exception)
+            {
+                rejectionReason = "identity-unavailable";
+                return false;
+            }
+            catch (InvalidOperationException)
+            {
+                rejectionReason = "identity-unavailable";
+                return false;
+            }
+        }
+
+        private static bool TryVerifyPeerExecutableIdentity(
+            string peerImagePath,
+            string expectedExeName,
+            out string resolvedPeerImagePath,
+            out string rejectionReason)
+        {
+            var ownImagePath = Environment.ProcessPath ?? throw new InvalidOperationException("The current process has no executable path.");
+            return TryVerifyPeerExecutableIdentity(peerImagePath, ownImagePath, expectedExeName, out resolvedPeerImagePath, out rejectionReason);
+        }
+
+        private static bool TryVerifyPeerExecutableIdentity(
+            string peerImagePath,
+            string ownImagePath,
+            string expectedExeName,
+            out string resolvedPeerImagePath,
+            out string rejectionReason)
+        {
+            resolvedPeerImagePath = string.Empty;
+            var normalizedPeerImagePath = Path.GetFullPath(peerImagePath);
+            var normalizedOwnImagePath = Path.GetFullPath(ownImagePath);
+
+            if (!string.Equals(Path.GetFileName(normalizedPeerImagePath), expectedExeName, StringComparison.OrdinalIgnoreCase))
+            {
+                rejectionReason = "wrong-image";
+                return false;
+            }
+
+            if (!HaveEqualOrNestedDirectories(
+                    Path.GetDirectoryName(normalizedOwnImagePath) ?? throw new InvalidOperationException("The current process has no executable directory."),
+                    Path.GetDirectoryName(normalizedPeerImagePath) ?? throw new InvalidOperationException("The peer process has no executable directory.")))
+            {
+                rejectionReason = "wrong-image";
+                return false;
+            }
+
+            resolvedPeerImagePath = normalizedPeerImagePath;
+            rejectionReason = string.Empty;
+            return true;
+        }
+
+        private static bool HaveEqualOrNestedDirectories(string firstDirectory, string secondDirectory)
+        {
+            var normalizedFirst = NormalizeDirectoryPath(firstDirectory);
+            var normalizedSecond = NormalizeDirectoryPath(secondDirectory);
+
+            return string.Equals(normalizedFirst, normalizedSecond, StringComparison.OrdinalIgnoreCase) ||
+                IsNestedDirectory(normalizedFirst, normalizedSecond) ||
+                IsNestedDirectory(normalizedSecond, normalizedFirst);
+        }
+
+        private static string NormalizeDirectoryPath(string directoryPath)
+        {
+            return Path.GetFullPath(directoryPath)
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        }
+
+        private static bool IsNestedDirectory(string candidateDirectory, string parentDirectory)
+        {
+            var normalizedParent = parentDirectory + Path.DirectorySeparatorChar;
+            return candidateDirectory.Length > normalizedParent.Length &&
+                candidateDirectory.StartsWith(normalizedParent, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool MeetsSigningPolicy(string ownImagePath, string peerImagePath)
+        {
+            if (!TryHasEmbeddedAuthenticodeSignature(ownImagePath, out var ownHasEmbeddedSignature))
+            {
+                return false;
+            }
+
+            return !ownHasEmbeddedSignature || HaveSameTrustedMicrosoftSigner(ownImagePath, peerImagePath);
+        }
+
+        private static bool TryHasEmbeddedAuthenticodeSignature(string imagePath, out bool hasEmbeddedSignature)
+        {
+            hasEmbeddedSignature = false;
+            try
+            {
+                using var image = File.OpenRead(imagePath);
+                using var reader = new PEReader(image);
+                var header = reader.PEHeaders.PEHeader;
+                if (header == null)
+                {
+                    return false;
+                }
+
+                // A malformed signature must not be mistaken for an unsigned development binary.
+                var certificateTable = header.CertificateTableDirectory;
+                hasEmbeddedSignature = certificateTable.RelativeVirtualAddress != 0 || certificateTable.Size != 0;
+                return true;
+            }
+            catch (IOException)
+            {
+                return false;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return false;
+            }
+            catch (BadImageFormatException)
+            {
+                return false;
+            }
+        }
+
+        private static bool HaveSameTrustedMicrosoftSigner(string firstImagePath, string secondImagePath)
+        {
+            X509Certificate2 firstSigner = null;
+            X509Certificate2 secondSigner = null;
+
+            try
+            {
+                if (!TryGetTrustedMicrosoftSignerCertificate(firstImagePath, out firstSigner) ||
+                    !TryGetTrustedMicrosoftSignerCertificate(secondImagePath, out secondSigner))
+                {
+                    return false;
+                }
+
+                return HaveMatchingSignerCertificate(firstSigner, secondSigner);
+            }
+            finally
+            {
+                firstSigner?.Dispose();
+                secondSigner?.Dispose();
+            }
+        }
+
+        private static bool HaveMatchingSignerCertificate(X509Certificate2 firstSigner, X509Certificate2 secondSigner)
+        {
+            ArgumentNullException.ThrowIfNull(firstSigner);
+            ArgumentNullException.ThrowIfNull(secondSigner);
+
+            return CryptographicOperations.FixedTimeEquals(firstSigner.RawData, secondSigner.RawData);
+        }
+
+        private static bool HasTrustedMicrosoftSignature(string imagePath)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(imagePath);
+
+            X509Certificate2 signer = null;
+            try
+            {
+                return TryGetTrustedMicrosoftSignerCertificate(imagePath, out signer);
+            }
+            finally
+            {
+                signer?.Dispose();
+            }
+        }
+
+        private static bool TryGetTrustedMicrosoftSignerCertificate(string imagePath, out X509Certificate2 signer)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(imagePath);
+
+            signer = null;
+
+            try
+            {
+                if (!TryVerifyAuthenticodeSignature(imagePath, out var verificationTime))
+                {
+                    return false;
+                }
+
+#pragma warning disable SYSLIB0057 // Embedded Authenticode signer extraction has no X509CertificateLoader equivalent.
+                using var imageSigner = new X509Certificate2(X509Certificate.CreateFromSignedFile(imagePath));
+#pragma warning restore SYSLIB0057
+                if (!imageSigner.Subject.Contains("Microsoft Corporation", StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+
+                using var roots = new X509Store(StoreName.Root, StoreLocation.LocalMachine);
+                roots.Open(OpenFlags.ReadOnly);
+
+                using var chain = new X509Chain();
+                chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+                chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+
+                // Check lifetime at the same current time or validated timestamp that Windows used.
+                chain.ChainPolicy.VerificationTime = verificationTime;
+                chain.ChainPolicy.ApplicationPolicy.Add(new Oid("1.3.6.1.5.5.7.3.3"));
+
+                var rootCertificates = roots.Certificates;
+                try
+                {
+                    chain.ChainPolicy.CustomTrustStore.AddRange(rootCertificates);
+
+                    if (TryGetEmbeddedPkcs7Store(imagePath, out var store, out var message))
+                    {
+                        using (store)
+                        using (message)
+                        using (var embeddedStore = new X509Store(store.DangerousGetHandle()))
+                        {
+                            var extraCertificates = embeddedStore.Certificates;
+                            try
+                            {
+                                chain.ChainPolicy.ExtraStore.AddRange(extraCertificates);
+                                if (!chain.Build(imageSigner))
+                                {
+                                    return false;
+                                }
+
+                                signer = X509CertificateLoader.LoadCertificate(imageSigner.RawData);
+                                return true;
+                            }
+                            finally
+                            {
+                                DisposeCertificates(extraCertificates);
+                            }
+                        }
+                    }
+
+                    if (!chain.Build(imageSigner))
+                    {
+                        return false;
+                    }
+
+                    signer = X509CertificateLoader.LoadCertificate(imageSigner.RawData);
+                    return true;
+                }
+                finally
+                {
+                    DisposeCertificates(rootCertificates);
+                }
+            }
+            catch (CryptographicException)
+            {
+                signer?.Dispose();
+                signer = null;
+                return false;
+            }
+        }
+
+        private static void DisposeCertificates(X509Certificate2Collection certificates)
+        {
+            foreach (var certificate in certificates)
+            {
+                certificate.Dispose();
+            }
+        }
+
+        private static bool HasIntactAuthenticodeSignature(string imagePath)
+        {
+            return TryVerifyAuthenticodeSignature(imagePath, out _);
+        }
+
+        private static bool TryVerifyAuthenticodeSignature(string imagePath, out DateTime verificationTime)
+        {
+            verificationTime = default;
+            var fileInfo = new WinTrustFileInfo
+            {
+                StructSize = unchecked((uint)Marshal.SizeOf<WinTrustFileInfo>()),
+                FilePath = imagePath,
+            };
+            var fileInfoPointer = Marshal.AllocHGlobal(Marshal.SizeOf<WinTrustFileInfo>());
+            try
+            {
+                Marshal.StructureToPtr(fileInfo, fileInfoPointer, false);
+                var trustData = new WinTrustData
+                {
+                    StructSize = unchecked((uint)Marshal.SizeOf<WinTrustData>()),
+                    UiChoice = NativeMethods.WinTrustUiNone,
+                    RevocationChecks = NativeMethods.WinTrustRevokeNone,
+                    UnionChoice = NativeMethods.WinTrustChoiceFile,
+                    FileInfo = fileInfoPointer,
+                    StateAction = NativeMethods.WinTrustStateActionVerify,
+                    ProviderFlags = NativeMethods.WinTrustSaferFlag | NativeMethods.WinTrustCacheOnlyUrlRetrieval,
+                };
+
+                var action = NativeMethods.WinTrustActionGenericVerifyV2;
+                var status = NativeMethods.WinVerifyTrust(new IntPtr(-1), ref action, ref trustData);
+                try
+                {
+                    if (status != 0)
+                    {
+                        return false;
+                    }
+
+                    var provider = NativeMethods.WTHelperProvDataFromStateData(trustData.StateData);
+                    if (provider == IntPtr.Zero)
+                    {
+                        return false;
+                    }
+
+                    var signer = NativeMethods.WTHelperGetProvSignerFromChain(provider, 0, false, 0);
+                    if (signer == IntPtr.Zero)
+                    {
+                        return false;
+                    }
+
+                    var signerTime = Marshal.PtrToStructure<WinTrustSignerTime>(signer);
+                    if (signerTime.StructSize < Marshal.SizeOf<WinTrustSignerTime>())
+                    {
+                        return false;
+                    }
+
+                    verificationTime = DateTime.FromFileTimeUtc(signerTime.VerificationTime.ToLong());
+                    return true;
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    return false;
+                }
+                finally
+                {
+                    trustData.StateAction = NativeMethods.WinTrustStateActionClose;
+                    _ = NativeMethods.WinVerifyTrust(new IntPtr(-1), ref action, ref trustData);
+                }
+            }
+            finally
+            {
+                Marshal.DestroyStructure<WinTrustFileInfo>(fileInfoPointer);
+                Marshal.FreeHGlobal(fileInfoPointer);
+            }
+        }
+
+        private static bool TryGetEmbeddedPkcs7Store(
+            string imagePath,
+            out SafeCertStoreHandle store,
+            out SafeCryptMsgHandle message)
+        {
+            if (NativeMethods.CryptQueryObject(
+                    NativeMethods.CertQueryObjectFile,
+                    imagePath,
+                    NativeMethods.CertQueryContentFlagPkcs7SignedEmbed,
+                    NativeMethods.CertQueryFormatFlagBinary,
+                    0,
+                    IntPtr.Zero,
+                    IntPtr.Zero,
+                    IntPtr.Zero,
+                    out store,
+                    out message,
+                    IntPtr.Zero))
+            {
+                return true;
+            }
+
+            store = new SafeCertStoreHandle();
+            message = new SafeCryptMsgHandle();
+            return false;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct FileTime
+        {
+            internal uint LowDateTime;
+            internal uint HighDateTime;
+
+            internal long ToLong()
+            {
+                return unchecked((long)(((ulong)HighDateTime << 32) | LowDateTime));
+            }
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        private struct WinTrustFileInfo
+        {
+            internal uint StructSize;
+            internal string FilePath;
+            internal IntPtr FileHandle;
+            internal IntPtr KnownSubject;
+        }
+
+        // Only the fixed prefix of CRYPT_PROVIDER_SGNR is needed.
+        [StructLayout(LayoutKind.Sequential)]
+        private struct WinTrustSignerTime
+        {
+            internal uint StructSize;
+            internal FileTime VerificationTime;
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        private struct WinTrustData
+        {
+            internal uint StructSize;
+            internal IntPtr PolicyCallbackData;
+            internal IntPtr SipClientData;
+            internal uint UiChoice;
+            internal uint RevocationChecks;
+            internal uint UnionChoice;
+            internal IntPtr FileInfo;
+            internal uint StateAction;
+            internal IntPtr StateData;
+            internal string UrlReference;
+            internal uint ProviderFlags;
+            internal uint UiContext;
+        }
+
+        private sealed class SafeCertStoreHandle : SafeHandleZeroOrMinusOneIsInvalid
+        {
+            public SafeCertStoreHandle()
+                : base(true)
+            {
+            }
+
+            protected override bool ReleaseHandle()
+            {
+                return NativeMethods.CertCloseStore(handle, 0);
+            }
+        }
+
+        private sealed class SafeCryptMsgHandle : SafeHandleZeroOrMinusOneIsInvalid
+        {
+            public SafeCryptMsgHandle()
+                : base(true)
+            {
+            }
+
+            protected override bool ReleaseHandle()
+            {
+                return NativeMethods.CryptMsgClose(handle);
+            }
+        }
+
+        private static class NativeMethods
+        {
+            internal const uint ProcessQueryLimitedInformation = 0x1000;
+            internal const uint TokenQuery = 0x0008;
+            internal const uint WinTrustUiNone = 2;
+            internal const uint WinTrustRevokeNone = 0;
+            internal const uint WinTrustChoiceFile = 1;
+            internal const uint WinTrustStateActionVerify = 1;
+            internal const uint WinTrustStateActionClose = 2;
+            internal const uint WinTrustSaferFlag = 0x100;
+            internal const uint WinTrustCacheOnlyUrlRetrieval = 0x1000;
+            internal const uint CertQueryObjectFile = 0x00000001;
+            internal const uint CertQueryContentFlagPkcs7SignedEmbed = 0x00000400;
+            internal const uint CertQueryFormatFlagBinary = 0x00000002;
+            internal static readonly Guid WinTrustActionGenericVerifyV2 = new("00AAC56B-CD44-11d0-8CC2-00C04FC295EE");
+
+            [DllImport("kernel32.dll", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            internal static extern bool GetNamedPipeClientProcessId(SafePipeHandle pipe, out uint clientProcessId);
+
+            [DllImport("kernel32.dll", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            internal static extern bool GetNamedPipeServerProcessId(SafePipeHandle pipe, out uint serverProcessId);
+
+            [DllImport("kernel32.dll", SetLastError = true)]
+            internal static extern SafeProcessHandle OpenProcess(
+                uint processAccess,
+                [MarshalAs(UnmanagedType.Bool)] bool inheritHandle,
+                uint processId);
+
+            [DllImport("kernel32.dll", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            internal static extern bool GetProcessTimes(
+                SafeProcessHandle process,
+                out FileTime creationTime,
+                out FileTime exitTime,
+                out FileTime kernelTime,
+                out FileTime userTime);
+
+            [DllImport("kernel32.dll", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            internal static extern bool ProcessIdToSessionId(uint processId, out uint sessionId);
+
+            [DllImport("advapi32.dll", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            internal static extern bool OpenProcessToken(
+                SafeProcessHandle processHandle,
+                uint desiredAccess,
+                out SafeAccessTokenHandle tokenHandle);
+
+            [DllImport("kernel32.dll", EntryPoint = "QueryFullProcessImageNameW", CharSet = CharSet.Unicode, SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            private static extern bool QueryFullProcessImageName(
+                SafeProcessHandle process,
+                uint flags,
+                char[] exeName,
+                ref uint size);
+
+            [DllImport("wintrust.dll", ExactSpelling = true, SetLastError = true)]
+            internal static extern int WinVerifyTrust(
+                IntPtr windowHandle,
+                [In] ref Guid actionId,
+                ref WinTrustData trustData);
+
+            [DllImport("wintrust.dll", ExactSpelling = true)]
+            internal static extern IntPtr WTHelperProvDataFromStateData(IntPtr stateData);
+
+            [DllImport("wintrust.dll", ExactSpelling = true)]
+            internal static extern IntPtr WTHelperGetProvSignerFromChain(
+                IntPtr providerData,
+                uint signerIndex,
+                [MarshalAs(UnmanagedType.Bool)] bool counterSigner,
+                uint counterSignerIndex);
+
+            [DllImport("crypt32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            internal static extern bool CryptQueryObject(
+                uint objectType,
+                string @object,
+                uint expectedContentTypeFlags,
+                uint expectedFormatTypeFlags,
+                uint flags,
+                IntPtr messageAndCertEncodingType,
+                IntPtr contentType,
+                IntPtr formatType,
+                out SafeCertStoreHandle certStore,
+                out SafeCryptMsgHandle message,
+                IntPtr context);
+
+            [DllImport("crypt32.dll", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            internal static extern bool CertCloseStore(IntPtr certStore, uint flags);
+
+            [DllImport("crypt32.dll", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            internal static extern bool CryptMsgClose(IntPtr cryptMsg);
+
+            internal static string GetProcessImagePath(SafeProcessHandle process)
+            {
+                var buffer = new char[32768];
+                var length = unchecked((uint)buffer.Length);
+                if (!QueryFullProcessImageName(process, 0, buffer, ref length))
+                {
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                }
+
+                return new string(buffer, 0, unchecked((int)length));
+            }
+        }
+    }
+}

--- a/src/settings-ui/Settings.UI.Library/Utilities/NamedPipePeerVerification.cs
+++ b/src/settings-ui/Settings.UI.Library/Utilities/NamedPipePeerVerification.cs
@@ -366,8 +366,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library.Utilities
                 roots.Open(OpenFlags.ReadOnly);
 
                 using var chain = new X509Chain();
-                chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+                chain.ChainPolicy.RevocationMode = X509RevocationMode.Offline;
                 chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+                chain.ChainPolicy.VerificationFlags = X509VerificationFlags.IgnoreEndRevocationUnknown | X509VerificationFlags.IgnoreCertificateAuthorityRevocationUnknown | X509VerificationFlags.IgnoreRootRevocationUnknown;
 
                 // Check lifetime at the same current time or validated timestamp that Windows used.
                 chain.ChainPolicy.VerificationTime = verificationTime;

--- a/src/settings-ui/Settings.UI.UnitTests/MouseWithoutBordersIpcSecurityTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/MouseWithoutBordersIpcSecurityTests.cs
@@ -1,0 +1,550 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Pipes;
+using System.Reflection;
+using System.Security.AccessControl;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Principal;
+using System.Threading.Tasks;
+
+using Microsoft.PowerToys.Settings.UI.Library.Utilities;
+using Microsoft.PowerToys.Settings.UI.ViewModels;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+
+namespace Microsoft.PowerToys.Settings.UI.UnitTests
+{
+    [TestClass]
+    public sealed class MouseWithoutBordersIpcSecurityTests
+    {
+        [TestMethod]
+        public void PipeNameIsStableAndSessionQualified()
+        {
+            Assert.AreEqual(
+                "PowerToys.MouseWithoutBorders.v2.SettingsSync.Session.42",
+                MouseWithoutBordersIpc.GetSettingsSyncPipeName(42));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => MouseWithoutBordersIpc.GetSettingsSyncPipeName(-1));
+        }
+
+        [TestMethod]
+        public async Task LegitimateSameSessionClientConnectionIsAccepted()
+        {
+            var pair = await CreateConnectedPairAsync();
+            await using var server = pair.Server;
+            await using var client = pair.Client;
+
+            var result = NamedPipePeerVerification.TryVerifyClient(
+                server,
+                Path.GetFileName(GetCurrentExecutablePath()),
+                GetCurrentUserSid(),
+                Process.GetCurrentProcess().SessionId,
+                out var rejectionReason);
+
+            Assert.IsTrue(result, rejectionReason);
+        }
+
+        [TestMethod]
+        public async Task LegitimateSameSessionServerConnectionIsAccepted()
+        {
+            var pair = await CreateConnectedPairAsync();
+            await using var server = pair.Server;
+            await using var client = pair.Client;
+
+            var result = NamedPipePeerVerification.TryVerifyServer(
+                client,
+                Path.GetFileName(GetCurrentExecutablePath()),
+                GetCurrentUserSid(),
+                Process.GetCurrentProcess().SessionId,
+                allowLocalSystem: false,
+                out var rejectionReason);
+
+            Assert.IsTrue(result, rejectionReason);
+        }
+
+        [TestMethod]
+        public async Task UnexpectedClientPathIsRejected()
+        {
+            var pair = await CreateConnectedPairAsync();
+            await using var server = pair.Server;
+            await using var client = pair.Client;
+
+            var accepted = NamedPipePeerVerification.TryVerifyClient(
+                server,
+                "unexpected-settings.exe",
+                GetCurrentUserSid(),
+                Process.GetCurrentProcess().SessionId,
+                out var rejectionReason);
+
+            Assert.IsFalse(accepted);
+            Assert.AreEqual("wrong-image", rejectionReason);
+        }
+
+        [TestMethod]
+        public async Task UnexpectedClientUserIsRejected()
+        {
+            var pair = await CreateConnectedPairAsync();
+            await using var server = pair.Server;
+            await using var client = pair.Client;
+
+            var accepted = NamedPipePeerVerification.TryVerifyClient(
+                server,
+                Path.GetFileName(GetCurrentExecutablePath()),
+                new SecurityIdentifier(WellKnownSidType.AnonymousSid, null).Value,
+                Process.GetCurrentProcess().SessionId,
+                out var rejectionReason);
+
+            Assert.IsFalse(accepted);
+            Assert.AreEqual("wrong-user", rejectionReason);
+        }
+
+        [TestMethod]
+        public async Task UnexpectedClientSessionIsRejected()
+        {
+            var pair = await CreateConnectedPairAsync();
+            await using var server = pair.Server;
+            await using var client = pair.Client;
+
+            var accepted = NamedPipePeerVerification.TryVerifyClient(
+                server,
+                Path.GetFileName(GetCurrentExecutablePath()),
+                GetCurrentUserSid(),
+                Process.GetCurrentProcess().SessionId + 1,
+                out var rejectionReason);
+
+            Assert.IsFalse(accepted);
+            Assert.AreEqual("wrong-session", rejectionReason);
+        }
+
+        [TestMethod]
+        public void DisconnectedPipeIsRejected()
+        {
+            using var server = new NamedPipeServerStream(UniquePipeName(), PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+
+            var accepted = NamedPipePeerVerification.TryVerifyClient(
+                server,
+                Path.GetFileName(GetCurrentExecutablePath()),
+                GetCurrentUserSid(),
+                Process.GetCurrentProcess().SessionId,
+                out var rejectionReason);
+
+            Assert.IsFalse(accepted);
+            Assert.AreEqual("pipe-not-connected", rejectionReason);
+        }
+
+        [TestMethod]
+        public void InvalidPeerIdentityFailsClosed()
+        {
+            var method = typeof(NamedPipePeerVerification).GetMethod("TryVerifyPeerProcess", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.IsNotNull(method);
+
+            var arguments = new object[]
+            {
+                uint.MaxValue,
+                Path.GetFileName(GetCurrentExecutablePath()),
+                GetCurrentUserSid(),
+                Process.GetCurrentProcess().SessionId,
+                false,
+                null,
+            };
+
+            var accepted = (bool)method!.Invoke(null, arguments)!;
+
+            Assert.IsFalse(accepted);
+            Assert.AreEqual("identity-unavailable", arguments[^1]);
+        }
+
+        [TestMethod]
+        public async Task FakeServerAndPipeSquattingAreRejected()
+        {
+            var pipeName = UniquePipeName();
+            using var currentIdentity = WindowsIdentity.GetCurrent();
+
+            await using (var fakeServer = RestrictedNamedPipeServer.Create(pipeName, currentIdentity.User!))
+            {
+                Assert.ThrowsException<Win32Exception>(() => RestrictedNamedPipeServer.Create(pipeName, currentIdentity.User!));
+
+                var waitTask = fakeServer.WaitForConnectionAsync();
+                await using var fakeClient = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+                await fakeClient.ConnectAsync(5000);
+                await waitTask;
+
+                var accepted = NamedPipePeerVerification.TryVerifyServer(
+                    fakeClient,
+                    MouseWithoutBordersIpc.MouseWithoutBordersExecutableFileName,
+                    GetCurrentUserSid(),
+                    Process.GetCurrentProcess().SessionId,
+                    allowLocalSystem: false,
+                    out var rejectionReason);
+
+                Assert.IsFalse(accepted);
+                Assert.AreEqual("wrong-image", rejectionReason);
+            }
+
+            await using var legitimateServer = RestrictedNamedPipeServer.Create(pipeName, currentIdentity.User!);
+            var legitimateWaitTask = legitimateServer.WaitForConnectionAsync();
+            await using var legitimateClient = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+            await legitimateClient.ConnectAsync(5000);
+            await legitimateWaitTask;
+
+            var legitimateAccepted = NamedPipePeerVerification.TryVerifyServer(
+                legitimateClient,
+                Path.GetFileName(GetCurrentExecutablePath()),
+                GetCurrentUserSid(),
+                Process.GetCurrentProcess().SessionId,
+                allowLocalSystem: false,
+                out var legitimateRejectionReason);
+
+            Assert.IsTrue(legitimateAccepted, legitimateRejectionReason);
+        }
+
+        [TestMethod]
+        public void PipeDaclAllowsOnlyExpectedUserAndLocalSystem()
+        {
+            using var currentIdentity = WindowsIdentity.GetCurrent();
+            using var server = RestrictedNamedPipeServer.Create(UniquePipeName(), currentIdentity.User!);
+            var expectedIdentities = new[]
+            {
+                currentIdentity.User!,
+                new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null),
+            };
+            var accessRules = server.GetAccessControl().GetAccessRules(true, false, typeof(SecurityIdentifier));
+
+            Assert.AreEqual(expectedIdentities.Length, accessRules.Count);
+            foreach (AuthorizationRule rule in accessRules)
+            {
+                var pipeRule = (PipeAccessRule)rule;
+                Assert.AreEqual(AccessControlType.Allow, pipeRule.AccessControlType);
+                Assert.AreEqual(
+                    PipeAccessRights.FullControl,
+                    pipeRule.PipeAccessRights & PipeAccessRights.FullControl);
+                Assert.IsTrue(Array.Exists(expectedIdentities, sid => sid.Equals(pipeRule.IdentityReference)));
+            }
+        }
+
+        [TestMethod]
+        public async Task ServerRestartAllowsVerifiedReconnect()
+        {
+            var pipeName = UniquePipeName();
+            using var currentIdentity = WindowsIdentity.GetCurrent();
+            var executablePath = GetCurrentExecutablePath();
+            var userSid = GetCurrentUserSid();
+            var sessionId = Process.GetCurrentProcess().SessionId;
+
+            for (var attempt = 0; attempt < 2; attempt++)
+            {
+                await using var server = RestrictedNamedPipeServer.Create(pipeName, currentIdentity.User!);
+                var waitTask = server.WaitForConnectionAsync();
+                await using var client = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+                await client.ConnectAsync(5000);
+                await waitTask;
+
+                var accepted = NamedPipePeerVerification.TryVerifyServer(
+                    client,
+                    Path.GetFileName(executablePath),
+                    userSid,
+                    sessionId,
+                    allowLocalSystem: false,
+                    out var rejectionReason);
+
+                Assert.IsTrue(accepted, rejectionReason);
+            }
+        }
+
+        [TestMethod]
+        public void IntactAuthenticodeSignatureAcceptsEmbeddedMicrosoftSignedDependency()
+        {
+            var signedBinary = GetKnownEmbeddedMicrosoftSignedDependencyPath();
+
+            Assert.IsTrue(HasIntactAuthenticodeSignature(signedBinary));
+        }
+
+        [TestMethod]
+        public void RealVerifierAcceptsEmbeddedMicrosoftSignedDependency()
+        {
+            var signedBinary = GetKnownEmbeddedMicrosoftSignedDependencyPath();
+
+            Assert.IsTrue(HasTrustedMicrosoftSignature(signedBinary));
+        }
+
+        [TestMethod]
+        public void RealVerifierRejectsUnsignedTestAssembly()
+        {
+            Assert.IsFalse(HasTrustedMicrosoftSignature(typeof(MouseWithoutBordersIpcSecurityTests).Assembly.Location));
+        }
+
+        [TestMethod]
+        public void RealVerifierRejectsTamperedSignedBinary()
+        {
+            var signedBinary = GetKnownEmbeddedMicrosoftSignedDependencyPath();
+            var artifactDirectory = CreateTestArtifactDirectory();
+            var tamperedBinary = Path.Combine(artifactDirectory, Path.GetFileName(signedBinary));
+
+            try
+            {
+                File.Copy(signedBinary, tamperedBinary, overwrite: true);
+                TamperFile(tamperedBinary);
+
+                Assert.IsFalse(HasTrustedMicrosoftSignature(tamperedBinary));
+            }
+            finally
+            {
+                if (Directory.Exists(artifactDirectory))
+                {
+                    Directory.Delete(artifactDirectory, recursive: true);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void CustomRootTrustChainAcceptsIntermediateFromExtraStore()
+        {
+            using var rootKey = RSA.Create(2048);
+            using var root = CreateRootCertificate(rootKey);
+            using var intermediateKey = RSA.Create(2048);
+            using var intermediate = CreateIntermediateCertificate(root, intermediateKey);
+            using var leaf = CreateCodeSigningLeafCertificate(intermediate);
+
+            using var chainWithoutIntermediate = CreateCodeSigningChain(root);
+            Assert.IsFalse(chainWithoutIntermediate.Build(leaf));
+
+            using var chainWithIntermediate = CreateCodeSigningChain(root);
+            chainWithIntermediate.ChainPolicy.ExtraStore.Add(intermediate);
+            Assert.IsTrue(chainWithIntermediate.Build(leaf));
+        }
+
+        [TestMethod]
+        public void SignerCertificateEqualityRejectsDistinctCertificatesWithSameSubject_FallbackWithoutSecondTrustedFixture()
+        {
+            using var firstKey = RSA.Create(2048);
+            using var secondKey = RSA.Create(2048);
+            using var first = CreateSubjectCertificate("CN=Microsoft Corporation Unit Test", firstKey);
+            using var second = CreateSubjectCertificate("CN=Microsoft Corporation Unit Test", secondKey);
+
+            Assert.IsFalse(HaveMatchingSignerCertificate(first, second));
+        }
+
+        [TestMethod]
+        public void DirectoryRelationshipAcceptsEqualDirectories()
+        {
+            Assert.IsTrue(HaveEqualOrNestedDirectories(
+                @"C:\Program Files\PowerToys",
+                @"C:\Program Files\PowerToys"));
+        }
+
+        [TestMethod]
+        public void DirectoryRelationshipAcceptsChildDirectory()
+        {
+            Assert.IsTrue(HaveEqualOrNestedDirectories(
+                @"C:\Program Files\PowerToys",
+                @"C:\Program Files\PowerToys\WinUI3Apps"));
+        }
+
+        [TestMethod]
+        public void DirectoryRelationshipAcceptsParentDirectory()
+        {
+            Assert.IsTrue(HaveEqualOrNestedDirectories(
+                @"C:\Program Files\PowerToys\WinUI3Apps",
+                @"C:\Program Files\PowerToys"));
+        }
+
+        [TestMethod]
+        public void DirectoryRelationshipRejectsPrefixSibling()
+        {
+            Assert.IsFalse(HaveEqualOrNestedDirectories(
+                @"C:\Program Files\PowerToys",
+                @"C:\Program Files\PowerToysOther"));
+        }
+
+        [TestMethod]
+        public void DirectoryRelationshipRejectsSiblingDirectories()
+        {
+            Assert.IsFalse(HaveEqualOrNestedDirectories(
+                @"C:\Program Files\PowerToys\WinUI3Apps",
+                @"C:\Program Files\PowerToys\Modules"));
+        }
+
+        [TestMethod]
+        public void SettingsSyncPayloadKeepsExistingJsonShape()
+        {
+            var contract = typeof(MouseWithoutBordersViewModel).GetNestedType("ISettingsSyncHelper", BindingFlags.NonPublic);
+            var stateType = contract!.GetNestedType("MachineSocketState");
+            var state = Activator.CreateInstance(stateType!);
+            stateType!.GetField("Name")!.SetValue(state, "PC");
+            stateType.GetField("Status")!.SetValue(state, Enum.ToObject(stateType.GetField("Status")!.FieldType, 9));
+
+            Assert.AreEqual("""{"Name":"PC","Status":9}""", JsonConvert.SerializeObject(state));
+        }
+
+        private static async Task<(NamedPipeServerStream Server, NamedPipeClientStream Client)> CreateConnectedPairAsync(string pipeName = null)
+        {
+            pipeName ??= UniquePipeName();
+            using var currentIdentity = WindowsIdentity.GetCurrent();
+            var server = RestrictedNamedPipeServer.Create(pipeName, currentIdentity.User!);
+            var client = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+            var waitTask = server.WaitForConnectionAsync();
+            await client.ConnectAsync(5000);
+            await waitTask;
+            return (server, client);
+        }
+
+        private static string GetCurrentExecutablePath()
+        {
+            return Process.GetCurrentProcess().MainModule?.FileName
+                ?? Environment.ProcessPath
+                ?? throw new InvalidOperationException("The current process has no executable path.");
+        }
+
+        private static string GetCurrentUserSid()
+        {
+            using var identity = WindowsIdentity.GetCurrent();
+            return identity.User?.Value ?? throw new InvalidOperationException("The current process has no user SID.");
+        }
+
+        private static string UniquePipeName()
+        {
+            return $"PowerToys.MWB.v2.UnitTest.{Environment.ProcessId}.{Guid.NewGuid():N}";
+        }
+
+        private static string GetKnownEmbeddedMicrosoftSignedDependencyPath()
+        {
+            var path = Path.Combine(AppContext.BaseDirectory, "Microsoft.WindowsAppRuntime.dll");
+            Assert.IsTrue(File.Exists(path), $"Expected Microsoft-signed dependency was not found: {path}");
+            return path;
+        }
+
+        private static string CreateTestArtifactDirectory()
+        {
+            var path = Path.Combine(
+                AppContext.BaseDirectory,
+                "MouseWithoutBordersIpcSecurityTests",
+                Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(path);
+            return path;
+        }
+
+        private static void TamperFile(string path)
+        {
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            var offset = stream.Length > 4096 ? 4096 : 0;
+            stream.Position = offset;
+            var original = stream.ReadByte();
+            Assert.AreNotEqual(-1, original);
+            stream.Position = offset;
+            stream.WriteByte(unchecked((byte)(original ^ 0x5A)));
+        }
+
+        private static void CleanupArtifactDirectory(string artifactDirectory)
+        {
+            if (Directory.Exists(artifactDirectory))
+            {
+                Directory.Delete(artifactDirectory, recursive: true);
+            }
+        }
+
+        private static bool HasIntactAuthenticodeSignature(string path)
+        {
+            var method = typeof(NamedPipePeerVerification).GetMethod("HasIntactAuthenticodeSignature", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.IsNotNull(method);
+            return (bool)method!.Invoke(null, new object[] { path })!;
+        }
+
+        private static bool HasTrustedMicrosoftSignature(string path)
+        {
+            var method = typeof(NamedPipePeerVerification).GetMethod("HasTrustedMicrosoftSignature", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.IsNotNull(method);
+            return (bool)method!.Invoke(null, new object[] { path })!;
+        }
+
+        private static bool HaveMatchingSignerCertificate(X509Certificate2 firstSigner, X509Certificate2 secondSigner)
+        {
+            var method = typeof(NamedPipePeerVerification).GetMethod("HaveMatchingSignerCertificate", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.IsNotNull(method);
+            return (bool)method!.Invoke(null, new object[] { firstSigner, secondSigner })!;
+        }
+
+        private static bool HaveEqualOrNestedDirectories(string firstDirectory, string secondDirectory)
+        {
+            var method = typeof(NamedPipePeerVerification).GetMethod("HaveEqualOrNestedDirectories", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.IsNotNull(method);
+            return (bool)method!.Invoke(null, new object[] { firstDirectory, secondDirectory })!;
+        }
+
+        private static X509Chain CreateCodeSigningChain(X509Certificate2 root)
+        {
+            var chain = new X509Chain();
+            chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+            chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+            chain.ChainPolicy.CustomTrustStore.Add(root);
+            chain.ChainPolicy.ApplicationPolicy.Add(new Oid("1.3.6.1.5.5.7.3.3"));
+            return chain;
+        }
+
+        private static X509Certificate2 CreateRootCertificate(RSA rootKey)
+        {
+            var request = new CertificateRequest(
+                "CN=MWB IPC Test Root",
+                rootKey,
+                HashAlgorithmName.SHA256,
+                RSASignaturePadding.Pkcs1);
+            request.CertificateExtensions.Add(new X509BasicConstraintsExtension(true, false, 1, true));
+            request.CertificateExtensions.Add(new X509KeyUsageExtension(X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign, true));
+            request.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
+            return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(7));
+        }
+
+        private static X509Certificate2 CreateIntermediateCertificate(X509Certificate2 root, RSA intermediateKey)
+        {
+            var request = new CertificateRequest(
+                "CN=MWB IPC Test Intermediate",
+                intermediateKey,
+                HashAlgorithmName.SHA256,
+                RSASignaturePadding.Pkcs1);
+            request.CertificateExtensions.Add(new X509BasicConstraintsExtension(true, false, 0, true));
+            request.CertificateExtensions.Add(new X509KeyUsageExtension(X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign, true));
+            request.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
+
+            using var intermediate = request.Create(root, DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(7), RandomNumberGenerator.GetBytes(16));
+            return intermediate.CopyWithPrivateKey(intermediateKey);
+        }
+
+        private static X509Certificate2 CreateCodeSigningLeafCertificate(X509Certificate2 intermediate)
+        {
+            using var leafKey = RSA.Create(2048);
+            var request = new CertificateRequest(
+                "CN=Microsoft Corporation Unit Test",
+                leafKey,
+                HashAlgorithmName.SHA256,
+                RSASignaturePadding.Pkcs1);
+            request.CertificateExtensions.Add(new X509BasicConstraintsExtension(false, false, 0, true));
+            request.CertificateExtensions.Add(new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature, true));
+            request.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
+
+            var enhancedKeyUsage = new OidCollection
+            {
+                new Oid("1.3.6.1.5.5.7.3.3"),
+            };
+            request.CertificateExtensions.Add(new X509EnhancedKeyUsageExtension(enhancedKeyUsage, true));
+
+            return request.Create(intermediate, DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(7), RandomNumberGenerator.GetBytes(16));
+        }
+
+        private static X509Certificate2 CreateSubjectCertificate(string subject, RSA key)
+        {
+            var request = new CertificateRequest(
+                subject,
+                key,
+                HashAlgorithmName.SHA256,
+                RSASignaturePadding.Pkcs1);
+            request.CertificateExtensions.Add(new X509BasicConstraintsExtension(false, false, 0, true));
+            request.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
+            return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(7));
+        }
+    }
+}

--- a/src/settings-ui/Settings.UI/ViewModels/MouseWithoutBordersViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/MouseWithoutBordersViewModel.cs
@@ -4,12 +4,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.IO.Pipes;
 using System.Linq;
 using System.Net;
 using System.Runtime.CompilerServices;
+using System.Security.Principal;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,6 +21,7 @@ using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.Library.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library.Interfaces;
+using Microsoft.PowerToys.Settings.UI.Library.Utilities;
 using Microsoft.PowerToys.Settings.UI.Library.ViewModels.Commands;
 using Microsoft.PowerToys.Settings.UI.SerializationContext;
 using Microsoft.UI;
@@ -321,8 +324,39 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
                 if (recreateStream)
                 {
-                    syncHelperStream = new NamedPipeClientStream(".", "MouseWithoutBorders/SettingsSync", PipeDirection.InOut, PipeOptions.Asynchronous);
-                    await syncHelperStream.ConnectAsync(10000);
+                    var sessionId = Process.GetCurrentProcess().SessionId;
+                    using var currentIdentity = WindowsIdentity.GetCurrent();
+                    var currentUserSid = currentIdentity.User?.Value ?? throw new InvalidOperationException("Settings process has no user SID.");
+                    var candidateStream = new NamedPipeClientStream(
+                        ".",
+                        MouseWithoutBordersIpc.GetSettingsSyncPipeName(sessionId),
+                        PipeDirection.InOut,
+                        PipeOptions.Asynchronous);
+
+                    try
+                    {
+                        await candidateStream.ConnectAsync(10000);
+                        if (!NamedPipePeerVerification.TryVerifyServer(
+                                candidateStream,
+                                MouseWithoutBordersIpc.MouseWithoutBordersExecutableFileName,
+                                currentUserSid,
+                                sessionId,
+                                allowLocalSystem: true,
+                                out var rejectionReason))
+                        {
+                            throw new UnauthorizedAccessException($"Rejected SettingsSync server: {rejectionReason}");
+                        }
+
+                        syncHelperStream = candidateStream;
+                        candidateStream = null;
+                    }
+                    finally
+                    {
+                        if (candidateStream != null)
+                        {
+                            await candidateStream.DisposeAsync();
+                        }
+                    }
                 }
 
                 return new SyncHelper(syncHelperStream);


### PR DESCRIPTION
## Summary of the Pull Request

Improve Mouse Without Borders handling of unexpected callers on its local Settings connection.

## PR Checklist

- [x] **Tests:** Automated tests and a manual unsigned Debug tryout.

## Detailed Description of the Pull Request / Additional comments

- Check the connected process before accepting Settings requests, using a shared helper for executable identity, user/session, and signer checks.
- Recheck new connections after a restart or reconnect, while supporting unsigned development builds.
- Preserve normal Settings operations and cross-machine pairing behavior.

## Validation Steps Performed

- Focused Settings and MWB automated tests.
- Private two-process named-pipe tests using the production helper, covering accepted and rejected callers.
- Manual one-PC Debug tryout: MWB on/off and New key. Two-machine and service-mode scenarios were not exercised.
