### PR TITLE
[Settings] Defer shortcut editor construction until first open

### DIFF
--- a/src/settings-ui/Settings.UI.UnitTests/Controls/ShortcutControlTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/Controls/ShortcutControlTests.cs
@@ -1,0 +1,380 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.WinUI;
+using CommunityToolkit.WinUI.Converters;
+using Microsoft.PowerToys.Settings.UI.Controls;
+using Microsoft.PowerToys.Settings.UI.Helpers;
+using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Markup;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using VirtualKey = Windows.System.VirtualKey;
+using XamlMetaDataProvider = Microsoft.PowerToys.Settings.UI.PowerToys_Settings_XamlTypeInfo.XamlMetaDataProvider;
+
+namespace Microsoft.PowerToys.Settings.UI.UnitTests.Controls
+{
+    [TestClass]
+    [DoNotParallelize]
+    public partial class ShortcutControlTests
+    {
+        private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+        private static readonly FieldInfo RepositoryField = typeof(SettingsRepository<GeneralSettings>).GetField("settingsRepository", BindingFlags.Static | BindingFlags.NonPublic);
+        private static DispatcherQueue dispatcher;
+        private static Thread uiThread;
+        private static object previousRepository;
+
+        [ClassInitialize]
+        public static async Task Initialize(TestContext context)
+        {
+            // Use an in-memory repository before the conflict helper is initialized.
+            // No Settings app, settings files, IPC connection or visible window is needed.
+            previousRepository = RepositoryField.GetValue(null);
+            var repository = (SettingsRepository<GeneralSettings>)Activator.CreateInstance(typeof(SettingsRepository<GeneralSettings>), nonPublic: true);
+            repository.SettingsConfig = new GeneralSettings();
+            RepositoryField.SetValue(null, repository);
+
+            var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            uiThread = new Thread(() =>
+            {
+                try
+                {
+                    // Initialize the referenced Settings runtime before calling into WinUI.
+                    RuntimeHelpers.RunModuleConstructor(typeof(ShortcutControl).Module.ModuleHandle);
+                    WinRT.ComWrappersSupport.InitializeComWrappers();
+                    Application.Start(initializationParameters =>
+                    {
+                        try
+                        {
+                            _ = new ShortcutTestApplication(ready);
+                            dispatcher = DispatcherQueue.GetForCurrentThread();
+                        }
+                        catch (Exception ex)
+                        {
+                            ready.SetException(ex);
+                        }
+                    });
+                }
+                catch (Exception ex)
+                {
+                    ready.TrySetException(ex);
+                }
+            });
+            uiThread.IsBackground = true;
+            uiThread.SetApartmentState(ApartmentState.STA);
+            uiThread.Start();
+            await ready.Task.WaitAsync(Timeout);
+        }
+
+        [ClassCleanup]
+        public static void Cleanup()
+        {
+            if (dispatcher != null)
+            {
+                Assert.IsTrue(dispatcher.TryEnqueue(() => Application.Current.Exit()));
+                Assert.IsTrue(uiThread.Join(Timeout), "The test XAML thread did not exit.");
+            }
+
+            RepositoryField.SetValue(null, previousRepository);
+        }
+
+        [TestMethod]
+        public Task SummaryAndReloadDoNotConstructEditor()
+        {
+            return RunOnUIThread(() =>
+            {
+                using var control = new ShortcutControl
+                {
+                    Enabled = true,
+                    AllowDisable = true,
+                    HotkeySettings = new HotkeySettings(true, false, false, false, 38),
+                };
+
+                var settings = control.HotkeySettings;
+                for (var i = 0; i < 3; i++)
+                {
+                    Invoke(control, "ShortcutControl_Loaded", control, null);
+                    settings.ConflictDescription = $"Conflict {i}";
+                    settings.HasConflict = true;
+                    Assert.AreEqual(settings.ConflictDescription, control.Tooltip);
+                    Assert.IsTrue(control.HasConflict);
+                    Assert.IsNull(Field<ShortcutDialogContentControl>(control, "c"));
+                    Assert.IsNull(Field<ContentDialog>(control, "shortcutDialog"));
+                    Invoke(control, "ShortcutControl_Unloaded", control, null);
+                    settings.HasConflict = false;
+                    Assert.IsTrue(control.HasConflict, "Unloaded controls should not observe settings changes.");
+                }
+
+                Invoke(control, "ShortcutControl_Loaded", control, null);
+                Assert.IsFalse(control.HasConflict, "Reload should refresh changes made while unloaded.");
+            });
+        }
+
+        [TestMethod]
+        public Task FirstOpenPrimesCurrentStateAndReusesEditor()
+        {
+            return RunOnUIThread(() =>
+            {
+                using var control = new ShortcutControl
+                {
+                    AllowDisable = true,
+                    HotkeySettings = new HotkeySettings(false, true, true, false, 38)
+                    {
+                        HasConflict = true,
+                        ConflictDescription = "A conflicting shortcut",
+                    },
+                    IgnoreConflict = true,
+                    RequestedTheme = ElementTheme.Dark,
+                };
+
+                Invoke(control, "PrepareEditor");
+                var content = Field<ShortcutDialogContentControl>(control, "c");
+                var dialog = Field<ContentDialog>(control, "shortcutDialog");
+                Assert.AreSame(content, dialog.Content);
+                CollectionAssert.AreEqual(control.HotkeySettings.GetKeysList(), content.Keys);
+                Assert.IsTrue(content.HasConflict);
+                Assert.IsTrue(content.IgnoreConflict);
+                Assert.AreEqual(control.HotkeySettings.ConflictDescription, content.ConflictMessage);
+                Assert.IsTrue(content.IsWarningAltGr);
+                Assert.AreEqual(control.ActualTheme, dialog.RequestedTheme);
+                Assert.AreSame(control.HotkeySettings, Field<HotkeySettings>(control, "lastValidSettings"));
+                Assert.AreEqual(
+                    ResourceLoaderInstance.ResourceLoader.GetString("Activation_Shortcut_With_Disable_Description"),
+                    content.FindDescendant<TextBlock>().Text);
+
+                // Discard a partially entered chord and use updated settings on reopening.
+                Field<HotkeySettings>(control, "internalSettings").Ctrl = true;
+                control.HotkeySettings = new HotkeySettings(true, false, false, false, 40);
+                control.AllowDisable = false;
+                control.RequestedTheme = ElementTheme.Light;
+                Invoke(control, "PrepareEditor");
+                Assert.AreSame(content, Field<ShortcutDialogContentControl>(control, "c"));
+                Assert.AreSame(dialog, Field<ContentDialog>(control, "shortcutDialog"));
+                Assert.IsTrue(Field<HotkeySettings>(control, "internalSettings").IsEmpty());
+                Assert.AreSame(control.HotkeySettings, Field<HotkeySettings>(control, "lastValidSettings"));
+                CollectionAssert.AreEqual(control.HotkeySettings.GetKeysList(), content.Keys);
+                Assert.IsFalse(content.HasConflict);
+                Assert.IsFalse(content.IsWarningAltGr);
+                Assert.AreEqual(control.ActualTheme, dialog.RequestedTheme);
+                Assert.AreEqual(
+                    ResourceLoaderInstance.ResourceLoader.GetString("Activation_Shortcut_Description"),
+                    content.FindDescendant<TextBlock>().Text);
+            });
+        }
+
+        [TestMethod]
+        public Task EditorHandlersSurviveReloadWithoutDuplicates()
+        {
+            return RunOnUIThread(() =>
+            {
+                using var control = new ShortcutControl();
+                Invoke(control, "PrepareEditor");
+                var content = Field<ShortcutDialogContentControl>(control, "c");
+
+                for (var i = 0; i < 3; i++)
+                {
+                    Invoke(control, "ShortcutControl_Loaded", control, null);
+                    Invoke(control, "ShortcutControl_Unloaded", control, null);
+                    Invoke(control, "PrepareEditor");
+
+                    Assert.AreEqual(1, Field<Delegate>(content, "ResetClick").GetInvocationList().Length);
+                    Assert.AreEqual(1, Field<Delegate>(content, "ClearClick").GetInvocationList().Length);
+                    Assert.AreEqual(1, Field<Delegate>(content, "LearnMoreClick").GetInvocationList().Length);
+                }
+            });
+        }
+
+        [TestMethod]
+        public Task EmptyAndMissingShortcutsCanPrimeEditor()
+        {
+            return RunOnUIThread(() =>
+            {
+                using var control = new ShortcutControl();
+                Invoke(control, "PrepareEditor");
+                var content = Field<ShortcutDialogContentControl>(control, "c");
+                Assert.AreEqual(0, content.Keys.Count);
+                Assert.IsFalse(content.IsWarningAltGr);
+                Assert.IsFalse(content.HasConflict);
+                Invoke(control, "ShortcutDialog_Opened", null, null);
+                Assert.IsFalse(Field<ContentDialog>(control, "shortcutDialog").IsPrimaryButtonEnabled);
+                Invoke(control, "ShortcutDialog_Closing", null, null);
+
+                control.HotkeySettings = new HotkeySettings();
+                Invoke(control, "PrepareEditor");
+                Assert.AreEqual(0, content.Keys.Count);
+                Assert.AreSame(control.HotkeySettings, Field<HotkeySettings>(control, "lastValidSettings"));
+                Invoke(control, "ShortcutDialog_Opened", null, null);
+                Assert.IsTrue(Field<ContentDialog>(control, "shortcutDialog").IsPrimaryButtonEnabled);
+                Assert.IsFalse(content.IsError);
+                Invoke(control, "ShortcutDialog_Closing", null, null);
+            });
+        }
+
+        [TestMethod]
+        [DataRow(false, true, true)]
+        [DataRow(true, true, false)]
+        [DataRow(false, false, false)]
+        public Task ModifierCaptureAndAltGrWarningWorkAfterLazyCreation(bool win, bool alt, bool warning)
+        {
+            return RunOnUIThread(() =>
+            {
+                using var control = new ShortcutControl
+                {
+                    HotkeySettings = new HotkeySettings(win, true, alt, false, (int)VirtualKey.Up),
+                };
+                Invoke(control, "PrepareEditor");
+                var content = Field<ShortcutDialogContentControl>(control, "c");
+                Invoke(control, "Hotkey_KeyDown", (int)VirtualKey.Control);
+                if (win)
+                {
+                    Invoke(control, "Hotkey_KeyDown", (int)VirtualKey.LeftWindows);
+                }
+
+                if (alt)
+                {
+                    Invoke(control, "Hotkey_KeyDown", (int)VirtualKey.Menu);
+                }
+
+                Invoke(control, "Hotkey_KeyDown", (int)VirtualKey.Up);
+                Assert.AreEqual(warning, content.IsWarningAltGr);
+                Assert.IsFalse(content.IsError);
+                Assert.IsTrue(Field<ContentDialog>(control, "shortcutDialog").IsPrimaryButtonEnabled);
+                CollectionAssert.AreEqual(control.HotkeySettings.GetKeysList(), content.Keys);
+
+                Invoke(control, "Hotkey_KeyUp", (int)VirtualKey.Up);
+                Invoke(control, "Hotkey_KeyUp", (int)VirtualKey.Control);
+                Invoke(control, "Hotkey_KeyUp", (int)VirtualKey.Menu);
+                Invoke(control, "Hotkey_KeyUp", (int)VirtualKey.LeftWindows);
+                Assert.IsTrue(Field<HotkeySettings>(control, "internalSettings").IsEmpty());
+            });
+        }
+
+        [TestMethod]
+        public Task ReopeningDiscardsCancelledInputAndSavesCurrentShortcut()
+        {
+            return RunOnUIThread(() =>
+            {
+                using var control = new ShortcutControl
+                {
+                    HotkeySettings = new HotkeySettings(true, false, false, false, 38),
+                };
+                Invoke(control, "PrepareEditor");
+                var original = control.HotkeySettings;
+                typeof(ShortcutControl).GetField("lastValidSettings", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .SetValue(control, new HotkeySettings(false, true, false, false, 40));
+                Invoke(control, "ShortcutDialog_Closing", null, null);
+                Assert.AreSame(original, control.HotkeySettings);
+
+                control.HotkeySettings = new HotkeySettings(false, false, true, false, 37);
+                var updated = control.HotkeySettings.GetKeysList();
+                Invoke(control, "PrepareEditor");
+                Invoke(control, "ShortcutDialog_Opened", null, null);
+                Assert.IsTrue(Field<ContentDialog>(control, "shortcutDialog").IsPrimaryButtonEnabled);
+                Invoke(control, "ShortcutDialog_PrimaryButtonClick", null, null);
+                Invoke(control, "ShortcutDialog_Closing", null, null);
+                CollectionAssert.AreEqual(updated, control.HotkeySettings.GetKeysList());
+            });
+        }
+
+        [TestMethod]
+        [DataRow("C_ResetClick")]
+        [DataRow("C_ClearClick")]
+        public Task ResetAndClearKeepObservingTheReplacementSettings(string handler)
+        {
+            return RunOnUIThread(() =>
+            {
+                using var control = new ShortcutControl
+                {
+                    HotkeySettings = new HotkeySettings(true, false, false, false, 38),
+                };
+                var previous = control.HotkeySettings;
+                Invoke(control, "PrepareEditor");
+                Invoke(control, handler, null, null);
+                Assert.IsTrue(control.HotkeySettings.IsEmpty());
+
+                previous.HasConflict = true;
+                Assert.IsFalse(control.HasConflict);
+                control.HotkeySettings.HasConflict = true;
+                Assert.IsTrue(control.HasConflict);
+            });
+        }
+
+        private static async Task RunOnUIThread(Action action)
+        {
+            var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            Assert.IsTrue(dispatcher.TryEnqueue(() =>
+            {
+                try
+                {
+                    action();
+                    completion.SetResult();
+                }
+                catch (Exception ex)
+                {
+                    completion.SetException(ex);
+                }
+            }));
+            await completion.Task.WaitAsync(Timeout);
+        }
+
+        private static T Field<T>(object instance, string name)
+        {
+            return (T)instance.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic).GetValue(instance);
+        }
+
+        private static void Invoke(object instance, string name, params object[] arguments)
+        {
+            instance.GetType().GetMethod(name, BindingFlags.Instance | BindingFlags.NonPublic).Invoke(instance, arguments);
+        }
+
+        private sealed partial class ShortcutTestApplication : Application, IXamlMetadataProvider
+        {
+            private readonly XamlMetaDataProvider metadata = new XamlMetaDataProvider();
+            private readonly TaskCompletionSource ready;
+
+            public ShortcutTestApplication(TaskCompletionSource ready)
+            {
+                this.ready = ready;
+            }
+
+            protected override void OnLaunched(LaunchActivatedEventArgs args)
+            {
+                try
+                {
+                    InitializeResources();
+                    ready.SetResult();
+                }
+                catch (Exception ex)
+                {
+                    ready.SetException(new InvalidOperationException($"Test XAML initialization failed (0x{ex.HResult:X8}).", ex));
+                }
+            }
+
+            private void InitializeResources()
+            {
+                Resources = new ResourceDictionary();
+                Resources.MergedDictionaries.Add(new XamlControlsResources());
+                Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("ms-appx:///PowerToys.Common.UI.Controls/Controls/KeyVisual/KeyVisual.xaml") });
+                Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("ms-appx:///PowerToys.Common.UI.Controls/Controls/KeyVisual/KeyCharPresenter.xaml") });
+                Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("ms-appx:///PowerToys.Common.UI.Controls/Controls/IsEnabledTextBlock/IsEnabledTextBlock.xaml") });
+                Resources["SettingActionControlMinWidth"] = 240.0;
+                Resources["DoubleToVisibilityConverter"] = new DoubleToVisibilityConverter { GreaterThan = 0, TrueValue = Visibility.Visible, FalseValue = Visibility.Collapsed };
+                Resources["DoubleToInvertedVisibilityConverter"] = new DoubleToVisibilityConverter { GreaterThan = 0, TrueValue = Visibility.Collapsed, FalseValue = Visibility.Visible };
+            }
+
+            public IXamlType GetXamlType(Type type) => metadata.GetXamlType(type);
+
+            public IXamlType GetXamlType(string fullName) => metadata.GetXamlType(fullName);
+
+            public XmlnsDefinition[] GetXmlnsDefinitions() => metadata.GetXmlnsDefinitions();
+        }
+    }
+}

--- a/src/settings-ui/Settings.UI.UnitTests/Settings.UI.UnitTests.csproj
+++ b/src/settings-ui/Settings.UI.UnitTests/Settings.UI.UnitTests.csproj
@@ -4,6 +4,10 @@
 
   <PropertyGroup>
     <SelfContained>true</SelfContained>
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <WindowsPackageType>None</WindowsPackageType>
+    <!-- Reuse Settings' SDK initializer instead of generating duplicate internal types. -->
+    <WindowsAppSdkUndockedRegFreeWinRTInitialize>false</WindowsAppSdkUndockedRegFreeWinRTInitialize>
     <RuntimeIdentifier Condition="'$(Platform)' == 'x64'">win-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(Platform)' == 'ARM64'">win-arm64</RuntimeIdentifier>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Controls/ShortcutControl/ShortcutControl.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Controls/ShortcutControl/ShortcutControl.xaml.cs
@@ -40,6 +40,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
         private HotkeySettings internalSettings;
         private HotkeySettings lastValidSettings;
         private HotkeySettingsControlHook hook;
+        private Window settingsWindow;
         private bool _isActive;
         private bool disposedValue;
 
@@ -77,9 +78,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
                 return;
             }
 
-            var newValue = (bool)(e?.NewValue ?? false);
-
-            var text = newValue ? resourceLoader.GetString("Activation_Shortcut_With_Disable_Description") : resourceLoader.GetString("Activation_Shortcut_Description");
+            var text = me.AllowDisable ? resourceLoader.GetString("Activation_Shortcut_With_Disable_Description") : resourceLoader.GetString("Activation_Shortcut_Description");
             description.Text = text;
         }
 
@@ -146,7 +145,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             control.UpdateTooltip();
         }
 
-        private ShortcutDialogContentControl c = new ShortcutDialogContentControl();
+        private ShortcutDialogContentControl c;
         private ContentDialog shortcutDialog;
 
         public bool AllowDisable
@@ -238,7 +237,10 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
                     }
 
                     SetKeys();
-                    c.Keys = HotkeySettings?.GetKeysList();
+                    if (c != null)
+                    {
+                        c.Keys = HotkeySettings?.GetKeysList();
+                    }
                 }
             }
         }
@@ -277,23 +279,38 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             this.Unloaded += ShortcutControl_Unloaded;
             this.Loaded += ShortcutControl_Loaded;
 
-            c.ResetClick += C_ResetClick;
-            c.ClearClick += C_ClearClick;
-            c.LearnMoreClick += C_LearnMoreClick;
+            AutomationProperties.SetName(EditButton, resourceLoader.GetString("Activation_Shortcut_Title"));
+        }
+
+        private void EnsureEditor()
+        {
+            if (shortcutDialog != null)
+            {
+                return;
+            }
 
             // We create the Dialog in C# because doing it in XAML is giving WinUI/XAML Island bugs when using dark theme.
-            shortcutDialog = new ContentDialog
+            var content = new ShortcutDialogContentControl();
+            var dialog = new ContentDialog
             {
-                XamlRoot = this.XamlRoot,
                 Title = resourceLoader.GetString("Activation_Shortcut_Title"),
-                Content = c,
+                Content = content,
                 PrimaryButtonText = resourceLoader.GetString("Activation_Shortcut_Save"),
                 CloseButtonText = resourceLoader.GetString("Activation_Shortcut_Cancel"),
                 DefaultButton = ContentDialogButton.Primary,
             };
-            shortcutDialog.RightTapped += ShortcutDialog_Disable;
 
-            AutomationProperties.SetName(EditButton, resourceLoader.GetString("Activation_Shortcut_Title"));
+            c = content;
+            shortcutDialog = dialog;
+
+            // These handlers belong to the editor's lifetime, not the control's Loaded/Unloaded cycles.
+            c.ResetClick += C_ResetClick;
+            c.ClearClick += C_ClearClick;
+            c.LearnMoreClick += C_LearnMoreClick;
+            shortcutDialog.RightTapped += ShortcutDialog_Disable;
+            shortcutDialog.PrimaryButtonClick += ShortcutDialog_PrimaryButtonClick;
+            shortcutDialog.Opened += ShortcutDialog_Opened;
+            shortcutDialog.Closing += ShortcutDialog_Closing;
 
             OnAllowDisableChanged(this, null);
         }
@@ -331,15 +348,13 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
 
         private void ShortcutControl_Unloaded(object sender, RoutedEventArgs e)
         {
-            shortcutDialog.PrimaryButtonClick -= ShortcutDialog_PrimaryButtonClick;
-            shortcutDialog.Opened -= ShortcutDialog_Opened;
-            shortcutDialog.Closing -= ShortcutDialog_Closing;
+            shortcutDialog?.Hide();
+            _isActive = false;
 
-            c.LearnMoreClick -= C_LearnMoreClick;
-
-            if (App.GetSettingsWindow() != null)
+            if (settingsWindow != null)
             {
-                App.GetSettingsWindow().Activated -= ShortcutDialog_SettingsWindow_Activated;
+                settingsWindow.Activated -= ShortcutDialog_SettingsWindow_Activated;
+                settingsWindow = null;
             }
 
             // Unsubscribe from HotkeySettings property changes
@@ -361,13 +376,22 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
 
             hook = new HotkeySettingsControlHook(Hotkey_KeyDown, Hotkey_KeyUp, Hotkey_IsActive, FilterAccessibleKeyboardEvents);
 
-            shortcutDialog.PrimaryButtonClick += ShortcutDialog_PrimaryButtonClick;
-            shortcutDialog.Opened += ShortcutDialog_Opened;
-            shortcutDialog.Closing += ShortcutDialog_Closing;
-
-            if (App.GetSettingsWindow() != null)
+            if (hotkeySettings != null)
             {
-                App.GetSettingsWindow().Activated += ShortcutDialog_SettingsWindow_Activated;
+                hotkeySettings.PropertyChanged -= OnHotkeySettingsPropertyChanged;
+                hotkeySettings.PropertyChanged += OnHotkeySettingsPropertyChanged;
+                UpdateConflictStatusFromHotkeySettings();
+            }
+
+            if (settingsWindow != null)
+            {
+                settingsWindow.Activated -= ShortcutDialog_SettingsWindow_Activated;
+            }
+
+            settingsWindow = App.GetSettingsWindow();
+            if (settingsWindow != null)
+            {
+                settingsWindow.Activated += ShortcutDialog_SettingsWindow_Activated;
             }
 
             // Initialize tooltip when loaded
@@ -682,19 +706,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             _isDialogOpen = true;
             try
             {
-                c.Keys = null;
-                c.Keys = HotkeySettings?.GetKeysList() ?? new List<object>();
-
-                c.IgnoreConflict = IgnoreConflict;
-                c.HasConflict = hotkeySettings?.HasConflict ?? false;
-                c.ConflictMessage = hotkeySettings?.ConflictDescription;
-
-                // 92 means the Win key. The logic is: warning should be visible if the shortcut contains Alt AND contains Ctrl AND NOT contains Win.
-                // Additional key must be present, as this is a valid, previously used shortcut shown at dialog open. Check for presence of non-modifier-key is not necessary therefore
-                c.IsWarningAltGr = c.Keys.Contains("Ctrl") && c.Keys.Contains("Alt") && !c.Keys.Contains(92);
-
-                shortcutDialog.XamlRoot = this.XamlRoot;
-                shortcutDialog.RequestedTheme = this.ActualTheme;
+                PrepareEditor();
                 await shortcutDialog.ShowAsync();
             }
             catch (Exception ex)
@@ -707,6 +719,25 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             }
         }
 
+        private void PrepareEditor()
+        {
+            EnsureEditor();
+
+            internalSettings = new HotkeySettings();
+            lastValidSettings = hotkeySettings;
+            c.Keys = null;
+            c.Keys = HotkeySettings?.GetKeysList() ?? new List<object>();
+            c.IgnoreConflict = IgnoreConflict;
+            c.HasConflict = hotkeySettings?.HasConflict ?? false;
+            c.ConflictMessage = hotkeySettings?.ConflictDescription;
+
+            // 92 means the Win key. Warn for Ctrl+Alt shortcuts without Win.
+            c.IsWarningAltGr = c.Keys.Contains("Ctrl") && c.Keys.Contains("Alt") && !c.Keys.Contains(92);
+
+            shortcutDialog.XamlRoot = this.XamlRoot;
+            shortcutDialog.RequestedTheme = this.ActualTheme;
+        }
+
         private void C_ResetClick(object sender, RoutedEventArgs e)
         {
             // Use an empty HotkeySettings instead of null to avoid a native E_POINTER
@@ -715,10 +746,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             // dereference a null pointer during property-change notification.
             // An empty HotkeySettings (IsEmpty()==true) signals "no shortcut" without
             // breaking the binding chain.
-            hotkeySettings = new HotkeySettings();
-
-            SetValue(HotkeySettingsProperty, hotkeySettings);
-            SetKeys();
+            HotkeySettings = new HotkeySettings();
 
             lastValidSettings = hotkeySettings;
             shortcutDialog.Hide();
@@ -729,10 +757,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
 
         private void C_ClearClick(object sender, RoutedEventArgs e)
         {
-            hotkeySettings = new HotkeySettings();
-
-            SetValue(HotkeySettingsProperty, hotkeySettings);
-            SetKeys();
+            HotkeySettings = new HotkeySettings();
 
             lastValidSettings = hotkeySettings;
             shortcutDialog.Hide();
@@ -818,12 +843,9 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             {
                 if (disposing)
                 {
-                    if (hook != null)
-                    {
-                        hook.Dispose();
-                    }
-
-                    hook = null;
+                    ShortcutControl_Unloaded(this, null);
+                    this.Loaded -= ShortcutControl_Loaded;
+                    this.Unloaded -= ShortcutControl_Unloaded;
                 }
 
                 disposedValue = true;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Defer the shared Settings shortcut editor's `ShortcutDialogContentControl` and `ContentDialog` until the user first opens the editor. Displaying or updating a shortcut summary, including repeated Loaded/Unloaded cycles, no longer constructs the hidden editor.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: N/A - scoped follow-up to the Settings app performance audit.
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [x] **Communication:** Requested as an independent draft PR in the Settings audit-fix batch.
- [x] **Tests:** Added 10 lifecycle/state cases; all pass together with 42 existing related viewmodel tests.
- [x] **Localization:** No new end-user-facing strings; existing localized editor strings are reused.
- [x] **Dev docs:** N/A - no public interface or developer workflow changes.
- [x] **New binaries:** N/A - no new binaries.
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries - N/A
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder - N/A
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects - N/A
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml) - N/A
- [ ] **Documentation updated:** N/A - no user-facing configuration changes.

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

`src/settings-ui/Settings.UI/SettingsXAML/Controls/ShortcutControl/ShortcutControl.xaml.cs`:

- Creates both editor objects in one idempotent `EnsureEditor` method, invoked by the first-open preparation path.
- Primes current shortcut keys, conflict state, AltGr warning, XamlRoot, theme and the current save candidate on every open. Summary updates only touch editor content if it already exists.
- Applies the latest `AllowDisable` description when the deferred content is created.
- Gives editor-owned handlers the same lifetime as the reusable dialog, preserving Learn More after reload. The previous Unloaded path removed its handler permanently.
- Reattaches hotkey property notifications and refreshes conflict state after reload. Reset and Clear use the existing HotkeySettings setter so replacement settings keep the same notification wiring.
- Detaches window activation from the exact subscribed window; unload/dispose hides an existing dialog, deactivates capture and disposes the hook without creating editor UI.

`src/settings-ui/Settings.UI.UnitTests/Controls/ShortcutControlTests.cs` adds in-process XAML lifecycle/state coverage using the existing MSTest project. It does not instantiate the Settings application, connect to Runner, display a window, or use real-user settings.

`src/settings-ui/Settings.UI.UnitTests/Settings.UI.UnitTests.csproj` stages the existing Windows App SDK as self-contained and unpackaged for that in-process XAML host. It disables generation of the duplicate UndockedRegFreeWinRT initializer; the fixture explicitly runs the referenced Settings module's existing initializer before starting WinUI. No new package, warning suppression, project, output path, or platform/RID changes are introduced. The existing x64/ARM64 runtime-identifier selection is retained. The mixed test invocation below covers compatibility with existing non-UI tests; ARM64 build/runtime and CI artifact staging were not exercised locally.

**Deferral mechanism:** [`x:Load="False"` supersedes `x:DeferLoadStrategy="Lazy"`](https://learn.microsoft.com/windows/apps/develop/platform/xaml/x-deferloadstrategy-attribute) and additionally supports unloading. Both apply to XAML-created elements, not these C# constructors. Moving this dialog to markup would also abandon the existing dark-theme/XAML-island workaround. Resolving deferred names/content immediately from ordinary setters would defeat markup deferral. This change therefore uses actual C# lazy construction and keeps XAML unchanged; it does not assume deferral automatically improves whole-page latency.

**Performance scope:** The prior diagnostic Release A/B at `bb656da414` avoided eight hidden editor bodies on Advanced Paste and reduced the measured XAML initialization interval from 86.84 ms to 54.66 ms. That was a diagnostic experiment, not a measurement of this production patch, and did not establish a whole-page first-render improvement. This PR makes no end-to-end speedup claim.

**Risk/scope:** The shared control affects all Settings shortcut editors, so first-open, reopen and virtualization lifecycle behavior are the principal risks. Existing keyboard capture, accessibility filtering and modifier/AltGr handling are retained. No changes to Advanced Paste provider dialogs, Home rows, settings/IPC schemas, GPO, elevation, installers or dependencies.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Built Settings and the existing unit-test project in x64 Release through the affected graph:
  `tools\build\build.ps1 -Platform x64 -Configuration Release -Path src\settings-ui\Settings.UI.UnitTests /m:2` (exit 0).
- Restored missing fresh-worktree dependencies through the same script using `/t:Restore /p:RestorePackagesConfig=true /p:RestoreRepositoryPath=<worktree>\packages`, plus a targeted restore of `src\settings-ui\Settings.UI.XamlIndexBuilder`. No full-product build was required.
- Rebuilt the final test-host changes against the already-built product:
  `tools\build\build.ps1 -Platform x64 -Configuration Release -Path src\settings-ui\Settings.UI.UnitTests /m:2 /p:BuildProjectReferences=false` (exit 0).
- Ran the existing MSTest executable:
  `Release\x64\tests\SettingsTests\net10.0-windows10.0.26100.0\Settings.UI.UnitTests.exe --filter "FullyQualifiedName~ShortcutControlTests|FullyQualifiedName~ViewModelTests.ShortcutGuide|FullyQualifiedName~ViewModelTests.FancyZones" --report-trx`
  **52 passed, 0 failed, 0 skipped**. This includes 10 new cases for no construction while displaying/reloading summaries, latest state/description/theme on first open and reuse, empty/missing hotkeys, handler lifetime, modifier/AltGr capture logic, cancel/reopen/save, and Reset/Clear replacement subscriptions.
- Reviewed the patch and verified no editor construction occurs in the constructor, summary setters or Loaded/Unloaded paths.
- **Limits:** These tests drive actual WinUI controls and their lifecycle/input handlers in-process, not a visible modal dialog. They do not establish physical keyboard-hook, UIA/screen-reader, real XamlRoot/window migration, interactive Learn More navigation, Runner IPC, or end-to-end performance results. Installed Settings/Runner processes and real-user settings were not modified. ARM64 and the full Settings unit/UI suites were not run.