### PR TITLE
AltWindowCycle: revert overlay visuals + fix acrylic backdrop, thumbnail rendering, and icon size

### DIFF
--- a/src/modules/AltWindowCycle/AltWindowCycle.cpp
+++ b/src/modules/AltWindowCycle/AltWindowCycle.cpp
@@ -503,7 +503,7 @@ bool Switcher::Init(HINSTANCE instance)
 
     thumbHost = CreateWindowExW(
         WS_EX_TOPMOST | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE,
-        hc.lpszClassName, L"", WS_POPUP | WS_DISABLED,
+        hc.lpszClassName, L"", WS_POPUP,
         0, 0, 0, 0, nullptr, nullptr, hinst, nullptr);
     if (!thumbHost)
         return false;

--- a/src/modules/AltWindowCycle/AltWindowCycle.cpp
+++ b/src/modules/AltWindowCycle/AltWindowCycle.cpp
@@ -1316,11 +1316,14 @@ void Switcher::RenderLayered()
             {
                 int gPad = Scaled(10);
                 int gOut = gPad + Scaled(2);
+                // Both rings share the same corner radius (grown from the inner gap)
+                // so the outer accent ring stays concentric with the inner hairline
+                // instead of ballooning into a rounder, ill-fitting corner.
                 Gdiplus::GraphicsPath innerRing, out;
                 BuildRoundRect(innerRing, InflateF(tile, gPad),
                                static_cast<Gdiplus::REAL>(radius + gPad));
                 BuildRoundRect(out, InflateF(tile, gOut),
-                               static_cast<Gdiplus::REAL>(radius + gOut));
+                               static_cast<Gdiplus::REAL>(radius + gPad));
                 Gdiplus::Pen darkPen(AltTabStyle::FocusShadow(),
                                      static_cast<Gdiplus::REAL>((std::max)(1, Scaled(1))));
                 Gdiplus::Pen accentPen(accentClr,

--- a/src/modules/AltWindowCycle/AltWindowCycle.cpp
+++ b/src/modules/AltWindowCycle/AltWindowCycle.cpp
@@ -1362,19 +1362,7 @@ void Switcher::RenderLayered()
                 {
                     RECT avail = { 0, 0, snapshotSizes[slot].cx, snapshotSizes[slot].cy };
                     RECT rcSrc = AltWindowCycleLogic::CoverSource(pv, avail);
-                    // Uniform dark wash: scales each color channel down so a captured
-                    // snapshot reads consistently regardless of the source window's
-                    // own light/dark theme, instead of looking mismatched against the
-                    // surrounding dark card chrome.
-                    Gdiplus::ColorMatrix darkWash = {
-                        0.55f, 0.f,   0.f,   0.f, 0.f,
-                        0.f,   0.55f, 0.f,   0.f, 0.f,
-                        0.f,   0.f,   0.55f, 0.f, 0.f,
-                        0.f,   0.f,   0.f,   1.f, 0.f,
-                        0.f,   0.f,   0.f,   0.f, 1.f
-                    };
-                    Gdiplus::ImageAttributes attrs;
-                    attrs.SetColorMatrix(&darkWash);
+                    // Draw the captured window content as-is -- no color adjustment.
                     g.SetSmoothingMode(Gdiplus::SmoothingModeNone);
                     g.DrawImage(snap,
                                 Gdiplus::RectF(static_cast<Gdiplus::REAL>(pv.left),
@@ -1385,7 +1373,7 @@ void Switcher::RenderLayered()
                                 static_cast<Gdiplus::REAL>(rcSrc.top),
                                 static_cast<Gdiplus::REAL>(rcSrc.right - rcSrc.left),
                                 static_cast<Gdiplus::REAL>(rcSrc.bottom - rcSrc.top),
-                                Gdiplus::UnitPixel, &attrs);
+                                Gdiplus::UnitPixel);
                     g.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
                 }
                 else
@@ -1399,12 +1387,16 @@ void Switcher::RenderLayered()
                                     static_cast<Gdiplus::REAL>(pw),
                                     static_cast<Gdiplus::REAL>(ph));
                     g.SetCompositingMode(Gdiplus::CompositingModeSourceOver);
+                    // The subtle semi-transparent white stroke below is meant to catch
+                    // light against the blurred/transparent DWM punch above; it was
+                    // designed for that see-through case, not for an opaque snapshot
+                    // (where it reads as a harsh white border), so only draw it here.
+                    Gdiplus::Pen previewPen(AltTabStyle::PreviewStroke(sel),
+                                             static_cast<Gdiplus::REAL>((std::max)(1, Scaled(1))));
+                    g.SetSmoothingMode(Gdiplus::SmoothingModeNone);
+                    g.DrawRectangle(&previewPen, pv.left, pv.top, pw - 1, ph - 1);
+                    g.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
                 }
-                Gdiplus::Pen previewPen(AltTabStyle::PreviewStroke(sel),
-                                         static_cast<Gdiplus::REAL>((std::max)(1, Scaled(1))));
-                g.SetSmoothingMode(Gdiplus::SmoothingModeNone);
-                g.DrawRectangle(&previewPen, pv.left, pv.top, pw - 1, ph - 1);
-                g.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
             }
 
             // Header tab: app icon + window title.

--- a/src/modules/AltWindowCycle/AltWindowCycle.cpp
+++ b/src/modules/AltWindowCycle/AltWindowCycle.cpp
@@ -170,6 +170,17 @@ static LRESULT CALLBACK ThumbHostProc(HWND h, UINT msg, WPARAM w, LPARAM l)
         }
         return 1;
     }
+    if (msg == WM_NCCALCSIZE && w)
+    {
+        // thumbHost carries WS_CAPTION solely so DWM treats it as a "framed"
+        // top-level window -- DWMWA_SYSTEMBACKDROP_TYPE (Mica/acrylic) is
+        // silently ignored on plain WS_POPUP windows with no frame at all.
+        // Returning 0 here (instead of calling DefWindowProc) collapses the
+        // non-client caption/border to nothing, so the window still looks
+        // like a plain borderless popup while DWM still applies the
+        // backdrop material to it.
+        return 0;
+    }
     return DefWindowProcW(h, msg, w, l);
 }
 
@@ -503,7 +514,7 @@ bool Switcher::Init(HINSTANCE instance)
 
     thumbHost = CreateWindowExW(
         WS_EX_TOPMOST | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE,
-        hc.lpszClassName, L"", WS_POPUP,
+        hc.lpszClassName, L"", WS_POPUP | WS_CAPTION,
         0, 0, 0, 0, nullptr, nullptr, hinst, nullptr);
     if (!thumbHost)
         return false;

--- a/src/modules/AltWindowCycle/AltWindowCycle.cpp
+++ b/src/modules/AltWindowCycle/AltWindowCycle.cpp
@@ -35,12 +35,6 @@
 #ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
 #define DWMWA_USE_IMMERSIVE_DARK_MODE 20
 #endif
-#ifndef DWMWA_NCRENDERING_POLICY
-#define DWMWA_NCRENDERING_POLICY 2
-#endif
-#ifndef DWMNCRP_DISABLED
-#define DWMNCRP_DISABLED 1
-#endif
 #ifndef DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
 #define DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 ((DPI_AWARENESS_CONTEXT)-4)
 #endif
@@ -514,17 +508,6 @@ bool Switcher::Init(HINSTANCE instance)
     if (!thumbHost)
         return false;
 
-    // The system-backdrop material (DWMWA_SYSTEMBACKDROP_TYPE) draws DWM's
-    // default elevation shadow around the window's *rectangular* bounds. That
-    // shadow ignores the rounded SetWindowRgn applied below, so it peeks out
-    // past the rounded corners as a stray gray sliver. Disabling non-client
-    // rendering removes DWM's default shadow/border chrome while leaving the
-    // backdrop material and extended-frame glass (drawn per pixel by us)
-    // untouched.
-    DWORD ncRenderingPolicy = DWMNCRP_DISABLED;
-    DwmSetWindowAttribute(thumbHost, DWMWA_NCRENDERING_POLICY,
-                          &ncRenderingPolicy, sizeof(ncRenderingPolicy));
-
     WNDCLASSW wc = {};
     wc.style = CS_HREDRAW | CS_VREDRAW;
     wc.lpfnWndProc = &Switcher::WndProc;
@@ -767,20 +750,16 @@ void Switcher::ShowOverlayWindow()
     SetWindowPos(thumbHost, HWND_TOPMOST, x, y, panelW, panelH,
                  SWP_NOACTIVATE | SWP_NOOWNERZORDER);
     ApplyBackdrop(thumbHost);
+    // Let DWM itself round thumbHost's corners instead of cutting a manual
+    // SetWindowRgn. DWM's default elevation shadow is drawn to match whatever
+    // corner shape DWM is applying; a hand-cut region at a slightly different
+    // radius/metric than DWM's own rounding left a sliver of that shadow
+    // peeking out past our rounded corner. Using only DWMWA_WINDOW_CORNER_PREFERENCE
+    // keeps the corner shape and its shadow self-consistent.
     DWORD cornerPref = DWMWCP_ROUND;
     DwmSetWindowAttribute(thumbHost, DWMWA_WINDOW_CORNER_PREFERENCE,
                           &cornerPref, sizeof(cornerPref));
-    HRGN rgn = CreateRoundRectRgn(0, 0, panelW + 1, panelH + 1,
-                                  2 * Scaled(8), 2 * Scaled(8));
-    if (rgn != nullptr)
-    {
-        // SetWindowRgn takes ownership of the region on success; on failure the
-        // caller still owns it, so delete it to avoid leaking the HRGN.
-        if (SetWindowRgn(thumbHost, rgn, FALSE) == 0)
-        {
-            DeleteObject(rgn);
-        }
-    }
+    SetWindowRgn(thumbHost, nullptr, FALSE);
     RedrawWindow(thumbHost, nullptr, nullptr,
                  RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW | RDW_ALLCHILDREN);
     RegisterThumbnails();

--- a/src/modules/AltWindowCycle/AltWindowCycle.cpp
+++ b/src/modules/AltWindowCycle/AltWindowCycle.cpp
@@ -1314,7 +1314,7 @@ void Switcher::RenderLayered()
             // Single accent focus ring hugging the selected tile.
             if (sel)
             {
-                int gPad = Scaled(4);
+                int gPad = Scaled(6);
                 Gdiplus::GraphicsPath ring;
                 BuildRoundRect(ring, InflateF(tile, gPad),
                                static_cast<Gdiplus::REAL>(radius + gPad));

--- a/src/modules/AltWindowCycle/AltWindowCycle.cpp
+++ b/src/modules/AltWindowCycle/AltWindowCycle.cpp
@@ -202,6 +202,19 @@ static void ApplyBackdrop(HWND hwnd)
         DwmExtendFrameIntoClientArea(hwnd, &glass);
         int backdrop = DWMSBT_TRANSIENTWINDOW;
         DwmSetWindowAttribute(hwnd, DWMWA_SYSTEMBACKDROP_TYPE, &backdrop, sizeof(backdrop));
+
+        // DWM automatically flattens Mica/acrylic backdrop material to a
+        // solid, non-blurred tint on any window it considers "inactive".
+        // thumbHost is WS_EX_NOACTIVATE (it must never steal real
+        // keyboard/foreground focus from whatever app the user is
+        // switching away from), so without this call DWM would always see
+        // it as inactive and always render the flattened/opaque fallback
+        // color -- never live blur, no matter how correctly the backdrop
+        // attribute itself is set. WM_NCACTIVATE with wParam=TRUE tells DWM
+        // to paint this window's frame/backdrop as if it were active,
+        // purely for rendering purposes; it does not change real Win32
+        // input focus or activate the window.
+        SendMessageW(hwnd, WM_NCACTIVATE, TRUE, 0);
     }
     else
     {
@@ -786,6 +799,10 @@ void Switcher::ShowOverlayWindow()
     RenderLayered();
     SetWindowPos(thumbHost, HWND_TOPMOST, x, y, panelW, panelH,
                  SWP_NOACTIVATE | SWP_SHOWWINDOW);
+    // Re-assert the fake-active state after showing: some DWM paths reset
+    // a window's WM_NCACTIVATE state to inactive around SWP_SHOWWINDOW,
+    // which would flatten the Mica/acrylic backdrop right after it appears.
+    SendMessageW(thumbHost, WM_NCACTIVATE, TRUE, 0);
     SetWindowPos(overlay, HWND_TOPMOST, x, y, panelW, panelH,
                  SWP_NOACTIVATE | SWP_SHOWWINDOW);
     SetWindowPos(thumbHost, overlay, 0, 0, 0, 0,

--- a/src/modules/AltWindowCycle/AltWindowCycle.cpp
+++ b/src/modules/AltWindowCycle/AltWindowCycle.cpp
@@ -1362,19 +1362,25 @@ void Switcher::RenderLayered()
                 {
                     RECT avail = { 0, 0, snapshotSizes[slot].cx, snapshotSizes[slot].cy };
                     RECT rcSrc = AltWindowCycleLogic::CoverSource(pv, avail);
-                    // Draw the captured window content as-is -- no color adjustment.
-                    g.SetSmoothingMode(Gdiplus::SmoothingModeNone);
-                    g.DrawImage(snap,
-                                Gdiplus::RectF(static_cast<Gdiplus::REAL>(pv.left),
-                                               static_cast<Gdiplus::REAL>(pv.top),
-                                               static_cast<Gdiplus::REAL>(pw),
-                                               static_cast<Gdiplus::REAL>(ph)),
-                                static_cast<Gdiplus::REAL>(rcSrc.left),
-                                static_cast<Gdiplus::REAL>(rcSrc.top),
-                                static_cast<Gdiplus::REAL>(rcSrc.right - rcSrc.left),
-                                static_cast<Gdiplus::REAL>(rcSrc.bottom - rcSrc.top),
-                                Gdiplus::UnitPixel);
+                    // Unlike a live DWM thumbnail -- an OS-composited plain rectangle we
+                    // have no way to clip -- this bitmap is painted entirely by us, so we
+                    // can round its corners to match the card instead of using a square
+                    // punch. Map source->dest with a texture-brush transform and fill a
+                    // rounded-rect path so the clip edge is anti-aliased.
+                    Gdiplus::REAL srcW = static_cast<Gdiplus::REAL>(rcSrc.right - rcSrc.left);
+                    Gdiplus::REAL srcH = static_cast<Gdiplus::REAL>(rcSrc.bottom - rcSrc.top);
+                    Gdiplus::REAL scaleX = srcW > 0 ? static_cast<Gdiplus::REAL>(pw) / srcW : 1.0f;
+                    Gdiplus::REAL scaleY = srcH > 0 ? static_cast<Gdiplus::REAL>(ph) / srcH : 1.0f;
+                    Gdiplus::TextureBrush brush(snap, Gdiplus::WrapModeClamp);
+                    Gdiplus::Matrix xform(scaleX, 0.0f, 0.0f, scaleY,
+                                          static_cast<Gdiplus::REAL>(pv.left) - rcSrc.left * scaleX,
+                                          static_cast<Gdiplus::REAL>(pv.top) - rcSrc.top * scaleY);
+                    brush.SetTransform(&xform);
+
+                    Gdiplus::GraphicsPath previewPath;
+                    BuildRoundRect(previewPath, InflateF(pv, 0), static_cast<Gdiplus::REAL>(radius));
                     g.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
+                    g.FillPath(&brush, &previewPath);
                 }
                 else
                 {

--- a/src/modules/AltWindowCycle/AltWindowCycle.cpp
+++ b/src/modules/AltWindowCycle/AltWindowCycle.cpp
@@ -1037,6 +1037,25 @@ static void BuildRoundRect(Gdiplus::GraphicsPath& path, const Gdiplus::RectF& r,
     path.CloseFigure();
 }
 
+// Same as BuildRoundRect but only rounds the bottom-left/bottom-right corners,
+// leaving the top edge a hard cut. Used for the preview image, which now sits
+// flush under the header row (no gap to round away) but still needs to match
+// the card's rounded bottom corners where it meets the card edge.
+static void BuildBottomRoundRect(Gdiplus::GraphicsPath& path, const Gdiplus::RectF& r, Gdiplus::REAL rad)
+{
+    path.Reset();
+    Gdiplus::REAL d = rad * 2;
+    if (d <= 0 || d > r.Width || d > r.Height)
+    {
+        path.AddRectangle(r);
+        return;
+    }
+    path.AddLine(r.X, r.Y, r.GetRight(), r.Y);
+    path.AddArc(r.GetRight() - d, r.GetBottom() - d, d, d, 0, 90);
+    path.AddArc(r.X, r.GetBottom() - d, d, d, 90, 90);
+    path.CloseFigure();
+}
+
 static Gdiplus::RectF InflateF(const RECT& r, int by)
 {
     return Gdiplus::RectF(
@@ -1378,20 +1397,18 @@ void Switcher::RenderLayered()
                     brush.SetTransform(&xform);
 
                     Gdiplus::GraphicsPath previewPath;
-                    BuildRoundRect(previewPath, InflateF(pv, 0), static_cast<Gdiplus::REAL>(radius));
+                    BuildBottomRoundRect(previewPath, InflateF(pv, 0), static_cast<Gdiplus::REAL>(radius));
                     g.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
                     g.FillPath(&brush, &previewPath);
                 }
                 else
                 {
-                    g.SetSmoothingMode(Gdiplus::SmoothingModeNone);
+                    Gdiplus::GraphicsPath previewPath;
+                    BuildBottomRoundRect(previewPath, InflateF(pv, 0), static_cast<Gdiplus::REAL>(radius));
+                    g.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
                     g.SetCompositingMode(Gdiplus::CompositingModeSourceCopy);
                     Gdiplus::SolidBrush previewBrush(AltTabStyle::Transparent());
-                    g.FillRectangle(&previewBrush,
-                                    static_cast<Gdiplus::REAL>(pv.left),
-                                    static_cast<Gdiplus::REAL>(pv.top),
-                                    static_cast<Gdiplus::REAL>(pw),
-                                    static_cast<Gdiplus::REAL>(ph));
+                    g.FillPath(&previewBrush, &previewPath);
                     g.SetCompositingMode(Gdiplus::CompositingModeSourceOver);
                     // The subtle semi-transparent white stroke below is meant to catch
                     // light against the blurred/transparent DWM punch above; it was
@@ -1399,9 +1416,7 @@ void Switcher::RenderLayered()
                     // (where it reads as a harsh white border), so only draw it here.
                     Gdiplus::Pen previewPen(AltTabStyle::PreviewStroke(sel),
                                              static_cast<Gdiplus::REAL>((std::max)(1, Scaled(1))));
-                    g.SetSmoothingMode(Gdiplus::SmoothingModeNone);
-                    g.DrawRectangle(&previewPen, pv.left, pv.top, pw - 1, ph - 1);
-                    g.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
+                    g.DrawPath(&previewPen, &previewPath);
                 }
             }
 

--- a/src/modules/AltWindowCycle/AltWindowCycle.cpp
+++ b/src/modules/AltWindowCycle/AltWindowCycle.cpp
@@ -1311,25 +1311,16 @@ void Switcher::RenderLayered()
                                AltTabStyle::HeaderTextRef(sel), AltTabStyle::CardRef(sel));
             }
 
-            // Two-ring accent focus ring around the selected tile.
+            // Single accent focus ring hugging the selected tile.
             if (sel)
             {
-                int gPad = Scaled(10);
-                int gOut = gPad + Scaled(2);
-                // Both rings share the same corner radius (grown from the inner gap)
-                // so the outer accent ring stays concentric with the inner hairline
-                // instead of ballooning into a rounder, ill-fitting corner.
-                Gdiplus::GraphicsPath innerRing, out;
-                BuildRoundRect(innerRing, InflateF(tile, gPad),
+                int gPad = Scaled(4);
+                Gdiplus::GraphicsPath ring;
+                BuildRoundRect(ring, InflateF(tile, gPad),
                                static_cast<Gdiplus::REAL>(radius + gPad));
-                BuildRoundRect(out, InflateF(tile, gOut),
-                               static_cast<Gdiplus::REAL>(radius + gPad));
-                Gdiplus::Pen darkPen(AltTabStyle::FocusShadow(),
-                                     static_cast<Gdiplus::REAL>((std::max)(1, Scaled(1))));
                 Gdiplus::Pen accentPen(accentClr,
                                        static_cast<Gdiplus::REAL>((std::max)(2, Scaled(3))));
-                g.DrawPath(&darkPen, &innerRing);
-                g.DrawPath(&accentPen, &out);
+                g.DrawPath(&accentPen, &ring);
             }
         }
 

--- a/src/modules/AltWindowCycle/AltWindowCycle.cpp
+++ b/src/modules/AltWindowCycle/AltWindowCycle.cpp
@@ -14,6 +14,7 @@
 #include <objidl.h>
 #include <gdiplus.h>
 #include <atomic>
+#include <memory>
 
 // Win11 system backdrop / corner attributes (in case SDK is older).
 #ifndef DWMWA_SYSTEMBACKDROP_TYPE
@@ -142,6 +143,17 @@ static bool SupportsSystemBackdrop()
 // opaque with this tinted brush.
 static HBRUSH g_thumbSolidBrush = nullptr;
 static bool g_thumbSolidMode = false;
+
+// Prototype: preview mode. Live thumbnails (default) use the public DWM
+// thumbnail API for a real-time mirror of the target window, but that mirror
+// always shows the target window's own current light/dark rendering, which can
+// look mismatched against our fixed-dark card chrome. As an alternative, a
+// static-snapshot mode captures the window once (via the public PrintWindow
+// API) and draws it with a uniform dark wash so every preview looks
+// consistent regardless of the source window's theme, at the cost of live
+// updates. Hardcoded for now to evaluate the approach; intended to become a
+// user-facing setting (a per-user choice between live vs. static previews).
+constexpr bool kUseStaticSnapshotPreview = true;
 
 static LRESULT CALLBACK ThumbHostProc(HWND h, UINT msg, WPARAM w, LPARAM l)
 {
@@ -442,6 +454,10 @@ private:
     St state = St::Idle;
     std::vector<HWND> windows;
     std::vector<HTHUMBNAIL> thumbs;
+    // Static-snapshot preview mode only (kUseStaticSnapshotPreview): one captured
+    // bitmap + its native size per visible slot, refreshed on show/page change.
+    std::vector<std::unique_ptr<Gdiplus::Bitmap>> snapshots;
+    std::vector<SIZE> snapshotSizes;
     std::vector<HICON> icons;
     std::vector<std::wstring> titles;
     HWND anchorWindow = nullptr;
@@ -868,6 +884,59 @@ static SIZE ClientSourceSize(HWND hwnd)
     return { 0, 0 };
 }
 
+// Prototype (kUseStaticSnapshotPreview): captures a window's client area into a
+// GDI+ bitmap via the public PrintWindow API. Unlike a live DWM thumbnail this
+// is a one-shot snapshot (no further updates until the caller re-captures), but
+// it lets the renderer apply a uniform color treatment so previews don't look
+// mismatched when the source window's own light/dark theme differs from ours.
+static std::unique_ptr<Gdiplus::Bitmap> CaptureWindowSnapshot(HWND hwnd, SIZE& outSize)
+{
+    outSize = { 0, 0 };
+    SIZE clientSize = ClientSourceSize(hwnd);
+    if (clientSize.cx <= 0 || clientSize.cy <= 0)
+        return nullptr;
+
+    HDC hdcWindow = GetDC(hwnd);
+    if (!hdcWindow)
+        return nullptr;
+    HDC hdcMem = CreateCompatibleDC(hdcWindow);
+    HBITMAP hbmp = hdcMem ? CreateCompatibleBitmap(hdcWindow, clientSize.cx, clientSize.cy) : nullptr;
+    if (!hdcMem || !hbmp)
+    {
+        if (hdcMem) DeleteDC(hdcMem);
+        if (hbmp) DeleteObject(hbmp);
+        ReleaseDC(hwnd, hdcWindow);
+        return nullptr;
+    }
+
+    HGDIOBJ old = SelectObject(hdcMem, hbmp);
+    // PW_RENDERFULLCONTENT asks the window to render its full (potentially
+    // GPU/DirectComposition-backed) content; without it, many modern XAML/WinUI
+    // apps paint a blank surface into the DC.
+    BOOL ok = PrintWindow(hwnd, hdcMem, PW_CLIENTONLY | PW_RENDERFULLCONTENT);
+    SelectObject(hdcMem, old);
+    ReleaseDC(hwnd, hdcWindow);
+
+    std::unique_ptr<Gdiplus::Bitmap> bmp;
+    if (ok)
+    {
+        // The Gdiplus::Bitmap(HBITMAP, HPALETTE) constructor copies the pixel
+        // data, so hbmp can be safely destroyed once it returns.
+        bmp = std::make_unique<Gdiplus::Bitmap>(hbmp, static_cast<HPALETTE>(nullptr));
+        if (bmp->GetLastStatus() != Gdiplus::Ok)
+        {
+            bmp.reset();
+        }
+        else
+        {
+            outSize = clientSize;
+        }
+    }
+    DeleteObject(hbmp);
+    DeleteDC(hdcMem);
+    return bmp;
+}
+
 void Switcher::RegisterThumbnails()
 {
     UnregisterThumbnails();
@@ -878,6 +947,16 @@ void Switcher::RegisterThumbnails()
     for (int windowIndex = pageStart, slot = 0; windowIndex < pageEnd; ++windowIndex, ++slot)
     {
         RECT dest = PreviewRect(TileRect(slot));
+
+        if (kUseStaticSnapshotPreview)
+        {
+            SIZE srcSize = {};
+            snapshots.push_back(CaptureWindowSnapshot(windows[windowIndex], srcSize));
+            snapshotSizes.push_back(srcSize);
+            thumbs.push_back(nullptr);
+            continue;
+        }
+
         HTHUMBNAIL th = nullptr;
         if (FAILED(DwmRegisterThumbnail(thumbHost, windows[windowIndex], &th)) || !th)
         {
@@ -920,6 +999,8 @@ void Switcher::UnregisterThumbnails()
         if (th)
             DwmUnregisterThumbnail(th);
     thumbs.clear();
+    snapshots.clear();
+    snapshotSizes.clear();
 }
 
 void Switcher::EnsureFont()
@@ -1274,15 +1355,51 @@ void Switcher::RenderLayered()
             int ph = pv.bottom - pv.top;
             if (pw > 0 && ph > 0)
             {
-                g.SetSmoothingMode(Gdiplus::SmoothingModeNone);
-                g.SetCompositingMode(Gdiplus::CompositingModeSourceCopy);
-                Gdiplus::SolidBrush previewBrush(AltTabStyle::Transparent());
-                g.FillRectangle(&previewBrush,
-                                static_cast<Gdiplus::REAL>(pv.left),
-                                static_cast<Gdiplus::REAL>(pv.top),
-                                static_cast<Gdiplus::REAL>(pw),
-                                static_cast<Gdiplus::REAL>(ph));
-                g.SetCompositingMode(Gdiplus::CompositingModeSourceOver);
+                Gdiplus::Bitmap* snap = (kUseStaticSnapshotPreview && slot < static_cast<int>(snapshots.size()))
+                                             ? snapshots[slot].get()
+                                             : nullptr;
+                if (snap)
+                {
+                    RECT avail = { 0, 0, snapshotSizes[slot].cx, snapshotSizes[slot].cy };
+                    RECT rcSrc = AltWindowCycleLogic::CoverSource(pv, avail);
+                    // Uniform dark wash: scales each color channel down so a captured
+                    // snapshot reads consistently regardless of the source window's
+                    // own light/dark theme, instead of looking mismatched against the
+                    // surrounding dark card chrome.
+                    Gdiplus::ColorMatrix darkWash = {
+                        0.55f, 0.f,   0.f,   0.f, 0.f,
+                        0.f,   0.55f, 0.f,   0.f, 0.f,
+                        0.f,   0.f,   0.55f, 0.f, 0.f,
+                        0.f,   0.f,   0.f,   1.f, 0.f,
+                        0.f,   0.f,   0.f,   0.f, 1.f
+                    };
+                    Gdiplus::ImageAttributes attrs;
+                    attrs.SetColorMatrix(&darkWash);
+                    g.SetSmoothingMode(Gdiplus::SmoothingModeNone);
+                    g.DrawImage(snap,
+                                Gdiplus::RectF(static_cast<Gdiplus::REAL>(pv.left),
+                                               static_cast<Gdiplus::REAL>(pv.top),
+                                               static_cast<Gdiplus::REAL>(pw),
+                                               static_cast<Gdiplus::REAL>(ph)),
+                                static_cast<Gdiplus::REAL>(rcSrc.left),
+                                static_cast<Gdiplus::REAL>(rcSrc.top),
+                                static_cast<Gdiplus::REAL>(rcSrc.right - rcSrc.left),
+                                static_cast<Gdiplus::REAL>(rcSrc.bottom - rcSrc.top),
+                                Gdiplus::UnitPixel, &attrs);
+                    g.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
+                }
+                else
+                {
+                    g.SetSmoothingMode(Gdiplus::SmoothingModeNone);
+                    g.SetCompositingMode(Gdiplus::CompositingModeSourceCopy);
+                    Gdiplus::SolidBrush previewBrush(AltTabStyle::Transparent());
+                    g.FillRectangle(&previewBrush,
+                                    static_cast<Gdiplus::REAL>(pv.left),
+                                    static_cast<Gdiplus::REAL>(pv.top),
+                                    static_cast<Gdiplus::REAL>(pw),
+                                    static_cast<Gdiplus::REAL>(ph));
+                    g.SetCompositingMode(Gdiplus::CompositingModeSourceOver);
+                }
                 Gdiplus::Pen previewPen(AltTabStyle::PreviewStroke(sel),
                                          static_cast<Gdiplus::REAL>((std::max)(1, Scaled(1))));
                 g.SetSmoothingMode(Gdiplus::SmoothingModeNone);

--- a/src/modules/AltWindowCycle/AltWindowCycle.cpp
+++ b/src/modules/AltWindowCycle/AltWindowCycle.cpp
@@ -32,6 +32,9 @@
 #ifndef DWMWCP_ROUND
 #define DWMWCP_ROUND 2
 #endif
+#ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
+#define DWMWA_USE_IMMERSIVE_DARK_MODE 20
+#endif
 #ifndef DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
 #define DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 ((DPI_AWARENESS_CONTEXT)-4)
 #endif
@@ -171,9 +174,16 @@ static LRESULT CALLBACK ThumbHostProc(HWND h, UINT msg, WPARAM w, LPARAM l)
 }
 
 // Apply the overlay backdrop to thumbHost. Win11 22H2+ gets public acrylic via
-// DWMWA_SYSTEMBACKDROP_TYPE; older builds get an opaque tinted fill.
-static void ApplyBackdrop(HWND hwnd, bool light)
+// DWMWA_SYSTEMBACKDROP_TYPE; older builds get an opaque tinted fill. The card
+// chrome is a fixed dark look regardless of the user's OS theme, so the
+// backdrop is forced dark too (DWMWA_USE_IMMERSIVE_DARK_MODE) -- otherwise
+// DWMSBT_TRANSIENTWINDOW would tint itself light on a light-mode system and
+// clash with the dark cards drawn on top of it.
+static void ApplyBackdrop(HWND hwnd)
 {
+    BOOL dark = TRUE;
+    DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &dark, sizeof(dark));
+
     if (SupportsSystemBackdrop())
     {
         g_thumbSolidMode = false;
@@ -187,7 +197,7 @@ static void ApplyBackdrop(HWND hwnd, bool light)
         g_thumbSolidMode = true;
         if (g_thumbSolidBrush)
             DeleteObject(g_thumbSolidBrush);
-        g_thumbSolidBrush = CreateSolidBrush(AltTabStyle::BackdropSolidRef(light));
+        g_thumbSolidBrush = CreateSolidBrush(AltTabStyle::BackdropSolidRef(false));
     }
 }
 
@@ -739,7 +749,7 @@ void Switcher::ShowOverlayWindow()
 
     SetWindowPos(thumbHost, HWND_TOPMOST, x, y, panelW, panelH,
                  SWP_NOACTIVATE | SWP_NOOWNERZORDER);
-    ApplyBackdrop(thumbHost, AltTabStyle::IsLightTheme());
+    ApplyBackdrop(thumbHost);
     DWORD cornerPref = DWMWCP_ROUND;
     DwmSetWindowAttribute(thumbHost, DWMWA_WINDOW_CORNER_PREFERENCE,
                           &cornerPref, sizeof(cornerPref));
@@ -812,13 +822,15 @@ void Switcher::SetSelection(int index)
     RenderLayered();
 }
 
-// React to a live OS Light/Dark theme switch while the overlay is visible:
-// refresh the backdrop (re-tints the solid fallback) and repaint the chrome.
+// React to a live OS Light/Dark theme switch while the overlay is visible.
+// The backdrop is forced dark regardless of system theme (to match the fixed
+// dark card chrome), so this just re-applies it defensively -- e.g. in case
+// DWM cleared window attributes across a theme transition -- and repaints.
 void Switcher::OnThemeChanged()
 {
     if (state != St::Visible)
         return;
-    ApplyBackdrop(thumbHost, AltTabStyle::IsLightTheme());
+    ApplyBackdrop(thumbHost);
     RedrawWindow(thumbHost, nullptr, nullptr,
                  RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW | RDW_ALLCHILDREN);
     RenderLayered();

--- a/src/modules/AltWindowCycle/AltWindowCycle.cpp
+++ b/src/modules/AltWindowCycle/AltWindowCycle.cpp
@@ -1396,16 +1396,28 @@ void Switcher::RenderLayered()
                     // Unlike a live DWM thumbnail -- an OS-composited plain rectangle we
                     // have no way to clip -- this bitmap is painted entirely by us, so we
                     // can round its corners to match the card instead of using a square
-                    // punch. Map source->dest with a texture-brush transform and fill a
-                    // rounded-rect path so the clip edge is anti-aliased.
+                    // punch. Pre-render the cropped/scaled image into a dest-sized
+                    // offscreen bitmap via a plain DrawImage first, then use *that* as
+                    // an identity-scale texture brush to fill the rounded-rect path.
+                    // (A TextureBrush sampled through a non-identity scale Matrix bleeds
+                    // a thin edge from outside its WrapModeClamp bounds -- a known GDI+
+                    // artifact -- so scaling has to happen in DrawImage, not the brush.)
+                    Gdiplus::REAL srcLeft = static_cast<Gdiplus::REAL>(rcSrc.left);
+                    Gdiplus::REAL srcTop = static_cast<Gdiplus::REAL>(rcSrc.top);
                     Gdiplus::REAL srcW = static_cast<Gdiplus::REAL>(rcSrc.right - rcSrc.left);
                     Gdiplus::REAL srcH = static_cast<Gdiplus::REAL>(rcSrc.bottom - rcSrc.top);
-                    Gdiplus::REAL scaleX = srcW > 0 ? static_cast<Gdiplus::REAL>(pw) / srcW : 1.0f;
-                    Gdiplus::REAL scaleY = srcH > 0 ? static_cast<Gdiplus::REAL>(ph) / srcH : 1.0f;
-                    Gdiplus::TextureBrush brush(snap, Gdiplus::WrapModeClamp);
-                    Gdiplus::Matrix xform(scaleX, 0.0f, 0.0f, scaleY,
-                                          static_cast<Gdiplus::REAL>(pv.left) - rcSrc.left * scaleX,
-                                          static_cast<Gdiplus::REAL>(pv.top) - rcSrc.top * scaleY);
+
+                    Gdiplus::Bitmap scaled(pw, ph, PixelFormat32bppPARGB);
+                    Gdiplus::Graphics tg(&scaled);
+                    tg.SetInterpolationMode(Gdiplus::InterpolationModeHighQualityBicubic);
+                    tg.SetPixelOffsetMode(Gdiplus::PixelOffsetModeHighQuality);
+                    tg.DrawImage(snap, Gdiplus::RectF(0.0f, 0.0f, static_cast<Gdiplus::REAL>(pw), static_cast<Gdiplus::REAL>(ph)),
+                                 srcLeft, srcTop, srcW, srcH, Gdiplus::UnitPixel);
+
+                    Gdiplus::TextureBrush brush(&scaled, Gdiplus::WrapModeClamp);
+                    Gdiplus::Matrix xform(1.0f, 0.0f, 0.0f, 1.0f,
+                                          static_cast<Gdiplus::REAL>(pv.left),
+                                          static_cast<Gdiplus::REAL>(pv.top));
                     brush.SetTransform(&xform);
 
                     Gdiplus::GraphicsPath previewPath;

--- a/src/modules/AltWindowCycle/AltWindowCycle.cpp
+++ b/src/modules/AltWindowCycle/AltWindowCycle.cpp
@@ -1314,7 +1314,7 @@ void Switcher::RenderLayered()
             // Single accent focus ring hugging the selected tile.
             if (sel)
             {
-                int gPad = Scaled(6);
+                int gPad = Scaled(10);
                 Gdiplus::GraphicsPath ring;
                 BuildRoundRect(ring, InflateF(tile, gPad),
                                static_cast<Gdiplus::REAL>(radius + gPad));

--- a/src/modules/AltWindowCycle/AltWindowCycle.cpp
+++ b/src/modules/AltWindowCycle/AltWindowCycle.cpp
@@ -35,6 +35,12 @@
 #ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
 #define DWMWA_USE_IMMERSIVE_DARK_MODE 20
 #endif
+#ifndef DWMWA_NCRENDERING_POLICY
+#define DWMWA_NCRENDERING_POLICY 2
+#endif
+#ifndef DWMNCRP_DISABLED
+#define DWMNCRP_DISABLED 1
+#endif
 #ifndef DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
 #define DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 ((DPI_AWARENESS_CONTEXT)-4)
 #endif
@@ -507,6 +513,17 @@ bool Switcher::Init(HINSTANCE instance)
         0, 0, 0, 0, nullptr, nullptr, hinst, nullptr);
     if (!thumbHost)
         return false;
+
+    // The system-backdrop material (DWMWA_SYSTEMBACKDROP_TYPE) draws DWM's
+    // default elevation shadow around the window's *rectangular* bounds. That
+    // shadow ignores the rounded SetWindowRgn applied below, so it peeks out
+    // past the rounded corners as a stray gray sliver. Disabling non-client
+    // rendering removes DWM's default shadow/border chrome while leaving the
+    // backdrop material and extended-frame glass (drawn per pixel by us)
+    // untouched.
+    DWORD ncRenderingPolicy = DWMNCRP_DISABLED;
+    DwmSetWindowAttribute(thumbHost, DWMWA_NCRENDERING_POLICY,
+                          &ncRenderingPolicy, sizeof(ncRenderingPolicy));
 
     WNDCLASSW wc = {};
     wc.style = CS_HREDRAW | CS_VREDRAW;

--- a/src/modules/AltWindowCycle/AltWindowCycle.cpp
+++ b/src/modules/AltWindowCycle/AltWindowCycle.cpp
@@ -760,6 +760,12 @@ void Switcher::ShowOverlayWindow()
     DwmSetWindowAttribute(thumbHost, DWMWA_WINDOW_CORNER_PREFERENCE,
                           &cornerPref, sizeof(cornerPref));
     SetWindowRgn(thumbHost, nullptr, FALSE);
+    // DWM doesn't always repaint non-client chrome immediately after
+    // DwmSetWindowAttribute calls (backdrop type, corner preference, dark
+    // mode) on a window whose size didn't change. A no-op SWP_FRAMECHANGED
+    // forces DWM to recompute and actually apply them.
+    SetWindowPos(thumbHost, nullptr, 0, 0, 0, 0,
+                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
     RedrawWindow(thumbHost, nullptr, nullptr,
                  RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW | RDW_ALLCHILDREN);
     RegisterThumbnails();

--- a/src/modules/AltWindowCycle/AltWindowCycle.cpp
+++ b/src/modules/AltWindowCycle/AltWindowCycle.cpp
@@ -82,52 +82,37 @@ namespace AltTabStyle
     }
 
     inline COLORREF AccentFallbackRef() { return RGB(0, 120, 215); }
-    constexpr COLORREF HeaderTextRef(bool light)
+    constexpr COLORREF HeaderTextRef(bool selected)
     {
-        return light ? RGB(26, 26, 26) : RGB(235, 235, 235);
+        return selected ? RGB(255, 255, 255) : RGB(207, 207, 207);
     }
 
     inline Gdiplus::Color Transparent() { return Gdiplus::Color(0, 0, 0, 0); }
-
-    // WinUI CardBackgroundFillColorDefault. Same for every tile; selection is shown
-    // only by the accent focus outline. Semi-transparent so the acrylic shows through.
-    inline Gdiplus::Color Card(bool light)
+    inline Gdiplus::Color Card(bool selected)
     {
-        return light ? Gdiplus::Color(179, 255, 255, 255)  // #B3FFFFFF
-                     : Gdiplus::Color(210, 18, 18, 18);     // dark, mostly-opaque tile
+        return selected ? Gdiplus::Color(255, 58, 58, 62)
+                        : Gdiplus::Color(255, 43, 43, 46);
     }
-    constexpr COLORREF CardRef(bool light)
+    constexpr COLORREF CardRef(bool selected)
     {
-        // Opaque approximation of the card-over-acrylic color, available for any
-        // surface that needs a solid blend background.
-        return light ? RGB(248, 248, 248) : RGB(20, 20, 20);
-    }
-    // WinUI CardStrokeColorDefault: a subtle 1px edge around each card.
-    inline Gdiplus::Color CardStroke(bool light)
-    {
-        return light ? Gdiplus::Color(15, 0, 0, 0)
-                     : Gdiplus::Color(25, 0, 0, 0);
+        return selected ? RGB(58, 58, 62) : RGB(43, 43, 46);
     }
     inline Gdiplus::Color Accent(COLORREF accent)
     {
         return Gdiplus::Color(255, GetRValue(accent), GetGValue(accent), GetBValue(accent));
     }
-    inline Gdiplus::Color SurfaceStrokeDefault(bool light)
+    inline Gdiplus::Color SurfaceStrokeDefault()
     {
-        return light ? Gdiplus::Color(24, 0, 0, 0)
-                     : Gdiplus::Color(64, 255, 255, 255);
+        return Gdiplus::Color(64, 255, 255, 255);
     }
-    inline Gdiplus::Color PreviewStroke(bool light)
+    inline Gdiplus::Color PreviewStroke(bool selected)
     {
-        return light ? Gdiplus::Color(28, 0, 0, 0)
-                     : Gdiplus::Color(60, 255, 255, 255);
+        return selected ? Gdiplus::Color(90, 255, 255, 255)
+                        : Gdiplus::Color(45, 255, 255, 255);
     }
-    inline Gdiplus::Color FocusShadow(bool light)
+    inline Gdiplus::Color FocusShadow()
     {
-        // Contrast hairline just inside the accent ring: white in light mode,
-        // black in dark mode.
-        return light ? Gdiplus::Color(120, 255, 255, 255)
-                     : Gdiplus::Color(150, 0, 0, 0);
+        return Gdiplus::Color(150, 0, 0, 0);
     }
 }
 
@@ -946,7 +931,7 @@ void Switcher::EnsureFont()
         DeleteObject(font);
         font = nullptr;
     }
-    int height = -Scaled(14);
+    int height = -Scaled(15);
     font = CreateFontW(height, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE,
                        DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS,
                        CLEARTYPE_NATURAL_QUALITY, DEFAULT_PITCH | FF_DONTCARE, L"Segoe UI");
@@ -966,24 +951,6 @@ static void BuildRoundRect(Gdiplus::GraphicsPath& path, const Gdiplus::RectF& r,
     }
     path.AddArc(r.X, r.Y, d, d, 180, 90);
     path.AddArc(r.GetRight() - d, r.Y, d, d, 270, 90);
-    path.AddArc(r.GetRight() - d, r.GetBottom() - d, d, d, 0, 90);
-    path.AddArc(r.X, r.GetBottom() - d, d, d, 90, 90);
-    path.CloseFigure();
-}
-
-// Square top edge, rounded bottom corners. Used for the live preview viewport so
-// the full-bleed DWM thumbnail reads as rounded at the bottom of the card.
-static void BuildBottomRoundRect(Gdiplus::GraphicsPath& path, const Gdiplus::RectF& r, Gdiplus::REAL rad)
-{
-    path.Reset();
-    Gdiplus::REAL d = rad * 2;
-    if (d <= 0 || d > r.Width || d > r.Height)
-    {
-        path.AddRectangle(r);
-        return;
-    }
-    path.AddLine(r.X, r.Y, r.GetRight(), r.Y);
-    path.AddLine(r.GetRight(), r.Y, r.GetRight(), r.GetBottom() - rad);
     path.AddArc(r.GetRight() - d, r.GetBottom() - d, d, d, 0, 90);
     path.AddArc(r.X, r.GetBottom() - d, d, d, 90, 90);
     path.CloseFigure();
@@ -1139,7 +1106,7 @@ static void DrawIconOverPARGB(void* destBits, int destW, int destH,
 
 static void DrawHeaderText(BYTE* destBits, int destW, int destH, HFONT fontHandle,
                            const RECT& rc, const std::wstring& text,
-                           COLORREF textColor,
+                           COLORREF textColor, COLORREF backgroundColor,
                            UINT alignFlag = DT_LEFT)
 {
     if (!destBits || destW <= 0 || destH <= 0 || text.empty() || !fontHandle)
@@ -1173,15 +1140,12 @@ static void DrawHeaderText(BYTE* destBits, int destW, int destH, HFONT fontHandl
     HGDIOBJ oldBmp = SelectObject(textDC, scratch);
     HGDIOBJ oldFont = SelectObject(textDC, fontHandle);
     RECT fill = { 0, 0, w, h };
-    // Render white text on a black scratch; the luminance doubles as a coverage
-    // mask so the glyphs can be composited onto the translucent card without
-    // painting an opaque background box behind them.
-    HBRUSH bg = CreateSolidBrush(RGB(0, 0, 0));
+    HBRUSH bg = CreateSolidBrush(backgroundColor);
     FillRect(textDC, &fill, bg);
     DeleteObject(bg);
 
     int oldBk = SetBkMode(textDC, TRANSPARENT);
-    COLORREF oldColor = SetTextColor(textDC, RGB(255, 255, 255));
+    COLORREF oldColor = SetTextColor(textDC, textColor);
 
     RECT textRc = fill;
     DrawTextW(textDC, text.c_str(), static_cast<int>(text.size()), &textRc,
@@ -1191,9 +1155,6 @@ static void DrawHeaderText(BYTE* destBits, int destW, int destH, HFONT fontHandl
     SetBkMode(textDC, oldBk);
     SelectObject(textDC, oldFont);
 
-    const int tb = GetBValue(textColor);
-    const int tg = GetGValue(textColor);
-    const int tr = GetRValue(textColor);
     const BYTE* src = static_cast<const BYTE*>(scratchBits);
     for (int y = 0; y < h; ++y)
     {
@@ -1207,18 +1168,11 @@ static void DrawHeaderText(BYTE* destBits, int destW, int destH, HFONT fontHandl
                 continue;
 
             const BYTE* s = src + (static_cast<size_t>(y) * w + x) * 4;
-            int a = (s[0] + s[1] + s[2] + 1) / 3; // glyph coverage 0..255
-            if (a == 0)
-                continue;
-
-            // Source-over onto premultiplied-alpha dest (BGRA). The text is opaque,
-            // so its premultiplied contribution is colour * coverage.
             BYTE* d = destBits + (static_cast<size_t>(dy) * destW + dx) * 4;
-            int inv = 255 - a;
-            d[0] = static_cast<BYTE>((tb * a + 127) / 255 + (d[0] * inv + 127) / 255);
-            d[1] = static_cast<BYTE>((tg * a + 127) / 255 + (d[1] * inv + 127) / 255);
-            d[2] = static_cast<BYTE>((tr * a + 127) / 255 + (d[2] * inv + 127) / 255);
-            d[3] = static_cast<BYTE>(a + (d[3] * inv + 127) / 255);
+            d[0] = s[0];
+            d[1] = s[1];
+            d[2] = s[2];
+            d[3] = 255;
         }
     }
 
@@ -1285,7 +1239,6 @@ void Switcher::RenderLayered()
         g.SetTextRenderingHint(Gdiplus::TextRenderingHintAntiAliasGridFit);
 
         // Leave the panel background transparent; acrylic lives on thumbHost.
-        bool light = AltTabStyle::IsLightTheme();
         Gdiplus::REAL panelRadius = static_cast<Gdiplus::REAL>(Scaled(8));
         RECT panelRect = { 0, 0, w, h };
         Gdiplus::GraphicsPath panel;
@@ -1294,7 +1247,7 @@ void Switcher::RenderLayered()
         g.SetCompositingMode(Gdiplus::CompositingModeSourceCopy);
         g.FillPath(&panelBrush, &panel);
         g.SetCompositingMode(Gdiplus::CompositingModeSourceOver);
-        Gdiplus::Pen panelStroke(AltTabStyle::SurfaceStrokeDefault(light),
+        Gdiplus::Pen panelStroke(AltTabStyle::SurfaceStrokeDefault(),
                                  static_cast<Gdiplus::REAL>((std::max)(1, Scaled(1))));
         g.DrawPath(&panelStroke, &panel);
 
@@ -1314,51 +1267,27 @@ void Switcher::RenderLayered()
             // viewport inside it, which avoids fighting public DWM's square thumbnail.
             Gdiplus::GraphicsPath cardPath;
             BuildRoundRect(cardPath, InflateF(tile, 0), static_cast<Gdiplus::REAL>(radius));
-            Gdiplus::SolidBrush cardBrush(AltTabStyle::Card(light));
+            Gdiplus::SolidBrush cardBrush(AltTabStyle::Card(sel));
             g.FillPath(&cardBrush, &cardPath);
-
-            g.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
-            Gdiplus::Pen cardPen(AltTabStyle::CardStroke(light),
-                                 static_cast<Gdiplus::REAL>((std::max)(1, Scaled(1))));
-            g.DrawPath(&cardPen, &cardPath);
 
             int pw = pv.right - pv.left;
             int ph = pv.bottom - pv.top;
             if (pw > 0 && ph > 0)
             {
-                Gdiplus::RectF pvF(
-                    static_cast<Gdiplus::REAL>(pv.left),
-                    static_cast<Gdiplus::REAL>(pv.top),
-                    static_cast<Gdiplus::REAL>(pw),
-                    static_cast<Gdiplus::REAL>(ph));
-
-                // Bottom-rounded viewport for the DWM thumbnail (square top, rounded
-                // bottom corners matching the card radius).
-                Gdiplus::GraphicsPath pvHole;
-                BuildBottomRoundRect(pvHole, pvF, static_cast<Gdiplus::REAL>(radius));
-
-                // The DWM thumbnail is a square rectangle that lives on the acrylic
-                // host behind this layer. Lay an OPAQUE card backing across the whole
-                // preview (clipped to the rounded card so it can't spill past the
-                // card's corners), then punch the rounded-bottom hole. The thumbnail
-                // only shows through the rounded viewport; its square bottom corners
-                // stay hidden behind the opaque backing. (A translucent card alone
-                // would let those square corners bleed through.)
-                COLORREF cardSolid = AltTabStyle::CardRef(light);
-                Gdiplus::SolidBrush previewBacking(Gdiplus::Color(
-                    255, GetRValue(cardSolid), GetGValue(cardSolid), GetBValue(cardSolid)));
-                g.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
-                g.SetClip(&cardPath, Gdiplus::CombineModeReplace);
-                g.SetCompositingMode(Gdiplus::CompositingModeSourceOver);
-                g.FillRectangle(&previewBacking, pvF);
-
-                // Punch the rounded-bottom transparent hole; the acrylic host with the
-                // live thumbnail composites behind it.
+                g.SetSmoothingMode(Gdiplus::SmoothingModeNone);
                 g.SetCompositingMode(Gdiplus::CompositingModeSourceCopy);
                 Gdiplus::SolidBrush previewBrush(AltTabStyle::Transparent());
-                g.FillPath(&previewBrush, &pvHole);
+                g.FillRectangle(&previewBrush,
+                                static_cast<Gdiplus::REAL>(pv.left),
+                                static_cast<Gdiplus::REAL>(pv.top),
+                                static_cast<Gdiplus::REAL>(pw),
+                                static_cast<Gdiplus::REAL>(ph));
                 g.SetCompositingMode(Gdiplus::CompositingModeSourceOver);
-                g.ResetClip();
+                Gdiplus::Pen previewPen(AltTabStyle::PreviewStroke(sel),
+                                         static_cast<Gdiplus::REAL>((std::max)(1, Scaled(1))));
+                g.SetSmoothingMode(Gdiplus::SmoothingModeNone);
+                g.DrawRectangle(&previewPen, pv.left, pv.top, pw - 1, ph - 1);
+                g.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
             }
 
             // Header tab: app icon + window title.
@@ -1379,25 +1308,23 @@ void Switcher::RenderLayered()
                 g.Flush();
                 RECT textRc = { textLeft, tile.top, hdr.right, tile.top + headerH };
                 DrawHeaderText(static_cast<BYTE*>(bits), w, h, font, textRc, *text,
-                               AltTabStyle::HeaderTextRef(light));
+                               AltTabStyle::HeaderTextRef(sel), AltTabStyle::CardRef(sel));
             }
 
             // Two-ring accent focus ring around the selected tile.
             if (sel)
             {
-                int gPad = Scaled(6);
+                int gPad = Scaled(10);
                 int gOut = gPad + Scaled(2);
-                int outerRadius = Scaled(18);
-                int innerRadius = outerRadius - Scaled(2);
                 Gdiplus::GraphicsPath innerRing, out;
                 BuildRoundRect(innerRing, InflateF(tile, gPad),
-                               static_cast<Gdiplus::REAL>(innerRadius));
+                               static_cast<Gdiplus::REAL>(radius + gPad));
                 BuildRoundRect(out, InflateF(tile, gOut),
-                               static_cast<Gdiplus::REAL>(outerRadius));
-                Gdiplus::Pen darkPen(AltTabStyle::FocusShadow(light),
+                               static_cast<Gdiplus::REAL>(radius + gOut));
+                Gdiplus::Pen darkPen(AltTabStyle::FocusShadow(),
                                      static_cast<Gdiplus::REAL>((std::max)(1, Scaled(1))));
                 Gdiplus::Pen accentPen(accentClr,
-                                       static_cast<Gdiplus::REAL>((std::max)(2, Scaled(4))));
+                                       static_cast<Gdiplus::REAL>((std::max)(2, Scaled(3))));
                 g.DrawPath(&darkPen, &innerRing);
                 g.DrawPath(&accentPen, &out);
             }
@@ -1414,7 +1341,7 @@ void Switcher::RenderLayered()
                 std::to_wstring(currentPage) + L" / " + std::to_wstring(totalPages);
             RECT pageRc = { pad, h - pad, w - pad, h };
             DrawHeaderText(static_cast<BYTE*>(bits), w, h, font, pageRc, pageText,
-                           AltTabStyle::HeaderTextRef(light), DT_CENTER);
+                           AltTabStyle::HeaderTextRef(false), AltTabStyle::CardRef(false), DT_CENTER);
         }
 
         g.Flush();

--- a/src/modules/AltWindowCycle/AltWindowCycleLogic.h
+++ b/src/modules/AltWindowCycle/AltWindowCycleLogic.h
@@ -173,13 +173,14 @@ namespace AltWindowCycleLogic
         return { left, top, left + layout.tileW, top + layout.tileH - layout.cardTrimBottom };
     }
 
-    // Flush to the card's left/right/bottom edges -- like the native Alt-Tab
-    // switcher's thumbnail -- with only a small gap under the header row.
+    // Flush to the card's left/right/bottom edges, and now flush directly
+    // under the header row too -- like the native Alt-Tab switcher's
+    // thumbnail, with no inset padding on any side.
     inline RECT PreviewRect(const OverlayLayout& layout, const RECT& tile)
     {
         return {
             tile.left,
-            tile.top + layout.headerH + layout.inner,
+            tile.top + layout.headerH,
             tile.right,
             tile.bottom
         };

--- a/src/modules/AltWindowCycle/AltWindowCycleLogic.h
+++ b/src/modules/AltWindowCycle/AltWindowCycleLogic.h
@@ -100,13 +100,13 @@ namespace AltWindowCycleLogic
         layout.scale = scale;
         layout.pad = ScaledValue(scale, 32);
         layout.gap = ScaledValue(scale, 26);
-        layout.tileW = ScaledValue(scale, 270);
-        layout.headerH = ScaledValue(scale, 48);
-        layout.previewH = ScaledValue(scale, 142);
-        layout.inner = ScaledValue(scale, 6);
-        layout.radius = ScaledValue(scale, 10);
+        layout.tileW = ScaledValue(scale, 300);
+        layout.headerH = ScaledValue(scale, 44);
+        layout.previewH = ScaledValue(scale, 158);
+        layout.inner = ScaledValue(scale, 8);
+        layout.radius = ScaledValue(scale, 8);
         layout.cardTrimBottom = 0;
-        layout.iconSize = ScaledValue(scale, 16);
+        layout.iconSize = ScaledValue(scale, 24);
         layout.tileH = layout.headerH + layout.inner + layout.previewH + layout.inner;
 
         const int workW = work.right - work.left;
@@ -175,14 +175,11 @@ namespace AltWindowCycleLogic
 
     inline RECT PreviewRect(const OverlayLayout& layout, const RECT& tile)
     {
-        // Sits directly below the header band, inset by the 1px card stroke on the
-        // left/right/bottom so the card border stays visible around the image.
-        const int stroke = ScaledValue(layout.scale, 1);
         return {
-            tile.left + stroke,
-            tile.top + layout.headerH,
-            tile.right - stroke,
-            tile.bottom - stroke
+            tile.left + layout.inner,
+            tile.top + layout.headerH + layout.inner,
+            tile.right - layout.inner,
+            tile.bottom - layout.inner
         };
     }
 

--- a/src/modules/AltWindowCycle/AltWindowCycleLogic.h
+++ b/src/modules/AltWindowCycle/AltWindowCycleLogic.h
@@ -173,13 +173,15 @@ namespace AltWindowCycleLogic
         return { left, top, left + layout.tileW, top + layout.tileH - layout.cardTrimBottom };
     }
 
+    // Flush to the card's left/right/bottom edges -- like the native Alt-Tab
+    // switcher's thumbnail -- with only a small gap under the header row.
     inline RECT PreviewRect(const OverlayLayout& layout, const RECT& tile)
     {
         return {
-            tile.left + layout.inner,
+            tile.left,
             tile.top + layout.headerH + layout.inner,
-            tile.right - layout.inner,
-            tile.bottom - layout.inner
+            tile.right,
+            tile.bottom
         };
     }
 

--- a/src/modules/AltWindowCycle/AltWindowCycleLogic.h
+++ b/src/modules/AltWindowCycle/AltWindowCycleLogic.h
@@ -106,7 +106,7 @@ namespace AltWindowCycleLogic
         layout.inner = ScaledValue(scale, 8);
         layout.radius = ScaledValue(scale, 8);
         layout.cardTrimBottom = 0;
-        layout.iconSize = ScaledValue(scale, 24);
+        layout.iconSize = ScaledValue(scale, 16);
         layout.tileH = layout.headerH + layout.inner + layout.previewH + layout.inner;
 
         const int workW = work.right - work.left;

--- a/src/modules/AltWindowCycle/UnitTests/AltWindowCycleLogicTests.cpp
+++ b/src/modules/AltWindowCycle/UnitTests/AltWindowCycleLogicTests.cpp
@@ -62,20 +62,20 @@ namespace AltWindowCycleUnitTests
 
             Assert::AreEqual(32, layout.pad);
             Assert::AreEqual(26, layout.gap);
-            Assert::AreEqual(270, layout.tileW);
-            Assert::AreEqual(48, layout.headerH);
-            Assert::AreEqual(142, layout.previewH);
-            Assert::AreEqual(6, layout.inner);
-            Assert::AreEqual(10, layout.radius);
-            Assert::AreEqual(16, layout.iconSize);
-            Assert::AreEqual(202, layout.tileH);
+            Assert::AreEqual(300, layout.tileW);
+            Assert::AreEqual(44, layout.headerH);
+            Assert::AreEqual(158, layout.previewH);
+            Assert::AreEqual(8, layout.inner);
+            Assert::AreEqual(8, layout.radius);
+            Assert::AreEqual(24, layout.iconSize);
+            Assert::AreEqual(218, layout.tileH);
             Assert::AreEqual(4, layout.cols);
             Assert::AreEqual(1, layout.rows);
             Assert::AreEqual(4, layout.pageSize);
-            Assert::AreEqual(1222, layout.panelW);
-            Assert::AreEqual(266, layout.panelH);
-            Assert::AreEqual(349, layout.panelX);
-            Assert::AreEqual(407, layout.panelY);
+            Assert::AreEqual(1342, layout.panelW);
+            Assert::AreEqual(282, layout.panelH);
+            Assert::AreEqual(289, layout.panelX);
+            Assert::AreEqual(399, layout.panelY);
         }
 
         TEST_METHOD(ComputeOverlayLayoutUsesRoundedScaledGeometry)
@@ -86,20 +86,20 @@ namespace AltWindowCycleUnitTests
 
             Assert::AreEqual(48, layout.pad);
             Assert::AreEqual(39, layout.gap);
-            Assert::AreEqual(405, layout.tileW);
-            Assert::AreEqual(72, layout.headerH);
-            Assert::AreEqual(213, layout.previewH);
-            Assert::AreEqual(9, layout.inner);
-            Assert::AreEqual(15, layout.radius);
-            Assert::AreEqual(24, layout.iconSize);
-            Assert::AreEqual(303, layout.tileH);
-            Assert::AreEqual(4, layout.cols);
+            Assert::AreEqual(450, layout.tileW);
+            Assert::AreEqual(66, layout.headerH);
+            Assert::AreEqual(237, layout.previewH);
+            Assert::AreEqual(12, layout.inner);
+            Assert::AreEqual(12, layout.radius);
+            Assert::AreEqual(36, layout.iconSize);
+            Assert::AreEqual(327, layout.tileH);
+            Assert::AreEqual(3, layout.cols);
             Assert::AreEqual(2, layout.rows);
             Assert::AreEqual(6, layout.pageSize);
-            Assert::AreEqual(1833, layout.panelW);
-            Assert::AreEqual(741, layout.panelH);
-            Assert::AreEqual(43, layout.panelX);
-            Assert::AreEqual(169, layout.panelY);
+            Assert::AreEqual(1524, layout.panelW);
+            Assert::AreEqual(789, layout.panelH);
+            Assert::AreEqual(198, layout.panelX);
+            Assert::AreEqual(145, layout.panelY);
         }
 
         TEST_METHOD(ComputeOverlayLayoutHandlesEmptyWindowCount)
@@ -119,13 +119,13 @@ namespace AltWindowCycleUnitTests
             const auto layout = AltWindowCycleLogic::ComputeOverlayLayout(work, 4, 1.0);
 
             const RECT tile = AltWindowCycleLogic::TileRect(layout, 0);
-            AssertRectEqual({ 32, 32, 302, 234 }, tile);
+            AssertRectEqual({ 32, 32, 332, 250 }, tile);
 
             const RECT preview = AltWindowCycleLogic::PreviewRect(layout, tile);
-            AssertRectEqual({ 33, 80, 301, 233 }, preview);
+            AssertRectEqual({ 40, 84, 324, 242 }, preview);
 
             const RECT header = AltWindowCycleLogic::HeaderRect(layout, tile);
-            AssertRectEqual({ 44, 32, 290, 80 }, header);
+            AssertRectEqual({ 44, 32, 320, 76 }, header);
         }
 
         TEST_METHOD(CoverSourceCropsWideSourceToDestinationAspectRatio)
@@ -332,10 +332,10 @@ namespace AltWindowCycleUnitTests
 
             const auto layout = AltWindowCycleLogic::ComputeOverlayLayout(work, 8, 1.0);
 
-            // (640 - 64 + 26) / (270 + 26) = 2 columns fit the work area.
-            Assert::AreEqual(2, layout.cols);
+            // (640 - 64 + 26) / (300 + 26) = 1 column fits the work area.
+            Assert::AreEqual(1, layout.cols);
             Assert::AreEqual(1, layout.rows);
-            Assert::AreEqual(2, layout.pageSize);
+            Assert::AreEqual(1, layout.pageSize);
             Assert::IsTrue(layout.panelH <= work.bottom - work.top);
         }
 
@@ -355,9 +355,9 @@ namespace AltWindowCycleUnitTests
 
             const auto layout = AltWindowCycleLogic::ComputeOverlayLayout(work, 13, 1.5);
 
-            Assert::AreEqual(4, layout.cols);
+            Assert::AreEqual(3, layout.cols);
             Assert::AreEqual(2, layout.rows);
-            Assert::AreEqual(8, layout.pageSize);
+            Assert::AreEqual(6, layout.pageSize);
             Assert::IsTrue(layout.panelH <= work.bottom - work.top);
         }
 
@@ -388,12 +388,12 @@ namespace AltWindowCycleUnitTests
             const RECT work = { 0, 0, 1920, 1080 };
             const auto layout = AltWindowCycleLogic::ComputeOverlayLayout(work, 8, 1.0);
 
-            Assert::AreEqual(6, layout.cols); // sanity: second row exists
+            Assert::AreEqual(5, layout.cols); // sanity: second row exists
 
             // Second column, first row.
-            AssertRectEqual({ 328, 32, 598, 234 }, AltWindowCycleLogic::TileRect(layout, 1));
+            AssertRectEqual({ 358, 32, 658, 250 }, AltWindowCycleLogic::TileRect(layout, 1));
             // First column, second row.
-            AssertRectEqual({ 32, 260, 302, 462 }, AltWindowCycleLogic::TileRect(layout, 6));
+            AssertRectEqual({ 32, 276, 332, 494 }, AltWindowCycleLogic::TileRect(layout, 5));
         }
 
         TEST_METHOD(WrapIndexNormalizesNegativeAndOversizedIndices)

--- a/src/modules/AltWindowCycle/UnitTests/AltWindowCycleLogicTests.cpp
+++ b/src/modules/AltWindowCycle/UnitTests/AltWindowCycleLogicTests.cpp
@@ -67,7 +67,7 @@ namespace AltWindowCycleUnitTests
             Assert::AreEqual(158, layout.previewH);
             Assert::AreEqual(8, layout.inner);
             Assert::AreEqual(8, layout.radius);
-            Assert::AreEqual(24, layout.iconSize);
+            Assert::AreEqual(16, layout.iconSize);
             Assert::AreEqual(218, layout.tileH);
             Assert::AreEqual(4, layout.cols);
             Assert::AreEqual(1, layout.rows);
@@ -91,7 +91,7 @@ namespace AltWindowCycleUnitTests
             Assert::AreEqual(237, layout.previewH);
             Assert::AreEqual(12, layout.inner);
             Assert::AreEqual(12, layout.radius);
-            Assert::AreEqual(36, layout.iconSize);
+            Assert::AreEqual(24, layout.iconSize);
             Assert::AreEqual(327, layout.tileH);
             Assert::AreEqual(3, layout.cols);
             Assert::AreEqual(2, layout.rows);

--- a/src/modules/AltWindowCycle/UnitTests/AltWindowCycleLogicTests.cpp
+++ b/src/modules/AltWindowCycle/UnitTests/AltWindowCycleLogicTests.cpp
@@ -122,7 +122,7 @@ namespace AltWindowCycleUnitTests
             AssertRectEqual({ 32, 32, 332, 250 }, tile);
 
             const RECT preview = AltWindowCycleLogic::PreviewRect(layout, tile);
-            AssertRectEqual({ 32, 84, 332, 250 }, preview);
+            AssertRectEqual({ 32, 76, 332, 250 }, preview);
 
             const RECT header = AltWindowCycleLogic::HeaderRect(layout, tile);
             AssertRectEqual({ 44, 32, 320, 76 }, header);

--- a/src/modules/AltWindowCycle/UnitTests/AltWindowCycleLogicTests.cpp
+++ b/src/modules/AltWindowCycle/UnitTests/AltWindowCycleLogicTests.cpp
@@ -122,7 +122,7 @@ namespace AltWindowCycleUnitTests
             AssertRectEqual({ 32, 32, 332, 250 }, tile);
 
             const RECT preview = AltWindowCycleLogic::PreviewRect(layout, tile);
-            AssertRectEqual({ 40, 84, 324, 242 }, preview);
+            AssertRectEqual({ 32, 84, 332, 250 }, preview);
 
             const RECT header = AltWindowCycleLogic::HeaderRect(layout, tile);
             AssertRectEqual({ 44, 32, 320, 76 }, header);


### PR DESCRIPTION
## Summary

This PR restores crutkas's original "Window Hopper" (AltWindowCycle) overlay visual design (fixed dark card look, original layout constants/geometry/rendering approach from commit `6800dd2a`), while keeping all of Niels Laute's technical/functional work layered on top, and adds several follow-up fixes discovered while live-testing the reverted overlay.

## What's preserved from Niels' / later work
- Public `DWMWA_SYSTEMBACKDROP_TYPE` (`DWMSBT_TRANSIENTWINDOW`) backdrop API rework (replacing the private `SetWindowCompositionAttribute`/`ACCENT_POLICY` path) — **no private APIs reintroduced**, verified by repeated grep audits.
- "Window Hopper" rename, OOBE page, and icon assets.
- All later functional/threading/escape-handling changes.

## What's reverted to the original (`6800dd2a`) design
- `AltTabStyle` fixed dark Card/CardRef/HeaderTextRef/SurfaceStrokeDefault/PreviewStroke/FocusShadow colors (dropped the light/dark theme-aware WinUI card look and the `CardStroke` border).
- Original layout constants: `tileW` 300, `headerH` 44, `previewH` 158, `inner` 8, `radius` 8.
- Original font height (-15) and focus-ring geometry (`gPad` 10).
- Original header text rendering (opaque background box) instead of alpha-blended glyph compositing.

## Follow-up fixes made while live-testing the reverted overlay
- Static-snapshot preview prototype using the public `PrintWindow` API (dropped an earlier color-matrix wash; edge-to-edge preview with rounded bottom corners matching the card).
- Fixed white edge-bleed on the snapshot preview and removed the header/preview gap.
- Forced the panel's acrylic backdrop dark and fixed a DWM corner-shadow leak (root cause: `thumbHost` was rounded two conflicting ways — manual `SetWindowRgn` + `DWMWA_WINDOW_CORNER_PREFERENCE`; now uses only the DWM attribute).
- Fixed live acrylic not rendering on `thumbHost`: DWM silently ignores `DWMWA_SYSTEMBACKDROP_TYPE` on frameless `WS_POPUP` windows (added `WS_CAPTION` + a `WM_NCCALCSIZE` handler collapsing the non-client area to keep the borderless look), and DWM flattens backdrop material to a solid tint on windows it considers inactive (added `WM_NCACTIVATE(TRUE)` to make DWM render `thumbHost` as active for compositing purposes only — no real focus/activation change, safe on a `WS_EX_NOACTIVATE` window).
- Shrunk the header icon (`iconSize` 24 → 16) to match reference proportions.

All changes use only public, documented Win32/DWM APIs (verified via repeated grep audits for `SetWindowCompositionAttribute`/`ACCENT_POLICY`).

## Testing
- `AltWindowCycle.UnitTests` — all 32 tests passing (layout constants and icon size updated to match).
- Manual build + relaunch verification throughout, confirmed visually by crutkas via live Alt+\` testing at each step.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>