### PR TITLE
Ready for Review - [Mouse Jump] - fixing small preview image in settings ui - #50436

### DIFF
--- a/src/modules/MouseUtils/MouseJump.Common.UnitTests/Helpers/DrawingHelperTests.cs
+++ b/src/modules/MouseUtils/MouseJump.Common.UnitTests/Helpers/DrawingHelperTests.cs
@@ -152,8 +152,7 @@ public static class DrawingHelperTests
             var formLayout = LayoutHelper.GetFormLayout(
                 previewStyle: data.PreviewStyle,
                 displayInfo: data.DisplayInfo,
-                activatedScreen: data.ActivatedScreen,
-                activatedLocation: data.ActivatedLocation);
+                maximumSize: data.ActivatedScreen.DisplayArea.Size);
 
             var imageCopyServices = formLayout.CanvasLayout.DeviceLayouts
                 .Select(
@@ -234,6 +233,109 @@ public static class DrawingHelperTests
                         $"images differ at pixel ({x}, {y}) - expected: {expectedPixel}, actual: {actualPixel}");
                 }
             }
+        }
+    }
+
+    [TestClass]
+    public sealed class RenderPreviewAsyncTests
+    {
+        /// <summary>
+        /// Verifies that GetFormLayout's maximumSize parameter is respected when the
+        /// resulting layout is larger than the activatedScreen.DisplayArea. This is a
+        /// regression test for https://github.com/microsoft/PowerToys/issues/50436 where
+        /// the SettingsUI preview image was incorrectly scaled down to fit into the first
+        /// logical screen rather than scaled to fit into the SettingsUI settings card
+        /// (which is larger than the first logical screen), resulting in a preview
+        /// image that was too small and didn't fill the settings card.
+        /// </summary>
+        [TestMethod]
+        public async Task RenderPreviewAsync_GivenSettingsUiStyleInputs_RespectsMaximumSize()
+        {
+            // the same fake two-screen desktop as MouseUtilsViewModel_MouseJump.cs's
+            // MouseJumpPreviewImage getter (a small secondary screen, a larger primary one)
+            var screenA = new ScreenInfo(
+                handle: 0,
+                primary: false,
+                displayArea: new RectangleInfo(635, 172, 272, 168),
+                workingArea: new RectangleInfo(635, 172, 272, 168));
+            var screenB = new ScreenInfo(
+                handle: 0,
+                primary: true,
+                displayArea: new RectangleInfo(0, 0, 635, 339),
+                workingArea: new RectangleInfo(0, 0, 635, 339));
+            var displayInfo = new DisplayInfo(
+                devices: new DeviceInfo[]
+                {
+                    new(
+                        hostname: "FakeDisplay1",
+                        localhost: true,
+                        screens: new List<ScreenInfo> { screenA, screenB }),
+                });
+
+            var desktopSize = LayoutHelper.GetCombinedScreenBounds(
+                    displayInfo.Devices[0].Screens
+                        .Select(screen => screen.DisplayArea)
+                        .ToList())
+                .Size;
+
+            // hard-coded to match what MouseJumpPreviewImage's own settingsCardContentHeight
+            // math currently computes for this same fake desktop (907 wide x 283 tall) -
+            // deliberately much taller/wider than screenA's own 272x168 display area, so this
+            // test can tell "respects maximumSize" apart from "coincidentally small enough to
+            // fit inside screenA anyway".
+            var maximumSize = new SizeInfo(desktopSize.Width, 283);
+
+            var activatedScreen = displayInfo.Devices[0].Screens[0];
+            var previewStyle = StyleHelper.BezelledPreviewStyle.WithCanvasSize(desktopSize);
+
+            var formLayout = LayoutHelper.GetFormLayout(
+                previewStyle: previewStyle,
+                displayInfo: displayInfo,
+                maximumSize: maximumSize);
+
+            using var desktopImage = RenderPreviewAsyncTests.CreateSyntheticDesktopImage(desktopSize, displayInfo.Devices[0]);
+            var imageCopyServices = formLayout.CanvasLayout.DeviceLayouts
+                .Select(deviceLayout => (IImageRegionCopyService)new StaticImageRegionCopyService(desktopImage))
+                .ToList();
+
+            using var actual = await DrawingHelper.RenderPreviewAsync(formLayout.CanvasLayout, activatedScreen, imageCopyServices);
+
+            // the whole point of maximumSize is to bound the rendered image - it must
+            // never come out bigger than that in either dimension...
+            Assert.IsTrue(
+                actual.Width <= (int)maximumSize.Width,
+                $"actual width {actual.Width} exceeds maximumSize.Width {maximumSize.Width}");
+            Assert.IsTrue(
+                actual.Height <= (int)maximumSize.Height,
+                $"actual height {actual.Height} exceeds maximumSize.Height {maximumSize.Height}");
+
+            // ...and the resulting image must be larger than activatedScreen's own tiny
+            // display area (272x168) - this is the actual regression check: before the fix,
+            // GetFormLayout clamped against activatedScreen.DisplayArea.Size instead of
+            // maximumSize, so the preview came out far too small.
+            Assert.IsTrue(
+                actual.Width > (int)activatedScreen.DisplayArea.Width,
+                $"actual width {actual.Width} is no bigger than activatedScreen's own display area width {activatedScreen.DisplayArea.Width} - looks like maximumSize isn't being respected");
+            Assert.IsTrue(
+                actual.Height > (int)activatedScreen.DisplayArea.Height,
+                $"actual height {actual.Height} is no bigger than activatedScreen's own display area height {activatedScreen.DisplayArea.Height} - looks like maximumSize isn't being respected");
+        }
+
+        private static Bitmap CreateSyntheticDesktopImage(SizeInfo desktopSize, DeviceInfo deviceInfo)
+        {
+            var screenColors = new[] { Color.Red, Color.Blue, Color.Green, Color.Yellow, Color.Magenta };
+
+            var bitmap = new Bitmap((int)desktopSize.Width, (int)desktopSize.Height, PixelFormat.Format32bppArgb);
+            using var graphics = Graphics.FromImage(bitmap);
+            graphics.Clear(Color.Black);
+            for (var screenIndex = 0; screenIndex < deviceInfo.Screens.Count; screenIndex++)
+            {
+                var color = screenColors[screenIndex % screenColors.Length];
+                using var brush = new SolidBrush(color);
+                graphics.FillRectangle(brush, deviceInfo.Screens[screenIndex].DisplayArea.ToRectangle());
+            }
+
+            return bitmap;
         }
     }
 }

--- a/src/modules/MouseUtils/MouseJump.Common.UnitTests/Helpers/LayoutHelperTests.cs
+++ b/src/modules/MouseUtils/MouseJump.Common.UnitTests/Helpers/LayoutHelperTests.cs
@@ -112,13 +112,14 @@ public static class LayoutHelperTests
     {
         public sealed class TestCase
         {
-            public TestCase(string testName, PreviewStyle previewStyle, DisplayInfo displayInfo, ScreenInfo activatedScreen, PointInfo activatedLocation, FormViewModel expectedResult)
+            public TestCase(string testName, PreviewStyle previewStyle, DisplayInfo displayInfo, ScreenInfo activatedScreen, PointInfo activatedLocation, RectangleInfo expectedFormBounds, FormViewModel expectedResult)
             {
                 this.TestName = testName;
                 this.PreviewStyle = previewStyle;
                 this.DisplayInfo = displayInfo;
                 this.ActivatedLocation = activatedLocation;
                 this.ActivatedScreen = activatedScreen;
+                this.ExpectedFormBounds = expectedFormBounds;
                 this.ExpectedResult = expectedResult;
             }
 
@@ -131,6 +132,8 @@ public static class LayoutHelperTests
             public ScreenInfo ActivatedScreen { get; }
 
             public PointInfo ActivatedLocation { get; }
+
+            public RectangleInfo ExpectedFormBounds { get; }
 
             public FormViewModel ExpectedResult { get; }
         }
@@ -184,8 +187,8 @@ public static class LayoutHelperTests
                 });
             var activatedScreen = displayInfo.Devices[0].Screens[0];
             var activatedLocation = activatedScreen.DisplayArea.Midpoint;
+            var expectedFormBounds = new RectangleInfo(250, 186, 524, 396);
             var expectedResult = new FormViewModel(
-                formBounds: new(250, 186, 524, 396),
                 canvasLayout: new(
                     canvasBounds: BoxBounds.CreateFromOuterBounds(
                         outerBounds: new(0, 0, 524, 396),
@@ -211,7 +214,7 @@ public static class LayoutHelperTests
                         ),
                     }
                 ));
-            yield return new object[] { new TestCase(testName, previewStyle, displayInfo, activatedScreen, activatedLocation, expectedResult) };
+            yield return new object[] { new TestCase(testName, previewStyle, displayInfo, activatedScreen, activatedLocation, expectedFormBounds, expectedResult) };
 
             // happy path - single device with screen and 50% scaling,
             // *no* preview borders but *has* screenshot borders
@@ -259,8 +262,8 @@ public static class LayoutHelperTests
                 });
             activatedScreen = displayInfo.Devices[0].Screens[0];
             activatedLocation = activatedScreen.DisplayArea.Midpoint;
+            expectedFormBounds = new RectangleInfo(256, 192, 512, 384);
             expectedResult = new FormViewModel(
-                formBounds: new(256, 192, 512, 384),
                 canvasLayout: new(
                     canvasBounds: BoxBounds.CreateFromOuterBounds(
                         outerBounds: new(0, 0, 512, 384),
@@ -286,7 +289,7 @@ public static class LayoutHelperTests
                         ),
                     }
                 ));
-            yield return new object[] { new TestCase(testName, previewStyle, displayInfo, activatedScreen, activatedLocation, expectedResult) };
+            yield return new object[] { new TestCase(testName, previewStyle, displayInfo, activatedScreen, activatedLocation, expectedFormBounds, expectedResult) };
 
             // rounding error check - single screen with 33% scaling,
             // no borders, check to make sure form scales to exactly
@@ -330,8 +333,8 @@ public static class LayoutHelperTests
                 });
             activatedScreen = displayInfo.Devices[0].Screens[0];
             activatedLocation = activatedScreen.DisplayArea.Midpoint;
+            expectedFormBounds = new RectangleInfo(300, 66.5m, 300, 67);
             expectedResult = new FormViewModel(
-                formBounds: new(300, 66.5m, 300, 67),
                 canvasLayout: new(
                     canvasBounds: BoxBounds.CreateFromOuterBounds(
                         outerBounds: new(0, 0, 300, 67),
@@ -357,7 +360,7 @@ public static class LayoutHelperTests
                         ),
                     }
                 ));
-            yield return new object[] { new TestCase(testName, previewStyle, displayInfo, activatedScreen, activatedLocation, expectedResult) };
+            yield return new object[] { new TestCase(testName, previewStyle, displayInfo, activatedScreen, activatedLocation, expectedFormBounds, expectedResult) };
 
             // primary monitor not topmost / leftmost - if there are screens
             // that are further left or higher up than the primary monitor
@@ -426,8 +429,8 @@ public static class LayoutHelperTests
                 });
             activatedScreen = displayInfo.Devices[0].Screens[0];
             activatedLocation = activatedScreen.DisplayArea.Midpoint;
+            expectedFormBounds = new RectangleInfo(-1318, -42, 716, 204);
             expectedResult = new FormViewModel(
-                formBounds: new(-1318, -42, 716, 204),
                 canvasLayout: new(
                     canvasBounds: BoxBounds.CreateFromOuterBounds(
                         outerBounds: new(0, 0, 716, 204),
@@ -459,7 +462,7 @@ public static class LayoutHelperTests
                         ),
                     }
                 ));
-            yield return new object[] { new TestCase(testName, previewStyle, displayInfo, activatedScreen, activatedLocation, expectedResult) };
+            yield return new object[] { new TestCase(testName, previewStyle, displayInfo, activatedScreen, activatedLocation, expectedFormBounds, expectedResult) };
 
             // two devices side-by-side with a single screen each
             //
@@ -508,8 +511,8 @@ public static class LayoutHelperTests
                 });
             activatedScreen = displayInfo.Devices[0].Screens[0];
             activatedLocation = activatedScreen.DisplayArea.Midpoint;
+            expectedFormBounds = new RectangleInfo(1760, 607.5m, 1600, 225);
             expectedResult = new FormViewModel(
-                formBounds: new(1760, 607.5m, 1600, 225),
                 canvasLayout: new(
                     canvasBounds: BoxBounds.CreateFromOuterBounds(
                         outerBounds: new(0, 0, 1600, 225),
@@ -551,7 +554,7 @@ public static class LayoutHelperTests
                         ),
                     }
                 ));
-            yield return new object[] { new TestCase(testName, previewStyle, displayInfo, activatedScreen, activatedLocation, expectedResult) };
+            yield return new object[] { new TestCase(testName, previewStyle, displayInfo, activatedScreen, activatedLocation, expectedFormBounds, expectedResult) };
 
             // TODO: add a test to make sure the form is nudged into the bounds
             // of the screen if it's activated near an edge or corner
@@ -568,7 +571,8 @@ public static class LayoutHelperTests
             // (int)1280.000000000000 -> 1280
             // so we'll compare the raw values, *and* convert to an int-based
             // Rectangle to compare rounded values
-            var actual = LayoutHelper.GetFormLayout(data.PreviewStyle, data.DisplayInfo, data.ActivatedScreen, data.ActivatedLocation);
+            var actual = LayoutHelper.GetFormLayout(data.PreviewStyle, data.DisplayInfo, data.ActivatedScreen.DisplayArea.Size);
+            var actualFormBounds = LayoutHelper.PositionOnScreen(actual.CanvasLayout.CanvasBounds.OuterBounds, data.ActivatedScreen, data.ActivatedLocation);
             var expected = data.ExpectedResult;
             var options = new JsonSerializerOptions
             {
@@ -577,6 +581,10 @@ public static class LayoutHelperTests
             var actualJson = JsonSerializer.Serialize(actual, options);
             var expectedJson = JsonSerializer.Serialize(expected, options);
             Assert.AreEqual(expectedJson, actualJson);
+
+            var actualFormBoundsJson = JsonSerializer.Serialize(actualFormBounds, options);
+            var expectedFormBoundsJson = JsonSerializer.Serialize(data.ExpectedFormBounds, options);
+            Assert.AreEqual(expectedFormBoundsJson, actualFormBoundsJson);
         }
 
         /// <summary>
@@ -656,7 +664,8 @@ public static class LayoutHelperTests
             var timer = Stopwatch.StartNew();
             for (var i = 0; i < 10_000; i++)
             {
-                var formLayout = LayoutHelper.GetFormLayout(previewStyle, displayInfo, activatedScreen, activatedLocation);
+                var formLayout = LayoutHelper.GetFormLayout(previewStyle, displayInfo, activatedScreen.DisplayArea.Size);
+                _ = LayoutHelper.PositionOnScreen(formLayout.CanvasLayout.CanvasBounds.OuterBounds, activatedScreen, activatedLocation);
             }
 
             timer.Stop();

--- a/src/modules/MouseUtils/MouseJump.Common/Helpers/LayoutHelper.cs
+++ b/src/modules/MouseUtils/MouseJump.Common/Helpers/LayoutHelper.cs
@@ -21,13 +21,19 @@ public static class LayoutHelper
             (combined, screenBounds) => combined.Union(screenBounds));
     }
 
+    /// <param name="maximumSize">
+    /// An upper bound on the layout's size. In real usage, pass the size of the screen the
+    /// preview form was activated on to ensure the entire form is scaled to fit on that
+    /// screen. For Settings UI, specify the available size of the control the preview image
+    /// will be placed into in order to ensure the preview is rendered at 100% and avoid
+    /// distorting bezels and screenshots.
+    /// </param>
     public static FormViewModel GetFormLayout(
-        PreviewStyle previewStyle, DisplayInfo displayInfo, ScreenInfo activatedScreen, PointInfo activatedLocation)
+        PreviewStyle previewStyle, DisplayInfo displayInfo, SizeInfo maximumSize)
     {
         ArgumentNullException.ThrowIfNull(previewStyle);
         ArgumentNullException.ThrowIfNull(displayInfo);
-        ArgumentNullException.ThrowIfNull(activatedScreen);
-        ArgumentNullException.ThrowIfNull(activatedLocation);
+        ArgumentNullException.ThrowIfNull(maximumSize);
 
         /*
 
@@ -68,20 +74,40 @@ public static class LayoutHelper
         */
 
         // arrange the form, canvas, devices and screens
-        var formLayout = LayoutHelper.CreateInitialFormLayout(previewStyle, displayInfo, activatedScreen);
+        var formLayout = LayoutHelper.CreateInitialFormLayout(previewStyle, displayInfo, maximumSize);
         LayoutHelper.ArrangeAndScaleDeviceLayouts(formLayout);
         LayoutHelper.ArrangeAndScaleScreenLayouts(formLayout);
         LayoutHelper.ArrangeAndResizeCanvasLayout(formLayout);
-        LayoutHelper.ArrangeAndResizeFormLayout(formLayout, activatedScreen, activatedLocation);
 
         return formLayout.Build();
     }
 
+    /// <summary>
+    /// Positions an arbitrary rectangle (typically a preview form's own outer bounds) on
+    /// the desktop - centered on the activated location, but also nudged to ensure it
+    /// lands entirely within the bounds of the activated screen and doesn't fall across
+    /// multiple screens. If this cannot be achieved it throws an exception.
+    /// </summary>
+    public static RectangleInfo PositionOnScreen(RectangleInfo formBounds, ScreenInfo activatedScreen, PointInfo activatedLocation)
+    {
+        ArgumentNullException.ThrowIfNull(formBounds);
+        ArgumentNullException.ThrowIfNull(activatedScreen);
+        ArgumentNullException.ThrowIfNull(activatedLocation);
+
+        // center the bounds on the activated location, *but* if the activated location is
+        // near the edge of the screen that *could* cause the bounding box to fall partially
+        // outside the screen bounds so we'll nudge it back inside the screen bounds as well
+        return formBounds
+            .Center(activatedLocation)
+            .MoveInside(activatedScreen.DisplayArea);
+    }
+
     internal static FormViewModel.Builder CreateInitialFormLayout(
-        PreviewStyle previewStyle, DisplayInfo displayInfo, ScreenInfo activatedScreen)
+        PreviewStyle previewStyle, DisplayInfo displayInfo, SizeInfo maximumSize)
     {
         ArgumentNullException.ThrowIfNull(previewStyle);
         ArgumentNullException.ThrowIfNull(displayInfo);
+        ArgumentNullException.ThrowIfNull(maximumSize);
 
         // check we have at least one device
         if (displayInfo.Devices.Count == 0)
@@ -102,11 +128,11 @@ public static class LayoutHelper
         */
 
         // work out the maximum allowed size of the preview form:
-        // * can't be bigger than the activated screen
+        // * can't be bigger than maximumSize
         // * can't be bigger than the configured canvas size
         var formMaxBounds = new RectangleInfo(
             previewStyle.CanvasSize
-                .Clamp(activatedScreen.DisplayArea.Size));
+                .Clamp(maximumSize));
 
         var screenStyles = LayoutHelper.GetDeviceScreenStyles(previewStyle, displayInfo.Devices.Count).ToList();
 
@@ -115,7 +141,6 @@ public static class LayoutHelper
         // build the final immutable layout objects once all the bounds have been calculated
         var formLayout = new FormViewModel.Builder
         {
-            FormBounds = RectangleInfo.Empty,
             CanvasLayout = new()
             {
                 CanvasBounds = BoxBounds.CreateFromOuterBounds(
@@ -387,16 +412,5 @@ public static class LayoutHelper
         canvasLayout.CanvasBounds = BoxBounds.CreateFromOuterBounds(
             outerBounds: positionedOuterBounds,
             boxStyle: formLayout.CanvasLayout.CanvasStyle);
-    }
-
-    internal static void ArrangeAndResizeFormLayout(FormViewModel.Builder formLayout, ScreenInfo activatedScreen, PointInfo activatedLocation)
-    {
-        var canvasOuterBounds = formLayout.CanvasLayout?.CanvasBounds?.OuterBounds
-            ?? throw new InvalidOperationException();
-
-        // resize and center the form on the activated location
-        formLayout.FormBounds = canvasOuterBounds
-            .Center(activatedLocation)
-            .MoveInside(activatedScreen.DisplayArea);
     }
 }

--- a/src/modules/MouseUtils/MouseJump.Models/ViewModel/FormViewModel.cs
+++ b/src/modules/MouseUtils/MouseJump.Models/ViewModel/FormViewModel.cs
@@ -1,28 +1,16 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-using MouseJump.Models.Drawing;
 
 namespace MouseJump.Models.ViewModel;
 
 /// <summary>
-/// Defines the preview form size and location.
+/// Defines the preview form's layout.
 /// </summary>
 public sealed class FormViewModel
 {
     public sealed class Builder
     {
-        /// <summary>
-        /// Gets or sets the coordinates of the preview form on the host computer's desktop.
-        /// Coordinates are relative to the actual host desktop.
-        /// </summary>
-        public RectangleInfo? FormBounds
-        {
-            get;
-            set;
-        }
-
         public CanvasViewModel.Builder? CanvasLayout
         {
             get;
@@ -32,27 +20,15 @@ public sealed class FormViewModel
         public FormViewModel Build()
         {
             return new FormViewModel(
-                formBounds: this.FormBounds ?? throw new InvalidOperationException($"{nameof(this.FormBounds)} must be initialized before calling {nameof(this.Build)}."),
                 canvasLayout: (this.CanvasLayout ?? throw new InvalidOperationException($"{nameof(this.CanvasLayout)} must be initialized before calling {nameof(this.Build)}."))
                     .Build());
         }
     }
 
     public FormViewModel(
-        RectangleInfo formBounds,
         CanvasViewModel canvasLayout)
     {
-        this.FormBounds = formBounds ?? throw new ArgumentNullException(nameof(formBounds));
         this.CanvasLayout = canvasLayout ?? throw new ArgumentNullException(nameof(canvasLayout));
-    }
-
-    /// <summary>
-    /// Gets the coordinates of the preview form on the host computer's desktop.
-    /// Coordinates are relative to the actual host virtual screen / desktop that the preview image will be shown on.
-    /// </summary>
-    public RectangleInfo FormBounds
-    {
-        get;
     }
 
     public CanvasViewModel CanvasLayout

--- a/src/modules/MouseUtils/MouseJump.WinUI3/MouseJumpXAML/PreviewWindow.xaml.cs
+++ b/src/modules/MouseUtils/MouseJump.WinUI3/MouseJumpXAML/PreviewWindow.xaml.cs
@@ -315,14 +315,15 @@ internal sealed partial class PreviewWindow : Window
         var formLayout = LayoutHelper.GetFormLayout(
             previewStyle,
             displayInfo,
-            activatedScreen: activatedScreen,
-            activatedLocation: activatedLocation);
+            maximumSize: activatedScreen.DisplayArea.Size);
 
         // remember the layout so we can map the mouse clicks back to
         // the appropriate device and screen location
         this.FormLayout = formLayout;
 
-        await this.PositionWindowAsync(formLayout.FormBounds)
+        var formBounds = LayoutHelper.PositionOnScreen(
+            formLayout.CanvasLayout.CanvasBounds.OuterBounds, activatedScreen, activatedLocation);
+        await this.PositionWindowAsync(formBounds)
             .ConfigureAwait(false);
 
         var imageCopyServices = displayInfo.Devices

--- a/src/settings-ui/Settings.UI/ViewModels/MouseUtilsViewModel_MouseJump.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/MouseUtilsViewModel_MouseJump.cs
@@ -195,7 +195,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
                         300px settings card height - 1px top border - 7px top margin - 8px bottom margin - 1px bottom border = 283px image height
 
-                    this ensures we get a preview image scaled at 100% so borders, etc., are shown at exact pixel sizes in the preview
+                    this ensures we get a preview image scaled at 100% so borders, etc, are shown at exact pixel sizes in the preview
                 */
                 const int settingsCardHeight = 300;
                 const int settingsCardTopBorder = 1;
@@ -205,6 +205,12 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 const int settingsCardContentHeight = // 283
                     settingsCardHeight - settingsCardTopBorder - settingsCardTopMargin - settingsCardBottomBorder - settingsCardBottomMargin;
 
+                // TODO: we only calculate settingsCardContentHeight and assume the
+                // preview image is constrained by height, not by width. That's true
+                // today but if the fake displayInfo above or the Settings UI form's
+                // MinWidth are changed in future this might create an image that is
+                // too wide for the control, and we might need to calculate
+                // settingsCardContentWidth as well.
                 var canvasSize = new SizeInfo(desktopSize.Width, settingsCardContentHeight).Clamp(desktopSize);
 
                 var previewType = Enum.TryParse<PreviewType>(this.MouseJumpPreviewType, true, out var previewTypeResult)
@@ -262,8 +268,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 var previewLayout = LayoutHelper.GetFormLayout(
                     previewStyle: previewStyle,
                     displayInfo: displayInfo,
-                    activatedScreen: activatedScreen,
-                    activatedLocation: new(0, 0));
+                    maximumSize: canvasSize);
 
                 var desktopImage = MouseUtilsViewModel.MouseJumpDesktopImage.Value;
                 var imageCopyService = new StaticImageRegionCopyService(desktopImage);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Fixes a regression in the Mouse Jump WinUI migration that caused the Settings UI to have a small preview image.

| WinUI Migration (Regression) | This PR (Fix) |
| --- | --- |
|  <img width="1593" height="1267" alt="image" src="https://github.com/user-attachments/assets/f1e46852-3191-4ac4-8f10-a1223f7e6a31" /> | <img width="1593" height="1267" alt="image" src="https://github.com/user-attachments/assets/fd6ded7c-17a4-4815-b8f3-2f82d7b23fea" /> |

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes #50436
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
  -  all ui strings come from Resources.resw
- [x] **Dev docs:** Added/updated
  -  no changes required
- [x] **New binaries:** Added on the required places
  -  no changes required
- [x] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx
  -  no changes required

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The problem was caused by a change to the code generating the thumbnail in the Settings UI - there was a pure coincidence which meant the preview image *happened* to be generated at the correct size based on a false premise:

* the fake desktop image used to generate the preview contains two fake screens - ```Screen 1: (0, 0, 635, 339)``` and ```Screen 0: (635, 172, 272, 168)```
* the preview image was generated with Screen 1 as the "activated screen" so the preview image in Settings UI was clamped to 635 x 339 pixels, which was bigger than area for the preview image in Settings UI, so it rendered correctly

This was changed in the WinUI to use Screen 0 as the "activated screen" so the preview image was now clamped to 272 x 168 pixels which is smaller than the area for the preview image in Settings UI so it was rendered too small.

The fix is to remove the "activated screen" as a size constraint in layout calculation and pass a "maximum size" instead - the real app code can pass the size of the activated screen for the maximum size to preserve existing behaviour, and Settings UI can now pass the size of the area for the preview image instead so both scenarios work correctly.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- **Workflow tests**
  - [x] Automated tests passing locally
  - [x] Minimal actions workflow (spelling check) passing for PR
  - [ ] Full actions workflow (msbuild) passing for PR
- **UI tests**
  - [ ] Happy path
    - [x] preview image appears when activated
    - [x] clicking the preview image moves the mouse cursor to the correct location
    - [x] right-click dismisses the preview image without moving the mouse
    - [ ] pressing escape dismisses the preview image without moving the mouse
      - **FAILS** - but this is a separate regression in v0.101 - see https://github.com/microsoft/PowerToys/issues/50533
    - [x] left or right clicking another application / desktop dismisses the preview image without moving the mouse
  - [x] Works on multiple monitors with different dpi scaling settings (e.g. 100% vs 150%)
    * https://github.com/microsoft/PowerToys/pull/23566#issuecomment-1411869418
    * https://github.com/microsoft/PowerToys/pull/23566#issuecomment-1412834413
  - [x] Handling negative coordinates on non-primary monitors if higher or "lefter" than primary monitor 
    * https://github.com/microsoft/PowerToys/pull/23566#issuecomment-1404931694
  - [x] Mouse crosshair moves when Mouse Jump moves the cursor (mouse clicks *and* keyboard shortcuts)
    * #24523
    * #24527
  - [x] Activating when the preview window is already visible moves the form to the new mouse position
  - [ ] Number and key shortcuts (1-9, Home / End, Left / Right Arrow) jump to the appropriate monitor
      - **FAILS** - but this is a separate regression in v0.101 - see https://github.com/microsoft/PowerToys/issues/50533
  - [ ] Number-pad shortcuts (1-9 jump to the appropriate monitor
      - **FAILS** - but this is a separate regression in v0.101 - see https://github.com/microsoft/PowerToys/issues/50533
- **Settings tests**
  - [x] Changing thumbnail size settings updates the size of the thumbnail
  - [x] Changing preview type between Compact, Bezelled and Custom shows the correct preview type
  - [x] Changing custom preview settings shows the correct settings
  - [ ] Launching with settings version 1.0 upgrades settings to version 1.1, with "Bezelled" as the default style and the "Custom" settings preconfigured to match "Bezelled"
- **Lifecycle tests**
  - [x] Starting PowerToys Runner launches MouseJump exe when enabled, and not when disabled
  - [x] Enabling / disabling Mouse Jump in settings starts / stops MouseJump exe
  - [x] Exiting PowerToys Runner stops MouseJump exe
  - [ ] Killing runner exe via Task Manager stops MouseJump exe
  - [x] Stopping Visual Studio local debug run stops MouseJump exe
    - note - runner needs to be in *non*-admin mode otherwise Visual Studio debugger disconnects at launch
  - [x] Hotkey and size settings are automatically reloaded when config file is modified from Settings UI
  - [ ] ~~Hotkey and size settings are automatically reloaded when config file is modified manually (e.g. in notepad) while runner and MouseJumpUI.exe are running~~
- **[Internal Test Suite](https://github.com/microsoft/PowerToys/blob/5bc7201ae2b75b53d3a4bc35119c867ecf71c5f6/doc/releases/tests-checklist-template.md#mouse-utils)**
  - [ ] Enable Mouse Jump. Then:
  - [ ] Press the activation shortcut and verify the screens preview appears.
  - [ ] Change activation shortcut and verify that new shortcut triggers Mouse Jump.
  - [ ] Click around the screen preview and ensure that mouse cursor jumped to clicked location.
  - [ ] Reorder screens in Display settings and confirm that Mouse Jump reflects the change and still works correctly.
  - [ ] Change scaling of screens and confirm that Mouse Jump still works correctly.
  - [ ] Unplug additional monitors and confirm that Mouse Jump still works correctly.
  - [ ] Disable Mouse Jump and verify that the module is not activated when you press the activation shortcut.

