### PR TITLE
CmdPal: Prevent failing event handlers from blocking updates

### DIFF
--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.PerformanceMonitor.UnitTests/PageActivationTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.PerformanceMonitor.UnitTests/PageActivationTests.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using CoreWidgetProvider.Widgets.Enums;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -13,13 +15,15 @@ namespace Microsoft.CmdPal.Ext.PerformanceMonitor.UnitTests;
 [TestClass]
 public partial class PageActivationTests
 {
+    private static readonly int[] _expectedItemCounts = [1, 2, 3];
+
     private sealed partial class TrackingPage : OnLoadBasePage
     {
         public int LoadCount { get; private set; }
 
         public int UnloadCount { get; private set; }
 
-        public void TriggerItemsChanged() => RaiseItemsChanged();
+        public void TriggerItemsChanged(int totalItems = -1) => RaiseItemsChanged(totalItems);
 
         protected override void Loaded() => LoadCount++;
 
@@ -109,6 +113,38 @@ public partial class PageActivationTests
                 throw new InvalidOperationException("Deactivation failed.");
             }
         }
+    }
+
+    [TestMethod]
+    [DataRow(unchecked((int)0x800706BA))]
+    [DataRow(unchecked((int)0x80010108))]
+    [DataRow(unchecked((int)0x80004005))]
+    public void ItemsChanged_ContinuesAfterSubscriberFailureWithoutChangingPageLifetime(int hresult)
+    {
+        var page = new TrackingPage();
+        var failures = 0;
+        List<int> notifications = [];
+        TypedEventHandler<object, IItemsChangedEventArgs> broken = (_, _) =>
+        {
+            failures++;
+            Marshal.ThrowExceptionForHR(hresult);
+        };
+        TypedEventHandler<object, IItemsChangedEventArgs> healthy = (_, args) => notifications.Add(args.TotalItems);
+        page.ItemsChanged += broken;
+        page.ItemsChanged += healthy;
+
+        page.TriggerItemsChanged(1);
+        page.TriggerItemsChanged(2);
+        page.ItemsChanged -= broken;
+        page.TriggerItemsChanged(3);
+
+        Assert.AreEqual(2, failures);
+        CollectionAssert.AreEqual(_expectedItemCounts, notifications);
+        Assert.AreEqual(1, page.LoadCount);
+        Assert.AreEqual(0, page.UnloadCount);
+
+        page.ItemsChanged -= healthy;
+        Assert.AreEqual(1, page.UnloadCount);
     }
 
     [TestMethod]

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.TimeDate.UnitTests/OnLoadDynamicListPageTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.TimeDate.UnitTests/OnLoadDynamicListPageTests.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Microsoft.CmdPal.Ext.TimeDate.Pages;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Foundation;
+
+namespace Microsoft.CmdPal.Ext.TimeDate.UnitTests;
+
+[TestClass]
+public partial class OnLoadDynamicListPageTests
+{
+    private static readonly int[] _expectedItemCounts = [1, 2, 3];
+
+    [TestMethod]
+    [DataRow(unchecked((int)0x800706BA))]
+    [DataRow(unchecked((int)0x80010108))]
+    [DataRow(unchecked((int)0x80004005))]
+    public void ItemsChanged_ContinuesAfterSubscriberFailureWithoutChangingPageLifetime(int hresult)
+    {
+        var page = new TrackingPage();
+        var failures = 0;
+        List<int> notifications = [];
+        TypedEventHandler<object, IItemsChangedEventArgs> broken = (_, _) =>
+        {
+            failures++;
+            Marshal.ThrowExceptionForHR(hresult);
+        };
+        TypedEventHandler<object, IItemsChangedEventArgs> healthy = (_, args) => notifications.Add(args.TotalItems);
+        page.ItemsChanged += broken;
+        page.ItemsChanged += healthy;
+
+        page.TriggerItemsChanged(1);
+        page.TriggerItemsChanged(2);
+        page.ItemsChanged -= broken;
+        page.TriggerItemsChanged(3);
+
+        Assert.AreEqual(2, failures);
+        CollectionAssert.AreEqual(_expectedItemCounts, notifications);
+        Assert.AreEqual(1, page.LoadCount);
+        Assert.AreEqual(0, page.UnloadCount);
+
+        page.ItemsChanged -= healthy;
+        Assert.AreEqual(1, page.UnloadCount);
+    }
+
+    private sealed partial class TrackingPage : OnLoadDynamicListPage
+    {
+        public int LoadCount { get; private set; }
+
+        public int UnloadCount { get; private set; }
+
+        public override IListItem[] GetItems() => [];
+
+        public override void UpdateSearchText(string oldSearch, string newSearch)
+        {
+        }
+
+        public void TriggerItemsChanged(int totalItems) => RaiseItemsChanged(totalItems);
+
+        protected override void Loaded() => LoadCount++;
+
+        protected override void Unloaded() => UnloadCount++;
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CommandPalette.Extensions.Toolkit.UnitTests/EventNotificationTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CommandPalette.Extensions.Toolkit.UnitTests/EventNotificationTests.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Foundation;
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit.UnitTests;
+
+[TestClass]
+public class EventNotificationTests
+{
+    [TestMethod]
+    [DataRow(unchecked((int)0x800706BA), 1)]
+    [DataRow(unchecked((int)0x80010108), 1)]
+    [DataRow(unchecked((int)0x80004005), 2)]
+    public void PropChanged_ContinuesAfterFailureAndRemovesOnlyDeadSubscribers(int hresult, int expectedFailures)
+    {
+        var page = new Page();
+        var failures = 0;
+        List<(object Sender, string PropertyName, string Title)> notifications = [];
+        page.PropChanged += (_, _) =>
+        {
+            failures++;
+            Marshal.ThrowExceptionForHR(hresult);
+        };
+        page.PropChanged += (sender, args) => notifications.Add((sender, args.PropertyName, page.Title));
+
+        page.Title = "First";
+        page.Title = "Second";
+        page.Title = "Second";
+
+        Assert.AreEqual("Second", page.Title);
+        Assert.AreEqual(expectedFailures, failures);
+        CollectionAssert.AreEqual(
+            new[] { ((object)page, nameof(Page.Title), "First"), ((object)page, nameof(Page.Title), "Second") },
+            notifications);
+    }
+
+    [TestMethod]
+    public void ItemsChanged_AllPublishersContinueAfterFailureAndPreserveSubscriptionChanges()
+    {
+        var listPage = new TestListPage();
+        VerifyItemNotifications(listPage, listPage.NotifyChanged);
+
+        var contentPage = new TestContentPage();
+        VerifyItemNotifications(contentPage, contentPage.NotifyChanged);
+
+        var treeContent = new TestTreeContent();
+        VerifyItemNotifications(treeContent, treeContent.NotifyChanged);
+
+        var provider = new TestCommandProvider();
+        VerifyItemNotifications(provider, provider.NotifyChanged);
+    }
+
+    private static void VerifyItemNotifications(INotifyItemsChanged source, Action<int> raise)
+    {
+        raise(0);
+
+        var unavailableCalls = 0;
+        var disconnectedCalls = 0;
+        var otherFailureCalls = 0;
+        var addedCalls = 0;
+        List<(object Sender, int TotalItems)> notifications = [];
+        TypedEventHandler<object, IItemsChangedEventArgs> addedHandler = (_, _) => addedCalls++;
+        TypedEventHandler<object, IItemsChangedEventArgs> healthyHandler =
+            (sender, args) => notifications.Add((sender, args.TotalItems));
+
+        source.ItemsChanged += (_, _) =>
+        {
+            unavailableCalls++;
+            source.ItemsChanged += addedHandler;
+            Marshal.ThrowExceptionForHR(unchecked((int)0x800706BA));
+        };
+        source.ItemsChanged += (_, _) =>
+        {
+            disconnectedCalls++;
+            Marshal.ThrowExceptionForHR(unchecked((int)0x80010108));
+        };
+        source.ItemsChanged += (_, _) =>
+        {
+            otherFailureCalls++;
+            throw new InvalidOperationException("Ordinary callback failure");
+        };
+        source.ItemsChanged += healthyHandler;
+
+        raise(1);
+        Assert.AreEqual(0, addedCalls, "A new subscriber joins the next notification.");
+        raise(2);
+        source.ItemsChanged -= healthyHandler;
+        raise(3);
+
+        Assert.AreEqual(1, unavailableCalls, source.GetType().Name);
+        Assert.AreEqual(1, disconnectedCalls, source.GetType().Name);
+        Assert.AreEqual(3, otherFailureCalls, "Ordinary failures must not unsubscribe the callback.");
+        Assert.AreEqual(2, addedCalls, "Removing a dead callback must preserve a newly added subscriber.");
+        CollectionAssert.AreEqual(new[] { ((object)source, 1), ((object)source, 2) }, notifications);
+    }
+
+    private sealed partial class TestListPage : ListPage
+    {
+        public void NotifyChanged(int totalItems) => RaiseItemsChanged(totalItems);
+    }
+
+    private sealed partial class TestContentPage : ContentPage
+    {
+        public override IContent[] GetContent() => [];
+
+        public void NotifyChanged(int totalItems) => RaiseItemsChanged(totalItems);
+    }
+
+    private sealed partial class TestTreeContent : TreeContent
+    {
+        public void NotifyChanged(int totalItems) => RaiseItemsChanged(totalItems);
+    }
+
+    private sealed partial class TestCommandProvider : CommandProvider
+    {
+        public override ICommandItem[] TopLevelCommands() => [];
+
+        public void NotifyChanged(int totalItems) => RaiseItemsChanged(totalItems);
+    }
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/OnLoadStaticPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/OnLoadStaticPage.cs
@@ -121,14 +121,7 @@ internal abstract partial class OnLoadBasePage : Page
             handlers = InternalItemsChanged;
         }
 
-        try
-        {
-            // TODO #181 - This is the same thing that BaseObservable has to deal with.
-            handlers?.Invoke(this, new ItemsChangedEventArgs(totalItems));
-        }
-        catch
-        {
-        }
+        EventHelpers.Raise(handlers, this, new ItemsChangedEventArgs(totalItems));
     }
 
     private (Exception Exception, bool Loading)? ReconcileLoadState()

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Pages/OnLoadDynamicListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Pages/OnLoadDynamicListPage.cs
@@ -88,14 +88,7 @@ internal abstract partial class OnLoadDynamicListPage : Page, IDynamicListPage
 
     protected void RaiseItemsChanged(int totalItems = -1)
     {
-        try
-        {
-            // TODO #181 - This is the same thing that BaseObservable has to deal with.
-            InternalItemsChanged?.Invoke(this, new ItemsChangedEventArgs(totalItems));
-        }
-        catch
-        {
-        }
+        EventHelpers.Raise(InternalItemsChanged, this, new ItemsChangedEventArgs(totalItems));
     }
 
     protected abstract void Loaded();

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/BaseObservable.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/BaseObservable.cs
@@ -17,17 +17,7 @@ public partial class BaseObservable : INotifyPropChanged
 
     protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
     {
-        try
-        {
-            // TODO #181 - This is dangerous! If the original host goes away,
-            // this can crash as we try to invoke the handlers from that process.
-            // However, just catching it seems to still raise the event on the
-            // new host?
-            PropChanged?.Invoke(this, new PropChangedEventArgs(propertyName!));
-        }
-        catch
-        {
-        }
+        EventHelpers.Raise(PropChanged, this, new PropChangedEventArgs(propertyName!), handler => PropChanged -= handler);
     }
 
     /// <summary>

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/CommandProvider.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/CommandProvider.cs
@@ -44,14 +44,7 @@ public abstract partial class CommandProvider :
 
     protected void RaiseItemsChanged(int totalItems = -1)
     {
-        try
-        {
-            // TODO #181 - This is the same thing that BaseObservable has to deal with.
-            ItemsChanged?.Invoke(this, new ItemsChangedEventArgs(totalItems));
-        }
-        catch
-        {
-        }
+        EventHelpers.Raise(ItemsChanged, this, new ItemsChangedEventArgs(totalItems), handler => ItemsChanged -= handler);
     }
 
     /// <summary>

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ContentPage.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ContentPage.cs
@@ -18,13 +18,6 @@ public abstract partial class ContentPage : Page, IContentPage
 
     protected void RaiseItemsChanged(int totalItems = -1)
     {
-        try
-        {
-            // TODO #181 - This is the same thing that BaseObservable has to deal with.
-            ItemsChanged?.Invoke(this, new ItemsChangedEventArgs(totalItems));
-        }
-        catch
-        {
-        }
+        EventHelpers.Raise(ItemsChanged, this, new ItemsChangedEventArgs(totalItems), handler => ItemsChanged -= handler);
     }
 }

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/EventHelpers.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/EventHelpers.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Windows.Foundation;
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit;
+
+/// <summary>
+/// Helpers for delivering notifications independently to each subscriber.
+/// </summary>
+public static class EventHelpers
+{
+    private const int RpcDisconnectedHResult = unchecked((int)0x80010108); // RPC_E_DISCONNECTED
+    private const int RpcServerUnavailableHResult = unchecked((int)0x800706BA); // HRESULT_FROM_WIN32(RPC_S_SERVER_UNAVAILABLE)
+
+    /// <summary>
+    /// Raises an event without allowing one subscriber's failure to block the others.
+    /// </summary>
+    /// <param name="handlers">The subscribers to notify.</param>
+    /// <param name="sender">The event source.</param>
+    /// <param name="args">The event arguments.</param>
+    /// <param name="unsubscribe">
+    /// Optional callback to remove disconnected recipients. Omit when the publisher
+    /// manages subscription lifetime separately.
+    /// </param>
+    /// <typeparam name="TEventArgs">The event argument type.</typeparam>
+    public static void Raise<TEventArgs>(
+        TypedEventHandler<object, TEventArgs>? handlers,
+        object sender,
+        TEventArgs args,
+        Action<TypedEventHandler<object, TEventArgs>>? unsubscribe = null)
+    {
+        // A callback to a previous host must not prevent delivery to the current host.
+        foreach (TypedEventHandler<object, TEventArgs> handler in handlers?.GetInvocationList() ?? [])
+        {
+            try
+            {
+                handler(sender, args);
+            }
+            catch (Exception ex) when (ex.HResult is RpcDisconnectedHResult or RpcServerUnavailableHResult)
+            {
+                // RPC_E_DISCONNECTED and RPC_S_SERVER_UNAVAILABLE identify dead recipients.
+                // Let the publisher decide whether to remove them.
+                // https://devblogs.microsoft.com/oldnewthing/20190521-00/?p=102505
+                unsubscribe?.Invoke(handler);
+            }
+            catch
+            {
+                // Preserve the existing exception policy, but continue with the other subscribers.
+            }
+        }
+    }
+}

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/EventHelpers.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/EventHelpers.cs
@@ -32,7 +32,7 @@ public static class EventHelpers
         Action<TypedEventHandler<object, TEventArgs>>? unsubscribe = null)
     {
         // A callback to a previous host must not prevent delivery to the current host.
-        foreach (TypedEventHandler<object, TEventArgs> handler in handlers?.GetInvocationList() ?? [])
+        foreach (TypedEventHandler<object, TEventArgs> handler in Delegate.EnumerateInvocationList(handlers))
         {
             try
             {

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ListPage.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ListPage.cs
@@ -34,14 +34,7 @@ public partial class ListPage : Page, IListPage
 
     protected void RaiseItemsChanged(int totalItems = -1)
     {
-        try
-        {
-            // TODO #181 - This is the same thing that BaseObservable has to deal with.
-            ItemsChanged?.Invoke(this, new ItemsChangedEventArgs(totalItems));
-        }
-        catch
-        {
-        }
+        EventHelpers.Raise(ItemsChanged, this, new ItemsChangedEventArgs(totalItems), handler => ItemsChanged -= handler);
     }
 
     protected void SetSearchNoUpdate(string newSearchText)

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/TreeContent.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/TreeContent.cs
@@ -18,13 +18,6 @@ public partial class TreeContent : BaseObservable, ITreeContent
 
     protected void RaiseItemsChanged(int totalItems = -1)
     {
-        try
-        {
-            // TODO #181 - This is the same thing that BaseObservable has to deal with.
-            ItemsChanged?.Invoke(this, new ItemsChangedEventArgs(totalItems));
-        }
-        catch
-        {
-        }
+        EventHelpers.Raise(ItemsChanged, this, new ItemsChangedEventArgs(totalItems), handler => ItemsChanged -= handler);
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

This PR updates the way events are raised from Extension SDK. Ooopsies during event invocations are handled seperately for each subscribed handle, so one failure doesn't block other listeners. 

This should allow us to eliminate this class of issues from the triage, but itself is not the root of all evil.

Changes:
- Dispatches property and item notifications independently per subscriber.
- Removes disconnected RPC handlers from SDK event invocation lists.
- Ports it to shared dispatch in Time and Date and Performance Monitor.
- Plus, few toasted tests on top, to prove the point and regression.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #50483
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

