### PR TITLE
CmdPal: Clean up discarded pages and preserve back navigation

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentPageViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentPageViewModel.cs
@@ -61,6 +61,12 @@ public partial class ContentPageViewModel : PageViewModel, ICommandBarContext
     //// Run on background thread, from InitializeAsync or Model_ItemsChanged
     private void FetchContent()
     {
+        using var operation = TryBeginPageOperation();
+        if (operation is null)
+        {
+            return;
+        }
+
         List<ContentViewModel> newContent = [];
         try
         {
@@ -71,13 +77,14 @@ public partial class ContentPageViewModel : PageViewModel, ICommandBarContext
                 var viewModel = ViewModelFromContent(item, PageContext);
                 if (viewModel is not null)
                 {
-                    viewModel.InitializeProperties();
                     newContent.Add(viewModel);
+                    viewModel.InitializeProperties();
                 }
             }
         }
         catch (Exception ex)
         {
+            CleanupContent(newContent);
             ShowException(ex, _model?.Unsafe?.Name);
             throw;
         }
@@ -86,11 +93,29 @@ public partial class ContentPageViewModel : PageViewModel, ICommandBarContext
         newContent.ForEach(c => c.OnlyControlOnPage = oneContent);
 
         // Now, back to a UI thread to update the observable collection
-        DoOnUiThread(
+        if (!TryDoOnUiThread(
         () =>
         {
+            using var publication = TryBeginPageOperation();
+            if (publication is null)
+            {
+                _ = Task.Run(() => CleanupContent(newContent));
+                return;
+            }
+
             ListHelpers.InPlaceUpdateList(Content, newContent);
-        });
+        }))
+        {
+            CleanupContent(newContent);
+        }
+    }
+
+    private static void CleanupContent(IEnumerable<ContentViewModel> content)
+    {
+        foreach (var item in content)
+        {
+            item.SafeCleanup();
+        }
     }
 
     public virtual ContentViewModel? ViewModelFromContent(IContent content, WeakReference<IPageContext> context)
@@ -103,6 +128,12 @@ public partial class ContentPageViewModel : PageViewModel, ICommandBarContext
 
     public override void InitializeProperties()
     {
+        using var operation = TryBeginPageOperation();
+        if (operation is null)
+        {
+            return;
+        }
+
         base.InitializeProperties();
 
         var model = _model.Unsafe;
@@ -132,7 +163,7 @@ public partial class ContentPageViewModel : PageViewModel, ICommandBarContext
         FetchContent();
         model.ItemsChanged += Model_ItemsChanged;
 
-        DoOnUiThread(
+        DoOnActivePage(
         () =>
         {
             WeakReferenceMessenger.Default.Send<UpdateCommandBarMessage>(new(this));
@@ -189,7 +220,7 @@ public partial class ContentPageViewModel : PageViewModel, ICommandBarContext
                 UpdateProperty(nameof(CanOpenContextMenu));
                 UpdateProperty(nameof(MoreCommands));
                 UpdateProperty(nameof(AllCommands));
-                DoOnUiThread(
+                DoOnActivePage(
                 () =>
                 {
                     WeakReferenceMessenger.Default.Send<UpdateCommandBarMessage>(new(this));
@@ -211,7 +242,7 @@ public partial class ContentPageViewModel : PageViewModel, ICommandBarContext
         UpdateProperty(nameof(Details));
         UpdateProperty(nameof(HasDetails));
 
-        DoOnUiThread(
+        DoOnActivePage(
             () =>
             {
                 if (HasDetails)
@@ -310,6 +341,14 @@ public partial class ContentPageViewModel : PageViewModel, ICommandBarContext
         {
             WeakReferenceMessenger.Default.Send<PerformCommandMessage>(new(SecondaryCommand.Command.Model, SecondaryCommand.Model));
         }
+    }
+
+    internal override Task ResumeAfterNavigation()
+    {
+        base.ResumeAfterNavigation();
+        UpdateDetails();
+        DoOnActivePage(() => WeakReferenceMessenger.Default.Send(new UpdateCommandBarMessage(this)));
+        return Task.CompletedTask;
     }
 
     protected override void UnsafeCleanup()

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
@@ -176,6 +176,12 @@ public partial class ListViewModel : PageViewModel, IDisposable
 
     protected override void OnSearchTextBoxUpdated(string searchTextBox)
     {
+        using var operation = TryBeginPageOperation();
+        if (operation is null)
+        {
+            return;
+        }
+
         // Dynamic pages will handler their own filtering. They will tell us if
         // something needs to change, by raising ItemsChanged.
         if (_isDynamic)
@@ -325,6 +331,12 @@ public partial class ListViewModel : PageViewModel, IDisposable
     //// Run on background thread, from InitializeAsync or Model_ItemsChanged
     private void FetchItems(bool keepSelection, bool ensureSelectionVisible, int? recoveryGeneration = null)
     {
+        using var operation = TryBeginPageOperation();
+        if (operation is null)
+        {
+            return;
+        }
+
         System.Diagnostics.Debug.Assert(!IsCurrentThreadUiThread(), "FetchItems should not run on the UI thread.");
 
         CancellationToken cancellationToken;
@@ -1051,6 +1063,12 @@ public partial class ListViewModel : PageViewModel, IDisposable
 
     public override void InitializeProperties()
     {
+        using var operation = TryBeginPageOperation();
+        if (operation is null)
+        {
+            return;
+        }
+
         base.InitializeProperties();
 
         var model = _model.Unsafe;
@@ -1218,7 +1236,7 @@ public partial class ListViewModel : PageViewModel, IDisposable
 
         UpdateProperty(nameof(EmptyContent));
 
-        DoOnUiThread(
+        DoOnActivePage(
            () =>
            {
                WeakReferenceMessenger.Default.Send<UpdateCommandBarMessage>(new(EmptyContent));
@@ -1242,16 +1260,18 @@ public partial class ListViewModel : PageViewModel, IDisposable
 
     // The shell serializes navigation transitions on the UI thread. Terminal
     // cleanup may race them, but resumption can only transition Suspended -> Active.
-    internal void SuspendForNavigation()
+    internal override void SuspendForNavigation()
     {
+        base.SuspendForNavigation();
         if (TryChangeWorkStatus(ListPageWorkStatus.Active, ListPageWorkStatus.Suspended) is not null)
         {
             CancelPendingWork();
         }
     }
 
-    internal Task ResumeAfterNavigation()
+    internal override Task ResumeAfterNavigation()
     {
+        base.ResumeAfterNavigation();
         var work = TryChangeWorkStatus(ListPageWorkStatus.Suspended, ListPageWorkStatus.Active);
         if (work is null)
         {
@@ -1436,6 +1456,8 @@ public partial class ListViewModel : PageViewModel, IDisposable
 
         CancelPendingWork();
     }
+
+    protected override void OnCleanupRequested() => StopWork();
 
     protected override void UnsafeCleanup()
     {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/PageViewModel.Lifecycle.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/PageViewModel.Lifecycle.cs
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.Common;
+
+namespace Microsoft.CmdPal.UI.ViewModels;
+
+public partial class PageViewModel
+{
+    private readonly Lock _lifetimeLock = new();
+    private readonly TaskCompletionSource _operationsCompleted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private int _activeOperations;
+    private volatile bool _isDiscarded;
+    private volatile bool _isActive = true;
+    private Task? _cleanupTask;
+
+    /// <summary>Gets a value indicating whether terminal cleanup has been requested.</summary>
+    /// <remarks>Becomes true before cleanup finishes; the page can no longer be resumed.</remarks>
+    public bool IsDiscarded => _isDiscarded;
+
+    /// <summary>Gets a value indicating whether the page is active for navigation and shared UI presentation.</summary>
+    /// <remarks>Does not indicate window visibility or whether extension work is running.</remarks>
+    protected bool IsPageActive => _isActive && !_isDiscarded;
+
+    /// <summary>Deactivates the page for navigation while retaining it for resumption.</summary>
+    /// <remarks>Subscriptions and some background work may continue while suspended.</remarks>
+    internal virtual void SuspendForNavigation() => _isActive = false;
+
+    /// <summary>Reactivates a retained page unless terminal cleanup has been requested.</summary>
+    /// <returns>A task representing resumption work.</returns>
+    internal virtual Task ResumeAfterNavigation()
+    {
+        _isActive = !_isDiscarded;
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Permanently discards the page and cleans it up on a worker after in-flight page operations finish.</summary>
+    /// <returns>The shared task that completes when cleanup finishes.</returns>
+    /// <remarks>
+    /// Detach the page's controls and bindings before calling this on the UI thread.
+    /// Detachment does not discard the model; decide whether to retain it before requesting cleanup.
+    /// </remarks>
+    public Task CleanupAsync()
+    {
+        TaskCompletionSource completion;
+        lock (_lifetimeLock)
+        {
+            if (_cleanupTask is not null)
+            {
+                return _cleanupTask;
+            }
+
+            _isDiscarded = true;
+            completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            _cleanupTask = completion.Task;
+            if (_activeOperations == 0)
+            {
+                _operationsCompleted.SetResult();
+            }
+        }
+
+        try
+        {
+            OnCleanupRequested();
+        }
+        catch (Exception ex)
+        {
+            CoreLogger.LogError("Failed to stop discarded page work", ex);
+        }
+
+        _ = Task.Run(async () =>
+        {
+            await _operationsCompleted.Task.ConfigureAwait(false);
+            SafeCleanup();
+            completion.SetResult();
+        });
+
+        return completion.Task;
+    }
+
+    /// <summary>Stops local work immediately. Must not call extensions or wait for their work.</summary>
+    protected virtual void OnCleanupRequested()
+    {
+    }
+
+    /// <summary>Keeps cleanup behind a page operation without holding a lock across extension calls.</summary>
+    /// <remarks>Operations may begin while suspended; terminal cleanup prevents new operations.</remarks>
+    protected PageOperation? TryBeginPageOperation()
+    {
+        lock (_lifetimeLock)
+        {
+            if (_isDiscarded)
+            {
+                return null;
+            }
+
+            _activeOperations++;
+            return new(this);
+        }
+    }
+
+    private void EndPageOperation()
+    {
+        lock (_lifetimeLock)
+        {
+            if (--_activeOperations == 0 && _isDiscarded)
+            {
+                _operationsCompleted.SetResult();
+            }
+        }
+    }
+
+    protected void DoOnActivePage(Action action)
+    {
+        DoOnUiThread(() =>
+        {
+            using var operation = TryBeginPageOperation();
+            if (operation is not null && IsPageActive)
+            {
+                action();
+            }
+        });
+    }
+
+    /// <summary>Releases one page operation at the end of its using scope.</summary>
+    protected readonly struct PageOperation(PageViewModel owner) : IDisposable
+    {
+        public void Dispose() => owner.EndPageOperation();
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/PageViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/PageViewModel.cs
@@ -143,21 +143,29 @@ public partial class PageViewModel : ExtensionObjectViewModel, IPageContext
         }
 
         // Notify we're done back on the UI Thread.
-        Task.Factory.StartNew(
+        DoOnUiThread(
             () =>
             {
+                if (IsDiscarded)
+                {
+                    return;
+                }
+
                 IsInitialized = true;
 
                 // TODO: Do we want an event/signal here that the Page Views can listen to? (i.e. ListPage setting the selected index to 0, however, in async world the user may have already started navigating around page...)
-            },
-            CancellationToken.None,
-            TaskCreationOptions.None,
-            Scheduler);
+            });
         return Task.FromResult(true);
     }
 
     public override void InitializeProperties()
     {
+        using var operation = TryBeginPageOperation();
+        if (operation is null)
+        {
+            return;
+        }
+
         var page = _pageModel.Unsafe;
         if (page is null)
         {
@@ -186,6 +194,12 @@ public partial class PageViewModel : ExtensionObjectViewModel, IPageContext
 
     private void Model_PropChanged(object sender, IPropChangedEventArgs args)
     {
+        using var operation = TryBeginPageOperation();
+        if (operation is null)
+        {
+            return;
+        }
+
         try
         {
             var propName = args.PropertyName;
@@ -255,15 +269,17 @@ public partial class PageViewModel : ExtensionObjectViewModel, IPageContext
         // Set the extensionHint to the Page Title (if we have one, and one not provided).
         // extensionHint ??= _pageModel?.Unsafe?.Title;
         extensionHint ??= ExtensionHost.GetExtensionDisplayName() ?? Title;
-        Task.Factory.StartNew(
+        DoOnUiThread(
             () =>
             {
+                if (IsDiscarded)
+                {
+                    return;
+                }
+
                 var message = DiagnosticsHelper.BuildExceptionMessage(ex, extensionHint);
                 ErrorMessage += message;
-            },
-            CancellationToken.None,
-            TaskCreationOptions.None,
-            Scheduler);
+            });
     }
 
     public override string ToString() => $"{Title} ViewModel";

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ParametersViewModels.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ParametersViewModels.cs
@@ -521,8 +521,10 @@ public partial class CommandParameterRunViewModel : ParameterValueRunViewModel, 
     {
         base.UnsafeCleanup();
 
-        _listViewModel?.Dispose();
+        _ = _listViewModel?.CleanupAsync();
         _listViewModel = null;
+        _commandViewModel?.SafeCleanup();
+        _commandViewModel = null;
     }
 
     public void Dispose()
@@ -574,7 +576,13 @@ public partial class ParametersPageViewModel : PageViewModel, IDisposable
         {
             if (_activeListViewModel != value)
             {
+                _activeListViewModel?.SuspendForNavigation();
                 _activeListViewModel = value;
+                if (IsPageActive)
+                {
+                    _ = value?.ResumeAfterNavigation();
+                }
+
                 UpdateProperty(nameof(ActiveListViewModel));
                 UpdateProperty(nameof(HasActiveList));
             }
@@ -621,6 +629,12 @@ public partial class ParametersPageViewModel : PageViewModel, IDisposable
     //// Run on background thread, from InitializeAsync
     public override void InitializeProperties()
     {
+        using var operation = TryBeginPageOperation();
+        if (operation is null)
+        {
+            return;
+        }
+
         base.InitializeProperties();
 
         var model = _model.Unsafe;
@@ -667,6 +681,12 @@ public partial class ParametersPageViewModel : PageViewModel, IDisposable
 
                     if (itemVm is CommandParameterRunViewModel cmdParamVm)
                     {
+                        // Lists load eagerly on entry; switching parameters suspends the previous list.
+                        if (!IsPageActive)
+                        {
+                            cmdParamVm.ListViewModel?.SuspendForNavigation();
+                        }
+
                         cmdParamVm.ValueChanged += ListParamValueChanged;
                     }
                 }
@@ -715,7 +735,7 @@ public partial class ParametersPageViewModel : PageViewModel, IDisposable
             }
         }
 
-        DoOnUiThread(
+        DoOnActivePage(
             () =>
             {
                 CoreLogger.LogDebug($"raising parameter items changed, {Items.Count} parameters");
@@ -763,7 +783,7 @@ public partial class ParametersPageViewModel : PageViewModel, IDisposable
 
         UpdateProperty(nameof(Command));
 
-        DoOnUiThread(
+        DoOnActivePage(
            () =>
            {
                WeakReferenceMessenger.Default.Send<UpdateCommandBarMessage>(new(Command));
@@ -786,7 +806,7 @@ public partial class ParametersPageViewModel : PageViewModel, IDisposable
             // fires for NeedsValue, DisplayText, and Icon changes, so it
             // covers both first-pick and re-pick. Handling it here as well
             // would risk a double-advance race.
-            DoOnUiThread(() =>
+            DoOnActivePage(() =>
             {
                 UpdateCommand();
             });
@@ -797,21 +817,29 @@ public partial class ParametersPageViewModel : PageViewModel, IDisposable
     {
         CoreLogger.LogDebug($"[ParametersPageVM] ListParamValueChanged from {sender?.GetType().Name}, _activeListParam set: {_activeListParam != null}, same: {sender == _activeListParam}");
 
-        // Marshal to UI thread — ValueChanged is raised from the extension's
+        // Marshal to UI thread - ValueChanged is raised from the extension's
         // PropChanged callback on a background thread, but FocusNextParameter
         // sends a message that ultimately calls ContainerFromItem on a UI control.
         DoOnUiThread(() =>
         {
-            // The extension confirmed a value on a list param. If it's the
-            // active one (whether first pick or re-pick), clear the list and
-            // move focus forward.
+            using var operation = TryBeginPageOperation();
+            if (operation is null)
+            {
+                return;
+            }
+
+            // Reconcile a completed picker while suspended, but only advance focus on the active page.
             if (sender is CommandParameterRunViewModel cmdParam &&
                 cmdParam == _activeListParam &&
                 !cmdParam.NeedsValue)
             {
                 CoreLogger.LogDebug($"[ParametersPageVM] Clearing active list param after value change");
                 SetActiveListParameter(null);
-                FocusNextParameter(cmdParam);
+                if (IsPageActive)
+                {
+                    FocusNextParameter(cmdParam);
+                }
+
                 UpdateCommand();
             }
             else
@@ -887,6 +915,36 @@ public partial class ParametersPageViewModel : PageViewModel, IDisposable
         SafeCleanup();
     }
 
+    internal override void SuspendForNavigation()
+    {
+        base.SuspendForNavigation();
+        lock (_listLock)
+        {
+            foreach (var item in Items.OfType<CommandParameterRunViewModel>())
+            {
+                item.ListViewModel?.SuspendForNavigation();
+            }
+        }
+    }
+
+    internal override Task ResumeAfterNavigation()
+    {
+        base.ResumeAfterNavigation();
+        UpdateCommand();
+        return ActiveListViewModel?.ResumeAfterNavigation() ?? Task.CompletedTask;
+    }
+
+    protected override void OnCleanupRequested()
+    {
+        lock (_listLock)
+        {
+            foreach (var item in Items.OfType<CommandParameterRunViewModel>())
+            {
+                _ = item.ListViewModel?.CleanupAsync();
+            }
+        }
+    }
+
     protected override void UnsafeCleanup()
     {
         base.UnsafeCleanup();
@@ -895,20 +953,16 @@ public partial class ParametersPageViewModel : PageViewModel, IDisposable
         // don't end up pointing at a disposed ListViewModel.
         SetActiveListParameter(null);
 
+        ParameterRunViewModel[] items;
         lock (_listLock)
         {
-            foreach (var item in Items)
-            {
-                item.PropertyChanged -= ItemPropertyChanged;
-                if (item is CommandParameterRunViewModel cmdParam)
-                {
-                    cmdParam.ValueChanged -= ListParamValueChanged;
-                }
-
-                item.SafeCleanup();
-            }
-
+            items = [.. Items];
             Items.Clear();
+        }
+
+        foreach (var item in items)
+        {
+            ReleaseItem(item);
         }
 
         _command.SafeCleanup();

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ShellViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ShellViewModel.cs
@@ -69,26 +69,15 @@ public partial class ShellViewModel : ObservableObject,
 
                 try
                 {
-                    if (oldValue is ListViewModel previousList)
-                    {
-                        // Frame keeps the VM in its navigation parameter for Back.
-                        // Cancel this visit's work without permanently disposing it.
-                        previousList.SuspendForNavigation();
-                    }
-                    else if (oldValue is IDisposable disposable)
-                    {
-                        disposable.Dispose();
-                    }
+                    // Frame retains the page for Back until its history entry is discarded.
+                    oldValue.SuspendForNavigation();
                 }
                 catch (Exception ex)
                 {
                     CoreLogger.LogError(ex.ToString());
                 }
 
-                if (value is ListViewModel currentList)
-                {
-                    _ = currentList.ResumeAfterNavigation();
-                }
+                _ = value.ResumeAfterNavigation();
             }
         }
     }
@@ -200,6 +189,11 @@ public partial class ShellViewModel : ObservableObject,
                         var t = Task.Factory.StartNew(
                             () =>
                             {
+                                if (viewModel.IsDiscarded)
+                                {
+                                    return;
+                                }
+
                                 if (cancellationToken.IsCancellationRequested)
                                 {
                                     if (viewModel is IDisposable disposable)
@@ -230,6 +224,11 @@ public partial class ShellViewModel : ObservableObject,
         }
         else
         {
+            if (viewModel.IsDiscarded)
+            {
+                return;
+            }
+
             if (cancellationToken.IsCancellationRequested)
             {
                 if (viewModel is IDisposable disposable)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/CleanupHelper.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/CleanupHelper.xaml.cs
@@ -8,9 +8,17 @@ using Microsoft.UI.Xaml.Media;
 
 namespace Microsoft.CmdPal.UI;
 
+/// <summary>
+/// Provides helpers for detaching item sources from a visual tree.
+/// </summary>
 public static class CleanupHelper
 {
-    public static void Cleanup(FrameworkElement element)
+    /// <summary>
+    /// Clears item sources on the specified element and its visual descendants.
+    /// </summary>
+    /// <param name="element">The root of the visual subtree to detach.</param>
+    /// <remarks>Must be called on the UI thread.</remarks>
+    public static void ClearItemsSources(FrameworkElement element)
     {
         var count = VisualTreeHelper.GetChildrenCount(element);
         for (var index = 0; index < count; index++)
@@ -18,20 +26,20 @@ public static class CleanupHelper
             var child = VisualTreeHelper.GetChild(element, index);
             if (child is FrameworkElement childElement)
             {
-                Cleanup(childElement);
+                ClearItemsSources(childElement);
             }
         }
 
         switch (element)
         {
             case ItemsControl itemsControl:
-                itemsControl.ItemsSource = null;
+                itemsControl.ItemsSource = null!;
                 break;
             case ItemsRepeater itemsRepeater:
-                itemsRepeater.ItemsSource = null;
+                itemsRepeater.ItemsSource = null!;
                 break;
             case TabView tabView:
-                tabView.TabItemsSource = null;
+                tabView.TabItemsSource = null!;
                 break;
         }
     }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ContentPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ContentPage.xaml.cs
@@ -71,20 +71,21 @@ public sealed partial class ContentPage : Page,
         base.OnNavigatedTo(e);
     }
 
-    protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
+    protected override void OnNavigatedFrom(NavigationEventArgs e)
     {
-        base.OnNavigatingFrom(e);
+        base.OnNavigatedFrom(e);
         WeakReferenceMessenger.Default.Unregister<ActivateSelectedListItemMessage>(this);
         WeakReferenceMessenger.Default.Unregister<ActivateSecondaryCommandMessage>(this);
 
-        // Clean-up event listeners
+        var viewModel = ViewModel;
+        Bindings.StopTracking();
+        ViewModel = null;
+        CleanupHelper.ClearItemsSources(this);
+
         if (e.NavigationMode != NavigationMode.New)
         {
-            ViewModel?.SafeCleanup();
-            CleanupHelper.Cleanup(this);
+            _ = viewModel?.CleanupAsync();
         }
-
-        ViewModel = null;
     }
 
     // this comes in on Enter keypresses in the SearchBox

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListItemsView.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListItemsView.xaml.cs
@@ -97,6 +97,13 @@ public sealed partial class ListItemsView : UserControl,
         RegisterExistingRealizedItems();
     }
 
+    internal void DetachFromPage()
+    {
+        Bindings.StopTracking();
+        ViewModel = null;
+        ItemsList.ItemsSource = null;
+    }
+
     private void OnUnloaded(object sender, RoutedEventArgs e)
     {
         _isLoaded = false;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
@@ -5,7 +5,6 @@
 using ManagedCommon;
 using Microsoft.CmdPal.UI.Helpers;
 using Microsoft.CmdPal.UI.ViewModels;
-using Microsoft.CmdPal.UI.ViewModels.Commands;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
@@ -62,18 +61,20 @@ public sealed partial class ListPage : Page
         base.OnNavigatedTo(e);
     }
 
-    protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
+    protected override void OnNavigatedFrom(NavigationEventArgs e)
     {
-        base.OnNavigatingFrom(e);
+        base.OnNavigatedFrom(e);
+
+        var viewModel = ViewModel;
+        Bindings.StopTracking();
+        ViewModel = null;
+        ListView.DetachFromPage();
+        CleanupHelper.ClearItemsSources(this);
 
         if (e.NavigationMode != NavigationMode.New)
         {
-            ViewModel?.SafeCleanup();
-            CleanupHelper.Cleanup(this);
+            _ = viewModel?.CleanupAsync();
         }
-
-        // Clean-up event listeners
-        ViewModel = null;
 
         ExtensionObjectReleaser.AfterNavigation();
     }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ParametersPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ParametersPage.xaml
@@ -22,7 +22,7 @@
                     Show list items from the active list parameter using the same
                     list view used by ListPage so behavior stays in one place.
                 -->
-                <cmdpalUI:ListItemsView ViewModel="{x:Bind ViewModel.ActiveListViewModel, Mode=OneWay}" />
+                <cmdpalUI:ListItemsView x:Name="ParameterListView" ViewModel="{x:Bind ViewModel.ActiveListViewModel, Mode=OneWay}" />
             </controls:Case>
             <controls:Case Value="False">
                 <controls:SwitchPresenter

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ParametersPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ParametersPage.xaml.cs
@@ -4,7 +4,6 @@
 
 using Microsoft.CmdPal.Common;
 using Microsoft.CmdPal.UI.ViewModels;
-using Microsoft.CmdPal.UI.ViewModels.Commands;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
@@ -50,12 +49,20 @@ public sealed partial class ParametersPage : Page
         base.OnNavigatedTo(e);
     }
 
-    protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
+    protected override void OnNavigatedFrom(NavigationEventArgs e)
     {
-        base.OnNavigatingFrom(e);
+        base.OnNavigatedFrom(e);
 
-        // Clean-up event listeners
+        var viewModel = ViewModel;
+        Bindings.StopTracking();
         ViewModel = null;
+        ParameterListView.DetachFromPage();
+        CleanupHelper.ClearItemsSources(this);
+
+        if (e.NavigationMode != NavigationMode.New)
+        {
+            _ = viewModel?.CleanupAsync();
+        }
     }
 
     private static void OnViewModelChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
@@ -243,10 +243,22 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
 
             if (!ViewModel.IsNested)
             {
-                // todo BODGY
-                RootFrame.BackStack.Clear();
+                ClearPageHistory(RootFrame.BackStack);
             }
         });
+    }
+
+    private static void ClearPageHistory(IList<Microsoft.UI.Xaml.Navigation.PageStackEntry> history)
+    {
+        var discardedEntries = history.ToArray();
+        history.Clear();
+        foreach (var entry in discardedEntries)
+        {
+            if (entry.Parameter is AsyncNavigationRequest { TargetViewModel: PageViewModel page })
+            {
+                _ = page.CleanupAsync();
+            }
+        }
     }
 
     public void Receive(ShowConfirmationMessage message)
@@ -601,7 +613,7 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
             // TODO: In the future we probably want a short cache (3-5?) of recent VMs in case the user re-navigates
             // back to a recent page they visited (like the Pokedex) so we don't have to reload it from  scratch.
             // That'd be retrieved as we re-navigate in the PerformCommandMessage logic above
-            RootFrame.ForwardStack.Clear();
+            ClearPageHistory(RootFrame.ForwardStack);
         }
 
         if (!RootFrame.CanGoBack)

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/PageCleanupTests.Failures.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/PageCleanupTests.Failures.cs
@@ -1,0 +1,128 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Windows.Foundation;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+public sealed partial class PageCleanupTests
+{
+    [TestMethod]
+    public async Task ContentInitializationFailureReleasesTheWholeUnpublishedBatch()
+    {
+        var scheduler = new QueuedTaskScheduler();
+        var firstContent = new Mock<IMarkdownContent>();
+        var failingContent = new Mock<IMarkdownContent>();
+        var failure = new InvalidOperationException("Failed to read markdown content.");
+        failingContent.SetupGet(c => c.Body).Throws(failure);
+        var page = new Mock<IContentPage>();
+        page.Setup(p => p.GetContent()).Returns([firstContent.Object, failingContent.Object]);
+        var viewModel = new CommandPaletteContentPageViewModel(page.Object, scheduler, new TestHost(), CommandProviderContext.Empty);
+        var publications = 0;
+        viewModel.Content.CollectionChanged += (_, _) => publications++;
+
+        try
+        {
+            Assert.AreSame(failure, Assert.ThrowsExactly<InvalidOperationException>(viewModel.InitializeProperties));
+            scheduler.Drain();
+            Assert.AreEqual(0, publications);
+            Assert.AreEqual(0, viewModel.Content.Count);
+        }
+        finally
+        {
+            await viewModel.CleanupAsync().WaitAsync(TestTimeout);
+        }
+
+        Assert.IsTrue(viewModel.IsDiscarded);
+        firstContent.VerifyAdd(c => c.PropChanged += It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>(), Times.Once);
+        failingContent.VerifyGet(c => c.Body, Times.Once);
+        failingContent.VerifyAdd(c => c.PropChanged += It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>(), Times.Never);
+        firstContent.VerifyRemove(c => c.PropChanged -= It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>(), Times.Once);
+        failingContent.VerifyRemove(c => c.PropChanged -= It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>(), Times.Once);
+        page.VerifyRemove(p => p.PropChanged -= It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>(), Times.Once);
+    }
+
+    [DataTestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
+    public async Task CleanupCompletesAndRemainsTerminalWhenTeardownThrows(bool failStopHook)
+    {
+        using var release = new ManualResetEventSlim();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var scheduler = new QueuedTaskScheduler();
+        var page = new Mock<IPage>();
+        TypedEventHandler<object, IPropChangedEventArgs>? notification = null;
+        page.SetupAdd(p => p.PropChanged += It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>())
+            .Callback<TypedEventHandler<object, IPropChangedEventArgs>>(handler => notification = handler);
+        if (!failStopHook)
+        {
+            page.SetupRemove(p => p.PropChanged -= It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>())
+                .Throws(new InvalidOperationException("Extension disconnected during cleanup."));
+        }
+
+        var viewModel = new CleanupFailurePageViewModel(page.Object, scheduler, failStopHook);
+        viewModel.InitializeProperties();
+        Assert.IsNotNull(notification);
+        page.SetupGet(p => p.Title).Returns(() =>
+        {
+            Block(entered, release);
+            return "Updated title";
+        });
+
+        var update = Task.Run(() => notification(page.Object, new PropChangedEventArgs(nameof(IPage.Title))));
+        Task? cleanup = null;
+        try
+        {
+            await entered.Task.WaitAsync(TestTimeout);
+            cleanup = viewModel.CleanupAsync();
+            Assert.IsTrue(viewModel.IsDiscarded);
+            Assert.IsFalse(cleanup.IsCompleted);
+            Assert.AreSame(cleanup, viewModel.CleanupAsync());
+            page.VerifyRemove(p => p.PropChanged -= It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>(), Times.Never);
+        }
+        finally
+        {
+            release.Set();
+            await update.WaitAsync(TestTimeout);
+            await (cleanup ?? viewModel.CleanupAsync()).WaitAsync(TestTimeout);
+        }
+
+        Assert.AreSame(cleanup, viewModel.CleanupAsync());
+        await viewModel.ResumeAfterNavigation().WaitAsync(TestTimeout);
+        viewModel.InitializeProperties();
+        notification(page.Object, new PropChangedEventArgs(nameof(IPage.Title)));
+        scheduler.Drain();
+
+        Assert.IsTrue(viewModel.IsDiscarded);
+        Assert.IsFalse(viewModel.IsActive);
+        Assert.AreEqual(1, viewModel.CleanupRequestCount);
+        page.VerifyGet(p => p.Title, Times.Exactly(2));
+        page.VerifyAdd(p => p.PropChanged += It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>(), Times.Once);
+        page.VerifyRemove(p => p.PropChanged -= It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>(), Times.Once);
+    }
+
+    private sealed partial class CleanupFailurePageViewModel(IPage page, TaskScheduler scheduler, bool failStopHook)
+        : PageViewModel(page, scheduler, new TestHost(), CommandProviderContext.Empty)
+    {
+        internal bool IsActive => IsPageActive;
+
+        internal int CleanupRequestCount { get; private set; }
+
+        protected override void OnCleanupRequested()
+        {
+            CleanupRequestCount++;
+            if (failStopHook)
+            {
+                throw new InvalidOperationException("Failed to stop page work.");
+            }
+        }
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/PageCleanupTests.Races.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/PageCleanupTests.Races.cs
@@ -1,0 +1,424 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.CmdPal.UI.ViewModels.Messages;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Windows.Foundation;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+public sealed partial class PageCleanupTests
+{
+    private static readonly string[] ExpectedSubscriptionEvents = ["add", "remove"];
+
+    [TestMethod]
+    public async Task ConcurrentCleanupCallsShareOneTaskAndRunTeardownOnce()
+    {
+        using var release = new ManualResetEventSlim();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var page = new Mock<IPage>();
+        var viewModel = new BlockingCleanupPageViewModel(page.Object, entered, release);
+        viewModel.InitializeProperties();
+        Task? firstCleanup = null;
+        Task? secondCleanup = null;
+        var secondCall = Task.CompletedTask;
+        var firstCall = Task.Run(() =>
+        {
+            firstCleanup = viewModel.CleanupAsync();
+        });
+
+        try
+        {
+            await entered.Task.WaitAsync(TestTimeout);
+            secondCall = Task.Run(() =>
+            {
+                secondCleanup = viewModel.CleanupAsync();
+            });
+            await secondCall.WaitAsync(TestTimeout);
+
+            Assert.IsTrue(viewModel.IsDiscarded);
+            Assert.IsFalse(firstCall.IsCompleted);
+            Assert.IsNotNull(secondCleanup);
+            Assert.IsFalse(secondCleanup.IsCompleted);
+            page.VerifyRemove(p => p.PropChanged -= It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>(), Times.Never);
+        }
+        finally
+        {
+            release.Set();
+            await Task.WhenAll(firstCall, secondCall).WaitAsync(TestTimeout);
+            await Task.WhenAll(firstCleanup ?? viewModel.CleanupAsync(), secondCleanup ?? Task.CompletedTask).WaitAsync(TestTimeout);
+        }
+
+        Assert.AreSame(firstCleanup, secondCleanup);
+        Assert.AreSame(firstCleanup, viewModel.CleanupAsync());
+        Assert.AreEqual(1, viewModel.CleanupRequestCount);
+        page.VerifyRemove(p => p.PropChanged -= It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>(), Times.Once);
+    }
+
+    [DataTestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
+    public async Task CleanupWaitsForEveryInFlightNotification(bool finishTitleFirst)
+    {
+        using var releaseTitle = new ManualResetEventSlim();
+        using var releaseLoading = new ManualResetEventSlim();
+        var titleEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var loadingEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var page = new Mock<IPage>();
+        TypedEventHandler<object, IPropChangedEventArgs>? notification = null;
+        page.SetupAdd(p => p.PropChanged += It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>())
+            .Callback<TypedEventHandler<object, IPropChangedEventArgs>>(handler => notification = handler);
+        var viewModel = new PageViewModel(page.Object, new QueuedTaskScheduler(), new TestHost(), CommandProviderContext.Empty);
+        viewModel.InitializeProperties();
+        Assert.IsNotNull(notification);
+
+        page.SetupGet(p => p.Title).Returns(() =>
+        {
+            Block(titleEntered, releaseTitle);
+            return "Updated title";
+        });
+        page.SetupGet(p => p.IsLoading).Returns(() =>
+        {
+            Block(loadingEntered, releaseLoading);
+            return false;
+        });
+
+        var titleUpdate = Task.Run(() => notification(page.Object, new PropChangedEventArgs(nameof(IPage.Title))));
+        var loadingUpdate = Task.Run(() => notification(page.Object, new PropChangedEventArgs(nameof(IPage.IsLoading))));
+        Task? cleanup = null;
+        try
+        {
+            await Task.WhenAll(titleEntered.Task, loadingEntered.Task).WaitAsync(TestTimeout);
+            cleanup = viewModel.CleanupAsync();
+            Assert.IsTrue(viewModel.IsDiscarded);
+            Assert.IsFalse(cleanup.IsCompleted);
+
+            await Task.Run(() => notification(page.Object, new PropChangedEventArgs(nameof(IPage.Title)))).WaitAsync(TestTimeout);
+            if (finishTitleFirst)
+            {
+                releaseTitle.Set();
+                await titleUpdate.WaitAsync(TestTimeout);
+            }
+            else
+            {
+                releaseLoading.Set();
+                await loadingUpdate.WaitAsync(TestTimeout);
+            }
+
+            Assert.IsFalse(cleanup.IsCompleted, "The other extension call still owns a page operation.");
+            page.VerifyRemove(p => p.PropChanged -= It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>(), Times.Never);
+        }
+        finally
+        {
+            releaseTitle.Set();
+            releaseLoading.Set();
+            await Task.WhenAll(titleUpdate, loadingUpdate).WaitAsync(TestTimeout);
+            await (cleanup ?? viewModel.CleanupAsync()).WaitAsync(TestTimeout);
+        }
+
+        page.VerifyGet(p => p.Title, Times.Exactly(2));
+        page.VerifyGet(p => p.IsLoading, Times.Exactly(2));
+        page.VerifyRemove(p => p.PropChanged -= It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>(), Times.Once);
+    }
+
+    [DataTestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
+    public async Task CleanupRequestedInsideAnExtensionGetterDoesNotDeadlock(bool duringInitialization)
+    {
+        var page = new Mock<IPage>();
+        var subscriptionEvents = new ConcurrentQueue<string>();
+        TypedEventHandler<object, IPropChangedEventArgs>? notification = null;
+        page.SetupAdd(p => p.PropChanged += It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>())
+            .Callback<TypedEventHandler<object, IPropChangedEventArgs>>(handler =>
+            {
+                notification = handler;
+                subscriptionEvents.Enqueue("add");
+            });
+        page.SetupRemove(p => p.PropChanged -= It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>())
+            .Callback(() => subscriptionEvents.Enqueue("remove"));
+        var viewModel = new PageViewModel(page.Object, new QueuedTaskScheduler(), new TestHost(), CommandProviderContext.Empty);
+        if (!duringInitialization)
+        {
+            viewModel.InitializeProperties();
+        }
+
+        Task? cleanup = null;
+        var cleanupReturnedBeforeGetter = false;
+        page.SetupGet(p => p.Title).Returns(() =>
+        {
+            cleanup = viewModel.CleanupAsync();
+            cleanupReturnedBeforeGetter = !cleanup.IsCompleted;
+            return "Reentrant title";
+        });
+
+        try
+        {
+            if (duringInitialization)
+            {
+                await Task.Run(viewModel.InitializeProperties).WaitAsync(TestTimeout);
+            }
+            else
+            {
+                Assert.IsNotNull(notification);
+                await Task.Run(() => notification(page.Object, new PropChangedEventArgs(nameof(IPage.Title)))).WaitAsync(TestTimeout);
+            }
+
+            Assert.IsNotNull(cleanup);
+            Assert.IsTrue(cleanupReturnedBeforeGetter);
+            await cleanup.WaitAsync(TestTimeout);
+            Assert.IsTrue(viewModel.IsDiscarded);
+            CollectionAssert.AreEqual(ExpectedSubscriptionEvents, subscriptionEvents.ToArray());
+        }
+        finally
+        {
+            await (cleanup ?? viewModel.CleanupAsync()).WaitAsync(TestTimeout);
+        }
+    }
+
+    [TestMethod]
+    public async Task ParametersCreatedAfterCleanupWasRequestedReleaseTheirListSubscriptions()
+    {
+        using var release = new ManualResetEventSlim();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var childUnsubscribed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var list = CreateListPage();
+        list.SetupRemove(p => p.ItemsChanged -= It.IsAny<TypedEventHandler<object, IItemsChangedEventArgs>>())
+            .Callback(() => childUnsubscribed.TrySetResult());
+        var page = new Mock<IParametersPage>();
+        page.SetupGet(p => p.Command).Returns(new ListItem(new NoOpCommand()));
+        page.SetupGet(p => p.Parameters).Returns(() =>
+        {
+            Block(entered, release);
+            return [new CommandParameterRun { Command = list.Object }];
+        });
+        var viewModel = new ParametersPageViewModel(
+            page.Object, new QueuedTaskScheduler(), new TestHost(), CommandProviderContext.Empty, DefaultContextMenuFactory.Instance);
+        var initialization = Task.Run(viewModel.InitializeProperties);
+        Task? cleanup = null;
+        try
+        {
+            await entered.Task.WaitAsync(TestTimeout);
+            cleanup = viewModel.CleanupAsync();
+            Assert.IsTrue(viewModel.IsDiscarded);
+            Assert.IsFalse(cleanup.IsCompleted);
+            Assert.AreEqual(0, viewModel.Items.Count);
+            list.VerifyAdd(p => p.ItemsChanged += It.IsAny<TypedEventHandler<object, IItemsChangedEventArgs>>(), Times.Never);
+        }
+        finally
+        {
+            release.Set();
+            await initialization.WaitAsync(TestTimeout);
+            await (cleanup ?? viewModel.CleanupAsync()).WaitAsync(TestTimeout);
+        }
+
+        await childUnsubscribed.Task.WaitAsync(TestTimeout);
+        Assert.AreEqual(0, viewModel.Items.Count);
+        list.VerifyAdd(p => p.PropChanged += It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>(), Times.Once);
+        list.VerifyAdd(p => p.ItemsChanged += It.IsAny<TypedEventHandler<object, IItemsChangedEventArgs>>(), Times.Once);
+        list.VerifyRemove(p => p.PropChanged -= It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>(), Times.Once);
+        list.VerifyRemove(p => p.ItemsChanged -= It.IsAny<TypedEventHandler<object, IItemsChangedEventArgs>>(), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task ParametersCleanupDoesNotWaitForABlockedChildUnsubscribe()
+    {
+        using var release = new ManualResetEventSlim();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var list = CreateListPage();
+        var page = new Mock<IParametersPage>();
+        page.SetupGet(p => p.Command).Returns(new ListItem(new NoOpCommand()));
+        page.SetupGet(p => p.Parameters).Returns([new CommandParameterRun { Command = list.Object }]);
+        var viewModel = new ParametersPageViewModel(
+            page.Object, new QueuedTaskScheduler(), new TestHost(), CommandProviderContext.Empty, DefaultContextMenuFactory.Instance);
+        viewModel.InitializeProperties();
+        var ownedList = ((CommandParameterRunViewModel)viewModel.Items[0]).ListViewModel;
+        Assert.IsNotNull(ownedList);
+        list.SetupRemove(p => p.PropChanged -= It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>())
+            .Callback(() => Block(entered, release));
+
+        var cleanup = viewModel.CleanupAsync();
+        try
+        {
+            await entered.Task.WaitAsync(TestTimeout);
+            Assert.IsTrue(ownedList.IsDiscarded);
+            Assert.IsFalse(ownedList.CleanupAsync().IsCompleted);
+            await cleanup.WaitAsync(TestTimeout);
+            Assert.AreEqual(0, viewModel.Items.Count);
+            list.VerifyRemove(p => p.ItemsChanged -= It.IsAny<TypedEventHandler<object, IItemsChangedEventArgs>>(), Times.Never);
+        }
+        finally
+        {
+            release.Set();
+            await cleanup.WaitAsync(TestTimeout);
+            await ownedList.CleanupAsync().WaitAsync(TestTimeout);
+        }
+
+        list.VerifyRemove(p => p.ItemsChanged -= It.IsAny<TypedEventHandler<object, IItemsChangedEventArgs>>(), Times.Once);
+    }
+
+    [DataTestMethod]
+    [DataRow(false, false)]
+    [DataRow(true, false)]
+    [DataRow(false, true)]
+    public async Task CompletedParameterClearsItsListAndOnlyFocusesWhenActive(bool suspendBeforeCompletion, bool suspendBeforeDispatch)
+    {
+        var scheduler = new QueuedTaskScheduler();
+        var list = CreateListPage();
+        var parameter = new CommandParameterRun { Command = list.Object, Value = "Old value" };
+        var page = new Mock<IParametersPage>();
+        page.SetupGet(p => p.Command).Returns(new ListItem(new NoOpCommand()));
+        page.SetupGet(p => p.Parameters).Returns([parameter, new StringParameterRun { Text = "Filled value" }]);
+        var viewModel = new ParametersPageViewModel(
+            page.Object, scheduler, new TestHost(), CommandProviderContext.Empty, DefaultContextMenuFactory.Instance);
+        await viewModel.InitializeAsync();
+        scheduler.Drain();
+        var parameterViewModel = (CommandParameterRunViewModel)viewModel.Items[0];
+        var nextParameter = viewModel.Items[1];
+        var ownedList = parameterViewModel.ListViewModel;
+        Assert.IsNotNull(ownedList);
+
+        var recipient = new object();
+        var focusUpdates = 0;
+        var commandUpdates = 0;
+        WeakReferenceMessenger.Default.Register<FocusParamMessage>(recipient, (_, message) =>
+        {
+            if (ReferenceEquals(message.Parameter, nextParameter))
+            {
+                focusUpdates++;
+            }
+        });
+        WeakReferenceMessenger.Default.Register<UpdateCommandBarMessage>(recipient, (_, message) =>
+        {
+            if (ReferenceEquals(message.ViewModel, viewModel.Command))
+            {
+                commandUpdates++;
+            }
+        });
+
+        try
+        {
+            parameterViewModel.BeginEditing();
+            viewModel.SetActiveListParameter(parameterViewModel);
+            scheduler.Drain();
+            Assert.IsTrue(viewModel.HasActiveList);
+            if (suspendBeforeCompletion)
+            {
+                viewModel.SuspendForNavigation();
+            }
+
+            parameter.Value = "New value";
+            if (suspendBeforeDispatch)
+            {
+                viewModel.SuspendForNavigation();
+            }
+
+            Assert.IsTrue(viewModel.HasActiveList, "Picker state must be reconciled on the UI scheduler.");
+            scheduler.Drain();
+            Assert.IsFalse(parameterViewModel.NeedsValue);
+            Assert.IsFalse(parameterViewModel.IsEditing);
+            Assert.IsFalse(viewModel.HasActiveList, "A completed parameter must stop showing its picker while the page is retained.");
+            Assert.IsNull(viewModel.ActiveListViewModel);
+            var isSuspended = suspendBeforeCompletion || suspendBeforeDispatch;
+            var expectedFocusUpdates = isSuspended ? 0 : 1;
+            Assert.AreEqual(expectedFocusUpdates, focusUpdates);
+            if (isSuspended)
+            {
+                Assert.AreEqual(0, commandUpdates);
+            }
+
+            var updatesBeforeResume = commandUpdates;
+            await viewModel.ResumeAfterNavigation();
+            scheduler.Drain();
+            Assert.IsTrue(viewModel.ShowCommand);
+            Assert.IsFalse(viewModel.HasActiveList, "The completed picker must not hide the ready command after returning.");
+            Assert.AreEqual(expectedFocusUpdates, focusUpdates);
+            Assert.AreEqual(updatesBeforeResume + 1, commandUpdates);
+        }
+        finally
+        {
+            WeakReferenceMessenger.Default.UnregisterAll(recipient);
+            await viewModel.CleanupAsync().WaitAsync(TestTimeout);
+            await ownedList.CleanupAsync().WaitAsync(TestTimeout);
+        }
+    }
+
+    [TestMethod]
+    public async Task RetainedContentPageRestoresPresentationWithoutReloading()
+    {
+        var scheduler = new QueuedTaskScheduler();
+        var page = new Mock<IContentPage>();
+        page.Setup(p => p.GetContent()).Returns([]);
+        page.SetupGet(p => p.Details).Returns(Mock.Of<IDetails>());
+        var viewModel = new ContentPageViewModel(page.Object, scheduler, new TestHost(), CommandProviderContext.Empty);
+        var recipient = new object();
+        var commandUpdates = 0;
+        var detailsUpdates = 0;
+        WeakReferenceMessenger.Default.Register<UpdateCommandBarMessage>(recipient, (_, message) =>
+        {
+            if (ReferenceEquals(message.ViewModel, viewModel))
+            {
+                commandUpdates++;
+            }
+        });
+        WeakReferenceMessenger.Default.Register<ShowDetailsMessage>(recipient, (_, message) =>
+        {
+            if (ReferenceEquals(message.Details, viewModel.Details))
+            {
+                detailsUpdates++;
+            }
+        });
+
+        try
+        {
+            await viewModel.InitializeAsync();
+            Assert.IsNotNull(viewModel.Details);
+            for (var visit = 1; visit <= 2; visit++)
+            {
+                viewModel.SuspendForNavigation();
+                scheduler.Drain();
+                Assert.IsTrue(viewModel.IsInitialized);
+                Assert.IsFalse(viewModel.IsDiscarded);
+                Assert.AreEqual(visit - 1, commandUpdates);
+                Assert.AreEqual(visit - 1, detailsUpdates);
+
+                await viewModel.ResumeAfterNavigation();
+                scheduler.Drain();
+                Assert.AreEqual(visit, commandUpdates);
+                Assert.AreEqual(visit, detailsUpdates);
+            }
+
+            page.Verify(p => p.GetContent(), Times.Once);
+            page.VerifyAdd(p => p.ItemsChanged += It.IsAny<TypedEventHandler<object, IItemsChangedEventArgs>>(), Times.Once);
+            page.VerifyRemove(p => p.ItemsChanged -= It.IsAny<TypedEventHandler<object, IItemsChangedEventArgs>>(), Times.Never);
+            page.VerifyRemove(p => p.PropChanged -= It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>(), Times.Never);
+        }
+        finally
+        {
+            WeakReferenceMessenger.Default.UnregisterAll(recipient);
+            await viewModel.CleanupAsync().WaitAsync(TestTimeout);
+        }
+    }
+
+    private sealed partial class BlockingCleanupPageViewModel(IPage page, TaskCompletionSource entered, ManualResetEventSlim release)
+        : PageViewModel(page, new QueuedTaskScheduler(), new TestHost(), CommandProviderContext.Empty)
+    {
+        private int _cleanupRequestCount;
+
+        internal int CleanupRequestCount => Volatile.Read(ref _cleanupRequestCount);
+
+        protected override void OnCleanupRequested()
+        {
+            Interlocked.Increment(ref _cleanupRequestCount);
+            Block(entered, release);
+        }
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/PageCleanupTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/PageCleanupTests.cs
@@ -1,0 +1,275 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.CmdPal.UI.ViewModels.Messages;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Windows.Foundation;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+[TestClass]
+[DoNotParallelize]
+public sealed partial class PageCleanupTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(5);
+
+    [TestMethod]
+    public async Task CleanupReturnsBeforeAnExtensionUnsubscribeFinishes()
+    {
+        using var release = new ManualResetEventSlim();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var page = CreateListPage();
+        var viewModel = CreateListViewModel(page.Object);
+        viewModel.InitializeProperties();
+        page.SetupRemove(p => p.PropChanged -= It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>())
+            .Callback(() => Block(entered, release));
+
+        var cleanup = viewModel.CleanupAsync();
+        try
+        {
+            await entered.Task.WaitAsync(TestTimeout);
+            Assert.IsTrue(viewModel.IsDiscarded);
+            Assert.IsFalse(cleanup.IsCompleted);
+            Assert.AreSame(cleanup, viewModel.CleanupAsync());
+            await viewModel.ResumeAfterNavigation().WaitAsync(TestTimeout);
+            page.Verify(p => p.GetItems(), Times.Once);
+        }
+        finally
+        {
+            release.Set();
+            await cleanup.WaitAsync(TestTimeout);
+        }
+
+        page.VerifyRemove(p => p.PropChanged -= It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>(), Times.Once);
+    }
+
+    [DataTestMethod]
+    [DataRow("Id")]
+    [DataRow("GetItems")]
+    [DataRow("ItemsChanged")]
+    public async Task CleanupWaitsForLateInitializationWithoutBlockingNavigation(string blockedCall)
+    {
+        using var release = new ManualResetEventSlim();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var page = CreateListPage();
+        switch (blockedCall)
+        {
+            case "Id":
+                page.SetupGet(p => p.Id).Returns(() =>
+                {
+                    Block(entered, release);
+                    return "page";
+                });
+                break;
+            case "GetItems":
+                page.Setup(p => p.GetItems()).Returns(() =>
+                {
+                    Block(entered, release);
+                    return [];
+                });
+                break;
+            case "ItemsChanged":
+                page.SetupAdd(p => p.ItemsChanged += It.IsAny<TypedEventHandler<object, IItemsChangedEventArgs>>())
+                    .Callback(() => Block(entered, release));
+                break;
+        }
+
+        var viewModel = CreateListViewModel(page.Object);
+        var initialization = Task.Run(viewModel.InitializeProperties);
+        Task? cleanup = null;
+        try
+        {
+            await entered.Task.WaitAsync(TestTimeout);
+            cleanup = viewModel.CleanupAsync();
+            Assert.IsTrue(viewModel.IsDiscarded);
+            Assert.IsFalse(cleanup.IsCompleted);
+            page.VerifyRemove(p => p.PropChanged -= It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>(), Times.Never);
+        }
+        finally
+        {
+            release.Set();
+            await initialization.WaitAsync(TestTimeout);
+            await (cleanup ?? viewModel.CleanupAsync()).WaitAsync(TestTimeout);
+        }
+
+        page.VerifyAdd(p => p.PropChanged += It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>(), Times.Once);
+        page.VerifyAdd(p => p.ItemsChanged += It.IsAny<TypedEventHandler<object, IItemsChangedEventArgs>>(), Times.Once);
+        page.VerifyRemove(p => p.PropChanged -= It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>(), Times.Once);
+        page.VerifyRemove(p => p.ItemsChanged -= It.IsAny<TypedEventHandler<object, IItemsChangedEventArgs>>(), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task DiscardedPageIgnoresQueuedNotificationsAndReinitialization()
+    {
+        var scheduler = new QueuedTaskScheduler();
+        var page = new Mock<IPage>();
+        TypedEventHandler<object, IPropChangedEventArgs>? queuedNotification = null;
+        page.SetupAdd(p => p.PropChanged += It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>())
+            .Callback<TypedEventHandler<object, IPropChangedEventArgs>>(handler => queuedNotification = handler);
+        var viewModel = new PageViewModel(page.Object, scheduler, new TestHost(), CommandProviderContext.Empty);
+        await viewModel.InitializeAsync();
+        await viewModel.CleanupAsync().WaitAsync(TestTimeout);
+
+        Assert.IsNotNull(queuedNotification);
+        queuedNotification(page.Object, new PropChangedEventArgs(nameof(IPage.Title)));
+        viewModel.InitializeProperties();
+        scheduler.Drain();
+
+        Assert.IsFalse(viewModel.IsInitialized);
+        page.VerifyGet(p => p.Title, Times.Once);
+        page.VerifyAdd(p => p.PropChanged += It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>(), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task ContentWaitingForUiPublicationIsReleasedAfterDiscard()
+    {
+        var scheduler = new QueuedTaskScheduler();
+        var page = new Mock<IContentPage>();
+        page.Setup(p => p.GetContent()).Returns([Mock.Of<IContent>()]);
+        var viewModel = new TestContentPageViewModel(page.Object, scheduler);
+        viewModel.InitializeProperties();
+        var content = viewModel.CreatedContent;
+        Assert.IsNotNull(content);
+        Assert.AreEqual(0, viewModel.Content.Count);
+
+        await viewModel.CleanupAsync().WaitAsync(TestTimeout);
+        scheduler.Drain();
+        await content.Cleaned.Task.WaitAsync(TestTimeout);
+
+        Assert.AreEqual(0, viewModel.Content.Count);
+        page.VerifyRemove(p => p.ItemsChanged -= It.IsAny<TypedEventHandler<object, IItemsChangedEventArgs>>(), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task ParametersCleanupReleasesItsOwnedListSubscriptions()
+    {
+        var list = CreateListPage();
+        var page = new Mock<IParametersPage>();
+        page.SetupGet(p => p.Command).Returns(new ListItem(new NoOpCommand()));
+        page.SetupGet(p => p.Parameters).Returns([new CommandParameterRun { Command = list.Object }]);
+        var viewModel = new ParametersPageViewModel(
+            page.Object, TaskScheduler.Default, new TestHost(), CommandProviderContext.Empty, DefaultContextMenuFactory.Instance);
+        viewModel.InitializeProperties();
+        var ownedList = ((CommandParameterRunViewModel)viewModel.Items[0]).ListViewModel;
+        Assert.IsNotNull(ownedList);
+
+        await viewModel.CleanupAsync().WaitAsync(TestTimeout);
+        Assert.IsTrue(ownedList.IsDiscarded);
+        await ownedList.CleanupAsync().WaitAsync(TestTimeout);
+
+        Assert.AreEqual(0, viewModel.Items.Count);
+        list.VerifyRemove(p => p.PropChanged -= It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>(), Times.Once);
+        list.VerifyRemove(p => p.ItemsChanged -= It.IsAny<TypedEventHandler<object, IItemsChangedEventArgs>>(), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task RetainedParametersPageSuppressesCommandsUntilItReturns()
+    {
+        var scheduler = new QueuedTaskScheduler();
+        var page = new Mock<IParametersPage>();
+        page.SetupGet(p => p.Command).Returns(new ListItem(new NoOpCommand()));
+        page.SetupGet(p => p.Parameters).Returns([]);
+        var viewModel = new ParametersPageViewModel(
+            page.Object, scheduler, new TestHost(), CommandProviderContext.Empty, DefaultContextMenuFactory.Instance);
+        var recipient = new object();
+        var updates = 0;
+        WeakReferenceMessenger.Default.Register<UpdateCommandBarMessage>(recipient, (_, message) =>
+        {
+            if (ReferenceEquals(message.ViewModel, viewModel.Command))
+            {
+                updates++;
+            }
+        });
+
+        try
+        {
+            await viewModel.InitializeAsync();
+            viewModel.SuspendForNavigation();
+            scheduler.Drain();
+            Assert.IsTrue(viewModel.IsInitialized);
+            Assert.AreEqual(0, updates);
+            Assert.IsFalse(viewModel.IsDiscarded);
+
+            await viewModel.ResumeAfterNavigation();
+            scheduler.Drain();
+            Assert.AreEqual(1, updates);
+            page.VerifyRemove(p => p.PropChanged -= It.IsAny<TypedEventHandler<object, IPropChangedEventArgs>>(), Times.Never);
+        }
+        finally
+        {
+            WeakReferenceMessenger.Default.UnregisterAll(recipient);
+            await viewModel.CleanupAsync().WaitAsync(TestTimeout);
+        }
+    }
+
+    private static Mock<IListPage> CreateListPage()
+    {
+        var page = new Mock<IListPage>();
+        page.Setup(p => p.GetItems()).Returns([]);
+        return page;
+    }
+
+    private static ListViewModel CreateListViewModel(IListPage page) =>
+        new(page, TaskScheduler.Default, new TestHost(), CommandProviderContext.Empty, DefaultContextMenuFactory.Instance);
+
+    private static void Block(TaskCompletionSource entered, ManualResetEventSlim release)
+    {
+        entered.TrySetResult();
+        Assert.IsTrue(release.Wait(TestTimeout * 2), "The extension call was not released.");
+    }
+
+    private sealed partial class TestHost : AppExtensionHost
+    {
+        public override string? GetExtensionDisplayName() => "Page cleanup test host";
+    }
+
+    private sealed partial class TestContentPageViewModel(IContentPage page, TaskScheduler scheduler)
+        : ContentPageViewModel(page, scheduler, new TestHost(), CommandProviderContext.Empty)
+    {
+        internal TestContentViewModel? CreatedContent { get; private set; }
+
+        public override ContentViewModel? ViewModelFromContent(IContent content, WeakReference<IPageContext> context) =>
+            CreatedContent = new(context);
+    }
+
+    private sealed partial class TestContentViewModel(WeakReference<IPageContext> context) : ContentViewModel(context)
+    {
+        internal TaskCompletionSource Cleaned { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override void InitializeProperties()
+        {
+        }
+
+        protected override void UnsafeCleanup() => Cleaned.SetResult();
+    }
+
+    private sealed class QueuedTaskScheduler : TaskScheduler
+    {
+        private readonly ConcurrentQueue<Task> _tasks = new();
+
+        protected override IEnumerable<Task> GetScheduledTasks() => _tasks.ToArray();
+
+        protected override void QueueTask(Task task) => _tasks.Enqueue(task);
+
+        protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued) => false;
+
+        internal void Drain()
+        {
+            while (_tasks.TryDequeue(out var task))
+            {
+                TryExecuteTask(task);
+                task.GetAwaiter().GetResult();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary of the Pull Request

This PR separates temporary page suspension from permanent cleanup.

- Cleans up pages removed from navigation stacks.
- Detaches bindings and item sources after navigation completes, then defer cleanup until in-flight page operations finish.
- Prevents inactive pages from changing shared UI while preserving parameter updates for their next visit.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #50500
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

