### PR TITLE
perf(settings-ui): streamline Home module row templates

### DIFF
--- a/src/settings-ui/Settings.UI.Controls/ModuleList/ModuleList.xaml
+++ b/src/settings-ui/Settings.UI.Controls/ModuleList/ModuleList.xaml
@@ -45,7 +45,10 @@
             </Setter>
         </Style>
     </UserControl.Resources>
-    <ItemsRepeater x:Name="DashboardView" ItemsSource="{x:Bind ItemsSource, Mode=OneWay}">
+    <ItemsRepeater
+        x:Name="DashboardView"
+        ElementPrepared="OnElementPrepared"
+        ItemsSource="{x:Bind ItemsSource, Mode=OneWay}">
         <ItemsRepeater.Layout>
             <StackLayout Orientation="Vertical" Spacing="0" />
         </ItemsRepeater.Layout>

--- a/src/settings-ui/Settings.UI.Controls/ModuleList/ModuleList.xaml.cs
+++ b/src/settings-ui/Settings.UI.Controls/ModuleList/ModuleList.xaml.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using CommunityToolkit.WinUI.Controls;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
@@ -38,6 +39,18 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
 
         public static readonly DependencyProperty ItemsSourceProperty = DependencyProperty.Register(nameof(ItemsSource), typeof(object), typeof(ModuleList), new PropertyMetadata(null));
 
+        public Style? ItemContainerStyle
+        {
+            get => (Style?)GetValue(ItemContainerStyleProperty);
+            set => SetValue(ItemContainerStyleProperty, value);
+        }
+
+        public static readonly DependencyProperty ItemContainerStyleProperty = DependencyProperty.Register(
+            nameof(ItemContainerStyle),
+            typeof(Style),
+            typeof(ModuleList),
+            new PropertyMetadata(null, OnItemContainerStyleChanged));
+
         public ModuleListSortOption SortOption
         {
             get => (ModuleListSortOption)GetValue(SortOptionProperty);
@@ -45,6 +58,44 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
         }
 
         public static readonly DependencyProperty SortOptionProperty = DependencyProperty.Register(nameof(SortOption), typeof(ModuleListSortOption), typeof(ModuleList), new PropertyMetadata(ModuleListSortOption.Alphabetical));
+
+        private static void OnItemContainerStyleChanged(DependencyObject sender, DependencyPropertyChangedEventArgs args)
+        {
+            var control = (ModuleList)sender;
+            if (control.DashboardView?.ItemsSourceView is not { } items)
+            {
+                return;
+            }
+
+            for (int index = 0; index < items.Count; index++)
+            {
+                if (control.DashboardView.TryGetElement(index) is SettingsCard card)
+                {
+                    control.ApplyItemContainerStyle(card);
+                }
+            }
+        }
+
+        private void OnElementPrepared(ItemsRepeater sender, ItemsRepeaterElementPreparedEventArgs args)
+        {
+            if (args.Element is SettingsCard card)
+            {
+                // Apply before the first measure so the default template is not built and then replaced.
+                ApplyItemContainerStyle(card);
+            }
+        }
+
+        private void ApplyItemContainerStyle(SettingsCard card)
+        {
+            if (ItemContainerStyle is { } style)
+            {
+                card.Style = style;
+            }
+            else
+            {
+                card.ClearValue(StyleProperty);
+            }
+        }
 
         private void OnSettingsCardClick(object sender, RoutedEventArgs e)
         {

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/DashboardPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/DashboardPage.xaml
@@ -17,67 +17,212 @@
     DataContext="DashboardViewModel"
     mc:Ignorable="d">
     <local:NavigablePage.Resources>
-        <converters:ModuleItemTemplateSelector
-            x:Key="ModuleItemTemplateSelector"
-            ActivationTemplate="{StaticResource ModuleItemActivationTemplate}"
-            ShortcutTemplate="{StaticResource ModuleItemShortcutTemplate}" />
-        <controlConverters:EnumToBooleanConverter x:Key="EnumToBooleanConverter" />
-        <converters:EnumToModuleListSortOptionConverter x:Key="EnumToModuleListSortOptionConverter" />
-        <DataTemplate x:Key="ModuleItemShortcutTemplate" x:DataType="viewmodels:DashboardModuleShortcutItem">
-            <Grid MinHeight="36" ColumnSpacing="12">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" MinWidth="140" />
-                </Grid.ColumnDefinitions>
-                <ItemsControl
-                    Grid.Column="1"
-                    HorizontalAlignment="Left"
-                    AutomationProperties.AccessibilityView="Raw"
-                    IsTabStop="False"
-                    ItemsSource="{x:Bind Shortcut, Mode=OneWay}">
-                    <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <StackPanel Orientation="Horizontal" Spacing="4" />
-                        </ItemsPanelTemplate>
-                    </ItemsControl.ItemsPanel>
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <ptcontrols:KeyVisual
-                                VerticalAlignment="Center"
-                                AutomationProperties.AccessibilityView="Raw"
-                                Content="{Binding}"
-                                FontSize="12"
-                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                IsTabStop="False"
-                                RenderKeyAsGlyph="True" />
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-                <TextBlock
-                    VerticalAlignment="Center"
-                    Text="{x:Bind Label, Mode=OneWay}"
-                    TextWrapping="WrapWholeWords" />
-            </Grid>
-        </DataTemplate>
-        <DataTemplate x:Key="ModuleItemActivationTemplate" x:DataType="viewmodels:DashboardModuleActivationItem">
-            <Grid MinHeight="36" ColumnSpacing="12">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" MinWidth="140" />
-                </Grid.ColumnDefinitions>
-                <TextBlock
-                    VerticalAlignment="Center"
-                    Text="{x:Bind Label, Mode=OneWay}"
-                    TextWrapping="WrapWholeWords" />
-                <TextBlock
-                    Grid.Column="1"
-                    VerticalAlignment="Center"
-                    FontSize="12"
-                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                    Text="{x:Bind Activation, Mode=OneWay}"
-                    TextWrapping="WrapWholeWords" />
-            </Grid>
-        </DataTemplate>
+        <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Default">
+                    <StaticResource x:Key="DashboardRowBackgroundPointerOver" ResourceKey="ControlFillColorSecondaryBrush" />
+                    <StaticResource x:Key="DashboardRowBackgroundPressed" ResourceKey="ControlFillColorTertiaryBrush" />
+                    <StaticResource x:Key="DashboardRowBorderBrushPointerOver" ResourceKey="ControlElevationBorderBrush" />
+                    <StaticResource x:Key="DashboardRowBorderBrushPressed" ResourceKey="ControlStrokeColorDefaultBrush" />
+                    <StaticResource x:Key="DashboardRowForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
+                    <StaticResource x:Key="DashboardRowForegroundPressed" ResourceKey="TextFillColorSecondaryBrush" />
+                    <StaticResource x:Key="DashboardRowForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Light">
+                    <StaticResource x:Key="DashboardRowBackgroundPointerOver" ResourceKey="ControlFillColorSecondaryBrush" />
+                    <StaticResource x:Key="DashboardRowBackgroundPressed" ResourceKey="ControlFillColorTertiaryBrush" />
+                    <StaticResource x:Key="DashboardRowBorderBrushPointerOver" ResourceKey="ControlElevationBorderBrush" />
+                    <StaticResource x:Key="DashboardRowBorderBrushPressed" ResourceKey="ControlStrokeColorDefaultBrush" />
+                    <StaticResource x:Key="DashboardRowForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
+                    <StaticResource x:Key="DashboardRowForegroundPressed" ResourceKey="TextFillColorSecondaryBrush" />
+                    <StaticResource x:Key="DashboardRowForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="HighContrast">
+                    <StaticResource x:Key="DashboardRowBackgroundPointerOver" ResourceKey="SystemColorHighlightTextColorBrush" />
+                    <StaticResource x:Key="DashboardRowBackgroundPressed" ResourceKey="SystemColorHighlightTextColorBrush" />
+                    <StaticResource x:Key="DashboardRowBorderBrushPointerOver" ResourceKey="SystemColorHighlightColorBrush" />
+                    <StaticResource x:Key="DashboardRowBorderBrushPressed" ResourceKey="SystemColorHighlightTextColorBrush" />
+                    <StaticResource x:Key="DashboardRowForegroundPointerOver" ResourceKey="SystemColorHighlightColorBrush" />
+                    <StaticResource x:Key="DashboardRowForegroundPressed" ResourceKey="SystemColorHighlightColorBrush" />
+                    <StaticResource x:Key="DashboardRowForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
+            <converters:ModuleItemTemplateSelector
+                x:Key="ModuleItemTemplateSelector"
+                ActivationTemplate="{StaticResource ModuleItemActivationTemplate}"
+                ShortcutTemplate="{StaticResource ModuleItemShortcutTemplate}" />
+            <controlConverters:EnumToBooleanConverter x:Key="EnumToBooleanConverter" />
+            <converters:EnumToModuleListSortOptionConverter x:Key="EnumToModuleListSortOptionConverter" />
+            <!--  Derived from the Community Toolkit SettingsCard template, licensed by the .NET Foundation under the MIT license.  -->
+            <!--  Home rows have no description or wrapping content, so they do not need the general-purpose layout triggers.  -->
+            <Style x:Key="DashboardModuleListRowStyle" TargetType="tkcontrols:SettingsCard">
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="tkcontrols:SettingsCard">
+                            <Grid
+                                x:Name="PART_RootGrid"
+                                MinWidth="{TemplateBinding MinWidth}"
+                                MinHeight="{TemplateBinding MinHeight}"
+                                MaxWidth="{TemplateBinding MaxWidth}"
+                                Padding="{TemplateBinding Padding}"
+                                HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                                VerticalAlignment="{TemplateBinding VerticalAlignment}"
+                                Background="{TemplateBinding Background}"
+                                BackgroundSizing="{TemplateBinding BackgroundSizing}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{TemplateBinding CornerRadius}">
+                                <Grid.BackgroundTransition>
+                                    <BrushTransition Duration="0:0:0.083" />
+                                </Grid.BackgroundTransition>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <Viewbox
+                                    x:Name="PART_HeaderIconPresenterHolder"
+                                    MaxWidth="20"
+                                    MaxHeight="20"
+                                    Margin="2,0,20,0">
+                                    <ContentPresenter
+                                        x:Name="PART_HeaderIconPresenter"
+                                        AutomationProperties.AccessibilityView="Raw"
+                                        Content="{TemplateBinding HeaderIcon}"
+                                        HighContrastAdjustment="None" />
+                                </Viewbox>
+                                <ContentPresenter
+                                    x:Name="PART_HeaderPresenter"
+                                    Grid.Column="1"
+                                    Margin="0,0,24,0"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center"
+                                    Content="{TemplateBinding Header}"
+                                    HighContrastAdjustment="None"
+                                    TextWrapping="Wrap" />
+                                <ContentPresenter
+                                    x:Name="PART_ContentPresenter"
+                                    Grid.Column="2"
+                                    HorizontalAlignment="Right"
+                                    VerticalAlignment="Center"
+                                    HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                    Content="{TemplateBinding Content}" />
+                                <Viewbox
+                                    x:Name="PART_ActionIconPresenterHolder"
+                                    Grid.Column="3"
+                                    MaxWidth="13"
+                                    MaxHeight="13"
+                                    Margin="14,0,0,0"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    HighContrastAdjustment="None"
+                                    Visibility="Collapsed">
+                                    <ContentPresenter
+                                        x:Name="PART_ActionIconPresenter"
+                                        AutomationProperties.AccessibilityView="Raw"
+                                        Content="{TemplateBinding ActionIcon}"
+                                        FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                        HighContrastAdjustment="None"
+                                        ToolTipService.ToolTip="{TemplateBinding ActionIconToolTip}" />
+                                </Viewbox>
+                                <VisualStateManager.VisualStateGroups>
+                                    <VisualStateGroup x:Name="CommonStates">
+                                        <VisualState x:Name="Normal" />
+                                        <VisualState x:Name="PointerOver">
+                                            <VisualState.Setters>
+                                                <Setter Target="PART_RootGrid.Background" Value="{ThemeResource DashboardRowBackgroundPointerOver}" />
+                                                <Setter Target="PART_RootGrid.BorderBrush" Value="{ThemeResource DashboardRowBorderBrushPointerOver}" />
+                                                <Setter Target="PART_HeaderPresenter.Foreground" Value="{ThemeResource DashboardRowForegroundPointerOver}" />
+                                                <Setter Target="PART_HeaderIconPresenter.Foreground" Value="{ThemeResource DashboardRowForegroundPointerOver}" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                        <VisualState x:Name="Pressed">
+                                            <VisualState.Setters>
+                                                <Setter Target="PART_RootGrid.Background" Value="{ThemeResource DashboardRowBackgroundPressed}" />
+                                                <Setter Target="PART_RootGrid.BorderBrush" Value="{ThemeResource DashboardRowBorderBrushPressed}" />
+                                                <Setter Target="PART_HeaderPresenter.Foreground" Value="{ThemeResource DashboardRowForegroundPressed}" />
+                                                <Setter Target="PART_HeaderIconPresenter.Foreground" Value="{ThemeResource DashboardRowForegroundPressed}" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                        <VisualState x:Name="Disabled">
+                                            <VisualState.Setters>
+                                                <Setter Target="PART_ActionIconPresenter.Foreground" Value="{ThemeResource DashboardRowForegroundDisabled}" />
+                                                <Setter Target="PART_HeaderPresenter.Foreground" Value="{ThemeResource DashboardRowForegroundDisabled}" />
+                                                <Setter Target="PART_HeaderIconPresenter.Foreground" Value="{ThemeResource DashboardRowForegroundDisabled}" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                    </VisualStateGroup>
+                                    <VisualStateGroup x:Name="BitmapHeaderIconStates">
+                                        <VisualState x:Name="BitmapHeaderIconEnabled" />
+                                        <VisualState x:Name="BitmapHeaderIconDisabled">
+                                            <VisualState.Setters>
+                                                <Setter Target="PART_HeaderIconPresenterHolder.Opacity" Value="0.4" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                    </VisualStateGroup>
+                                </VisualStateManager.VisualStateGroups>
+                            </Grid>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+            <DataTemplate x:Key="ModuleItemShortcutTemplate" x:DataType="viewmodels:DashboardModuleShortcutItem">
+                <Grid MinHeight="36" ColumnSpacing="12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" MinWidth="140" />
+                    </Grid.ColumnDefinitions>
+                    <ItemsControl
+                        Grid.Column="1"
+                        HorizontalAlignment="Left"
+                        AutomationProperties.AccessibilityView="Raw"
+                        IsTabStop="False"
+                        ItemsSource="{x:Bind Shortcut, Mode=OneWay}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Orientation="Horizontal" Spacing="4" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <ptcontrols:KeyVisual
+                                    VerticalAlignment="Center"
+                                    AutomationProperties.AccessibilityView="Raw"
+                                    Content="{Binding}"
+                                    FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    IsTabStop="False"
+                                    RenderKeyAsGlyph="True" />
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        Text="{x:Bind Label, Mode=OneWay}"
+                        TextWrapping="WrapWholeWords" />
+                </Grid>
+            </DataTemplate>
+            <DataTemplate x:Key="ModuleItemActivationTemplate" x:DataType="viewmodels:DashboardModuleActivationItem">
+                <Grid MinHeight="36" ColumnSpacing="12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" MinWidth="140" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        Text="{x:Bind Label, Mode=OneWay}"
+                        TextWrapping="WrapWholeWords" />
+                    <TextBlock
+                        Grid.Column="1"
+                        VerticalAlignment="Center"
+                        FontSize="12"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Text="{x:Bind Activation, Mode=OneWay}"
+                        TextWrapping="WrapWholeWords" />
+                </Grid>
+            </DataTemplate>
+        </ResourceDictionary>
     </local:NavigablePage.Resources>
     <Grid Margin="16,0,0,0" RowSpacing="12">
         <Grid.RowDefinitions>
@@ -259,6 +404,7 @@
                         <controls:ModuleList
                             x:Name="ModulesCard"
                             Grid.Row="1"
+                            ItemContainerStyle="{StaticResource DashboardModuleListRowStyle}"
                             ItemsSource="{x:Bind ViewModel.AllModules, Mode=OneWay}"
                             SortOption="{x:Bind ViewModel.DashboardSortOrder, Mode=TwoWay, Converter={StaticResource EnumToModuleListSortOptionConverter}}" />
                     </controls:Card>

--- a/src/settings-ui/Settings.UITests/SettingsTests.md
+++ b/src/settings-ui/Settings.UITests/SettingsTests.md
@@ -15,6 +15,16 @@
  - [x] turn on all the module, all module are now working
  - [] restart PT and verify that all module are still on in the settings page and they are actually working
 
+**Home module rows:**
+ - [ ] Clicking a module row opens that module's settings page, including when the module is disabled.
+ - [ ] Changing a row's toggle updates the module without navigating away from Home; restore its original state.
+ - [ ] Keyboard focus reaches the row and its toggle separately. Enter/Space on the row navigates; Space on the toggle changes only its state.
+ - [ ] Policy-controlled modules retain their lock indication and disabled toggle while the settings page remains reachable.
+ - [ ] Light, dark, and high-contrast themes preserve row spacing, icons, dividers, hover/pressed/disabled colors, and focus indicators.
+ - [ ] At narrow window sizes, larger text/display scale, and right-to-left layout, labels, badges, toggles, and chevrons retain their placement without overlap.
+ - [ ] Scrolling to the last module and back, then changing the sort order, retains the correct row labels, enabled states, navigation targets, and toggle targets.
+ - [ ] Quick Access's all-apps list retains its existing default row presentation and interactions.
+
 **Quick access tray icon flyout:**
  - [] Use left click on the system tray icon and verify the flyout appears.
  - [] Try to launch a module from the launch screen in the flyout.


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Reduce Home-page XAML materialization/layout work with a purpose-built module-row template, while retaining the existing SettingsCard control, commands, toggles, automation peer and virtualization. Quick Access keeps its original template.

In a matched x64 Release comparison, warm Home navigation-to-first-render median improved from **241.40 ms to 174.90 ms (27.5%)**. This is a scoped Home rendering improvement, not an overall Settings startup claim.

Related: #34026. Independent of the startup/activation work in #49891; this does not close the broader startup issue.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Communication:** Requested as an independently reviewable draft during the Settings audit.
- [ ] **Tests:** Home-row regression checklist updated; isolated rendering/behavior comparisons completed, but physical input, live high contrast and mixed-DPI scenarios remain pending.

Closes, localization, developer/API documentation, new binaries and external documentation updates: N/A. No new strings, dependencies or binaries.

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- `src\settings-ui\Settings.UI.Controls\ModuleList\ModuleList.xaml` and `ModuleList.xaml.cs`: add optional `ItemContainerStyle`. Apply it during `ItemsRepeater.ElementPrepared`, before first measure, rather than building the default template and replacing it afterward. Changing the style updates existing realized cards; clearing it restores implicit/default styling without realizing additional items.
- `src\settings-ui\Settings.UI\SettingsXAML\Views\DashboardPage.xaml`: opt Home into a scoped SettingsCard template. Remove the unused description subtree and general-purpose content/wrapping/spacing triggers, and replace instantaneous storyboard/keyframe objects with visual-state setters. Preserve row geometry, light/dark/high-contrast brush mappings, interactive states and the underlying SettingsCard/ButtonBase implementation.
- `src\settings-ui\Settings.UITests\SettingsTests.md`: add Home-row regression scenarios, including sorting, locked modules, row/toggle behavior, focus, themes, scaling and Quick Access isolation.

The template is derived from CommunityToolkit SettingsControls `8.2.251219` (source revision `a6b4dc451c0e54dd29f58743894a956100e7f713`). Toolkit-private resource keys are not available from the page, so the Home-scoped aliases use their corresponding public brushes.

**Risk: medium.** A specialized template must be kept aligned with future toolkit styling/input/accessibility changes. Scope is intentionally Home-only; no settings schemas, IPC, persistence, module activation or viewmodel lifecycle changes. Temporary measurement/fixture hooks are not included in the production diff.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

### Matched rendering comparison

| Metric | Original template | Home template | Reduction |
| --- | ---: | ---: | ---: |
| Warm first-render median | 241.40 ms | 174.90 ms | 27.5% |
| Warm first-render p95 | 265.87 ms | 189.37 ms | 28.8% |
| Median UI-thread CPU through first render | 234.38 ms | 156.25 ms | 33.3% |
| Realized module rows | 27 / 33 | 27 / 33 | Unchanged |
| Normal row visual nodes | 33 | 31 | 2 fewer |
| Home visual nodes | 1,410 | 1,356 | 54 fewer |

Protocol: same optimized x64 Release diagnostic binary, with the optional style cleared before row population for baseline and enabled for candidate; four fresh processes in baseline/candidate/candidate/baseline order; 20 warm Home visits per process, **40 samples per variant**, excluding first visits. Navigate to a minimal neutral page between visits. Fixed 1280 x 800 client pixels, XAML scale 1.0, light/LTR, identical synthetic settings and window placement. No UIA or visual-tree enumeration during timed samples. Baseline process medians were 242.06/241.01 ms; candidate medians were 174.12/177.97 ms.

Measurement source was `bb656da414e09808f6d25c98dca4313e7e37f828`; the branch was subsequently fast-forwarded over the unrelated PowerAccent change to `71340eed47f7cf6f53b68b86a7939ad1240c3de7` before publication. Timings end at the first `CompositionTarget.Rendering` callback after loading: **pre-present, not DWM presentation or physical input-to-screen latency**. Results apply to this workload/viewport, not every Settings page.

### Rendering and behavior parity

Content-validated in-process RenderTargetBitmap captures matched raw RGBA bytes exactly for all ten baseline/candidate pairs: light/dark Normal, PointerOver, Pressed and Disabled, plus light/dark RTL. Both the full captured XAML subtree and module-list region match. Initial valid Normal-light whole-window captures also matched. Blank broader HWND captures were rejected and replaced, not counted as evidence. XAML captures exclude the DWM backdrop and native captions.

Isolated baseline/candidate behavior checks each produced **12 passed, 0 failed, 3 unsupported**. Covered one model change per toggle with no row-command dispatch, distinct row/toggle focus stops, lock disabling only the toggle, programmatic status refresh suppressing user callbacks, stock-equivalent automation names, updating the same realized card on style change, and restoring the stock template on clear.

The detached RDP input desktop prevented physical click/keyboard validation. The stock peer also did not expose the expected WinRT Invoke-provider interface in this setup, so row-click dispatch is not claimed as a runtime pass. Live high contrast and mixed-DPI interaction remain manual checklist items; high-contrast resource correspondence was source-checked only.

### Normal build and isolation

Ordinary Settings x64 Release and Settings.UI.Controls ARM64 builds succeeded after all temporary profiling helpers/hooks were removed. ARM64 was compilation, not ARM64 hardware runtime coverage. The comparisons used synthetic settings with Runner actions suppressed and did not replace/stop the existing Settings or Runner instances. No committed automated UI-test suite was added; the isolated diagnostic comparisons and remaining manual scenarios are described above.