### PR TITLE
[PowerToys Run] Log successfully launched programs

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Main.cs
@@ -15,6 +15,7 @@ using Microsoft.Plugin.Program.Storage;
 using Wox.Infrastructure.Storage;
 using Wox.Plugin;
 using Wox.Plugin.Common;
+using Wox.Plugin.Logger;
 
 using Stopwatch = Wox.Infrastructure.Stopwatch;
 
@@ -183,6 +184,7 @@ namespace Microsoft.Plugin.Program
                 ArgumentNullException.ThrowIfNull(info);
 
                 runProcess(info);
+                Log.Info($"Launched program: {info.FileName}", typeof(Main));
             }
             catch (Exception ex)
             {

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWPApplication.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWPApplication.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Plugin.Program.Programs
                                 var info = ShellCommand.SetProcessStartInfo(command, verb: "runas");
                                 info.UseShellExecute = true;
                                 info.Arguments = queryArguments;
-                                Process.Start(info);
+                                Main.StartProcess(Process.Start, info);
                                 return true;
                             },
                         });
@@ -212,6 +212,7 @@ namespace Microsoft.Plugin.Program.Programs
                 try
                 {
                     appManager.ActivateApplication(UserModelId, queryArguments, noFlags, out var unusedPid);
+                    Log.Info($"Launched program: {DisplayName} ({UserModelId})", GetType());
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Summary of the Pull Request

Adds an informational audit log entry when the Program plugin successfully launches an application.

The change:

* logs the executable/target path after successful Win32 and shortcut launches;
* logs the display name and AppUserModelId after successful packaged-app activation;
* routes elevated packaged-app launches through the existing `Main.StartProcess` path so they receive the same success/failure handling and audit logging;
* intentionally does **not** log command-line arguments, since they may contain sensitive values.

## PR Checklist

* [x] Closes: #35627
* [x] **Communication:** The issue is labeled Help Wanted / Cost-Small, and a maintainer scoped the requested solution to adding an audit log for the Program plugin.
* [ ] **Tests:** A local PowerToys build could not be run because the available Windows environment does not have the required Visual Studio/.NET build toolchain on PATH. CI is expected to provide the full compile/test validation.
* [x] **Localization:** No end-user-facing strings were added.
* [x] **Dev docs:** No developer documentation changes are required.
* [x] **New binaries:** No new binaries are added.
* [ ] **Documentation updated:** Not applicable; this is internal logging behavior.

## Detailed Description of the Pull Request / Additional comments

`Microsoft.Plugin.Program.Main.StartProcess` is the common execution path for Win32 programs and shortcuts. The log entry is emitted only after the process launcher returns successfully, so failed launches continue to use the existing exception logging and user-facing error handling.

Packaged/UWP apps use `ApplicationActivationManager` rather than `Main.StartProcess`, so their successful activation is logged separately. The elevated packaged-app context action now uses `Main.StartProcess` instead of calling `Process.Start` directly, keeping launch auditing and failure handling consistent.

Only the launched target identity is recorded. Query and command arguments are deliberately omitted from the audit log.

## Validation Steps Performed

* Confirmed the Program plugin's Win32/shortcut result actions and elevated context actions converge on `Main.StartProcess`.
* Confirmed packaged/UWP normal activation bypasses `Main.StartProcess` and therefore needs its own success log entry.
* Confirmed no command-line arguments are included in the new log messages.
* Reviewed the fork diff against current `main`: 2 files changed, 4 additions and 1 deletion.
* Local compile/tests were not run because the available Windows environment lacks the required PowerToys Visual Studio/.NET build toolchain.
