### PR TITLE
CmdPal: fix display configuration query to preserve monitor identity

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Services/MonitorService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Services/MonitorService.cs
@@ -243,15 +243,14 @@ public sealed class MonitorService : IMonitorService
 
             var paths = new DISPLAYCONFIG_PATH_INFO[pathCount];
             var modes = new DISPLAYCONFIG_MODE_INFO[modeCount];
-            var topologyId = default(DISPLAYCONFIG_TOPOLOGY_ID);
 
+            // QDC_ONLY_ACTIVE_PATHS requires a null topology pointer, so omit the optional argument.
             result = PInvoke.QueryDisplayConfig(
                 QUERY_DISPLAY_CONFIG_FLAGS.QDC_ONLY_ACTIVE_PATHS,
                 ref pathCount,
                 paths,
                 ref modeCount,
-                modes,
-                ref topologyId);
+                modes);
             if (result != WIN32_ERROR.NO_ERROR)
             {
                 return map;

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/DockMultiMonitorTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/DockMultiMonitorTests.cs
@@ -752,7 +752,7 @@ public class DockMultiMonitorTests
     }
 
     [TestMethod]
-    public void Reconcile_DisconnectThenReconnect_PreservesCustomizations()
+    public void Reconcile_DisconnectThenReconnectWithNewGdiName_PreservesCustomizations()
     {
         // Step 1: Both monitors connected with customized secondary
         var customBands = ImmutableList.Create(new DockBandSettings { ProviderId = "custom", CommandId = "cmd1" });
@@ -778,14 +778,18 @@ public class DockMultiMonitorTests
 
         Assert.AreEqual(2, afterDisconnect.Count, "Disconnected monitor config should be retained");
 
-        // Step 3: Reconnect secondary monitor
-        var bothMonitors = new List<MonitorInfo> { PrimaryMonitor, SecondaryMonitor };
+        // Step 3: Reconnect the same secondary monitor under a new GDI name.
+        var reconnectedSecondary = SecondaryMonitor with { DeviceId = @"\\.\DISPLAY3" };
+        var bothMonitors = new List<MonitorInfo> { PrimaryMonitor, reconnectedSecondary };
         var afterReconnect = MonitorConfigReconciler.Reconcile(afterDisconnect, bothMonitors, now);
+
+        Assert.AreEqual(2, afterReconnect.Count, "A new GDI name should not create another monitor config");
 
         // Verify customizations survived the round-trip
         var secondaryConfig = afterReconnect.Find(c =>
             string.Equals(c.MonitorDeviceId, SecondaryMonitor.StableId, StringComparison.OrdinalIgnoreCase));
         Assert.IsNotNull(secondaryConfig, "Secondary config should be found after reconnection");
+        Assert.IsTrue(secondaryConfig.Enabled, "The Dock should remain enabled after the GDI name changes");
         Assert.IsTrue(secondaryConfig.IsCustomized, "Customization flag should survive");
         Assert.AreEqual(DockSide.Left, secondaryConfig.Side, "Side override should survive");
         Assert.AreEqual(1, secondaryConfig.StartBands?.Count ?? 0, "Custom start bands should survive");


### PR DESCRIPTION
## Summary of the Pull Request

When a Miracast secondary display reconnects with a different GDI name, Command Palette Dock creates a disabled, empty configuration instead of reusing the monitor's settings. Pass the required null topology pointer to `QueryDisplayConfig` when using `QDC_ONLY_ACTIVE_PATHS`, allowing the existing monitor-identification code to resolve hardware device paths.

The proposed scope and implementation are ready for maintainer review. Remaining validation and related UI observations are documented below.

## PR Checklist

- [x] Closes: #50486
- [ ] **Communication:** [Contribution interest registered in #28769](https://github.com/microsoft/PowerToys/issues/28769#issuecomment-5613725446); [scope and validation update posted on #50486](https://github.com/microsoft/PowerToys/issues/50486#issuecomment-5613743381). Awaiting maintainer confirmation.
- [x] **Tests:** Updated the reconnection test; all 39 `DockMultiMonitorTests` passed on the validation baseline described below. Final visual and mixed-DPI acceptance remains pending.
- [x] **Localization:** Not applicable; no end-user-facing strings are added.
- [x] **Dev docs:** The API argument requirement is explained in a code comment.
- [x] **New binaries:** Not applicable; no new binaries, dependencies or test projects are added.
- [x] **Documentation updated:** Not applicable; no public documentation changes are required.

## Detailed Description of the Pull Request / Additional comments

- `src/modules/cmdpal/Microsoft.CmdPal.UI/Services/MonitorService.cs`: remove the topology variable and use CsWin32's existing five-argument overload. It passes a null native `currentTopologyId` pointer, as required for active-path queries. Passing a zero-valued variable by reference still supplies a non-null pointer and causes `ERROR_INVALID_PARAMETER` (87).
- `src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/DockMultiMonitorTests.cs`: extend the existing disconnect/reconnect test to reconnect with a changed GDI `DeviceId` and the same `StableId`. Assert that no additional configuration is created and that the Dock remains enabled, alongside the existing customization checks.

API contract: [QueryDisplayConfig remarks](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-querydisplayconfig#remarks).

The existing reconciliation logic handles stable-ID matching and migration when a legacy GDI key still matches the connected monitor. Entries keyed only by an old, no-longer-matching GDI name cannot be reliably associated with a physical display, so this fix does not automatically restore those orphaned entries.

## Validation Steps Performed

Validation was performed on `071c25e115e8097117e26f6fcfe9901301307f7a` with these two file changes. This PR branch preserves that baseline and patch; preparation of the PR did not rerun the application build or physical display checks.

- Built the patched Command Palette UI as x64 Debug with Dev branding and built the affected ViewModels test project using `tools/build/build.ps1`: both exited with code 0.
- Ran all 39 `DockMultiMonitorTests` using `vstest.console.exe`: 39 passed, 0 failed, 0 skipped. Coverage includes the updated reconnection test and the existing legacy-GDI migration test.
- Compared both native calls using the repository's CsWin32 version: the non-null topology argument returned 87; the omitted argument returned 0 and resolved the device paths for both active monitors. The compiled patched `MonitorService` returned the same hardware paths.
- Performed a physical Miracast reconnect. The wireless display changed from `DISPLAY14` to `DISPLAY15`, while its hardware path and complete settings-file hash stayed unchanged. The display retained one enabled, customized configuration, and no additional monitor configuration was created.
- Checked the isolated two-file patch with `git diff --check` and verified that its source files match the prepared fix.

The unit tests use constructed monitor data and do not exercise the native API. Native API behavior and the physical reconnect were validated separately.

### Remaining validation and related observations

The initial reconnect also exposed a center-band visibility issue: the date/time entry remained saved but was initially hidden. A separate follow-up build addressed that visibility issue; testing that follow-up build at 144/96 DPI then exposed a popup-positioning issue. The `DockControl` and `MainWindow` follow-up changes are outside this PR, and their test results are not claimed as validation of this two-file patch.

Maintainer feedback on the scope is requested. Final visual/mixed-DPI acceptance for the selected PR build remains pending, including documentation of the separate UI findings. The automated legacy-GDI migration test passes; an additional running-app migration check would be useful.
