### PR TITLE
[Power Display] Persist only monitor preferences edited in Settings

### DIFF
--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/PowerDisplay.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/PowerDisplay.cs
@@ -2,12 +2,16 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.UnitTests.BackwardsCompatibility;
 using Microsoft.PowerToys.Settings.UI.UnitTests.Mocks;
 using Microsoft.PowerToys.Settings.UI.ViewModels;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 using PowerDisplay.Models;
 
 namespace ViewModelTests;
@@ -85,7 +89,128 @@ public class PowerDisplay
             nameof(PowerDisplayViewModel.MouseWheelControlModeIndex));
     }
 
+    [TestMethod]
+    [DataRow(nameof(MonitorInfo.EnableContrast))]
+    [DataRow(nameof(MonitorInfo.EnableVolume))]
+    [DataRow(nameof(MonitorInfo.EnableInputSource))]
+    [DataRow(nameof(MonitorInfo.EnableRotation))]
+    [DataRow(nameof(MonitorInfo.EnableColorTemperature))]
+    [DataRow(nameof(MonitorInfo.EnablePowerState))]
+    [DataRow(nameof(MonitorInfo.IsHidden))]
+    public void MonitorUserPreference_ChangesSaveAndSendOnce(string propertyName)
+    {
+        var monitor = CreateMonitor();
+        var namedEvents = new List<string>();
+        var operationOrder = new List<string>();
+        using var viewModel = CreateViewModel(out _, out var settingsUtils, out var ipcMessages, monitor, namedEvents: namedEvents, operationOrder: operationOrder);
+        var property = typeof(MonitorInfo).GetProperty(propertyName);
+
+        property.SetValue(monitor, true);
+
+        settingsUtils.Verify(
+            utils => utils.SaveSettings(It.IsAny<string>(), PowerDisplaySettings.ModuleName, SettingsUtils.DefaultFileName),
+            Times.Once);
+        Assert.AreEqual(1, ipcMessages.Count);
+        Assert.AreEqual(1, namedEvents.Count);
+        Assert.AreEqual("save,ipc,signal", string.Join(',', operationOrder));
+        Assert.IsTrue((bool)property.GetValue(GetSavedSettings(settingsUtils).Properties.Monitors.Single()));
+    }
+
+    [TestMethod]
+    public void MonitorRuntimeAndDerivedProperties_DoNotSaveOrSend()
+    {
+        var monitor = CreateMonitor();
+        var namedEvents = new List<string>();
+        using var viewModel = CreateViewModel(out _, out var settingsUtils, out var ipcMessages, monitor, namedEvents: namedEvents);
+
+        monitor.Name = "Updated monitor";
+        monitor.CurrentBrightness = 75;
+        monitor.ColorTemperatureVcp = 0x08;
+        monitor.SupportsColorTemperature = false;
+        monitor.CapabilitiesRaw = "(vcp(10))";
+        monitor.VcpCodesFormatted = new List<VcpCodeDisplayInfo>();
+
+        settingsUtils.Verify(
+            utils => utils.SaveSettings(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
+            Times.Never);
+        Assert.AreEqual(0, ipcMessages.Count);
+        Assert.AreEqual(0, namedEvents.Count);
+    }
+
+    [TestMethod]
+    public void ReloadMonitors_ChangedUserPreferencesDoNotSaveOrSend()
+    {
+        var monitor = CreateMonitor();
+        Action reloadMonitors = null;
+        var namedEvents = new List<string>();
+        using var viewModel = CreateViewModel(
+            out _,
+            out var settingsUtils,
+            out var ipcMessages,
+            monitor,
+            (_, callback) => reloadMonitors = callback,
+            namedEvents);
+        var updatedSettings = new PowerDisplaySettings();
+        var updatedMonitor = CreateMonitor();
+        updatedMonitor.EnableColorTemperature = true;
+        updatedMonitor.EnableInputSource = true;
+        updatedMonitor.CapabilitiesRaw = "(vcp(10 14(05 08) 60(11)))";
+        updatedSettings.Properties.Monitors.Add(updatedMonitor);
+        settingsUtils.Setup(utils => utils.GetSettingsOrDefault<PowerDisplaySettings>(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(updatedSettings);
+
+        reloadMonitors();
+
+        Assert.AreSame(monitor, viewModel.Monitors.Single());
+        Assert.IsTrue(monitor.EnableColorTemperature);
+        Assert.IsTrue(monitor.EnableInputSource);
+        Assert.AreEqual(updatedMonitor.CapabilitiesRaw, monitor.CapabilitiesRaw);
+        settingsUtils.Verify(
+            utils => utils.SaveSettings(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
+            Times.Never);
+        Assert.AreEqual(0, ipcMessages.Count);
+        Assert.AreEqual(0, namedEvents.Count);
+    }
+
+    private static MonitorInfo CreateMonitor()
+    {
+        return new MonitorInfo
+        {
+            Id = @"\\?\DISPLAY#TEST001#1",
+            SupportsColorTemperature = true,
+            ColorTemperatureVcp = 0x05,
+            VcpCodesFormatted = new List<VcpCodeDisplayInfo>
+            {
+                new()
+                {
+                    Code = "0x14",
+                    ValueList = new()
+                    {
+                        new() { Value = "0x05", Name = "6500 K" },
+                        new() { Value = "0x08", Name = "9300 K" },
+                    },
+                },
+            },
+        };
+    }
+
+    private static PowerDisplaySettings GetSavedSettings(Mock<SettingsUtils> settingsUtils)
+    {
+        var save = settingsUtils.Invocations.Single(invocation => invocation.Method.Name == nameof(SettingsUtils.SaveSettings));
+        return JsonSerializer.Deserialize((string)save.Arguments[0], SettingsSerializationContext.Default.PowerDisplaySettings);
+    }
+
     private static PowerDisplayViewModel CreateViewModel(out PowerDisplaySettings settings)
+        => CreateViewModel(out settings, out _, out _);
+
+    private static PowerDisplayViewModel CreateViewModel(
+        out PowerDisplaySettings settings,
+        out Mock<SettingsUtils> settingsUtils,
+        out List<string> ipcMessages,
+        MonitorInfo monitor = null,
+        Action<string, Action> waitForEventLoop = null,
+        List<string> namedEvents = null,
+        List<string> operationOrder = null)
     {
         var powerDisplaySettingsUtils =
             ISettingsUtilsMocks.GetStubSettingsUtils<PowerDisplaySettings>();
@@ -94,6 +219,18 @@ public class PowerDisplay
 
         settings = powerDisplaySettingsUtils.Object.GetSettingsOrDefault<PowerDisplaySettings>(
             PowerDisplaySettings.ModuleName);
+        if (monitor != null)
+        {
+            settings.Properties.Monitors.Add(monitor);
+        }
+
+        settingsUtils = powerDisplaySettingsUtils;
+        var messages = new List<string>();
+        ipcMessages = messages;
+        var events = namedEvents ?? new List<string>();
+        var operations = operationOrder ?? new List<string>();
+        powerDisplaySettingsUtils.Setup(utils => utils.SaveSettings(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Callback<string, string, string>((_, _, _) => operations.Add("save"));
 
         return new PowerDisplayViewModel(
             powerDisplaySettingsUtils.Object,
@@ -101,7 +238,17 @@ public class PowerDisplay
                 generalSettingsUtils.Object),
             new BackCompatTestProperties.MockSettingsRepository<PowerDisplaySettings>(
                 powerDisplaySettingsUtils.Object),
-            _ => 0,
-            (_, _) => { });
+            message =>
+            {
+                messages.Add(message);
+                operations.Add("ipc");
+                return 0;
+            },
+            waitForEventLoop ?? ((_, _) => { }),
+            eventName =>
+            {
+                events.Add(eventName);
+                operations.Add("signal");
+            });
     }
 }

--- a/src/settings-ui/Settings.UI/ViewModels/PowerDisplayViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/PowerDisplayViewModel.cs
@@ -36,6 +36,8 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             "PowerDisplay",
             "crash_detected.flag");
 
+        private readonly Action<string> _signalNamedEvent;
+
         private bool _isProfilesLoading;
 
         protected override string ModuleName => PowerDisplaySettings.ModuleName;
@@ -57,11 +59,18 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         }
 
         public PowerDisplayViewModel(SettingsUtils settingsUtils, ISettingsRepository<GeneralSettings> settingsRepository, ISettingsRepository<PowerDisplaySettings> powerDisplaySettingsRepository, Func<string, int> ipcMSGCallBackFunc, Action<string, Action> waitForEventLoop)
+            : this(settingsUtils, settingsRepository, powerDisplaySettingsRepository, ipcMSGCallBackFunc, waitForEventLoop, SignalNamedEvent)
+        {
+        }
+
+        internal PowerDisplayViewModel(SettingsUtils settingsUtils, ISettingsRepository<GeneralSettings> settingsRepository, ISettingsRepository<PowerDisplaySettings> powerDisplaySettingsRepository, Func<string, int> ipcMSGCallBackFunc, Action<string, Action> waitForEventLoop, Action<string> signalNamedEvent)
         {
             // To obtain the general settings configurations of PowerToys Settings.
             ArgumentNullException.ThrowIfNull(settingsRepository);
             ArgumentNullException.ThrowIfNull(waitForEventLoop);
+            ArgumentNullException.ThrowIfNull(signalNamedEvent);
 
+            _signalNamedEvent = signalNamedEvent;
             SettingsUtils = settingsUtils;
             GeneralSettingsConfig = settingsRepository.SettingsConfig;
 
@@ -361,7 +370,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 if (SetSettingsProperty(_settings.Properties.ActivationShortcut, value, v => _settings.Properties.ActivationShortcut = v))
                 {
                     // Signal PowerDisplay.exe to re-register the hotkey
-                    SignalNamedEvent(Constants.HotkeyUpdatedPowerDisplayEvent());
+                    _signalNamedEvent(Constants.HotkeyUpdatedPowerDisplayEvent());
                     Logger.LogInfo($"ActivationShortcut changed, signaled HotkeyUpdatedPowerDisplayEvent");
                 }
             }
@@ -590,24 +599,29 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 return;
             }
 
+            // Only these properties are edited by the Settings page. Runtime data and
+            // derived display properties must not save again after the update event:
+            // PowerDisplay may already be reading the file in response to that event.
+            if (e.PropertyName is not (nameof(MonitorInfo.EnableContrast) or
+                nameof(MonitorInfo.EnableVolume) or
+                nameof(MonitorInfo.EnableInputSource) or
+                nameof(MonitorInfo.EnableRotation) or
+                nameof(MonitorInfo.EnableColorTemperature) or
+                nameof(MonitorInfo.EnablePowerState) or
+                nameof(MonitorInfo.IsHidden)))
+            {
+                return;
+            }
+
             // MonitorInfo is a reference type shared between _monitors and
             // _settings.Properties.Monitors — the property change is already visible
             // in the persisted list, so just trigger save. Rebuilding the list from
             // _monitors here would silently drop legacy entries the filter hides.
             NotifySettingsChanged();
 
-            // For feature visibility properties, explicitly signal PowerDisplay to refresh
-            // This is needed because set_config() doesn't signal SettingsUpdatedEvent to avoid UI refresh issues
-            if (e.PropertyName == nameof(MonitorInfo.EnableContrast) ||
-                e.PropertyName == nameof(MonitorInfo.EnableVolume) ||
-                e.PropertyName == nameof(MonitorInfo.EnableInputSource) ||
-                e.PropertyName == nameof(MonitorInfo.EnableRotation) ||
-                e.PropertyName == nameof(MonitorInfo.EnableColorTemperature) ||
-                e.PropertyName == nameof(MonitorInfo.EnablePowerState) ||
-                e.PropertyName == nameof(MonitorInfo.IsHidden))
-            {
-                SignalSettingsUpdated();
-            }
+            // set_config() does not signal this event. Notify the module only after
+            // the user preference has been saved.
+            SignalSettingsUpdated();
         }
 
         /// <summary>
@@ -615,7 +629,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         /// </summary>
         private void SignalSettingsUpdated()
         {
-            SignalNamedEvent(Constants.SettingsUpdatedPowerDisplayEvent());
+            _signalNamedEvent(Constants.SettingsUpdatedPowerDisplayEvent());
             Logger.LogInfo("Signaled SettingsUpdatedPowerDisplayEvent for feature visibility change");
         }
 
@@ -627,7 +641,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         /// </summary>
         public void SignalRescanRequest()
         {
-            SignalNamedEvent(Constants.RescanPowerDisplayMonitorsEvent());
+            _signalNamedEvent(Constants.RescanPowerDisplayMonitorsEvent());
             Logger.LogInfo("Signaled RescanPowerDisplayMonitorsEvent (max-compat toggle finalized)");
         }
 


### PR DESCRIPTION
## Summary of the Pull Request

Power Display Settings currently saves the whole settings document for every monitor property notification, including runtime readings and derived display properties. Limit persistence and the subsequent module notification to the seven monitor preferences actually edited by the Settings page.

Keep disk reloads from writing their data back, and verify the save → IPC → module-notification order. An internal event-sender injection lets tests inspect notifications without signaling a running PowerDisplay process; existing public constructors keep the production sender.

This is an independent prerequisite extracted from #50458. It targets `main`, does not add a VCP restriction field, and can merge independently of the profile-editing PR. The VCP feature will add its new field to the allowlist and test that its derived notification causes no second save.

## PR Checklist

- [ ] Closes: no automatic issue closure; related to #50458.
- [ ] **Communication:** Draft for maintainer review.
- [x] **Tests:** Preference persistence, reload, ignored runtime changes, and notification order covered.
- [x] **Localization:** Not applicable; no new user-facing text.
- [ ] **Dev docs:** Not added.
- [x] **New binaries:** Not applicable; no new binary or test project.
- [ ] **Documentation updated:** No separate documentation PR.

## Validation Steps Performed

- Checked out commit `d03334cdeaeeb452f409a1cf6b417dce6b2c6a89` and built Settings UI and Settings.UI.UnitTests with the repository build script, x64 Debug: exit code 0.
- Ran the complete Settings test assembly through Visual Studio vstest: **261 passed**, none skipped, including all 14 PowerDisplay ViewModel instances.
- Preference tests verify exactly one save, IPC message, and captured event in that order. Runtime changes and reloads produce no writes or events.
- Verified the compiled assemblies contain neither the separate Profile preservation fix nor any VCP restriction model or `DisabledVcpValues` property.
- `git diff --check` passed. The build retained the existing CsWinRT1028 warning in unchanged `ManagedCommon/HotkeySettingsControlHook.cs`.

The JSON and IPC formats are unchanged. The change prevents writes caused by unrelated property notifications; it does not attempt to solve all cross-process settings concurrency.
