### PR TITLE
[Power Display] Preserve profiles across unavailable monitors and capabilities

### DIFF
--- a/src/settings-ui/Settings.UI.Library/MonitorInfo.cs
+++ b/src/settings-ui/Settings.UI.Library/MonitorInfo.cs
@@ -389,7 +389,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         /// <summary>
         /// Compare two VcpCodesFormatted lists for equality by content.
-        /// Returns true if both lists have the same VCP codes (by code value).
+        /// Returns true if both lists have the same codes, values, and display names.
         /// </summary>
         private static bool AreVcpCodesEqual(List<VcpCodeDisplayInfo> list1, List<VcpCodeDisplayInfo> list2)
         {
@@ -411,17 +411,30 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             // Compare by code values - order matters for our use case
             for (int i = 0; i < list1.Count; i++)
             {
-                if (list1[i].Code != list2[i].Code)
+                if (list1[i].Code != list2[i].Code
+                    || list1[i].Title != list2[i].Title
+                    || list1[i].Values != list2[i].Values
+                    || list1[i].HasValues != list2[i].HasValues)
                 {
                     return false;
                 }
 
-                // Also compare ValueList count to detect preset changes
+                // Compare values as well as their count; capability refreshes and custom
+                // names can change the available options without changing the list size.
                 var values1 = list1[i].ValueList;
                 var values2 = list2[i].ValueList;
                 if ((values1?.Count ?? 0) != (values2?.Count ?? 0))
                 {
                     return false;
+                }
+
+                for (int valueIndex = 0; valueIndex < (values1?.Count ?? 0); valueIndex++)
+                {
+                    if (values1[valueIndex].Value != values2[valueIndex].Value
+                        || values1[valueIndex].Name != values2[valueIndex].Name)
+                    {
+                        return false;
+                    }
                 }
             }
 

--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/ProfileEditorViewModelTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/ProfileEditorViewModelTests.cs
@@ -2,10 +2,14 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.ViewModels;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PowerDisplay.Models;
 
 namespace ViewModelTests
 {
@@ -15,7 +19,7 @@ namespace ViewModelTests
         [TestMethod]
         public void CreateProfile_DefaultProfileId_ReturnsZero()
         {
-            var viewModel = new ProfileEditorViewModel(
+            using var viewModel = new ProfileEditorViewModel(
                 new ObservableCollection<MonitorInfo>(),
                 "New profile");
 
@@ -28,7 +32,7 @@ namespace ViewModelTests
         public void CreateProfile_ExistingProfileId_PreservesId()
         {
             const int profileId = 42;
-            var viewModel = new ProfileEditorViewModel(
+            using var viewModel = new ProfileEditorViewModel(
                 new ObservableCollection<MonitorInfo>(),
                 "Existing profile",
                 profileId);
@@ -36,6 +40,712 @@ namespace ViewModelTests
             var profile = viewModel.CreateProfile();
 
             Assert.AreEqual(profileId, profile.Id);
+        }
+
+        [TestMethod]
+        [DataRow(0x0B)]
+        public void ColorTemperature_PrefillingAnUnavailableValuePreservesTheOriginalSetting(int savedValue)
+        {
+            var monitor = CreateMonitor();
+            monitor.ColorTemperatureVcp = 0x08;
+            using var viewModel = CreateViewModel(monitor);
+            var item = viewModel.Monitors.Single();
+            Assert.AreEqual((int?)0x08, item.ColorTemperature);
+
+            viewModel.PreFillProfile(new PowerDisplayProfile(
+                "Existing profile",
+                new List<ProfileMonitorSetting> { new(monitor.Id, colorTemperatureVcp: savedValue) }));
+
+            Assert.IsNull(item.ColorTemperature);
+            Assert.IsTrue(item.IncludeColorTemperature);
+            Assert.IsTrue(item.HasPreservedSettings);
+            Assert.IsTrue(viewModel.CanSave);
+            Assert.AreEqual((int?)savedValue, viewModel.CreateProfile().MonitorSettings.Single().ColorTemperatureVcp);
+        }
+
+        [TestMethod]
+        public void ColorTemperature_ClearingSelectionDoesNotIncludeTheSetting()
+        {
+            using var viewModel = CreateViewModel(CreateMonitor());
+            var item = viewModel.Monitors.Single();
+            Assert.IsFalse(item.IncludeColorTemperature);
+
+            item.ColorTemperature = null;
+
+            Assert.IsNull(item.ColorTemperature);
+            Assert.IsFalse(item.HasValidColorTemperature);
+            Assert.IsFalse(item.IncludeColorTemperature);
+
+            item.ColorTemperature = 0x08;
+
+            Assert.IsTrue(item.HasValidColorTemperature);
+            Assert.IsTrue(item.IncludeColorTemperature);
+        }
+
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public void ColorPresets_RenamingPreservesSelectionAndInclusion(bool includeColorTemperature)
+        {
+            var monitor = CreateMonitor();
+            using var viewModel = CreateViewModel(monitor);
+            var item = viewModel.Monitors.Single();
+            item.SuppressAutoSelection = true;
+            item.ColorTemperature = 0x08;
+            item.SuppressAutoSelection = false;
+            item.IncludeColorTemperature = includeColorTemperature;
+            var presetChanges = 0;
+            item.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName == nameof(MonitorSelectionItem.ColorPresetsForDisplay))
+                {
+                    presetChanges++;
+
+                    // Replacing ComboBox.ItemsSource can synchronously clear SelectedValue.
+                    item.ColorTemperature = null;
+                }
+            };
+
+            monitor.VcpCodesFormatted = CreateColorCapabilities("Renamed preset");
+
+            Assert.IsTrue(presetChanges > 0);
+            Assert.AreEqual((int?)0x08, item.ColorTemperature);
+            Assert.IsTrue(item.HasValidColorTemperature);
+            Assert.AreEqual(includeColorTemperature, item.IncludeColorTemperature);
+            Assert.AreEqual("Renamed preset", item.ColorPresetsForDisplay.Single(preset => preset.VcpValue == 0x08).DisplayName);
+        }
+
+        [TestMethod]
+        public void CanSave_UnsupportedColorTemperatureDoesNotBlockBrightness()
+        {
+            var monitor = CreateMonitor();
+            monitor.SupportsColorTemperature = false;
+            using var viewModel = CreateViewModel(monitor);
+            var item = viewModel.Monitors.Single();
+            item.IsSelected = true;
+            item.IncludeBrightness = true;
+            item.IncludeColorTemperature = true;
+
+            Assert.IsFalse(item.HasValidColorTemperature);
+            Assert.IsTrue(viewModel.CanSave);
+            var settings = viewModel.CreateProfile().MonitorSettings.Single();
+            Assert.AreEqual((int?)monitor.CurrentBrightness, settings.Brightness);
+            Assert.IsNull(settings.ColorTemperatureVcp);
+        }
+
+        [TestMethod]
+        public void PreFillProfile_CaseInsensitiveMonitorIdRestoresEverySettingOnMatchingInstance()
+        {
+            var monitor = CreateMonitor();
+            monitor.Id = @"\\?\DISPLAY#TEST001#FIRST";
+            monitor.SupportsContrast = true;
+            monitor.SupportsVolume = true;
+            var otherMonitor = CreateMonitor();
+            otherMonitor.Id = @"\\?\DISPLAY#TEST001#SECOND";
+            otherMonitor.CurrentBrightness = 90;
+            using var viewModel = new ProfileEditorViewModel(
+                new ObservableCollection<MonitorInfo> { otherMonitor, monitor },
+                "New profile");
+
+            viewModel.PreFillProfile(new PowerDisplayProfile(
+                "Existing profile",
+                new List<ProfileMonitorSetting>
+                {
+                    new(monitor.Id.ToLowerInvariant(), brightness: 25, colorTemperatureVcp: 0x08, contrast: 63, volume: 41),
+                }));
+
+            var item = viewModel.Monitors[1];
+            Assert.AreSame(monitor, item.Monitor);
+            Assert.AreEqual("Existing profile", viewModel.ProfileName);
+            Assert.IsTrue(item.IsSelected);
+            Assert.IsTrue(item.IncludeBrightness);
+            Assert.IsTrue(item.IncludeContrast);
+            Assert.IsTrue(item.IncludeVolume);
+            Assert.IsTrue(item.IncludeColorTemperature);
+            Assert.AreEqual(25, item.Brightness);
+            Assert.AreEqual(63, item.Contrast);
+            Assert.AreEqual(41, item.Volume);
+            Assert.AreEqual((int?)0x08, item.ColorTemperature);
+            Assert.IsTrue(viewModel.CanSave);
+
+            var otherItem = viewModel.Monitors[0];
+            Assert.AreSame(otherMonitor, otherItem.Monitor);
+            Assert.IsFalse(otherItem.IsSelected);
+            Assert.IsFalse(otherItem.IncludeBrightness);
+            Assert.IsFalse(otherItem.IncludeContrast);
+            Assert.IsFalse(otherItem.IncludeVolume);
+            Assert.IsFalse(otherItem.IncludeColorTemperature);
+            Assert.AreEqual(90, otherItem.Brightness);
+            Assert.AreEqual((int?)0x05, otherItem.ColorTemperature);
+
+            var savedSettings = viewModel.CreateProfile().MonitorSettings.Single();
+            Assert.IsTrue(MonitorIdComparer.Equal(monitor.Id, savedSettings.MonitorId));
+            Assert.AreEqual((int?)25, savedSettings.Brightness);
+            Assert.AreEqual((int?)63, savedSettings.Contrast);
+            Assert.AreEqual((int?)41, savedSettings.Volume);
+            Assert.AreEqual((int?)0x08, savedSettings.ColorTemperatureVcp);
+        }
+
+        [TestMethod]
+        [DataRow(nameof(ProfileMonitorSetting.Contrast))]
+        [DataRow(nameof(ProfileMonitorSetting.Volume))]
+        [DataRow(nameof(ProfileMonitorSetting.ColorTemperatureVcp))]
+        public void CanSave_PrefillingOnlyAnUnsupportedSettingPreservesIt(string settingName)
+        {
+            var monitor = CreateMonitor();
+            monitor.SupportsContrast = false;
+            monitor.SupportsVolume = false;
+            monitor.SupportsColorTemperature = false;
+            using var viewModel = CreateViewModel(monitor);
+
+            viewModel.PreFillProfile(CreateProfileWithOptionalSetting(monitor.Id, settingName));
+
+            var item = viewModel.Monitors.Single();
+            Assert.IsTrue(item.IsSelected);
+            Assert.AreEqual(settingName == nameof(ProfileMonitorSetting.Contrast), item.IncludeContrast);
+            Assert.AreEqual(settingName == nameof(ProfileMonitorSetting.Volume), item.IncludeVolume);
+            Assert.AreEqual(settingName == nameof(ProfileMonitorSetting.ColorTemperatureVcp), item.IncludeColorTemperature);
+            Assert.IsTrue(item.HasPreservedSettings);
+            Assert.IsTrue(viewModel.HasValidSettings);
+            Assert.IsTrue(viewModel.CanSave);
+            var savedSettings = viewModel.CreateProfile().MonitorSettings.Single();
+            Assert.IsNull(savedSettings.Brightness);
+            Assert.AreEqual(settingName == nameof(ProfileMonitorSetting.Contrast) ? (int?)63 : null, savedSettings.Contrast);
+            Assert.AreEqual(settingName == nameof(ProfileMonitorSetting.Volume) ? (int?)41 : null, savedSettings.Volume);
+            Assert.AreEqual(settingName == nameof(ProfileMonitorSetting.ColorTemperatureVcp) ? (int?)0x08 : null, savedSettings.ColorTemperatureVcp);
+            Assert.AreEqual(item.IncludeContrast, item.ShowContrast);
+            Assert.AreEqual(item.IncludeVolume, item.ShowVolume);
+            Assert.AreEqual(item.IncludeColorTemperature, item.ShowColorTemperature);
+        }
+
+        [TestMethod]
+        public void CanSave_EverySelectedMonitorNeedsAPersistedSetting()
+        {
+            var monitor = CreateMonitor();
+            var unsupportedMonitor = CreateMonitor();
+            unsupportedMonitor.Id = "DISPLAY#TEST001#2";
+            unsupportedMonitor.SupportsContrast = false;
+            using var viewModel = new ProfileEditorViewModel(
+                new ObservableCollection<MonitorInfo> { monitor, unsupportedMonitor },
+                "Profile");
+            viewModel.Monitors[0].IsSelected = true;
+            viewModel.Monitors[0].Brightness = 25;
+            viewModel.Monitors[1].IsSelected = true;
+            viewModel.Monitors[1].Contrast = 63;
+
+            Assert.IsTrue(viewModel.Monitors.All(item => item.IsSelected));
+            Assert.IsFalse(viewModel.CanSave);
+
+            viewModel.Monitors[1].IsSelected = false;
+
+            Assert.IsTrue(viewModel.CanSave);
+            var savedSettings = viewModel.CreateProfile().MonitorSettings.Single();
+            Assert.AreEqual(monitor.Id, savedSettings.MonitorId);
+            Assert.AreEqual((int?)25, savedSettings.Brightness);
+        }
+
+        [TestMethod]
+        [DataRow(nameof(ProfileMonitorSetting.Contrast))]
+        [DataRow(nameof(ProfileMonitorSetting.Volume))]
+        public void CanSave_OriginalOptionalSettingSurvivesSupportChanges(string settingName)
+        {
+            var monitor = CreateMonitor();
+            monitor.SupportsContrast = true;
+            monitor.SupportsVolume = true;
+            using var viewModel = CreateViewModel(monitor);
+            viewModel.PreFillProfile(CreateProfileWithOptionalSetting(monitor.Id, settingName));
+            Assert.IsTrue(viewModel.CanSave);
+            var canSaveChanges = 0;
+            viewModel.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName == nameof(ProfileEditorViewModel.CanSave))
+                {
+                    canSaveChanges++;
+                }
+            };
+
+            if (settingName == nameof(ProfileMonitorSetting.Contrast))
+            {
+                monitor.SupportsContrast = false;
+            }
+            else
+            {
+                monitor.SupportsVolume = false;
+            }
+
+            Assert.IsTrue(viewModel.CanSave);
+            Assert.IsTrue(viewModel.Monitors.Single().HasPreservedSettings);
+            var savedSettings = viewModel.CreateProfile().MonitorSettings.Single();
+            Assert.AreEqual(settingName == nameof(ProfileMonitorSetting.Contrast) ? (int?)63 : null, savedSettings.Contrast);
+            Assert.AreEqual(settingName == nameof(ProfileMonitorSetting.Volume) ? (int?)41 : null, savedSettings.Volume);
+            Assert.IsTrue(canSaveChanges > 0);
+            canSaveChanges = 0;
+
+            if (settingName == nameof(ProfileMonitorSetting.Contrast))
+            {
+                monitor.SupportsContrast = true;
+            }
+            else
+            {
+                monitor.SupportsVolume = true;
+            }
+
+            Assert.IsTrue(viewModel.CanSave);
+            Assert.IsFalse(viewModel.Monitors.Single().HasPreservedSettings);
+            Assert.IsTrue(canSaveChanges > 0);
+        }
+
+        [TestMethod]
+        public void CreateProfile_RenamingPreservesMetadataAndAnIndependentCopyOfOriginalSettings()
+        {
+            var monitor = CreateMonitor();
+            monitor.SupportsBrightness = false;
+            monitor.SupportsContrast = false;
+            monitor.SupportsVolume = false;
+            monitor.SupportsColorTemperature = false;
+            var createdDate = new DateTime(2024, 3, 15, 10, 30, 0, DateTimeKind.Utc);
+            var originalSetting = new ProfileMonitorSetting(monitor.Id, brightness: 25, colorTemperatureVcp: 0x08, contrast: 63, volume: 41);
+            var original = new PowerDisplayProfile("Original profile", new List<ProfileMonitorSetting> { originalSetting })
+            {
+                Id = 42,
+                CreatedDate = createdDate,
+            };
+            using var viewModel = new ProfileEditorViewModel(
+                new ObservableCollection<MonitorInfo> { monitor },
+                "Existing profile",
+                original.Id);
+            viewModel.PreFillProfile(original);
+            viewModel.ProfileName = "Renamed profile";
+
+            Assert.AreEqual("Original profile", original.Name);
+            Assert.IsTrue(viewModel.CanSave);
+            var item = viewModel.Monitors.Single();
+            Assert.IsTrue(item.HasPreservedSettings);
+            Assert.IsTrue(item.ShowBrightness);
+            Assert.IsTrue(item.ShowContrast);
+            Assert.IsTrue(item.ShowVolume);
+            Assert.IsTrue(item.ShowColorTemperature);
+
+            originalSetting.Brightness = 99;
+            originalSetting.ColorTemperatureVcp = 0x0B;
+            originalSetting.Contrast = null;
+            originalSetting.Volume = null;
+            original.Id = 7;
+            original.CreatedDate = DateTime.MinValue;
+            original.MonitorSettings.Clear();
+
+            var saved = viewModel.CreateProfile();
+            Assert.AreEqual(42, saved.Id);
+            Assert.AreEqual(createdDate, saved.CreatedDate);
+            Assert.AreEqual("Renamed profile", saved.Name);
+            var savedSettings = saved.MonitorSettings.Single();
+            Assert.AreNotSame(originalSetting, savedSettings);
+            Assert.AreEqual(monitor.Id, savedSettings.MonitorId);
+            Assert.AreEqual((int?)25, savedSettings.Brightness);
+            Assert.AreEqual((int?)0x08, savedSettings.ColorTemperatureVcp);
+            Assert.AreEqual((int?)63, savedSettings.Contrast);
+            Assert.AreEqual((int?)41, savedSettings.Volume);
+
+            savedSettings.Brightness = 1;
+            savedSettings.ColorTemperatureVcp = 0x0B;
+            savedSettings.Contrast = 2;
+            savedSettings.Volume = 3;
+            var savedAgain = viewModel.CreateProfile().MonitorSettings.Single();
+            Assert.AreNotSame(savedSettings, savedAgain);
+            Assert.AreEqual((int?)25, savedAgain.Brightness);
+            Assert.AreEqual((int?)0x08, savedAgain.ColorTemperatureVcp);
+            Assert.AreEqual((int?)63, savedAgain.Contrast);
+            Assert.AreEqual((int?)41, savedAgain.Volume);
+        }
+
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public void CreateProfile_RenamingPreservesMissingMonitors(bool includeConnectedMonitor)
+        {
+            var monitor = CreateMonitor();
+            const string missingMonitorId = "DISPLAY#TEST001#MISSING";
+            var availableMonitors = new ObservableCollection<MonitorInfo>();
+            if (includeConnectedMonitor)
+            {
+                availableMonitors.Add(monitor);
+            }
+
+            var original = new PowerDisplayProfile(
+                "Original profile",
+                new List<ProfileMonitorSetting>
+                {
+                    new(monitor.Id, brightness: 25),
+                    new(missingMonitorId, colorTemperatureVcp: 0x0B, contrast: 63, volume: 41),
+                });
+            using var viewModel = new ProfileEditorViewModel(availableMonitors, "Existing profile");
+            viewModel.PreFillProfile(original);
+            viewModel.ProfileName = "Renamed profile";
+            original.MonitorSettings[0].Brightness = 90;
+            original.MonitorSettings[1].Volume = 10;
+
+            Assert.IsTrue(viewModel.CanSave);
+            var saved = viewModel.CreateProfile();
+            Assert.AreEqual("Renamed profile", saved.Name);
+            Assert.AreEqual(2, saved.MonitorSettings.Count);
+            var connectedSettings = saved.MonitorSettings.Single(setting => setting.MonitorId == monitor.Id);
+            Assert.AreEqual((int?)25, connectedSettings.Brightness);
+            Assert.IsNull(connectedSettings.ColorTemperatureVcp);
+            Assert.IsNull(connectedSettings.Contrast);
+            Assert.IsNull(connectedSettings.Volume);
+            var missingSettings = saved.MonitorSettings.Single(setting => setting.MonitorId == missingMonitorId);
+            Assert.IsNull(missingSettings.Brightness);
+            Assert.AreEqual((int?)0x0B, missingSettings.ColorTemperatureVcp);
+            Assert.AreEqual((int?)63, missingSettings.Contrast);
+            Assert.AreEqual((int?)41, missingSettings.Volume);
+        }
+
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public void CreateProfile_DeselectingAnOriginalMonitorExplicitlyRemovesIt(bool includeMissingMonitor)
+        {
+            var monitor = CreateMonitor();
+            const string missingMonitorId = "DISPLAY#TEST001#MISSING";
+            var originalSettings = new List<ProfileMonitorSetting> { new(monitor.Id, brightness: 25) };
+            if (includeMissingMonitor)
+            {
+                originalSettings.Add(new ProfileMonitorSetting(missingMonitorId, brightness: 50));
+            }
+
+            using var viewModel = CreateViewModel(monitor);
+            viewModel.PreFillProfile(new PowerDisplayProfile("Existing profile", originalSettings));
+            viewModel.Monitors.Single().IsSelected = false;
+
+            Assert.AreEqual(includeMissingMonitor, viewModel.CanSave);
+            var saved = viewModel.CreateProfile();
+            Assert.AreEqual(includeMissingMonitor ? 1 : 0, saved.MonitorSettings.Count);
+            Assert.IsFalse(saved.MonitorSettings.Any(setting => MonitorIdComparer.Equal(setting.MonitorId, monitor.Id)));
+            if (includeMissingMonitor)
+            {
+                Assert.AreEqual(missingMonitorId, saved.MonitorSettings.Single().MonitorId);
+                Assert.AreEqual((int?)50, saved.MonitorSettings.Single().Brightness);
+            }
+
+            Assert.IsFalse(viewModel.CreateProfile().MonitorSettings.Any(setting => MonitorIdComparer.Equal(setting.MonitorId, monitor.Id)));
+        }
+
+        [TestMethod]
+        [DataRow(nameof(ProfileMonitorSetting.Contrast))]
+        [DataRow(nameof(ProfileMonitorSetting.Volume))]
+        [DataRow(nameof(ProfileMonitorSetting.ColorTemperatureVcp))]
+        public void CanSave_NewUnsupportedOnlySettingDoesNotAllowEmptyMonitorSettings(string settingName)
+        {
+            var monitor = CreateMonitor();
+            monitor.SupportsContrast = false;
+            monitor.SupportsVolume = false;
+            monitor.SupportsColorTemperature = false;
+            using var viewModel = CreateViewModel(monitor);
+            var item = viewModel.Monitors.Single();
+            item.IsSelected = true;
+            item.IncludeContrast = settingName == nameof(ProfileMonitorSetting.Contrast);
+            item.IncludeVolume = settingName == nameof(ProfileMonitorSetting.Volume);
+            item.IncludeColorTemperature = settingName == nameof(ProfileMonitorSetting.ColorTemperatureVcp);
+
+            Assert.IsFalse(item.HasPreservedSettings);
+            Assert.IsFalse(viewModel.HasValidSettings);
+            Assert.IsFalse(viewModel.CanSave);
+            var savedSettings = viewModel.CreateProfile().MonitorSettings.Single();
+            Assert.IsNull(savedSettings.Brightness);
+            Assert.IsNull(savedSettings.Contrast);
+            Assert.IsNull(savedSettings.Volume);
+            Assert.IsNull(savedSettings.ColorTemperatureVcp);
+        }
+
+        [TestMethod]
+        [DataRow(nameof(ProfileMonitorSetting.Contrast))]
+        [DataRow(nameof(ProfileMonitorSetting.Volume))]
+        public void CreateProfile_OriginalUnsupportedOptionalSettingCanBeEditedOrExplicitlyRemoved(string settingName)
+        {
+            var monitor = CreateMonitor();
+            monitor.SupportsContrast = true;
+            monitor.SupportsVolume = true;
+            var original = CreateProfileWithOptionalSetting(monitor.Id, settingName);
+            original.MonitorSettings.Single().Brightness = 25;
+            using var viewModel = CreateViewModel(monitor);
+            viewModel.PreFillProfile(original);
+            var item = viewModel.Monitors.Single();
+
+            if (settingName == nameof(ProfileMonitorSetting.Contrast))
+            {
+                monitor.SupportsContrast = false;
+                item.Contrast = 74;
+            }
+            else
+            {
+                monitor.SupportsVolume = false;
+                item.Volume = 74;
+            }
+
+            Assert.IsTrue(viewModel.CanSave);
+            var editedSettings = viewModel.CreateProfile().MonitorSettings.Single();
+            Assert.AreEqual((int?)25, editedSettings.Brightness);
+            Assert.AreEqual(settingName == nameof(ProfileMonitorSetting.Contrast) ? (int?)74 : null, editedSettings.Contrast);
+            Assert.AreEqual(settingName == nameof(ProfileMonitorSetting.Volume) ? (int?)74 : null, editedSettings.Volume);
+
+            item.IncludeContrast = false;
+            item.IncludeVolume = false;
+
+            Assert.IsTrue(viewModel.CanSave);
+            Assert.IsFalse(item.HasPreservedSettings);
+            var removedSettings = viewModel.CreateProfile().MonitorSettings.Single();
+            Assert.AreEqual((int?)25, removedSettings.Brightness);
+            Assert.IsNull(removedSettings.Contrast);
+            Assert.IsNull(removedSettings.Volume);
+        }
+
+        [TestMethod]
+        [DataRow("Unsupported")]
+        [DataRow("MissingCapabilities")]
+        public void CreateProfile_OriginalColorTemperatureSurvivesBecomingUnavailableUntilExplicitlyRemoved(string unavailableReason)
+        {
+            var monitor = CreateMonitor();
+            using var viewModel = CreateViewModel(monitor);
+            viewModel.PreFillProfile(new PowerDisplayProfile(
+                "Existing profile",
+                new List<ProfileMonitorSetting> { new(monitor.Id, brightness: 25, colorTemperatureVcp: 0x05) }));
+            var item = viewModel.Monitors.Single();
+
+            MakeColorTemperatureUnavailable(monitor, unavailableReason);
+
+            Assert.IsNull(item.ColorTemperature);
+            Assert.IsTrue(item.IncludeColorTemperature);
+            Assert.IsTrue(item.HasPreservedSettings);
+            Assert.IsTrue(viewModel.CanSave);
+            var savedSettings = viewModel.CreateProfile().MonitorSettings.Single();
+            Assert.AreEqual((int?)25, savedSettings.Brightness);
+            Assert.AreEqual((int?)0x05, savedSettings.ColorTemperatureVcp);
+
+            item.IncludeColorTemperature = false;
+
+            Assert.IsTrue(viewModel.CanSave);
+            Assert.IsFalse(item.HasPreservedSettings);
+            Assert.IsNull(viewModel.CreateProfile().MonitorSettings.Single().ColorTemperatureVcp);
+        }
+
+        [TestMethod]
+        [DataRow("Unsupported")]
+        [DataRow("MissingCapabilities")]
+        public void CanSave_NewColorTemperatureBecomingUnavailableDoesNotRestoreTheOriginalValue(string unavailableReason)
+        {
+            var monitor = CreateMonitor();
+            using var viewModel = CreateViewModel(monitor);
+            viewModel.PreFillProfile(new PowerDisplayProfile(
+                "Existing profile",
+                new List<ProfileMonitorSetting> { new(monitor.Id, brightness: 25, colorTemperatureVcp: 0x05) }));
+            var item = viewModel.Monitors.Single();
+            item.ColorTemperature = 0x08;
+            Assert.IsTrue(viewModel.CanSave);
+            Assert.AreEqual((int?)0x08, viewModel.CreateProfile().MonitorSettings.Single().ColorTemperatureVcp);
+
+            MakeColorTemperatureUnavailable(monitor, unavailableReason);
+
+            Assert.IsNull(item.ColorTemperature);
+            Assert.IsTrue(item.IncludeColorTemperature);
+            Assert.IsFalse(viewModel.CanSave);
+            Assert.IsNull(viewModel.CreateProfile().MonitorSettings.Single().ColorTemperatureVcp);
+
+            item.IncludeColorTemperature = false;
+
+            Assert.IsTrue(viewModel.CanSave);
+            Assert.IsNull(viewModel.CreateProfile().MonitorSettings.Single().ColorTemperatureVcp);
+        }
+
+        [TestMethod]
+        public void CanSave_ExplicitlySelectingAnUnsupportedColorTemperatureBlocksBrightness()
+        {
+            var monitor = CreateMonitor();
+            monitor.SupportsColorTemperature = false;
+            using var viewModel = CreateViewModel(monitor);
+            var item = viewModel.Monitors.Single();
+            item.IsSelected = true;
+            item.IncludeBrightness = true;
+            item.IncludeColorTemperature = true;
+
+            item.ColorTemperature = 0x08;
+
+            Assert.IsNull(item.ColorTemperature);
+            Assert.IsFalse(viewModel.CanSave);
+            var savedSettings = viewModel.CreateProfile().MonitorSettings.Single();
+            Assert.AreEqual((int?)monitor.CurrentBrightness, savedSettings.Brightness);
+            Assert.IsNull(savedSettings.ColorTemperatureVcp);
+        }
+
+        [TestMethod]
+        [DataRow("Unsupported")]
+        [DataRow("MissingCapabilities")]
+        public void ColorTemperature_RestoringOriginalAvailabilityRestoresSelectionAndClearsPreservationNotice(string unavailableReason)
+        {
+            var monitor = CreateMonitor();
+            using var viewModel = CreateViewModel(monitor);
+            viewModel.PreFillProfile(new PowerDisplayProfile(
+                "Existing profile",
+                new List<ProfileMonitorSetting> { new(monitor.Id, brightness: 25, colorTemperatureVcp: 0x05) }));
+            var item = viewModel.Monitors.Single();
+            Assert.IsFalse(viewModel.HasPreservedSettings);
+            var preservationChanges = 0;
+            viewModel.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName == nameof(ProfileEditorViewModel.HasPreservedSettings))
+                {
+                    preservationChanges++;
+                }
+            };
+            item.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName == nameof(MonitorSelectionItem.ColorPresetsForDisplay))
+                {
+                    // Match the synchronous selection clear when ComboBox.ItemsSource changes.
+                    item.ColorTemperature = null;
+                }
+            };
+
+            MakeColorTemperatureUnavailable(monitor, unavailableReason);
+
+            Assert.IsNull(item.ColorTemperature);
+            Assert.IsTrue(item.IncludeColorTemperature);
+            Assert.IsTrue(item.HasPreservedSettings);
+            Assert.IsTrue(viewModel.HasPreservedSettings);
+            Assert.IsTrue(preservationChanges > 0);
+            Assert.AreEqual((int?)0x05, viewModel.CreateProfile().MonitorSettings.Single().ColorTemperatureVcp);
+            preservationChanges = 0;
+
+            switch (unavailableReason)
+            {
+                case "Unsupported":
+                    monitor.SupportsColorTemperature = true;
+                    break;
+                case "MissingCapabilities":
+                    monitor.VcpCodesFormatted = CreateColorCapabilities();
+                    break;
+            }
+
+            Assert.AreEqual((int?)0x05, item.ColorTemperature);
+            Assert.IsTrue(item.IncludeColorTemperature);
+            Assert.IsTrue(item.HasValidColorTemperature);
+            Assert.IsFalse(item.HasPreservedSettings);
+            Assert.IsFalse(viewModel.HasPreservedSettings);
+            Assert.IsTrue(preservationChanges > 0);
+            Assert.IsTrue(viewModel.CanSave);
+            Assert.AreEqual((int?)0x05, viewModel.CreateProfile().MonitorSettings.Single().ColorTemperatureVcp);
+        }
+
+        [TestMethod]
+        public void CanSave_IncludingTheCurrentColorTemperatureCountsAsANewChoiceWhenSupportDisappears()
+        {
+            var monitor = CreateMonitor();
+            using var viewModel = CreateViewModel(monitor);
+            var item = viewModel.Monitors.Single();
+            item.IsSelected = true;
+            item.IncludeBrightness = true;
+            item.IncludeColorTemperature = true;
+            Assert.AreEqual((int?)0x05, item.ColorTemperature);
+            Assert.IsTrue(viewModel.CanSave);
+
+            monitor.SupportsColorTemperature = false;
+
+            Assert.IsNull(item.ColorTemperature);
+            Assert.IsTrue(item.IncludeColorTemperature);
+            Assert.IsFalse(viewModel.CanSave);
+            var savedSettings = viewModel.CreateProfile().MonitorSettings.Single();
+            Assert.AreEqual((int?)monitor.CurrentBrightness, savedSettings.Brightness);
+            Assert.IsNull(savedSettings.ColorTemperatureVcp);
+
+            item.IncludeColorTemperature = false;
+
+            Assert.IsTrue(viewModel.CanSave);
+        }
+
+        [TestMethod]
+        public void Dispose_MonitorChangesDoNotNotifyTheEditor()
+        {
+            var monitor = CreateMonitor();
+            using var viewModel = CreateViewModel(monitor);
+            var item = viewModel.Monitors.Single();
+            viewModel.Dispose();
+            var itemChanges = 0;
+            var editorChanges = 0;
+            item.PropertyChanged += (_, _) => itemChanges++;
+            viewModel.PropertyChanged += (_, _) => editorChanges++;
+
+            monitor.VcpCodesFormatted = CreateColorCapabilities("Renamed preset");
+            monitor.SupportsContrast = true;
+            monitor.SupportsVolume = true;
+            monitor.SupportsColorTemperature = false;
+
+            Assert.AreEqual(0, itemChanges);
+            Assert.AreEqual(0, editorChanges);
+        }
+
+        private static ProfileEditorViewModel CreateViewModel(MonitorInfo monitor)
+        {
+            return new ProfileEditorViewModel(new ObservableCollection<MonitorInfo> { monitor }, "Profile");
+        }
+
+        private static PowerDisplayProfile CreateProfileWithOptionalSetting(string monitorId, string settingName)
+        {
+            return new PowerDisplayProfile(
+                "Existing profile",
+                new List<ProfileMonitorSetting>
+                {
+                    new(
+                        monitorId,
+                        colorTemperatureVcp: settingName == nameof(ProfileMonitorSetting.ColorTemperatureVcp) ? 0x08 : null,
+                        contrast: settingName == nameof(ProfileMonitorSetting.Contrast) ? 63 : null,
+                        volume: settingName == nameof(ProfileMonitorSetting.Volume) ? 41 : null),
+                });
+        }
+
+        private static void MakeColorTemperatureUnavailable(MonitorInfo monitor, string reason)
+        {
+            switch (reason)
+            {
+                case "Unsupported":
+                    monitor.SupportsColorTemperature = false;
+                    break;
+                case "MissingCapabilities":
+                    monitor.VcpCodesFormatted = new List<VcpCodeDisplayInfo>();
+                    break;
+                default:
+                    Assert.Fail($"Unknown unavailable reason: {reason}");
+                    break;
+            }
+        }
+
+        private static MonitorInfo CreateMonitor()
+        {
+            return new MonitorInfo
+            {
+                Id = "DISPLAY#TEST001#1",
+                Name = "Monitor",
+                CurrentBrightness = 75,
+                ColorTemperatureVcp = 0x05,
+                SupportsColorTemperature = true,
+                VcpCodesFormatted = CreateColorCapabilities(),
+            };
+        }
+
+        private static List<VcpCodeDisplayInfo> CreateColorCapabilities(string secondPresetName = "9300 K")
+        {
+            return new()
+            {
+                new()
+                {
+                    Code = "0x14",
+                    Title = "Color preset (0x14)",
+                    HasValues = true,
+                    ValueList = new()
+                    {
+                        new() { Value = "0x05", Name = "6500 K" },
+                        new() { Value = "0x08", Name = secondPresetName },
+                    },
+                },
+            };
         }
     }
 }

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/ProfileEditorDialog.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/ProfileEditorDialog.xaml
@@ -37,6 +37,11 @@
         <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
             <StackPanel Spacing="16">
                 <TextBlock x:Uid="PowerDisplay_ProfileEditor_Description" Style="{StaticResource BodyStrongTextBlockStyle}" />
+                <InfoBar
+                    x:Uid="PowerDisplay_ProfileEditor_PreservedSettings"
+                    IsClosable="False"
+                    IsOpen="{x:Bind ViewModel.HasPreservedSettings, Mode=OneWay}"
+                    Severity="Informational" />
                 <ItemsControl ItemsSource="{x:Bind ViewModel.Monitors, Mode=OneWay}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate x:DataType="viewmodels:MonitorSelectionItem">
@@ -53,7 +58,7 @@
                                     <tkcontrols:SettingsCard
                                         Padding="16,8,16,8"
                                         IsEnabled="{x:Bind IsSelected, Mode=OneWay}"
-                                        Visibility="{x:Bind Monitor.SupportsBrightness, Converter={StaticResource BoolToVisibilityConverter}}">
+                                        Visibility="{x:Bind ShowBrightness, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
                                         <tkcontrols:SettingsCard.Header>
                                             <CheckBox IsChecked="{x:Bind IncludeBrightness, Mode=TwoWay}">
                                                 <StackPanel Orientation="Horizontal" Spacing="8">
@@ -65,6 +70,7 @@
                                         <Slider
                                             MinWidth="{StaticResource SettingActionControlMinWidth}"
                                             VerticalAlignment="Center"
+                                            IsEnabled="{x:Bind SupportsBrightness, Mode=OneWay}"
                                             Maximum="100"
                                             Minimum="0"
                                             Value="{x:Bind Brightness, Mode=TwoWay}" />
@@ -76,7 +82,7 @@
                                     <tkcontrols:SettingsCard
                                         Padding="16,8,16,8"
                                         IsEnabled="{x:Bind IsSelected, Mode=OneWay}"
-                                        Visibility="{x:Bind Monitor.SupportsContrast, Converter={StaticResource BoolToVisibilityConverter}}">
+                                        Visibility="{x:Bind ShowContrast, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
                                         <tkcontrols:SettingsCard.Header>
                                             <CheckBox IsChecked="{x:Bind IncludeContrast, Mode=TwoWay}">
                                                 <StackPanel Orientation="Horizontal" Spacing="8">
@@ -88,6 +94,7 @@
                                         <Slider
                                             MinWidth="{StaticResource SettingActionControlMinWidth}"
                                             VerticalAlignment="Center"
+                                            IsEnabled="{x:Bind SupportsContrast, Mode=OneWay}"
                                             Maximum="100"
                                             Minimum="0"
                                             Value="{x:Bind Contrast, Mode=TwoWay}" />
@@ -95,7 +102,7 @@
                                     <tkcontrols:SettingsCard
                                         Padding="16,8,16,8"
                                         IsEnabled="{x:Bind IsSelected, Mode=OneWay}"
-                                        Visibility="{x:Bind Monitor.SupportsVolume, Converter={StaticResource BoolToVisibilityConverter}}">
+                                        Visibility="{x:Bind ShowVolume, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
                                         <tkcontrols:SettingsCard.Header>
                                             <CheckBox IsChecked="{x:Bind IncludeVolume, Mode=TwoWay}">
                                                 <StackPanel Orientation="Horizontal" Spacing="8">
@@ -107,6 +114,7 @@
                                         <Slider
                                             MinWidth="{StaticResource SettingActionControlMinWidth}"
                                             VerticalAlignment="Center"
+                                            IsEnabled="{x:Bind SupportsVolume, Mode=OneWay}"
                                             Maximum="100"
                                             Minimum="0"
                                             Value="{x:Bind Volume, Mode=TwoWay}" />
@@ -114,7 +122,7 @@
                                     <tkcontrols:SettingsCard
                                         Padding="16,8,16,8"
                                         IsEnabled="{x:Bind IsSelected, Mode=OneWay}"
-                                        Visibility="{x:Bind Monitor.SupportsColorTemperature, Converter={StaticResource BoolToVisibilityConverter}}">
+                                        Visibility="{x:Bind ShowColorTemperature, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
                                         <tkcontrols:SettingsCard.Header>
                                             <CheckBox IsChecked="{x:Bind IncludeColorTemperature, Mode=TwoWay}">
                                                 <StackPanel Orientation="Horizontal" Spacing="8">
@@ -128,7 +136,8 @@
                                             MinWidth="{StaticResource SettingActionControlMinWidth}"
                                             VerticalAlignment="Center"
                                             DisplayMemberPath="DisplayName"
-                                            ItemsSource="{x:Bind Monitor.ColorPresetsForDisplay, Mode=OneWay}"
+                                            IsEnabled="{x:Bind SupportsColorTemperature, Mode=OneWay}"
+                                            ItemsSource="{x:Bind ColorPresetsForDisplay, Mode=OneWay}"
                                             SelectedValue="{x:Bind ColorTemperature, Mode=TwoWay}"
                                             SelectedValuePath="VcpValue" />
                                     </tkcontrols:SettingsCard>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/ProfileEditorDialog.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/ProfileEditorDialog.xaml.cs
@@ -5,7 +5,6 @@
 #nullable enable
 
 using System.Collections.ObjectModel;
-using System.Linq;
 using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.ViewModels;
@@ -31,6 +30,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
         {
             this.InitializeComponent();
             ViewModel = new ProfileEditorViewModel(availableMonitors, defaultName, profileId);
+            Closed += ProfileEditorDialog_Closed;
 
             // Set localized strings for ContentDialog
             var resourceLoader = ResourceLoaderInstance.ResourceLoader;
@@ -52,56 +52,17 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             ResultProfile = null;
         }
 
+        private void ProfileEditorDialog_Closed(ContentDialog sender, ContentDialogClosedEventArgs args)
+        {
+            ViewModel.Dispose();
+        }
+
         /// <summary>
         /// Pre-fill the dialog with existing profile data
         /// </summary>
         public void PreFillProfile(PowerDisplayProfile profile)
         {
-            if (profile == null || ViewModel == null)
-            {
-                return;
-            }
-
-            // Set profile name
-            ViewModel.ProfileName = profile.Name;
-
-            // Pre-fill monitor settings from existing profile
-            foreach (var monitorSetting in profile.MonitorSettings)
-            {
-                var monitorItem = ViewModel.Monitors.FirstOrDefault(m => m.Monitor.Id == monitorSetting.MonitorId);
-                if (monitorItem != null)
-                {
-                    monitorItem.IsSelected = true;
-
-                    // Set brightness if included in profile
-                    if (monitorSetting.Brightness.HasValue)
-                    {
-                        monitorItem.IncludeBrightness = true;
-                        monitorItem.Brightness = monitorSetting.Brightness.Value;
-                    }
-
-                    // Set color temperature if included in profile
-                    if (monitorSetting.ColorTemperatureVcp.HasValue)
-                    {
-                        monitorItem.IncludeColorTemperature = true;
-                        monitorItem.ColorTemperature = monitorSetting.ColorTemperatureVcp.Value;
-                    }
-
-                    // Set contrast if included in profile
-                    if (monitorSetting.Contrast.HasValue)
-                    {
-                        monitorItem.IncludeContrast = true;
-                        monitorItem.Contrast = monitorSetting.Contrast.Value;
-                    }
-
-                    // Set volume if included in profile
-                    if (monitorSetting.Volume.HasValue)
-                    {
-                        monitorItem.IncludeVolume = true;
-                        monitorItem.Volume = monitorSetting.Volume.Value;
-                    }
-                }
-            }
+            ViewModel.PreFillProfile(profile);
         }
     }
 }

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -6104,6 +6104,9 @@ The break timer font matches the text font.</value>
   <data name="PowerDisplay_ProfileEditor_Description.Text" xml:space="preserve">
     <value>Select what monitors and settings to include for this profile</value>
   </data>
+  <data name="PowerDisplay_ProfileEditor_PreservedSettings.Message" xml:space="preserve">
+    <value>Saved settings for unavailable monitors or features are kept. Uncheck a setting to remove it. Applying the profile still respects monitor capabilities.</value>
+  </data>
   <data name="PowerDisplay_ProfileEditor_Brightness.Text" xml:space="preserve">
     <value>Brightness</value>
   </data>

--- a/src/settings-ui/Settings.UI/ViewModels/MonitorSelectionItem.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/MonitorSelectionItem.cs
@@ -4,28 +4,66 @@
 
 #nullable enable
 
+using System;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.PowerToys.Settings.UI.Library;
+using PowerDisplay.Models;
 
 namespace Microsoft.PowerToys.Settings.UI.ViewModels
 {
     /// <summary>
     /// ViewModel for monitor selection in profile editor
     /// </summary>
-    public class MonitorSelectionItem : INotifyPropertyChanged
+    public class MonitorSelectionItem : INotifyPropertyChanged, IDisposable
     {
         private bool _isSelected;
         private int _brightness = 100;
         private int _contrast = 50;
         private int _volume = 50;
-        private int _colorTemperature = 6500;
+        private int? _colorTemperature;
         private bool _includeBrightness;
         private bool _includeContrast;
         private bool _includeVolume;
         private bool _includeColorTemperature;
+        private bool _hasOriginalBrightness;
+        private bool _hasOriginalContrast;
+        private bool _hasOriginalVolume;
+        private int? _originalColorTemperature;
+        private bool _isColorTemperatureEdited;
 
-        public required MonitorInfo Monitor { get; set; }
+        public MonitorSelectionItem(MonitorInfo monitor)
+        {
+            ArgumentNullException.ThrowIfNull(monitor);
+            Monitor = monitor;
+            Monitor.PropertyChanged += OnMonitorPropertyChanged;
+        }
+
+        public MonitorInfo Monitor { get; }
+
+        public ObservableCollection<ColorPresetItem> ColorPresetsForDisplay => Monitor.ColorPresetsForDisplay;
+
+        public bool HasValidColorTemperature => SupportsColorTemperature && IsColorTemperatureAvailable(_colorTemperature);
+
+        public bool HasValidSettings =>
+            (IncludeBrightness || ProfileContrast.HasValue || ProfileVolume.HasValue || ProfileColorTemperature.HasValue) &&
+            (!IncludeColorTemperature || ProfileColorTemperature.HasValue || (!SupportsColorTemperature && !_isColorTemperatureEdited));
+
+        public bool HasPreservedSettings =>
+            (IncludeBrightness && _hasOriginalBrightness && !SupportsBrightness) ||
+            (IncludeContrast && _hasOriginalContrast && !SupportsContrast) ||
+            (IncludeVolume && _hasOriginalVolume && !SupportsVolume) ||
+            (IncludeColorTemperature && CanPreserveColorTemperature && !HasValidColorTemperature);
+
+        public bool ShowBrightness => SupportsBrightness || IncludeBrightness;
+
+        public bool ShowContrast => SupportsContrast || IncludeContrast;
+
+        public bool ShowVolume => SupportsVolume || IncludeVolume;
+
+        public bool ShowColorTemperature => SupportsColorTemperature || IncludeColorTemperature;
 
         public bool SuppressAutoSelection { get; set; }
 
@@ -93,22 +131,37 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
-        public int ColorTemperature
+        public int? ColorTemperature
         {
             get => _colorTemperature;
             set
             {
-                if (_colorTemperature != value)
+                // Preserve an existing profile value until the user edits this field. A
+                // refresh can clear the ComboBox without representing a user edit.
+                bool edited = !SuppressAutoSelection && value != _colorTemperature;
+                bool editStateChanged = edited && !_isColorTemperatureEdited;
+                _isColorTemperatureEdited |= edited;
+                var selection = IsColorTemperatureAvailable(value) ? value : null;
+                if (_colorTemperature != selection)
                 {
-                    _colorTemperature = value;
+                    _colorTemperature = selection;
                     OnPropertyChanged();
-                    if (!SuppressAutoSelection)
-                    {
-                        IncludeColorTemperature = true;
-                    }
+                    OnPropertyChanged(nameof(HasValidColorTemperature));
+                    NotifyProfileStateChanged();
+                }
+                else if (editStateChanged)
+                {
+                    NotifyProfileStateChanged();
+                }
+
+                if (edited && value.HasValue)
+                {
+                    IncludeColorTemperature = true;
                 }
             }
         }
+
+        public bool SupportsBrightness => Monitor.SupportsBrightness;
 
         public bool SupportsContrast => Monitor?.SupportsContrast ?? false;
 
@@ -125,6 +178,8 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 {
                     _includeBrightness = value;
                     OnPropertyChanged();
+                    OnPropertyChanged(nameof(ShowBrightness));
+                    NotifyProfileStateChanged();
                 }
             }
         }
@@ -138,6 +193,8 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 {
                     _includeContrast = value;
                     OnPropertyChanged();
+                    OnPropertyChanged(nameof(ShowContrast));
+                    NotifyProfileStateChanged();
                 }
             }
         }
@@ -151,6 +208,8 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 {
                     _includeVolume = value;
                     OnPropertyChanged();
+                    OnPropertyChanged(nameof(ShowVolume));
+                    NotifyProfileStateChanged();
                 }
             }
         }
@@ -162,17 +221,141 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             {
                 if (_includeColorTemperature != value)
                 {
+                    // Opting into a currently available color value is a new choice,
+                    // even when the ComboBox still shows the monitor's current value.
+                    if (value && !SuppressAutoSelection && SupportsColorTemperature && !_originalColorTemperature.HasValue)
+                    {
+                        _isColorTemperatureEdited = true;
+                    }
+
                     _includeColorTemperature = value;
                     OnPropertyChanged();
+                    OnPropertyChanged(nameof(ShowColorTemperature));
+                    NotifyProfileStateChanged();
                 }
             }
         }
 
+        private bool CanPreserveColorTemperature => _originalColorTemperature.HasValue && !_isColorTemperatureEdited;
+
+        private int? ProfileContrast => IncludeContrast && (SupportsContrast || _hasOriginalContrast) ? Contrast : null;
+
+        private int? ProfileVolume => IncludeVolume && (SupportsVolume || _hasOriginalVolume) ? Volume : null;
+
+        private int? ProfileColorTemperature => !IncludeColorTemperature ? null
+            : CanPreserveColorTemperature ? _originalColorTemperature
+            : HasValidColorTemperature ? ColorTemperature : null;
+
         public event PropertyChangedEventHandler? PropertyChanged;
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        internal void LoadProfileSetting(ProfileMonitorSetting? setting)
+        {
+            var wasSuppressed = SuppressAutoSelection;
+            SuppressAutoSelection = true;
+            try
+            {
+                _hasOriginalBrightness = setting?.Brightness.HasValue ?? false;
+                _hasOriginalContrast = setting?.Contrast.HasValue ?? false;
+                _hasOriginalVolume = setting?.Volume.HasValue ?? false;
+                _originalColorTemperature = setting?.ColorTemperatureVcp;
+                _isColorTemperatureEdited = false;
+                IsSelected = setting != null;
+                Brightness = setting?.Brightness ?? Monitor.CurrentBrightness;
+                Contrast = setting?.Contrast ?? 50;
+                Volume = setting?.Volume ?? 50;
+                ColorTemperature = setting?.ColorTemperatureVcp ?? Monitor.ColorTemperatureVcp;
+                IncludeBrightness = _hasOriginalBrightness;
+                IncludeContrast = _hasOriginalContrast;
+                IncludeVolume = _hasOriginalVolume;
+                IncludeColorTemperature = _originalColorTemperature.HasValue;
+            }
+            finally
+            {
+                SuppressAutoSelection = wasSuppressed;
+            }
+
+            NotifyProfileStateChanged();
+        }
+
+        internal ProfileMonitorSetting CreateProfileSetting(string monitorId)
+        {
+            return new ProfileMonitorSetting(
+                monitorId,
+                IncludeBrightness ? Brightness : null,
+                ProfileColorTemperature,
+                ProfileContrast,
+                ProfileVolume);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                Monitor.PropertyChanged -= OnMonitorPropertyChanged;
+            }
+        }
 
         protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        private bool IsColorTemperatureAvailable(int? value)
+        {
+            return value.HasValue && ColorPresetsForDisplay.Any(preset => preset.VcpValue == value.Value);
+        }
+
+        private void OnMonitorPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(MonitorInfo.SupportsBrightness) ||
+                e.PropertyName == nameof(MonitorInfo.SupportsContrast) ||
+                e.PropertyName == nameof(MonitorInfo.SupportsVolume) ||
+                e.PropertyName == nameof(MonitorInfo.SupportsColorTemperature))
+            {
+                OnPropertyChanged(e.PropertyName);
+                OnPropertyChanged(nameof(ShowBrightness));
+                OnPropertyChanged(nameof(ShowContrast));
+                OnPropertyChanged(nameof(ShowVolume));
+                OnPropertyChanged(nameof(ShowColorTemperature));
+                NotifyProfileStateChanged();
+                return;
+            }
+
+            if (e.PropertyName != nameof(MonitorInfo.ColorPresetsForDisplay))
+            {
+                return;
+            }
+
+            var selection = _colorTemperature ?? (CanPreserveColorTemperature ? _originalColorTemperature : null);
+            var wasSuppressed = SuppressAutoSelection;
+            SuppressAutoSelection = true;
+            try
+            {
+                // Replacing ItemsSource can synchronously clear SelectedValue. Forward
+                // the list change here so that neither that clear nor restoring a valid
+                // selection is treated as the user opting into color temperature.
+                OnPropertyChanged(nameof(ColorPresetsForDisplay));
+                ColorTemperature = selection;
+                OnPropertyChanged(nameof(ColorTemperature));
+                OnPropertyChanged(nameof(HasValidColorTemperature));
+                NotifyProfileStateChanged();
+            }
+            finally
+            {
+                SuppressAutoSelection = wasSuppressed;
+            }
+        }
+
+        private void NotifyProfileStateChanged()
+        {
+            OnPropertyChanged(nameof(HasValidSettings));
+            OnPropertyChanged(nameof(HasPreservedSettings));
         }
     }
 }

--- a/src/settings-ui/Settings.UI/ViewModels/ProfileEditorViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/ProfileEditorViewModel.cs
@@ -4,6 +4,8 @@
 
 #nullable enable
 
+using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
@@ -16,11 +18,12 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
     /// <summary>
     /// ViewModel for Profile Editor Dialog
     /// </summary>
-    public class ProfileEditorViewModel : INotifyPropertyChanged
+    public class ProfileEditorViewModel : INotifyPropertyChanged, IDisposable
     {
         private readonly int _profileId;
+        private readonly ObservableCollection<MonitorSelectionItem> _monitors;
         private string _profileName = string.Empty;
-        private ObservableCollection<MonitorSelectionItem> _monitors;
+        private PowerDisplayProfile? _originalProfile;
 
         public ProfileEditorViewModel(
             ObservableCollection<MonitorInfo> availableMonitors,
@@ -41,10 +44,9 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             // Initialize monitor selection items
             foreach (var monitor in availableMonitors)
             {
-                var item = new MonitorSelectionItem
+                var item = new MonitorSelectionItem(monitor)
                 {
                     SuppressAutoSelection = true,
-                    Monitor = monitor,
                     IsSelected = false,
                     Brightness = monitor.CurrentBrightness,
                     Contrast = 50, // Default value (MonitorInfo doesn't store contrast)
@@ -75,48 +77,115 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
-        public ObservableCollection<MonitorSelectionItem> Monitors
-        {
-            get => _monitors;
-            set
-            {
-                if (_monitors != value)
-                {
-                    _monitors = value;
-                    OnPropertyChanged();
-                }
-            }
-        }
+        public ObservableCollection<MonitorSelectionItem> Monitors => _monitors;
 
-        public bool HasSelectedMonitors => _monitors?.Any(m => m.IsSelected) ?? false;
+        public bool HasSelectedMonitors => _monitors.Any(m => m.IsSelected) || HasMissingProfileMonitors;
 
-        public bool HasValidSettings => _monitors != null &&
-            _monitors.Any(m => m.IsSelected) &&
-            _monitors.Where(m => m.IsSelected).All(m => m.IncludeBrightness || m.IncludeContrast || m.IncludeVolume || m.IncludeColorTemperature);
+        public bool HasValidSettings => HasSelectedMonitors &&
+            _monitors.Where(m => m.IsSelected).All(m => m.HasValidSettings);
+
+        public bool HasPreservedSettings => HasMissingProfileMonitors ||
+            _monitors.Any(m => m.IsSelected && m.HasPreservedSettings);
 
         public bool CanSave => !string.IsNullOrWhiteSpace(_profileName) && HasSelectedMonitors && HasValidSettings;
 
-        public PowerDisplayProfile CreateProfile()
-        {
-            var settings = _monitors
-                .Where(m => m.IsSelected)
-                .Select(m => new ProfileMonitorSetting(
-                    m.Monitor.Id, // Monitor Id (unique identifier)
-                    m.IncludeBrightness ? (int?)m.Brightness : null,
-                    m.IncludeColorTemperature && m.SupportsColorTemperature ? (int?)m.ColorTemperature : null,
-                    m.IncludeContrast && m.SupportsContrast ? (int?)m.Contrast : null,
-                    m.IncludeVolume && m.SupportsVolume ? (int?)m.Volume : null))
-                .ToList();
-
-            return new PowerDisplayProfile(_profileName, settings) { Id = _profileId };
-        }
+        private bool HasMissingProfileMonitors => _originalProfile?.MonitorSettings.Any(setting =>
+            !_monitors.Any(m => MonitorIdComparer.Equal(m.Monitor.Id, setting.MonitorId))) ?? false;
 
         public event PropertyChangedEventHandler? PropertyChanged;
+
+        public PowerDisplayProfile CreateProfile()
+        {
+            var settings = new List<ProfileMonitorSetting>();
+            if (_originalProfile != null)
+            {
+                foreach (var original in _originalProfile.MonitorSettings)
+                {
+                    var item = _monitors.FirstOrDefault(m => MonitorIdComparer.Equal(m.Monitor.Id, original.MonitorId));
+                    if (item == null)
+                    {
+                        // Unavailable monitors have no editor controls. Keep their snapshots
+                        // until the user can explicitly change or remove them.
+                        settings.Add(CloneMonitorSetting(original));
+                    }
+                    else if (item.IsSelected)
+                    {
+                        settings.Add(item.CreateProfileSetting(original.MonitorId));
+                    }
+                }
+            }
+
+            foreach (var item in _monitors.Where(m => m.IsSelected))
+            {
+                if (_originalProfile?.MonitorSettings.Any(setting => MonitorIdComparer.Equal(setting.MonitorId, item.Monitor.Id)) != true)
+                {
+                    settings.Add(item.CreateProfileSetting(item.Monitor.Id));
+                }
+            }
+
+            var profile = new PowerDisplayProfile(_profileName, settings) { Id = _originalProfile?.Id ?? _profileId };
+            if (_originalProfile != null)
+            {
+                profile.CreatedDate = _originalProfile.CreatedDate;
+            }
+
+            return profile;
+        }
+
+        /// <summary>
+        /// Pre-fill a new editor with the existing profile's monitor settings.
+        /// </summary>
+        public void PreFillProfile(PowerDisplayProfile profile)
+        {
+            if (profile == null)
+            {
+                return;
+            }
+
+            _originalProfile = new PowerDisplayProfile(profile.Name, profile.MonitorSettings.Select(CloneMonitorSetting).ToList())
+            {
+                Id = profile.Id,
+                CreatedDate = profile.CreatedDate,
+                LastModified = profile.LastModified,
+            };
+            ProfileName = profile.Name;
+
+            foreach (var item in _monitors)
+            {
+                item.LoadProfileSetting(_originalProfile.MonitorSettings.FirstOrDefault(setting => MonitorIdComparer.Equal(item.Monitor.Id, setting.MonitorId)));
+            }
+
+            OnPropertyChanged(nameof(HasSelectedMonitors));
+            OnPropertyChanged(nameof(HasValidSettings));
+            OnPropertyChanged(nameof(CanSave));
+            OnPropertyChanged(nameof(HasPreservedSettings));
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                foreach (var monitor in _monitors)
+                {
+                    monitor.PropertyChanged -= OnMonitorItemPropertyChanged;
+                    monitor.Dispose();
+                }
+            }
+        }
 
         protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
+
+        private static ProfileMonitorSetting CloneMonitorSetting(ProfileMonitorSetting setting)
+            => new(setting.MonitorId, setting.Brightness, setting.ColorTemperatureVcp, setting.Contrast, setting.Volume);
 
         /// <summary>
         /// Handle property changes from monitor selection items.
@@ -132,13 +201,16 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
             // Update validation state for relevant property changes
             if (e.PropertyName == nameof(MonitorSelectionItem.IsSelected) ||
-                e.PropertyName == nameof(MonitorSelectionItem.IncludeBrightness) ||
-                e.PropertyName == nameof(MonitorSelectionItem.IncludeContrast) ||
-                e.PropertyName == nameof(MonitorSelectionItem.IncludeVolume) ||
-                e.PropertyName == nameof(MonitorSelectionItem.IncludeColorTemperature))
+                e.PropertyName == nameof(MonitorSelectionItem.HasValidSettings))
             {
                 OnPropertyChanged(nameof(CanSave));
                 OnPropertyChanged(nameof(HasValidSettings));
+            }
+
+            if (e.PropertyName == nameof(MonitorSelectionItem.IsSelected) ||
+                e.PropertyName == nameof(MonitorSelectionItem.HasPreservedSettings))
+            {
+                OnPropertyChanged(nameof(HasPreservedSettings));
             }
         }
     }


### PR DESCRIPTION
## Summary of the Pull Request

Editing a Power Display profile can drop settings when a saved monitor is missing or a capability is temporarily unavailable. Preserve the original monitor rows, fields, identity, and creation time when renaming, while honoring explicit removals and validating newly selected values.

Keep color-preset selection synchronized as capabilities change, including empty selections and restored capabilities. Unavailable included fields remain visible for removal, and the editor releases its monitor subscriptions when closed. Compare capability values and names so same-size updates refresh the editor.

This is an independent prerequisite extracted from #50458. It targets `main` and does not introduce VCP restriction settings or depend on the VCP editor. The settings-persistence PR can be reviewed and merged separately.

## PR Checklist

- [ ] Closes: no automatic issue closure; related to #50458.
- [ ] **Communication:** Draft for maintainer review.
- [x] **Tests:** Generic profile regression tests added and validated.
- [x] **Localization:** The preservation explanation uses an en-US resource string.
- [ ] **Dev docs:** Not added.
- [x] **New binaries:** Not applicable; no new binary or test project.
- [ ] **Documentation updated:** No separate documentation PR.

## Validation Steps Performed

- Checked out commit `5485193016f270f119b0f5df8a4fe9ad7e1f4be8` and built Settings UI and Settings.UI.UnitTests with the repository build script, x64 Debug: exit code 0.
- Ran all **33 ProfileEditorViewModelTests** through Visual Studio vstest: 33 passed, none skipped.
- Built and ran a native WinUI ComboBox probe using the generated XAML binding: capability-name refresh, empty selection, original-value preservation/restoration, and invalid new selections all passed; process exit code 0.
- Verified the compiled assemblies contain the Profile fix but no VCP restriction model or `DisabledVcpValues` property.
- `git diff --check` passed. The build retained the existing CsWinRT1028 warning in unchanged `ManagedCommon/HotkeySettingsControlHook.cs`.

The tests and control probe use synthetic monitor data; no physical monitor, full dialog layout, or multi-monitor DPI verification is claimed. The persisted JSON shape is unchanged.
