### PR TITLE
fix(cmdnotfound): preserve profiles with malformed removal markers

### DIFF
--- a/src/settings-ui/Settings.UI.UnitTests/Scripts/DisableModule.Tests.ps1
+++ b/src/settings-ui/Settings.UI.UnitTests/Scripts/DisableModule.Tests.ps1
@@ -1,0 +1,245 @@
+# Copyright (c) Microsoft Corporation
+# The Microsoft Corporation licenses this file to you under the MIT license.
+
+# Run with the existing Pester runner:
+# Invoke-Pester .\src\settings-ui\Settings.UI.UnitTests\Scripts\DisableModule.Tests.ps1
+$scriptPath = Join-Path $PSScriptRoot '..\..\Settings.UI\Assets\Settings\Scripts\DisableModule.ps1'
+$legacyGuid = '34de4b3d-13a8-4540-b76d-b9e8d3851756'
+$currentGuid = 'f45873b3-b655-43a6-b217-97c00aa0db58'
+$removedMessage = 'Removed the Command Not Found reference from the profile file.'
+$absentMessage = 'No instance of Command Not Found was found in the profile file.'
+
+function New-ModuleBlock {
+    param(
+        [string]$Guid = $currentGuid,
+        [string]$NewLine = "`r`n"
+    )
+
+    $import = 'Import-Module -Name Microsoft.WinGet.CommandNotFound'
+    if ($Guid -eq $legacyGuid) {
+        $import = 'Import-Module "C:\PowerToys\WinGetCommandNotFound.psd1"'
+    }
+
+    return "#$Guid PowerToys CommandNotFound module$NewLine$NewLine$import$NewLine#$Guid$NewLine"
+}
+
+function Invoke-ProfileRemoval {
+    param(
+        [byte[]]$Content,
+        [string]$ExpectedMessage = $removedMessage,
+        [switch]$ExpectFailure,
+        [switch]$ReadOnly,
+        [switch]$Missing,
+        [switch]$BracketedPath
+    )
+
+    # Shadow the automatic variable only inside this function. Never run a real profile.
+    $name = "profile-$([Guid]::NewGuid().ToString('N'))"
+    if ($BracketedPath) {
+        $name = "[$name]"
+    }
+    $PROFILE = Join-Path $TestDrive "$name.ps1"
+    if (-not $Missing) {
+        [System.IO.File]::WriteAllBytes($PROFILE, $Content)
+    }
+    if ($ReadOnly) {
+        [System.IO.File]::SetAttributes($PROFILE, [System.IO.FileAttributes]::ReadOnly)
+    }
+
+    $output = [System.Collections.Generic.List[string]]::new()
+    $failure = $null
+    try {
+        & $scriptPath 6>&1 | ForEach-Object { $output.Add($_.ToString()) }
+    }
+    catch {
+        $failure = $_
+    }
+    finally {
+        if ($ReadOnly) {
+            [System.IO.File]::SetAttributes($PROFILE, [System.IO.FileAttributes]::Normal)
+        }
+    }
+
+    $text = $output -join "`n"
+    if ($ExpectFailure) {
+        ($null -ne $failure) | Should Be $true | Out-Null
+        $text | Should Match 'Command Not Found removal failed' | Out-Null
+        $text.Contains($removedMessage) | Should Be $false | Out-Null
+        $text.Contains($absentMessage) | Should Be $false | Out-Null
+    }
+    else {
+        if ($null -ne $failure) {
+            throw $failure
+        }
+        $text | Should Be $ExpectedMessage | Out-Null
+    }
+
+    if ($Missing) {
+        [System.IO.File]::Exists($PROFILE) | Should Be $false | Out-Null
+        return
+    }
+
+    $actual = [System.IO.File]::ReadAllBytes($PROFILE)
+    if ($ExpectFailure) {
+        [Convert]::ToBase64String($actual) | Should Be ([Convert]::ToBase64String($Content)) | Out-Null
+    }
+
+    # A successful replacement or a failed write must not leave temporary siblings behind.
+    @(Get-ChildItem -LiteralPath $TestDrive -Force -Filter '*.tmp').Count | Should Be 0 | Out-Null
+    return ,$actual
+}
+
+Describe 'DisableModule profile preservation' {
+    It 'removes a complete current block and preserves a trailing function byte-for-byte' {
+        $prefix = "function Before { 'before' }`r`n`r`n"
+        $suffix = "function After { 'after' }`n# No final newline"
+        $bytes = [Text.Encoding]::UTF8.GetBytes($prefix + (New-ModuleBlock) + $suffix)
+        $actual = Invoke-ProfileRemoval -Content $bytes
+        [Convert]::ToBase64String($actual) | Should Be ([Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($prefix + $suffix)))
+    }
+
+    It 'preserves the tail when the closing marker is missing' {
+        $content = "#$currentGuid PowerToys CommandNotFound module`r`nImport-Module -Name Microsoft.WinGet.CommandNotFound`r`nfunction Keep { 'user content' }"
+        Invoke-ProfileRemoval -Content ([Text.Encoding]::UTF8.GetBytes($content)) -ExpectFailure | Out-Null
+    }
+
+    foreach ($guid in @($legacyGuid, $currentGuid)) {
+        It "removes a complete $guid block" {
+            $actual = Invoke-ProfileRemoval -Content ([Text.Encoding]::UTF8.GetBytes((New-ModuleBlock -Guid $guid)))
+            $actual.Length | Should Be 0
+        }
+
+        It "refuses a $guid closing marker without an opening marker" {
+            $content = "#$guid`nfunction Keep { 'user content' }"
+            Invoke-ProfileRemoval -Content ([Text.Encoding]::UTF8.GetBytes($content)) -ExpectFailure | Out-Null
+        }
+
+        It "refuses a $guid opening marker without a closing marker" {
+            $content = "#$guid PowerToys CommandNotFound module"
+            Invoke-ProfileRemoval -Content ([Text.Encoding]::UTF8.GetBytes($content)) -ExpectFailure | Out-Null
+        }
+    }
+
+    It 'removes multiple separate current and legacy blocks without touching intervening content' {
+        $userFunction = "function Keep { 'between blocks' }`n"
+        $suffix = '# tail'
+        $content = (New-ModuleBlock) + $userFunction + (New-ModuleBlock -Guid $legacyGuid -NewLine "`n") + (New-ModuleBlock) + $suffix
+        $actual = Invoke-ProfileRemoval -Content ([Text.Encoding]::UTF8.GetBytes($content))
+        [Text.Encoding]::UTF8.GetString($actual) | Should Be ($userFunction + $suffix)
+    }
+
+    $malformedCases = @{
+        'mixed GUIDs' = "#$currentGuid PowerToys CommandNotFound module`n#$legacyGuid`n"
+        'reverse mixed GUIDs' = "#$legacyGuid PowerToys CommandNotFound module`n#$currentGuid`n"
+        'duplicate opening markers' = "#$currentGuid PowerToys CommandNotFound module`n" + (New-ModuleBlock)
+        'duplicate closing markers' = (New-ModuleBlock) + "#$currentGuid`n"
+        'nested legacy block' = "#$currentGuid PowerToys CommandNotFound module`n" + (New-ModuleBlock -Guid $legacyGuid) + "#$currentGuid`n"
+        'valid block followed by an unclosed block' = (New-ModuleBlock) + "#$legacyGuid PowerToys CommandNotFound module`nfunction Keep { 'tail' }"
+        'valid block followed by an orphan closing marker' = (New-ModuleBlock) + "#$legacyGuid`nfunction Keep { 'tail' }"
+        'an orphan closing marker before a valid block' = "#$legacyGuid`n" + (New-ModuleBlock)
+    }
+    foreach ($name in $malformedCases.Keys) {
+        It "leaves the entire profile unchanged for $name" {
+            Invoke-ProfileRemoval -Content ([Text.Encoding]::UTF8.GetBytes($malformedCases[$name])) -ExpectFailure | Out-Null
+        }
+    }
+
+    It 'does not treat GUID substrings or marker-like comments as boundaries' {
+        $content = @"
+`$id = '$currentGuid'
+# A note about $legacyGuid
+Write-Output '#$currentGuid PowerToys CommandNotFound module'
+#${currentGuid}-not-a-marker
+#$legacyGuid unrelated comment
+function Keep { 'unchanged' }
+"@
+        $bytes = [Text.Encoding]::UTF8.GetBytes($content)
+        $actual = Invoke-ProfileRemoval -Content $bytes -ExpectedMessage $absentMessage
+        [Convert]::ToBase64String($actual) | Should Be ([Convert]::ToBase64String($bytes))
+    }
+
+    It 'does not remove marker examples inside strings or block comments' {
+        $example = New-ModuleBlock
+        $prefix = "`$example = @'`n$example'@`n<#`n$example#>`n"
+        $suffix = "function Keep { 'tail' }"
+        $actual = Invoke-ProfileRemoval -Content ([Text.Encoding]::UTF8.GetBytes($prefix + (New-ModuleBlock) + $suffix))
+        [Text.Encoding]::UTF8.GetString($actual) | Should Be ($prefix + $suffix)
+    }
+
+    It 'preserves marker-like text between complete blocks' {
+        $text = "Write-Output '$currentGuid'`n#$legacyGuid unrelated comment`n"
+        $content = (New-ModuleBlock) + $text + (New-ModuleBlock -Guid $legacyGuid)
+        $actual = Invoke-ProfileRemoval -Content ([Text.Encoding]::UTF8.GetBytes($content))
+        [Text.Encoding]::UTF8.GetString($actual) | Should Be $text
+    }
+
+    It 'accepts indentation and trailing horizontal whitespace on marker lines' {
+        $content = "  #$currentGuid PowerToys CommandNotFound module `t`nImport-Module -Name Microsoft.WinGet.CommandNotFound`n`t#$currentGuid `t`n# tail"
+        $actual = Invoke-ProfileRemoval -Content ([Text.Encoding]::UTF8.GetBytes($content))
+        [Text.Encoding]::UTF8.GetString($actual) | Should Be '# tail'
+    }
+
+    $encodings = @{
+        'UTF-8 without BOM' = [Text.UTF8Encoding]::new($false)
+        'UTF-8 with BOM' = [Text.UTF8Encoding]::new($true)
+        'UTF-16 LE' = [Text.UnicodeEncoding]::new($false, $true)
+        'UTF-16 BE' = [Text.UnicodeEncoding]::new($true, $true)
+        'UTF-32 LE' = [Text.UTF32Encoding]::new($false, $true)
+        'UTF-32 BE' = [Text.UTF32Encoding]::new($true, $true)
+        'Windows-1252' = [Text.Encoding]::GetEncoding(1252)
+    }
+    foreach ($name in $encodings.Keys) {
+        It "preserves $name bytes, BOM, mixed line endings, and non-ASCII content" {
+            $encoding = $encodings[$name]
+            $prefix = "# caf$([char]0xE9) $([char]0x20AC)`r`n`r`n"
+            $suffix = "function Keep { '$([char]0xE9)' }`n# tail`r# no final newline"
+            $bytes = $encoding.GetPreamble() + $encoding.GetBytes($prefix + (New-ModuleBlock -NewLine "`n") + $suffix)
+            $expected = $encoding.GetPreamble() + $encoding.GetBytes($prefix + $suffix)
+            $actual = Invoke-ProfileRemoval -Content $bytes
+            [Convert]::ToBase64String($actual) | Should Be ([Convert]::ToBase64String($expected))
+        }
+    }
+
+    foreach ($newLine in @("`r`n", "`n", "`r")) {
+        It "removes a block with line ending bytes $([Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes($newLine)))" {
+            $content = (New-ModuleBlock -NewLine $newLine) + '# tail'
+            $actual = Invoke-ProfileRemoval -Content ([Text.Encoding]::UTF8.GetBytes($content))
+            [Text.Encoding]::UTF8.GetString($actual) | Should Be '# tail'
+        }
+    }
+
+    It 'removes a block whose closing marker has no final newline' {
+        $content = (New-ModuleBlock).TrimEnd("`r", "`n")
+        $actual = Invoke-ProfileRemoval -Content ([Text.Encoding]::UTF8.GetBytes($content))
+        $actual.Length | Should Be 0
+    }
+
+    It 'uses the profile path literally when it contains wildcard characters' {
+        $actual = Invoke-ProfileRemoval -Content ([Text.Encoding]::UTF8.GetBytes((New-ModuleBlock))) -BracketedPath
+        $actual.Length | Should Be 0
+    }
+
+    It 'does not rewrite an empty profile' {
+        $actual = Invoke-ProfileRemoval -Content @() -ExpectedMessage $absentMessage
+        $actual.Length | Should Be 0
+    }
+
+    It 'does not rewrite a BOM-only profile' {
+        $bytes = [Text.Encoding]::UTF8.GetPreamble()
+        $actual = Invoke-ProfileRemoval -Content $bytes -ExpectedMessage $absentMessage
+        [Convert]::ToBase64String($actual) | Should Be ([Convert]::ToBase64String($bytes))
+    }
+
+    It 'refuses undecodable BOM-encoded content without replacing bytes' {
+        $bytes = [Text.Encoding]::UTF8.GetPreamble() + [Text.Encoding]::UTF8.GetBytes((New-ModuleBlock)) + [byte[]]@(0xFF)
+        Invoke-ProfileRemoval -Content $bytes -ExpectFailure | Out-Null
+    }
+
+    It 'reports a missing profile as an error rather than successful removal' {
+        Invoke-ProfileRemoval -Missing -ExpectFailure
+    }
+
+    It 'reports a read-only profile as an error without changing its bytes' {
+        Invoke-ProfileRemoval -Content ([Text.Encoding]::UTF8.GetBytes((New-ModuleBlock))) -ReadOnly -ExpectFailure | Out-Null
+    }
+}

--- a/src/settings-ui/Settings.UI/Assets/Settings/Scripts/DisableModule.ps1
+++ b/src/settings-ui/Settings.UI/Assets/Settings/Scripts/DisableModule.ps1
@@ -1,37 +1,104 @@
-$profileContent = Get-Content $PROFILE
+$temporaryPath = $null
+try {
+  $profileBytes = [System.IO.File]::ReadAllBytes($PROFILE)
+  $stream = [System.IO.MemoryStream]::new($profileBytes, $false)
+  $reader = [System.IO.StreamReader]::new($stream, [System.Text.UTF8Encoding]::new($false, $true), $true)
+  try {
+    try {
+      $profileContent = $reader.ReadToEnd()
+      $encoding = $reader.CurrentEncoding
+    }
+    catch [System.Text.DecoderFallbackException] {
+      if ($reader.CurrentEncoding.GetPreamble().Length -ne 0) {
+        throw
+      }
 
-$newContent = ""
-$linesToDeleteFound = $False
-$atLeastOneInstanceFound = $False
+      # BOM-less legacy profiles can contain non-UTF-8 bytes. Map them losslessly
+      # while recognizing the ASCII markers, without converting the user's text.
+      $encoding = [System.Text.Encoding]::GetEncoding(28591)
+      $profileContent = $encoding.GetString($profileBytes)
+    }
+  }
+  finally {
+    $reader.Dispose()
+  }
 
-$profileContent | ForEach-Object {
-  if (($_.Contains("34de4b3d-13a8-4540-b76d-b9e8d3851756") -or $_.Contains("f45873b3-b655-43a6-b217-97c00aa0db58")) -and !$linesToDeleteFound)
-  {
-    $linesToDeleteFound = $True
-    $atLeastOneInstanceFound = $True
+  $roundTripBytes = $encoding.GetPreamble() + $encoding.GetBytes($profileContent)
+  if ([Convert]::ToBase64String($profileBytes) -cne [Convert]::ToBase64String($roundTripBytes)) {
+    throw [System.IO.InvalidDataException]::new("The profile encoding could not be read losslessly. The profile was not changed.")
+  }
+
+  # Only actual comment tokens can delimit a block, not examples inside strings
+  # or block comments. Parsing does not execute any profile code.
+  $tokens = $null
+  $parseErrors = $null
+  [void][System.Management.Automation.Language.Parser]::ParseInput($profileContent, [ref]$tokens, [ref]$parseErrors)
+  $commentOffsets = [System.Collections.Generic.HashSet[int]]::new()
+  foreach ($token in $tokens) {
+    if ($token.Kind -eq [System.Management.Automation.Language.TokenKind]::Comment) {
+      [void]$commentOffsets.Add($token.Extent.StartOffset)
+    }
+  }
+
+  $markerPattern = '^[ \t]*#(?<guid>34de4b3d-13a8-4540-b76d-b9e8d3851756|f45873b3-b655-43a6-b217-97c00aa0db58)(?<opening> PowerToys CommandNotFound module)?[ \t]*$'
+  $blocks = [System.Collections.Generic.List[object]]::new()
+  $opening = $null
+  foreach ($line in [regex]::Matches($profileContent, '[^\r\n]+(?:\r\n|\r|\n|$)')) {
+    $marker = [regex]::Match($line.Value.TrimEnd("`r", "`n"), $markerPattern)
+    if (-not $marker.Success -or -not $commentOffsets.Contains($line.Index + $line.Value.IndexOf('#'))) {
+      continue
+    }
+
+    if ($marker.Groups['opening'].Success) {
+      if ($null -ne $opening) {
+        throw [System.IO.InvalidDataException]::new("Command Not Found has nested or duplicate opening markers. The profile was not changed. Repair the markers and try again.")
+      }
+
+      $opening = [PSCustomObject]@{ Index = $line.Index; Guid = $marker.Groups['guid'].Value }
+    }
+    else {
+      if ($null -eq $opening -or $opening.Guid -cne $marker.Groups['guid'].Value) {
+        throw [System.IO.InvalidDataException]::new("Command Not Found has an unmatched closing marker. The profile was not changed. Repair the markers and try again.")
+      }
+
+      $blocks.Add([PSCustomObject]@{ Index = $opening.Index; Length = $line.Index + $line.Length - $opening.Index })
+      $opening = $null
+    }
+  }
+
+  if ($null -ne $opening) {
+    throw [System.IO.InvalidDataException]::new("Command Not Found has an unclosed opening marker. The profile was not changed. Repair the markers and try again.")
+  }
+
+  if ($blocks.Count -eq 0) {
+    Write-Host "No instance of Command Not Found was found in the profile file."
+    # This message will be compared against in Command Not Found Settings page code behind. Take care when changing it.
     return
   }
 
-  if (($_.Contains("34de4b3d-13a8-4540-b76d-b9e8d3851756") -or $_.Contains("f45873b3-b655-43a6-b217-97c00aa0db58")) -and $linesToDeleteFound)
-  {
-    $linesToDeleteFound = $False
-    return
+  # Validate every boundary before removing any block, retaining all other characters
+  # including their original line endings and the absence of a final newline.
+  $newContent = $profileContent
+  for ($index = $blocks.Count - 1; $index -ge 0; $index--) {
+    $newContent = $newContent.Remove($blocks[$index].Index, $blocks[$index].Length)
   }
 
-  if($linesToDeleteFound)
-  {
-    return
+  $newBytes = $encoding.GetPreamble() + $encoding.GetBytes($newContent)
+  $temporaryPath = Join-Path ([System.IO.Path]::GetDirectoryName($PROFILE)) ".$([System.IO.Path]::GetFileName($PROFILE)).$([Guid]::NewGuid().ToString('N')).tmp"
+  [System.IO.File]::WriteAllBytes($temporaryPath, $newBytes)
+  # Publish only the completed file instead of truncating the original profile.
+  [System.IO.File]::Replace($temporaryPath, $PROFILE, [NullString]::Value)
+}
+catch [System.IO.InvalidDataException], [System.IO.IOException], [System.UnauthorizedAccessException], [System.Text.DecoderFallbackException] {
+  # Settings captures stdout, not stderr. Never emit either success message on failure.
+  Write-Host "Command Not Found removal failed: $($_.Exception.Message)"
+  throw
+}
+finally {
+  if ($null -ne $temporaryPath) {
+    [System.IO.File]::Delete($temporaryPath)
   }
-
-  $newContent += $_ + "`r`n"
 }
 
-if($atLeastOneInstanceFound)
-{
-  Set-Content -Path $PROFILE -Value $newContent
-  Write-Host "Removed the Command Not Found reference from the profile file."
-  # This message will be compared against in Command Not Found Settings page code behind. Take care when changing it.
-} else {
-  Write-Host "No instance of Command Not Found was found in the profile file."
-  # This message will be compared against in Command Not Found Settings page code behind. Take care when changing it.
-}
+Write-Host "Removed the Command Not Found reference from the profile file."
+# This message will be compared against in Command Not Found Settings page code behind. Take care when changing it.


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Prevent Command Not Found removal from deleting unrelated PowerShell profile content when its marker boundaries are malformed. Validate every recognized block before changing the file, retain legacy/current marker compatibility, and preserve unrelated bytes, encoding, BOM, and line endings.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- Closes: N/A — independently reviewable Settings audit fix; no exact issue linked.
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized

Communication: opened as a draft at the audit owner's request. Diagnostics follow the existing script's English console-output convention; localization remains unchecked. Dev docs, new binaries, and external documentation updates: N/A for this script-only fix. The fixture test file includes its invocation command.

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

`src\settings-ui\Settings.UI\Assets\Settings\Scripts\DisableModule.ps1` previously toggled deletion at any line containing either GUID and wrote the result even when an opening marker had no closing marker. An interrupted enable operation or manually damaged marker could therefore remove all trailing user functions while reporting success.

The removal script now:

- Recognizes whole-line opening and closing comments, not GUID substrings or examples inside strings/block comments.
- Requires non-nested pairs with matching GUIDs. Both legacy `34de4b3d-13a8-4540-b76d-b9e8d3851756` and current `f45873b3-b655-43a6-b217-97c00aa0db58` blocks remain supported, including multiple complete blocks of either version.
- Rejects missing, mixed, nested, or duplicate boundaries before any write, even if an earlier block was valid. The entire original file remains unchanged on these refusals.
- Checks lossless decoding and preserves unrelated content, BOM, mixed CRLF/LF/CR endings, and final-newline state. Writes a completed temporary sibling before replacing the profile instead of truncating the original first.
- Prints explicit failure diagnostics to stdout, which the existing Settings process wrapper captures, and rethrows the error. Neither existing success token is emitted on refusal or I/O failure. Both successful-removal and no-instance messages remain unchanged for `CmdNotFoundViewModel`.

`src\settings-ui\Settings.UI.UnitTests\Scripts\DisableModule.Tests.ps1` adds focused coverage using the repository's existing Pester mechanism. Every invocation shadows `$PROFILE` with a disposable `$TestDrive` fixture; profile contents are never executed.

**Behavioral risk:** This deliberately refuses to guess when recognized boundaries are malformed; users must repair those markers before removal. Lossy decoding and filesystem replacement failures are surfaced rather than falling back to a destructive write. Replacement was exercised on the local Windows filesystem, not every redirected/network profile location.

**Scope:** No changes to prerequisite detection, enable/upgrade scripts, package installation, process execution, Settings schemas, GPO, elevation, or installer behavior. This is profile-boundary safety, not the separate uninstall behavior tracked in #31039.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Existing Pester 3.4.0, running `src\settings-ui\Settings.UI.UnitTests\Scripts\DisableModule.Tests.ps1`:

| Host | Passed | Failed | Skipped |
| --- | ---: | ---: | ---: |
| PowerShell 7.6.6 (`pwsh.exe -NoProfile -NonInteractive`) | 38 | 0 | 0 |
| Windows PowerShell 5.1 (`powershell.exe -NoProfile -NonInteractive`) | 38 | 0 | 0 |

Coverage includes complete legacy/current blocks, missing open/close markers, mixed/duplicate/nested/multiple blocks, marker-like text, trailing functions, UTF-8 with/without BOM, UTF-16/UTF-32 LE/BE, Windows-1252, mixed line endings, missing final newlines, empty/BOM-only files, literal paths containing brackets, invalid BOM-encoded bytes, missing profiles, read-only profiles, and absence of temporary-file leftovers.

Direct disposable-fixture reproduction against baseline `71340eed47`: an unclosed marker followed by a user function reduced the profile from **187 to 18 bytes**, deleted the function, and printed the removal-success message. The fixed script keeps **all 187 bytes identical**, retains the function, and throws with an explicit stdout refusal and no success message.

Both fixture-suite commands exited 0; the committed diff also passes `git diff --check`. No Settings/native build was needed for these PowerShell-only changes. No real user profiles, execution policies, elevation/GPO/installer settings, or running PowerToys processes were changed.