### PR TITLE
feat(mouseutils): add haptic feedback to Cursor Wrap

### DIFF
--- a/src/modules/MouseUtils/CursorWrap/dllmain.cpp
+++ b/src/modules/MouseUtils/CursorWrap/dllmain.cpp
@@ -20,6 +20,7 @@
 #include <windows.h>
 #include <dbt.h>
 #include <sstream>
+#include <winrt/Windows.Devices.Haptics.h>
 #include "resource.h"
 #include "CursorWrapCore.h"
 
@@ -56,6 +57,7 @@ namespace
     const wchar_t JSON_KEY_WRAP_MODE[] = L"wrap_mode";
     const wchar_t JSON_KEY_ACTIVATION_MODE[] = L"activation_mode";
     const wchar_t JSON_KEY_DISABLE_ON_SINGLE_MONITOR[] = L"disable_cursor_wrap_on_single_monitor";
+    const wchar_t HAPTIC_EDGE_WINDOW_CLASS[] = L"CursorWrapHapticEdgeWindow";
 }
 
 // The PowerToy name that will be shown in the settings.
@@ -107,6 +109,12 @@ private:
     HDEVNOTIFY m_deviceNotify = nullptr;
     static constexpr UINT_PTR TIMER_UPDATE_MONITORS = 1;
     static constexpr UINT DEBOUNCE_DELAY_MS = 500;
+
+    winrt::Windows::Devices::Haptics::InputHapticsManager m_inputHapticsManager{ nullptr };
+    bool m_hapticDevicePresent = false;
+    HWND m_hapticEdgeWindows[4]{};
+    POINT m_pendingWrapDestination{};
+    bool m_hasPendingWrap = false;
 
 public:
     // Constructor
@@ -209,6 +217,18 @@ public:
             m_listening = true;
             m_eventThread = std::thread([this]() {
                 HANDLE handles[2] = { m_triggerEventHandle, m_terminateEventHandle };
+                bool apartmentInitialized = false;
+
+                try
+                {
+                    winrt::init_apartment(winrt::apartment_type::multi_threaded);
+                    apartmentInitialized = true;
+                    InitializeHaptics();
+                }
+                catch (const winrt::hresult_error& error)
+                {
+                    Logger::warn(L"CursorWrap haptics initialization failed: {}", error.message());
+                }
 
                 // WH_MOUSE_LL callbacks are delivered to the thread that installed the hook.
                 // Ensure this thread has a message queue and pumps messages while the hook is active.
@@ -259,6 +279,12 @@ public:
                 UnregisterDisplayChanges();
 
                 StopMouseHook();
+                m_inputHapticsManager = nullptr;
+                m_hapticDevicePresent = false;
+                if (apartmentInitialized)
+                {
+                    winrt::uninit_apartment();
+                }
                 Logger::info("CursorWrap event listener stopped");
             });
         }
@@ -340,6 +366,183 @@ public:
     }
 
 private:
+    void InitializeHaptics()
+    {
+        using namespace winrt::Windows::Devices::Haptics;
+
+        auto statics = winrt::try_get_activation_factory<InputHapticsManager, IInputHapticsManagerStatics>();
+        if (!statics)
+        {
+            Logger::info("CursorWrap haptic feedback API is unavailable");
+            return;
+        }
+
+        const bool isSupported = statics.IsSupported();
+        const bool isHapticDevicePresent = isSupported && statics.IsHapticDevicePresent();
+        Logger::info(
+            "CursorWrap haptic feedback status: API supported={}, haptic device present={}",
+            isSupported,
+            isHapticDevicePresent);
+
+        if (!isSupported)
+        {
+            return;
+        }
+
+        m_inputHapticsManager = statics.GetForCurrentThread();
+        m_hapticDevicePresent = isHapticDevicePresent;
+    }
+
+    void PlayWrapHaptic()
+    {
+        using namespace winrt::Windows::Devices::Haptics;
+
+        if (!m_inputHapticsManager)
+        {
+            return;
+        }
+
+        try
+        {
+#ifdef _DEBUG
+            const auto deviceType = m_inputHapticsManager.CurrentHapticsControllerDeviceType();
+            const bool hasController = m_inputHapticsManager.CurrentHapticsController() != nullptr;
+            Logger::info(
+                "CursorWrap current haptic input: device type={}, controller={}",
+                static_cast<int>(deviceType),
+                hasController);
+#endif
+            [[maybe_unused]] const bool feedbackSent = m_inputHapticsManager.TrySendHapticWaveform(
+                KnownSimpleHapticsControllerWaveforms::Grow(),
+                0);
+#ifdef _DEBUG
+            Logger::info("CursorWrap haptic feedback sent={}", feedbackSent);
+#endif
+        }
+        catch (const winrt::hresult_error& error)
+        {
+            Logger::warn(L"CursorWrap failed to play haptic feedback: {}", error.message());
+            m_inputHapticsManager = nullptr;
+        }
+    }
+
+    bool TryDeferWrapToHapticEdgeWindow(const POINT& currentPos, const POINT& destination)
+    {
+        if (!m_hapticDevicePresent)
+        {
+            return false;
+        }
+
+        const LONG virtualLeft = GetSystemMetrics(SM_XVIRTUALSCREEN);
+        const LONG virtualTop = GetSystemMetrics(SM_YVIRTUALSCREEN);
+        const LONG virtualRight = virtualLeft + GetSystemMetrics(SM_CXVIRTUALSCREEN) - 1;
+        const LONG virtualBottom = virtualTop + GetSystemMetrics(SM_CYVIRTUALSCREEN) - 1;
+        const POINT hitTestPoint{
+            std::clamp(currentPos.x, virtualLeft, virtualRight),
+            std::clamp(currentPos.y, virtualTop, virtualBottom)
+        };
+        const HWND inputWindow = WindowFromPoint(hitTestPoint);
+
+        if (std::find(std::begin(m_hapticEdgeWindows), std::end(m_hapticEdgeWindows), inputWindow) == std::end(m_hapticEdgeWindows))
+        {
+            return false;
+        }
+
+        m_pendingWrapDestination = destination;
+        m_hasPendingWrap = true;
+        return true;
+    }
+
+    void CompletePendingHapticWrap()
+    {
+        if (!m_hasPendingWrap)
+        {
+            return;
+        }
+
+        const POINT destination = m_pendingWrapDestination;
+        m_hasPendingWrap = false;
+        if (SetCursorPos(destination.x, destination.y))
+        {
+            PlayWrapHaptic();
+        }
+    }
+
+    void RegisterHapticEdgeWindows()
+    {
+        if (!m_hapticDevicePresent || m_hapticEdgeWindows[0])
+        {
+            return;
+        }
+
+        WNDCLASSEXW wc{ sizeof(wc) };
+        wc.lpfnWndProc = HapticEdgeWindowProc;
+        wc.hInstance = GetModuleHandle(nullptr);
+        wc.lpszClassName = HAPTIC_EDGE_WINDOW_CLASS;
+        RegisterClassExW(&wc);
+
+        const int virtualLeft = GetSystemMetrics(SM_XVIRTUALSCREEN);
+        const int virtualTop = GetSystemMetrics(SM_YVIRTUALSCREEN);
+        const int virtualWidth = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+        const int virtualHeight = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+        const RECT edgeRects[]{
+            { virtualLeft, virtualTop, virtualLeft + 1, virtualTop + virtualHeight },
+            { virtualLeft + virtualWidth - 1, virtualTop, virtualLeft + virtualWidth, virtualTop + virtualHeight },
+            { virtualLeft, virtualTop, virtualLeft + virtualWidth, virtualTop + 1 },
+            { virtualLeft, virtualTop + virtualHeight - 1, virtualLeft + virtualWidth, virtualTop + virtualHeight }
+        };
+
+        for (size_t index = 0; index < std::size(edgeRects); ++index)
+        {
+            const auto& rect = edgeRects[index];
+            m_hapticEdgeWindows[index] = CreateWindowExW(
+                WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE | WS_EX_TOPMOST | WS_EX_LAYERED,
+                HAPTIC_EDGE_WINDOW_CLASS,
+                nullptr,
+                WS_POPUP,
+                rect.left,
+                rect.top,
+                rect.right - rect.left,
+                rect.bottom - rect.top,
+                nullptr,
+                nullptr,
+                GetModuleHandle(nullptr),
+                nullptr);
+
+            if (m_hapticEdgeWindows[index])
+            {
+                SetLayeredWindowAttributes(m_hapticEdgeWindows[index], 0, 1, LWA_ALPHA);
+                ShowWindow(m_hapticEdgeWindows[index], SW_SHOWNOACTIVATE);
+            }
+        }
+    }
+
+    void UnregisterHapticEdgeWindows()
+    {
+        for (auto& window : m_hapticEdgeWindows)
+        {
+            if (window)
+            {
+                DestroyWindow(window);
+                window = nullptr;
+            }
+        }
+
+        m_hasPendingWrap = false;
+        UnregisterClassW(HAPTIC_EDGE_WINDOW_CLASS, GetModuleHandle(nullptr));
+    }
+
+    static LRESULT CALLBACK HapticEdgeWindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+    {
+        if (msg == WM_MOUSEMOVE && g_cursorWrapInstance)
+        {
+            g_cursorWrapInstance->CompletePendingHapticWrap();
+            return 0;
+        }
+
+        return DefWindowProcW(hwnd, msg, wParam, lParam);
+    }
+
     void ToggleMouseHook()
     {
         // Toggle cursor wrapping.
@@ -488,6 +691,7 @@ private:
 
         // Refresh monitor info before starting hook
         m_core.UpdateMonitorInfo();
+        RegisterHapticEdgeWindows();
         
         m_mouseHook = SetWindowsHookEx(WH_MOUSE_LL, MouseHookProc, GetModuleHandle(nullptr), 0);
         if (m_mouseHook)
@@ -500,6 +704,7 @@ private:
         }
         else
         {
+            UnregisterHapticEdgeWindows();
             DWORD error = GetLastError();
             Logger::error(L"Failed to install CursorWrap mouse hook, error: {}", error);
         }
@@ -512,6 +717,7 @@ private:
             UnhookWindowsHookEx(m_mouseHook);
             m_mouseHook = nullptr;
             m_hookActive = false;
+            UnregisterHapticEdgeWindows();
             Logger::info("CursorWrap mouse hook stopped");
 #ifdef _DEBUG
             Logger::info("CursorWrap DEBUG: Mouse hook stopped");
@@ -721,7 +927,16 @@ private:
                     Logger::info(L"CursorWrap DEBUG: Wrapping cursor from ({}, {}) to ({}, {})", 
                                 currentPos.x, currentPos.y, newPos.x, newPos.y);
 #endif
-                    SetCursorPos(newPos.x, newPos.y);
+                    if (g_cursorWrapInstance->TryDeferWrapToHapticEdgeWindow(currentPos, newPos))
+                    {
+                        return CallNextHookEx(nullptr, nCode, wParam, lParam);
+                    }
+
+                    if (SetCursorPos(newPos.x, newPos.y))
+                    {
+                        g_cursorWrapInstance->PlayWrapHaptic();
+                    }
+
                     return 1; // Suppress the original message
                 }
             }


### PR DESCRIPTION
## Summary of the Pull Request

Adds haptic feedback after Cursor Wrap successfully moves the pointer to the opposite screen edge.

The implementation uses `Windows.Devices.Haptics.InputHapticsManager` and plays the **Grow** waveform once per completed wrap. Because Cursor Wrap normally handles movement on a background low-level hook thread, `src/modules/MouseUtils/CursorWrap/dllmain.cpp` creates invisible one-pixel edge input windows while wrapping is active. The physical edge event is delivered to the module's thread before the pointer transition, allowing Windows to route feedback to the active haptic mouse.

## PR Checklist

- [ ] Closes: #50165
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** No new end-user-facing strings

## Detailed Description of the Pull Request / Additional comments

- Guards the API through `try_get_activation_factory`, `IsSupported`, and haptic-device availability checks so unsupported systems retain existing behavior.
- Initializes and releases the WinRT apartment on Cursor Wrap's event thread.
- Creates edge input windows only while the mouse hook is active and removes them when wrapping stops.
- Defers a detected wrap to the edge window's `WM_MOUSEMOVE` handler, performs `SetCursorPos`, and then requests `KnownSimpleHapticsControllerWaveforms::Grow` with a device-appropriate fallback.
- Preserves the existing immediate wrap path when haptics are unavailable.

This is a draft while shared global/per-utility settings and broader multi-monitor edge validation are still being evaluated.

## Validation Steps Performed

- Built `src/modules/MouseUtils/CursorWrap/CursorWrap.vcxproj` for x64 Debug successfully.
- Built `src/modules/MouseUtils/CursorWrap/CursorWrap.vcxproj` for x64 Release successfully.
- Manually validated on Windows build 26340 with a Logitech MX Master 4.
- Confirmed completed wraps produce a physical haptic pulse.
- Confirmed runtime diagnostics report the active device as Mouse, expose a haptics controller, and return `haptic feedback sent=true`.
- Automated tests were not added because this behavior depends on physical haptic hardware and thread-specific Windows input routing; existing cursor-wrap calculation logic is unchanged.