### PR TITLE
fix(settings-ui): reject empty normalized search queries

### DIFF
--- a/src/common/Common.Search/FuzzSearch/StringMatcher.cs
+++ b/src/common/Common.Search/FuzzSearch/StringMatcher.cs
@@ -29,7 +29,7 @@ public class StringMatcher
     {
         opt = opt ?? new MatchOption();
 
-        if (string.IsNullOrEmpty(stringToCompare))
+        if (string.IsNullOrEmpty(stringToCompare) || string.IsNullOrWhiteSpace(query))
         {
             return new MatchResult(false, SearchPrecisionScore.Regular);
         }

--- a/src/settings-ui/Settings.UI.UnitTests/Search/SearchIndexServiceTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/Search/SearchIndexServiceTests.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Threading;
+using Common.Search.FuzzSearch;
+using Microsoft.PowerToys.Settings.UI.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Settings.UI.Library;
+
+namespace Settings.UI.UnitTests.Search
+{
+    [TestClass]
+    [DoNotParallelize]
+    public class SearchIndexServiceTests
+    {
+        private ImmutableArray<SettingEntry> _originalIndex;
+        private FieldInfo _indexField;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            _indexField = typeof(SearchIndexService).GetField("_index", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.IsNotNull(_indexField);
+            _originalIndex = SearchIndexService.Index;
+
+            // Exercise a nonempty index without loading resources or populating the text/page caches.
+            _indexField.SetValue(null, ImmutableArray.Create(new SettingEntry { Description = "PowerToys settings" }));
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            _indexField.SetValue(null, _originalIndex);
+        }
+
+        [TestMethod]
+        [DataRow(null)]
+        [DataRow("")]
+        [DataRow(" \t\r\n")]
+        [DataRow("\u00A0\u2003\u3000")]
+        [DataRow("\u00A8")]
+        [DataRow("\u00A8\u00A8")]
+        [DataRow("\u0301\u0308")]
+        [DataRow(" \u0301 ")]
+        public void Search_EmptyOrWhitespaceAfterNormalization_ReturnsNoResults(string query)
+        {
+            Assert.AreEqual(1, SearchIndexService.Index.Length);
+            Assert.AreEqual(0, SearchIndexService.Search(query).Count);
+            Assert.AreEqual(0, SearchIndexService.Search(query, CancellationToken.None).Count);
+        }
+
+        [TestMethod]
+        [DataRow(null, "")]
+        [DataRow("", "")]
+        [DataRow("\u00A8", " ")]
+        [DataRow("\u00A8\u00A8", "  ")]
+        [DataRow("\u0301\u0308", "")]
+        [DataRow(" \u0301 ", "  ")]
+        [DataRow("\u00A0\u2003\u3000", "   ")]
+        public void NormalizeString_EmptyOrWhitespaceResult_DoesNotMatch(string query, string expected)
+        {
+            var normalized = SearchIndexService.NormalizeString(query);
+            var match = StringMatcher.FuzzyMatch(normalized, "PowerToys");
+
+            Assert.AreEqual(expected, normalized);
+            Assert.IsFalse(match.Success);
+            Assert.AreEqual(0, match.Score);
+        }
+
+        [TestMethod]
+        [DataRow("PowerToys", "powertoys")]
+        [DataRow("CAF\u00C9", "cafe")]
+        [DataRow("Cafe\u0301", "cafe")]
+        [DataRow("\uFF30\uFF4F\uFF57\uFF45\uFF52", "power")]
+        [DataRow("\u00A8PowerToys", " powertoys")]
+        public void NormalizeString_NonemptyQuery_PreservesMatching(string query, string expected)
+        {
+            var normalized = SearchIndexService.NormalizeString(query);
+            var match = StringMatcher.FuzzyMatch(normalized, expected.Trim());
+
+            Assert.AreEqual(expected, normalized);
+            Assert.IsTrue(match.Success);
+            Assert.IsTrue(match.Score > 0);
+        }
+    }
+}

--- a/src/settings-ui/Settings.UI.UnitTests/Search/StringMatcherTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/Search/StringMatcherTests.cs
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Common.Search.FuzzSearch;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Settings.UI.UnitTests.Search
+{
+    [TestClass]
+    public class StringMatcherTests
+    {
+        private static readonly int[] PrefixMatchData = [0, 1, 2, 3, 4];
+        private static readonly int[] MultiwordMatchData = [0, 1, 2, 5, 6, 7];
+
+        [TestMethod]
+        [DataRow(null)]
+        [DataRow("")]
+        [DataRow(" ")]
+        [DataRow("   ")]
+        [DataRow("\t")]
+        [DataRow("\r\n")]
+        [DataRow("\v\f")]
+        [DataRow("\u00A0")]
+        [DataRow("\u1680")]
+        [DataRow("\u2000\u2001\u2002\u2003\u2009")]
+        [DataRow("\u2028\u2029")]
+        [DataRow("\u202F")]
+        [DataRow("\u205F")]
+        [DataRow("\u3000")]
+        [DataRow("\t \u00A0\u3000\r\n")]
+        public void FuzzyMatch_EmptyOrWhitespaceQuery_ReturnsNoMatch(string query)
+        {
+            foreach (var ignoreCase in new[] { true, false })
+            {
+                var result = StringMatcher.FuzzyMatch(query, "PowerToys", new MatchOption { IgnoreCase = ignoreCase });
+
+                Assert.IsFalse(result.Success);
+                Assert.AreEqual(0, result.Score);
+                Assert.AreEqual(0, result.RawScore);
+                Assert.AreEqual(0, result.MatchData.Count);
+            }
+        }
+
+        [TestMethod]
+        [DataRow(null)]
+        [DataRow("")]
+        public void FuzzyMatch_EmptyCandidate_ReturnsNoMatch(string candidate)
+        {
+            var result = StringMatcher.FuzzyMatch("power", candidate);
+
+            Assert.IsFalse(result.Success);
+            Assert.AreEqual(0, result.Score);
+            Assert.AreEqual(0, result.MatchData.Count);
+        }
+
+        [TestMethod]
+        [DataRow("power")]
+        [DataRow("POWER")]
+        [DataRow(" power ")]
+        [DataRow("\tPOWER\r\n")]
+        [DataRow("\u00A0power\u3000")]
+        public void FuzzyMatch_NonemptyQuery_PreservesScoreAndHighlights(string query)
+        {
+            var result = StringMatcher.FuzzyMatch(query, "PowerToys");
+
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(157, result.Score);
+            CollectionAssert.AreEqual(PrefixMatchData, result.MatchData);
+        }
+
+        [TestMethod]
+        public void FuzzyMatch_ExactMatch_RanksAbovePrefix()
+        {
+            var exact = StringMatcher.FuzzyMatch("PowerToys", "PowerToys");
+            var prefix = StringMatcher.FuzzyMatch("PowerToys", "PowerToys Settings");
+
+            Assert.IsTrue(exact.Success);
+            Assert.IsTrue(prefix.Success);
+            Assert.AreEqual(190, exact.Score);
+            Assert.IsTrue(exact.Score > prefix.Score);
+        }
+
+        [TestMethod]
+        public void FuzzyMatch_MultiwordQuery_PreservesScoreAndHighlights()
+        {
+            var result = StringMatcher.FuzzyMatch("pow toy", "PowerToys");
+
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(154, result.Score);
+            CollectionAssert.AreEqual(MultiwordMatchData, result.MatchData);
+        }
+
+        [TestMethod]
+        public void FuzzyMatch_CaseSensitiveQuery_PreservesMatchOption()
+        {
+            var options = new MatchOption { IgnoreCase = false };
+
+            Assert.IsTrue(StringMatcher.FuzzyMatch("Power", "PowerToys", options).Success);
+            Assert.IsFalse(StringMatcher.FuzzyMatch("POWER", "PowerToys", options).Success);
+        }
+
+        [TestMethod]
+        public void FuzzyMatch_UnrelatedQuery_ReturnsNoMatch()
+        {
+            var result = StringMatcher.FuzzyMatch("unrelated", "PowerToys");
+
+            Assert.IsFalse(result.Success);
+            Assert.AreEqual(0, result.Score);
+        }
+    }
+}

--- a/src/settings-ui/Settings.UI/Services/SearchIndexService.cs
+++ b/src/settings-ui/Settings.UI/Services/SearchIndexService.cs
@@ -217,6 +217,11 @@ namespace Microsoft.PowerToys.Settings.UI.Services
             }
 
             var normalizedQuery = NormalizeString(query);
+            if (string.IsNullOrWhiteSpace(normalizedQuery))
+            {
+                return [];
+            }
+
             var bag = new ConcurrentBag<(SettingEntry Hit, double Score)>();
             var po = new ParallelOptions
             {
@@ -309,7 +314,7 @@ namespace Microsoft.PowerToys.Settings.UI.Services
             return (headerNorm, descNorm);
         }
 
-        private static string NormalizeString(string input)
+        internal static string NormalizeString(string input)
         {
             if (string.IsNullOrEmpty(input))
             {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Prevent Settings search from passing queries that normalize to empty or whitespace-only text into fuzzy matching, and make the shared matcher return its existing no-match result for whitespace-only queries.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Communication:** Scoped to the requested atomic Settings search-safety audit follow-up; submitted as a draft.
- [x] **Tests:** Added focused regression coverage; all 46 selected tests pass.
- [x] **Localization:** No new user-facing strings; normalization and existing localized search behavior are unchanged.

Issue closure, development/user documentation, and new-binary checklist items are N/A. No new projects, dependencies, binaries, or persisted settings changes.

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

**Trigger:** A query consisting of U+00A8 (spacing diaeresis) passes the initial whitespace check in `src\settings-ui\Settings.UI\Services\SearchIndexService.cs`. FormKD normalization decomposes it into U+0020 plus a combining mark; removing nonspacing marks leaves a single space. Previously, `src\common\Common.Search\FuzzSearch\StringMatcher.cs` checked only for null/empty input before trimming, then indexed the first element of an empty token array. With a populated search index, the resulting `IndexOutOfRangeException` can propagate through `Parallel.ForEach` to the live search handler, which catches cancellation only. This is a source/unit-test finding, not a claim of a reproduced live application crash.

The Settings service now returns no results after normalization when no searchable text remains. The shared matcher rejects null/empty/whitespace queries before its per-start-index matching loop, preventing empty trimmed/tokenized input from reaching the indexed access. Both use existing no-match behavior rather than adding an exception catch.

**Shared-caller risk:** Common.Search is also used by Shortcut Guide and the Command Palette PowerToys extension. Their existing blank-query handling remains unchanged, as do the matching algorithm, separators, scoring, highlighting, and case options for nonempty queries. No public API signature changes. `NormalizeString` becomes internal solely for direct coverage through the existing Settings test friend assembly.

Tests are in the existing `src\settings-ui\Settings.UI.UnitTests\Search\StringMatcherTests.cs` and `src\settings-ui\Settings.UI.UnitTests\Search\SearchIndexServiceTests.cs`; there is no standalone Common.Search test project on current main. The service fixture supplies a nonempty in-memory index, restores it afterward, and does not load Settings resources or change user settings.

This PR deliberately excludes expander-result filtering and prebuilt search-index generation/embedding changes. It does not auto-close the different search-crash reports #41817 or #47118.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Ran the repository first-build prerequisite `tools\build\build-essentials.cmd -Platform x64 -Configuration Release` after the fresh worktree reported missing NuGet assets; restore and essentials completed successfully.
- Built `Settings.UI.UnitTests` in Release x64 using `tools\build\build.ps1` with the worktree `SolutionDir`; exit code 0.
- Ran the existing Microsoft.Testing.Platform runner with `--filter "FullyQualifiedName~Settings.UI.UnitTests.Search" --minimum-expected-tests 46 --report-trx`: **46 passed, 0 failed, 0 skipped**.
- Covered null/empty/ASCII whitespace, Unicode spaces, U+00A8 compatibility normalization, combining-only queries, both Search overloads with a nonempty index, both case options, ordinary/padded/multiword queries, unchanged scores/highlights, exact-match ranking, and accented/fullwidth normalization.
- Did not launch or modify the installed/running PowerToys instance or user settings.