### PR TITLE
feat: Add Microsoft DSC FancyZonesLayouts resource

### DIFF
--- a/.pipelines/generateDscManifests.ps1
+++ b/.pipelines/generateDscManifests.ps1
@@ -77,7 +77,7 @@ Write-Host "DSC manifests will be generated to: '$dscOutputDir'"
 Write-Host "Cleaning previously generated DSC manifest files from '$dscOutputDir'."
 Get-ChildItem -Path $dscOutputDir -Filter 'microsoft.powertoys.*.dsc.resource.json' -ErrorAction SilentlyContinue | Remove-Item -Force
 
-foreach ($resource in @('settings', 'profile')) {
+foreach ($resource in @('settings', 'profile', 'layouts')) {
     $arguments = @('manifest', '--resource', $resource, '--outputDir', $dscOutputDir)
     Write-Host "Invoking DSC manifest generator: '$exePath' $($arguments -join ' ')"
     & $exePath @arguments

--- a/doc/devdocs/core/settings/dsc-configure.md
+++ b/doc/devdocs/core/settings/dsc-configure.md
@@ -1,6 +1,6 @@
 # What is it
 
-> **Note:** This document describes the legacy PowerShell-based `PowerToysConfigure` DSC resource. PowerToys also ships a DSC v3 implementation, `PowerToys.DSC.exe` (`src\dsc\v3\PowerToys.DSC`), which exposes a `settings` resource for whole-module settings and a `profile` resource for the Keyboard Manager remapping profile. See `doc\dsc\overview.md` and `doc\dsc\profile-resource.md`.
+> **Note:** This document describes the legacy PowerShell-based `PowerToysConfigure` DSC resource. PowerToys also ships a DSC v3 implementation, `PowerToys.DSC.exe` (`src\dsc\v3\PowerToys.DSC`), which exposes a `settings` resource for whole-module settings, a `profile` resource for the Keyboard Manager remapping profile and a `layouts` resource for the FancyZones layout files. See `doc\dsc\overview.md`, `doc\dsc\profile-resource.md` and `doc\dsc\layouts-resource.md`.
 
 We would like to enable our users to use [`winget configure`](https://learn.microsoft.com/en-us/windows/package-manager/winget/configure) command to install PowerToys and configure its settings with a [WinGet configuration file](https://learn.microsoft.com/en-us/windows/package-manager/configuration/create). For example:
 

--- a/doc/dsc/layouts-resource.md
+++ b/doc/dsc/layouts-resource.md
@@ -1,0 +1,335 @@
+---
+description: Reference for the PowerToys FancyZones layouts DSC resource
+ms.date:     09/12/2026
+ms.topic:    reference
+title:       FancyZones Layouts Resource
+---
+
+# FancyZones Layouts Resource
+
+## Synopsis
+
+Manages the FancyZones layouts — custom layouts, layout templates, quick
+layout hotkeys and default layouts — declaratively through DSC v3.
+
+## Description
+
+The `layouts` resource deploys the FancyZones layout data. While the
+[`settings` resource][01] manages the module's settings (for FancyZones: the
+enabled state and behavior options such as zone colors and activation keys),
+the `layouts` resource manages the layouts themselves, which FancyZones stores
+in separate files in `%LOCALAPPDATA%\Microsoft\PowerToys\FancyZones\`:
+
+| Section     | File                    | Content                                                    |
+| ----------- | ----------------------- | ---------------------------------------------------------- |
+| `custom`    | `custom-layouts.json`   | The custom layouts created in the editor (canvas or grid). |
+| `templates` | `layout-templates.json` | The settings of the built-in layout templates.             |
+| `hotkeys`   | `layout-hotkeys.json`   | The quick layout hotkeys (`Win+Ctrl+Alt+<number>`).        |
+| `defaults`  | `default-layouts.json`  | The layouts applied to new horizontal and vertical monitors. |
+
+Layouts are written with friendly, camel-cased property names and layout
+identifiers may be given with or without braces:
+
+```yaml
+layouts:
+  custom:
+    - uuid: "{5C4F1A20-9B3E-4C7D-8E2F-1A2B3C4D5E6F}"
+      name: Two columns 70/30
+      grid:
+        rows: 1
+        columns: 2
+        rowsPercentage: [10000]
+        columnsPercentage: [7000, 3000]
+        cellChildMap: [[0, 1]]
+  hotkeys:
+    - { key: 1, layoutId: "{5C4F1A20-9B3E-4C7D-8E2F-1A2B3C4D5E6F}" }
+```
+
+The only supported module is `FancyZones`. The DSC resource type is
+`Microsoft.PowerToys/FancyZonesLayouts`.
+
+> **Important — replace semantics per section:** Every section is optional. A
+> section that is present replaces the **whole** layout file it maps to with
+> the declared state: layouts created in the FancyZones editor that are not
+> part of the configuration are removed. A section that is omitted is left
+> unchanged (not managed). Use `export` to capture the current layouts before
+> switching a machine to declarative management.
+
+Files that are machine-specific are not managed by this resource: the layouts
+applied to each monitor (`applied-layouts.json`, keyed by monitor serial
+numbers and virtual desktops) and the per-application zone history
+(`app-zone-history.json`).
+
+When the layouts are applied while PowerToys is running, FancyZones picks up
+the changed files immediately; otherwise the layouts take effect the next time
+PowerToys starts. Note that the layouts are only used when the FancyZones
+utility is enabled (see the [FancyZones module][02]).
+
+## Layouts schema
+
+The `layouts` object is required. Each of its sections is optional.
+
+### `custom[]` — custom layouts
+
+| Property | Type   | Required | Description                                                                                                          |
+|----------|--------|----------|----------------------------------------------------------------------------------------------------------------------|
+| `uuid`   | string | yes      | The layout identifier, a GUID with or without braces. Must be unique. See [Layout identifiers](#layout-identifiers). |
+| `name`   | string | yes      | The layout name shown in the editor.                                                                                 |
+| `canvas` | object | one of   | Canvas layout definition (see below).                                                                                |
+| `grid`   | object | one of   | Grid layout definition (see below).                                                                                  |
+
+Exactly one of `canvas` or `grid` must be set; it determines the layout type.
+
+#### `canvas` object
+
+| Property            | Type     | Required | Description                                                                              |
+|---------------------|----------|----------|------------------------------------------------------------------------------------------|
+| `refWidth`          | integer  | yes      | Width, in pixels, of the work area the zones are defined for.                            |
+| `refHeight`         | integer  | yes      | Height, in pixels, of the work area the zones are defined for.                           |
+| `zones`             | object[] | yes      | The zones (1 to 128), each with `x`, `y`, `width` and `height` in pixels.                |
+| `sensitivityRadius` | integer  | no       | Distance from a zone edge at which the zone is highlighted while dragging. Default `20`. |
+
+Zones are scaled from the reference work area to the actual work area of the
+monitor they are applied to.
+
+#### `grid` object
+
+| Property            | Type        | Required | Description                                                                                                    |
+|---------------------|-------------|----------|----------------------------------------------------------------------------------------------------------------|
+| `rows`              | integer     | yes      | Number of rows.                                                                                                |
+| `columns`           | integer     | yes      | Number of columns.                                                                                             |
+| `rowsPercentage`    | integer[]   | yes      | Height of each row in hundredths of a percent; one value per row, summing to `10000`.                          |
+| `columnsPercentage` | integer[]   | yes      | Width of each column in hundredths of a percent; one value per column, summing to `10000`.                     |
+| `cellChildMap`      | integer[][] | yes      | Zone index of each cell, one array per row with one value per column. Cells with the same index form one zone. |
+| `showSpacing`       | boolean     | no       | Whether space is left between the zones. Default `true`.                                                       |
+| `spacing`           | integer     | no       | Space between the zones, in pixels. Default `16`.                                                              |
+| `sensitivityRadius` | integer     | no       | Distance from a zone edge at which the zone is highlighted while dragging. Default `20`.                       |
+
+For example, a 70/30 two-column layout has `rows: 1`, `columns: 2`,
+`rowsPercentage: [10000]`, `columnsPercentage: [7000, 3000]` and
+`cellChildMap: [[0, 1]]`.
+
+### `templates[]` — layout templates
+
+| Property            | Type    | Required | Description                                                                                     |
+|---------------------|---------|----------|-------------------------------------------------------------------------------------------------|
+| `type`              | string  | yes      | `blank`, `focus`, `rows`, `columns`, `grid`, or `priority-grid`. One entry per type.            |
+| `zoneCount`         | integer | no       | Number of zones. Default `3`.                                                                   |
+| `showSpacing`       | boolean | no       | Whether space is left between the zones. Default `true`. Not applicable to `blank` and `focus`. |
+| `spacing`           | integer | no       | Space between the zones, in pixels. Default `16`. Not applicable to `blank` and `focus`.        |
+| `sensitivityRadius` | integer | no       | Distance from a zone edge at which the zone is highlighted. Default `20`.                       |
+
+### `hotkeys[]` — quick layout hotkeys
+
+| Property   | Type    | Required | Description                                                                                                            |
+|------------|---------|----------|------------------------------------------------------------------------------------------------------------------------|
+| `key`      | integer | yes      | The number key, `0` to `9`. Each key can be assigned to one layout.                                                    |
+| `layoutId` | string  | yes      | The `uuid` of the custom layout to apply. Each layout can have one key. See [Layout identifiers](#layout-identifiers). |
+
+When the configuration also defines `custom`, every `layoutId` must refer to
+one of the declared custom layouts. When it does not, a reference to a layout
+that does not exist on the machine is reported as a warning.
+
+### `defaults` — default layouts
+
+An object with the optional members `horizontal` and `vertical`, one per
+monitor orientation. Each member is a layout:
+
+| Property            | Type    | Required | Description                                                                                                                                |
+|---------------------|---------|----------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| `type`              | string  | yes      | A template type (`blank`, `focus`, `rows`, `columns`, `grid`, `priority-grid`) or `custom`.                                                |
+| `uuid`              | string  | custom   | The identifier of the custom layout. Required when `type` is `custom`, not allowed otherwise.                                              |
+| `zoneCount`         | integer | no       | Number of zones of a template layout. Default `3`.                                                                                         |
+| `showSpacing`       | boolean | no       | Whether space is left between the zones. Default `true` for grid templates; for a custom layout the setting of the referenced grid layout. |
+| `spacing`           | integer | no       | Space between the zones, in pixels. Default `16` for grid templates; for a custom layout the setting of the referenced grid layout.        |
+| `sensitivityRadius` | integer | no       | Distance from a zone edge at which the zone is highlighted. Default `20` for template layouts.                                             |
+
+### Layout identifiers
+
+Every custom layout is identified by a GUID (`uuid`). Hotkeys (`layoutId`)
+and custom default layouts (`uuid`) refer to a custom layout by that GUID;
+built-in templates have no identifier and are referred to by `type`.
+
+Where the GUID comes from depends on what you are doing:
+
+- **Declaring new layouts in the configuration:** choose any new GUID, for
+  example with `New-Guid` in PowerShell or `uuidgen`, use it as the `uuid` of
+  the custom layout, and use the same value wherever the layout is referenced.
+  FancyZones does not generate identifiers for layouts deployed this way.
+- **Referencing layouts that already exist on the machine** (created in the
+  FancyZones editor, or deployed earlier): read the identifier from the current
+  state. Any of the following shows it:
+
+  ```powershell
+  # The uuid of each custom layout, in the same shape as the configuration
+  PowerToys.DSC.exe export --resource 'layouts' --module FancyZones
+
+  # The FancyZones command line tool lists the layouts with their identifiers
+  PowerToys.FancyZones.CLI.exe get-layouts
+  ```
+
+  The identifier is also the `uuid` property of the layout in
+  `%LOCALAPPDATA%\Microsoft\PowerToys\FancyZones\custom-layouts.json`.
+
+Identifiers may be written with or without braces and in any letter case; they
+are normalized to the form the editor writes (upper-case, with braces), so
+`5c4f1a20-9b3e-4c7d-8e2f-1a2b3c4d5e6f` and
+`{5C4F1A20-9B3E-4C7D-8E2F-1A2B3C4D5E6F}` denote the same layout.
+
+### Comparison
+
+Omitted optional values are filled with the defaults listed above before the
+desired state is compared with the current state. The order of the custom
+layouts only affects the editor list and is not compared.
+
+## Common operations
+
+```powershell
+# Get or export the current layouts
+PowerToys.DSC.exe get --resource 'layouts' --module FancyZones
+PowerToys.DSC.exe export --resource 'layouts' --module FancyZones
+
+# Apply layouts (only the sections present in the input are replaced)
+$input = '{"layouts":{"hotkeys":[{"key":1,"layoutId":"{5C4F1A20-9B3E-4C7D-8E2F-1A2B3C4D5E6F}"}]}}'
+PowerToys.DSC.exe set --resource 'layouts' --module FancyZones --input $input
+
+# Test whether the current layouts match the desired state
+PowerToys.DSC.exe test --resource 'layouts' --module FancyZones --input $input
+
+# Get the JSON schema of the resource
+PowerToys.DSC.exe schema --resource 'layouts' --module FancyZones
+```
+
+## Examples
+
+### Example 1 - Deploy layouts with Microsoft DSC
+
+Save the following configuration as `fancyzones-layouts.dsc.config.yaml`:
+
+```yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
+$schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
+resources:
+  - name: Deploy FancyZones layouts
+    type: Microsoft.PowerToys/FancyZonesLayouts
+    properties:
+      layouts:
+        custom:
+          - uuid: "{5C4F1A20-9B3E-4C7D-8E2F-1A2B3C4D5E6F}"
+            name: Two columns 70/30
+            grid:
+              rows: 1
+              columns: 2
+              rowsPercentage: [10000]
+              columnsPercentage: [7000, 3000]
+              cellChildMap: [[0, 1]]
+              spacing: 8
+          - uuid: "{8F0B6D3E-2C41-4A5B-9D7E-0F1A2B3C4D5E}"
+            name: Reference window
+            canvas:
+              refWidth: 1920
+              refHeight: 1080
+              zones:
+                - { x: 0, y: 0, width: 1280, height: 1080 }
+                - { x: 1280, y: 0, width: 640, height: 1080 }
+        templates:
+          - { type: priority-grid, zoneCount: 3, showSpacing: true, spacing: 16 }
+          - { type: focus, zoneCount: 4 }
+        hotkeys:
+          - { key: 1, layoutId: "{5C4F1A20-9B3E-4C7D-8E2F-1A2B3C4D5E6F}" }
+          - { key: 2, layoutId: "{8F0B6D3E-2C41-4A5B-9D7E-0F1A2B3C4D5E}" }
+        defaults:
+          horizontal: { type: custom, uuid: "{5C4F1A20-9B3E-4C7D-8E2F-1A2B3C4D5E6F}" }
+          vertical: { type: rows, zoneCount: 2 }
+```
+
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file fancyzones-layouts.dsc.config.yaml
+```
+
+### Example 2 - Install PowerToys and deploy layouts with WinGet
+
+Save the following configuration as `fancyzones-layouts.dsc.config.winget`:
+
+```yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+metadata:
+  winget:
+    processor: dscv3
+resources:
+  - name: Install PowerToys
+    type: Microsoft.WinGet.DSC/WinGetPackage
+    properties:
+      id: Microsoft.PowerToys
+      source: winget
+
+  - name: Enable FancyZones
+    type: Microsoft.PowerToys/FancyZonesSettings
+    properties:
+      settings:
+        properties:
+          Enabled: true
+        name: FancyZones
+        version: 1.0
+
+  - name: Deploy FancyZones layouts
+    type: Microsoft.PowerToys/FancyZonesLayouts
+    properties:
+      layouts:
+        custom:
+          - uuid: "{5C4F1A20-9B3E-4C7D-8E2F-1A2B3C4D5E6F}"
+            name: IDE and browser
+            grid:
+              rows: 1
+              columns: 2
+              rowsPercentage: [10000]
+              columnsPercentage: [6000, 4000]
+              cellChildMap: [[0, 1]]
+        hotkeys:
+          - { key: 1, layoutId: "{5C4F1A20-9B3E-4C7D-8E2F-1A2B3C4D5E6F}" }
+```
+
+Apply the configuration with WinGet:
+
+```bash
+winget configure fancyzones-layouts.dsc.config.winget
+```
+
+### Example 3 - Manage only the quick layout hotkeys
+
+Sections that are not part of the configuration are left unchanged, so the
+custom layouts created in the editor are kept:
+
+```yaml
+resources:
+  - name: Assign quick layout hotkeys
+    type: Microsoft.PowerToys/FancyZonesLayouts
+    properties:
+      layouts:
+        hotkeys:
+          - { key: 1, layoutId: "{5C4F1A20-9B3E-4C7D-8E2F-1A2B3C4D5E6F}" }
+```
+
+### Example 4 - Capture existing layouts
+
+Export the current layouts on a reference machine, then reuse them in a
+configuration document:
+
+```powershell
+PowerToys.DSC.exe export --resource 'layouts' --module FancyZones
+# {"layouts":{"custom":[{"uuid":"{5C4F1A20-9B3E-4C7D-8E2F-1A2B3C4D5E6F}","name":"Two columns 70/30","grid":{...}}],"templates":[...],"hotkeys":[...],"defaults":{...}}}
+```
+
+## See also
+
+- [FancyZones Module][02]
+- [Settings Resource Reference][01]
+- [PowerToys DSC Overview][03]
+
+<!-- Link reference definitions -->
+[01]: ./settings-resource.md
+[02]: ./modules/FancyZones.md
+[03]: ./overview.md

--- a/doc/dsc/modules/AdvancedPaste.md
+++ b/doc/dsc/modules/AdvancedPaste.md
@@ -100,12 +100,10 @@ PowerToys.DSC.exe set --resource 'settings' --module AdvancedPaste `
 
 This example customizes keyboard shortcuts for different paste formats.
 
-```bash
-dsc config set --file advancedpaste-hotkeys.dsc.yaml
-```
+Save the following configuration as `advancedpaste-hotkeys.dsc.config.yaml`:
 
 ```yaml
-# advancedpaste-hotkeys.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Configure Advanced Paste hotkeys
@@ -131,17 +129,21 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file advancedpaste-hotkeys.dsc.config.yaml
+```
+
 ### Example 3 - Install and configure with WinGet
 
 This example installs PowerToys and configures Advanced Paste with AI
 enabled.
 
-```bash
-winget configure winget-advancedpaste.yaml
-```
+Save the following configuration as `advancedpaste.dsc.config.winget`:
 
 ```yaml
-# winget-advancedpaste.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -165,16 +167,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with WinGet:
+
+```bash
+winget configure advancedpaste.dsc.config.winget
+```
+
 ### Example 4 - Enable with custom preview settings
 
 This example configures preview behavior for custom paste formats.
 
-```bash
-dsc config set --file advancedpaste-preview.dsc.yaml
-```
+Save the following configuration as `advancedpaste-preview.dsc.config.yaml`:
 
 ```yaml
-# advancedpaste-preview.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Configure preview settings
@@ -186,6 +192,12 @@ resources:
           CloseAfterLosingFocus: false
         name: AdvancedPaste
         version: 1.0
+```
+
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file advancedpaste-preview.dsc.config.yaml
 ```
 
 ### Example 5 - Test AI enablement

--- a/doc/dsc/modules/AlwaysOnTop.md
+++ b/doc/dsc/modules/AlwaysOnTop.md
@@ -131,12 +131,10 @@ PowerToys.DSC.exe set --resource 'settings' --module AlwaysOnTop `
 
 This example configures a custom border color and thickness.
 
-```bash
-dsc config set --file alwaysontop-appearance.dsc.yaml
-```
+Save the following configuration as `alwaysontop-appearance.dsc.config.yaml`:
 
 ```yaml
-# alwaysontop-appearance.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Customize Always On Top frame
@@ -153,17 +151,21 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file alwaysontop-appearance.dsc.config.yaml
+```
+
 ### Example 3 - Configure with accent color using WinGet
 
 This example installs PowerToys and configures Always On Top to use the
 Windows accent color.
 
-```bash
-winget configure winget-alwaysontop.yaml
-```
+Save the following configuration as `alwaysontop.dsc.config.winget`:
 
 ```yaml
-# winget-alwaysontop.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -188,12 +190,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with WinGet:
+
+```bash
+winget configure alwaysontop.dsc.config.winget
+```
+
 ### Example 4 - Disable for gaming
 
 This example ensures Always On Top is disabled during game mode.
 
+Save the following configuration as `alwaysontop-gaming.dsc.config.yaml`:
+
 ```yaml
-# alwaysontop-gaming.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Configure for gaming
@@ -231,8 +241,10 @@ PowerToys.DSC.exe set --resource 'settings' --module AlwaysOnTop --input $config
 
 This example excludes certain applications from Always On Top.
 
+Save the following configuration as `alwaysontop-exclusions.dsc.config.yaml`:
+
 ```yaml
-# alwaysontop-exclusions.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Exclude apps from Always On Top

--- a/doc/dsc/modules/App.md
+++ b/doc/dsc/modules/App.md
@@ -131,12 +131,10 @@ PowerToys.DSC.exe set --resource 'settings' --module App --input $config
 This example configures PowerToys to run at startup with elevated privileges
 and use dark theme.
 
-```bash
-dsc config set --file app-config.dsc.yaml
-```
+Save the following configuration as `app-config.dsc.config.yaml`:
 
 ```yaml
-# app-config.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Configure PowerToys general settings
@@ -151,16 +149,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file app-config.dsc.config.yaml
+```
+
 ### Example 3 - Enable all utilities with WinGet
 
 This example installs PowerToys and enables all available utilities.
 
-```bash
-winget configure winget-enable-all.yaml
-```
+Save the following configuration as `enable-all.dsc.config.winget`:
 
 ```yaml
-# winget-enable-all.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -204,6 +206,12 @@ resources:
             ZoomIt: true
         name: App
         version: 1.0
+```
+
+Apply the configuration with WinGet:
+
+```bash
+winget configure enable-all.dsc.config.winget
 ```
 
 ### Example 4 - Test if specific utilities are enabled

--- a/doc/dsc/modules/Awake.md
+++ b/doc/dsc/modules/Awake.md
@@ -108,12 +108,10 @@ PowerToys.DSC.exe set --resource 'settings' --module Awake --input $config
 
 This example configures a timed keep-awake period.
 
-```bash
-dsc config set --file awake-timed.dsc.yaml
-```
+Save the following configuration as `awake-timed.dsc.config.yaml`:
 
 ```yaml
-# awake-timed.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Configure Awake for 2 hours
@@ -129,16 +127,20 @@ resources:
         version: 0.0.1
 ```
 
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file awake-timed.dsc.config.yaml
+```
+
 ### Example 3 - Keep awake until specific time with WinGet
 
 This example configures Awake to stay active until a specific date and time.
 
-```bash
-winget configure winget-awake-scheduled.yaml
-```
+Save the following configuration as `awake-scheduled.dsc.config.winget`:
 
 ```yaml
-# winget-awake-scheduled.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -160,6 +162,12 @@ resources:
           expirationDateTime: "2025-10-18T17:00:00.0000000-07:00"
         name: Awake
         version: 0.0.1
+```
+
+Apply the configuration with WinGet:
+
+```bash
+winget configure awake-scheduled.dsc.config.winget
 ```
 
 ### Example 4 - Disable Awake
@@ -184,12 +192,10 @@ PowerToys.DSC.exe set --resource 'settings' --module Awake --input $config
 
 This example keeps the system awake while allowing the display to turn off.
 
-```bash
-dsc config set --file awake-system-only.dsc.yaml
-```
+Save the following configuration as `awake-system-only.dsc.config.yaml`:
 
 ```yaml
-# awake-system-only.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Keep system awake only
@@ -203,16 +209,20 @@ resources:
         version: 0.0.1
 ```
 
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file awake-system-only.dsc.config.yaml
+```
+
 ### Example 6 - Configure for presentation (4 hours)
 
 This example configures Awake for a presentation scenario using WinGet.
 
-```bash
-winget configure presentation-mode.yaml
-```
+Save the following configuration as `presentation-mode.dsc.config.winget`:
 
 ```yaml
-# presentation-mode.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -229,6 +239,12 @@ resources:
           intervalMinutes: 0
         name: Awake
         version: 0.0.1
+```
+
+Apply the configuration with WinGet:
+
+```bash
+winget configure presentation-mode.dsc.config.winget
 ```
 
 ### Example 7 - Test current configuration

--- a/doc/dsc/modules/ColorPicker.md
+++ b/doc/dsc/modules/ColorPicker.md
@@ -113,12 +113,10 @@ PowerToys.DSC.exe set --resource 'settings' --module ColorPicker --input $config
 This example configures the color picker to open directly without the
 editor.
 
-```bash
-dsc config set --file colorpicker-activation.dsc.yaml
-```
+Save the following configuration as `colorpicker-activation.dsc.config.yaml`:
 
 ```yaml
-# colorpicker-activation.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Configure Color Picker activation
@@ -133,17 +131,21 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file colorpicker-activation.dsc.config.yaml
+```
+
 ### Example 3 - Install and configure for web development with WinGet
 
 This example installs PowerToys and configures Color Picker for web
 developers.
 
-```bash
-winget configure winget-colorpicker-webdev.yaml
-```
+Save the following configuration as `colorpicker-webdev.dsc.config.winget`:
 
 ```yaml
-# winget-colorpicker-webdev.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -173,16 +175,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with WinGet:
+
+```bash
+winget configure colorpicker-webdev.dsc.config.winget
+```
+
 ### Example 4 - Configure visible formats
 
 This example enables only HEX, RGB, and HSL formats.
 
-```bash
-dsc config set --file colorpicker-formats.dsc.yaml
-```
+Save the following configuration as `colorpicker-formats.dsc.config.yaml`:
 
 ```yaml
-# colorpicker-formats.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Configure visible color formats
@@ -203,6 +209,12 @@ resources:
             Decimal: false
         name: ColorPicker
         version: 1.0
+```
+
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file colorpicker-formats.dsc.config.yaml
 ```
 
 ### Example 5 - Configure for graphic design

--- a/doc/dsc/modules/CropAndLock.md
+++ b/doc/dsc/modules/CropAndLock.md
@@ -73,12 +73,10 @@ PowerToys.DSC.exe set --resource 'settings' --module CropAndLock --input $config
 
 This example configures custom hotkeys for cropping and reparenting.
 
-```bash
-dsc config set --file cropandlock-hotkeys.dsc.yaml
-```
+Save the following configuration as `cropandlock-hotkeys.dsc.config.yaml`:
 
 ```yaml
-# cropandlock-hotkeys.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Configure Crop And Lock hotkeys
@@ -98,16 +96,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file cropandlock-hotkeys.dsc.config.yaml
+```
+
 ### Example 3 - Install and configure with WinGet
 
 This example installs PowerToys and configures Crop And Lock.
 
-```bash
-winget configure winget-cropandlock.yaml
-```
+Save the following configuration as `cropandlock.dsc.config.winget`:
 
 ```yaml
-# winget-cropandlock.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -129,12 +131,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with WinGet:
+
+```bash
+winget configure cropandlock.dsc.config.winget
+```
+
 ### Example 4 - Semi-transparent thumbnails
 
 This example configures thumbnails to be semi-transparent for overlay use.
 
+Save the following configuration as `cropandlock-transparent.dsc.config.yaml`:
+
 ```yaml
-# cropandlock-transparent.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Semi-transparent thumbnails

--- a/doc/dsc/modules/EnvironmentVariables.md
+++ b/doc/dsc/modules/EnvironmentVariables.md
@@ -51,12 +51,10 @@ PowerToys.DSC.exe set --resource 'settings' --module EnvironmentVariables --inpu
 
 This example enables administrator launch through DSC configuration.
 
-```bash
-dsc config set --file environmentvariables-config.dsc.yaml
-```
+Save the following configuration as `environmentvariables-config.dsc.config.yaml`:
 
 ```yaml
-# environmentvariables-config.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Configure Environment Variables editor
@@ -69,17 +67,21 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file environmentvariables-config.dsc.config.yaml
+```
+
 ### Example 3 - Install and configure with WinGet
 
 This example installs PowerToys and configures Environment Variables for
 admin launch.
 
-```bash
-winget configure winget-envvars.yaml
-```
+Save the following configuration as `envvars.dsc.config.winget`:
 
 ```yaml
-# winget-envvars.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -101,16 +103,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with WinGet:
+
+```bash
+winget configure envvars.dsc.config.winget
+```
+
 ### Example 4 - Standard user mode
 
 This example configures for standard user access (no elevation).
 
-```bash
-dsc config set --file envvars-user.dsc.yaml
-```
+Save the following configuration as `envvars-user.dsc.config.yaml`:
 
 ```yaml
-# envvars-user.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: User-level Environment Variables
@@ -121,6 +127,12 @@ resources:
           LaunchAdministrator: false
         name: EnvironmentVariables
         version: 1.0
+```
+
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file envvars-user.dsc.config.yaml
 ```
 
 ### Example 5 - Test admin launch configuration

--- a/doc/dsc/modules/FancyZones.md
+++ b/doc/dsc/modules/FancyZones.md
@@ -224,12 +224,10 @@ PowerToys.DSC.exe set --resource 'settings' --module FancyZones --input $config
 
 This example configures how windows behave when displays or zones change.
 
-```bash
-dsc config set --file fancyzones-window-behavior.dsc.yaml
-```
+Save the following configuration as `fancyzones-window-behavior.dsc.config.yaml`:
 
 ```yaml
-# fancyzones-window-behavior.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Configure FancyZones window behavior
@@ -245,17 +243,21 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file fancyzones-window-behavior.dsc.config.yaml
+```
+
 ### Example 3 - Customize zone appearance with WinGet
 
 This example installs PowerToys and configures custom zone colors and
 opacity.
 
-```bash
-winget configure winget-fancyzones-appearance.yaml
-```
+Save the following configuration as `fancyzones-appearance.dsc.config.winget`:
 
 ```yaml
-# winget-fancyzones-appearance.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -281,17 +283,21 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with WinGet:
+
+```bash
+winget configure fancyzones-appearance.dsc.config.winget
+```
+
 ### Example 4 - Override Windows Snap hotkeys
 
 This example configures FancyZones to replace Windows default snap
 functionality.
 
-```bash
-dsc config set --file fancyzones-snap-override.dsc.yaml
-```
+Save the following configuration as `fancyzones-snap-override.dsc.config.yaml`:
 
 ```yaml
-# fancyzones-snap-override.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Override Windows Snap
@@ -303,6 +309,12 @@ resources:
           fancyzones_moveWindowsBasedOnPosition: true
         name: FancyZones
         version: 1.0
+```
+
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file fancyzones-snap-override.dsc.config.yaml
 ```
 
 ### Example 5 - Configure editor hotkey
@@ -334,8 +346,10 @@ PowerToys.DSC.exe set --resource 'settings' --module FancyZones --input $config
 
 This example configures FancyZones to ignore specific applications.
 
+Save the following configuration as `fancyzones-exclusions.dsc.config.yaml`:
+
 ```yaml
-# fancyzones-exclusions.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Exclude apps from FancyZones
@@ -355,12 +369,10 @@ resources:
 
 This example configures FancyZones for optimal multi-monitor workflow.
 
-```bash
-dsc config set --file fancyzones-multimonitor.dsc.yaml
-```
+Save the following configuration as `fancyzones-multimonitor.dsc.config.yaml`:
 
 ```yaml
-# fancyzones-multimonitor.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Multi-monitor FancyZones setup
@@ -378,16 +390,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file fancyzones-multimonitor.dsc.config.yaml
+```
+
 ### Example 8 - Complete FancyZones configuration with WinGet
 
 This example shows a comprehensive FancyZones setup with installation.
 
-```bash
-winget configure winget-fancyzones-complete.yaml
-```
+Save the following configuration as `fancyzones-complete.dsc.config.winget`:
 
 ```yaml
-# winget-fancyzones-complete.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -438,6 +454,12 @@ resources:
           fancyzones_spanZonesAcrossMonitors: false
         name: FancyZones
         version: 1.0
+```
+
+Apply the configuration with WinGet:
+
+```bash
+winget configure fancyzones-complete.dsc.config.winget
 ```
 
 ### Example 9 - Test FancyZones configuration
@@ -531,8 +553,51 @@ resources:
         version: 1.0
 ```
 
+## Important notes
+
+> **Note:** The FancyZones module `settings` resource controls the enabled
+> state and the behavior options only. The layouts themselves (custom layouts,
+> layout templates, quick layout hotkeys and default layouts) are stored in
+> separate files and are managed by the dedicated [`layouts` resource][05]
+> (`Microsoft.PowerToys/FancyZonesLayouts`).
+
+To deploy layouts declaratively, combine both resources:
+
+```yaml
+resources:
+  - name: Configure FancyZones
+    type: Microsoft.PowerToys/FancyZonesSettings
+    properties:
+      settings:
+        properties:
+          fancyzones_shiftDrag: true
+        name: FancyZones
+        version: 1.0
+
+  - name: Deploy FancyZones layouts
+    type: Microsoft.PowerToys/FancyZonesLayouts
+    properties:
+      layouts:
+        custom:
+          - uuid: "{5C4F1A20-9B3E-4C7D-8E2F-1A2B3C4D5E6F}"
+            name: Two columns 70/30
+            grid:
+              rows: 1
+              columns: 2
+              rowsPercentage: [10000]
+              columnsPercentage: [7000, 3000]
+              cellChildMap: [[0, 1]]
+        hotkeys:
+          - { key: 1, layoutId: "{5C4F1A20-9B3E-4C7D-8E2F-1A2B3C4D5E6F}" }
+```
+
+Alternatively, layouts can still be created interactively in the FancyZones
+editor. Note that a section of the `layouts` resource replaces the whole
+corresponding layout file with the declared state.
+
 ## See also
 
+- [FancyZones Layouts Resource][05]
 - [Settings Resource][01]
 - [PowerToys DSC Overview][02]
 - [Peek][03]
@@ -543,3 +608,4 @@ resources:
 [02]: ../overview.md
 [03]: ./Peek.md
 [04]: https://learn.microsoft.com/windows/powertoys/fancyzones
+[05]: ../layouts-resource.md

--- a/doc/dsc/modules/FileLocksmith.md
+++ b/doc/dsc/modules/FileLocksmith.md
@@ -59,12 +59,10 @@ PowerToys.DSC.exe set --resource 'settings' --module FileLocksmith `
 This example configures File Locksmith to appear only in the extended
 context menu.
 
-```bash
-dsc config set --file filelocksmith-extended.dsc.yaml
-```
+Save the following configuration as `filelocksmith-extended.dsc.config.yaml`:
 
 ```yaml
-# filelocksmith-extended.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Configure File Locksmith for extended menu
@@ -77,17 +75,21 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file filelocksmith-extended.dsc.config.yaml
+```
+
 ### Example 3 - Install and configure with WinGet
 
 This example installs PowerToys and configures File Locksmith for standard
 menu access.
 
-```bash
-winget configure winget-filelocksmith.yaml
-```
+Save the following configuration as `filelocksmith.dsc.config.winget`:
 
 ```yaml
-# winget-filelocksmith.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -109,16 +111,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with WinGet:
+
+```bash
+winget configure filelocksmith.dsc.config.winget
+```
+
 ### Example 4 - Minimize context menu clutter
 
 This example configures for extended menu to reduce clutter.
 
-```bash
-dsc config set --file filelocksmith-minimal.dsc.yaml
-```
+Save the following configuration as `filelocksmith-minimal.dsc.config.yaml`:
 
 ```yaml
-# filelocksmith-minimal.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Minimal context menu
@@ -129,6 +135,12 @@ resources:
           ExtendedContextMenuOnly: true
         name: FileLocksmith
         version: 1.0
+```
+
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file filelocksmith-minimal.dsc.config.yaml
 ```
 
 ## Use cases

--- a/doc/dsc/modules/FindMyMouse.md
+++ b/doc/dsc/modules/FindMyMouse.md
@@ -113,12 +113,10 @@ PowerToys.DSC.exe set --resource 'settings' --module FindMyMouse --input $config
 
 This example customizes the spotlight animation behavior.
 
-```bash
-dsc config set --file findmymouse-animation.dsc.yaml
-```
+Save the following configuration as `findmymouse-animation.dsc.config.yaml`:
 
 ```yaml
-# findmymouse-animation.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Configure Find My Mouse animation
@@ -133,17 +131,21 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file findmymouse-animation.dsc.config.yaml
+```
+
 ### Example 3 - Install and configure with WinGet
 
 This example installs PowerToys and configures Find My Mouse with custom
 colors.
 
-```bash
-winget configure winget-findmymouse.yaml
-```
+Save the following configuration as `findmymouse.dsc.config.winget`:
 
 ```yaml
-# winget-findmymouse.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -169,16 +171,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with WinGet:
+
+```bash
+winget configure findmymouse.dsc.config.winget
+```
+
 ### Example 4 - Subtle configuration
 
 This example creates a subtle, less intrusive spotlight effect.
 
-```bash
-dsc config set --file findmymouse-subtle.dsc.yaml
-```
+Save the following configuration as `findmymouse-subtle.dsc.config.yaml`:
 
 ```yaml
-# findmymouse-subtle.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Subtle spotlight
@@ -191,6 +197,12 @@ resources:
           AnimationDurationMs: 300
         name: FindMyMouse
         version: 1.0
+```
+
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file findmymouse-subtle.dsc.config.yaml
 ```
 
 ### Example 5 - High visibility configuration
@@ -219,12 +231,10 @@ PowerToys.DSC.exe set --resource 'settings' --module FindMyMouse --input $config
 
 This example ensures Find My Mouse doesn't interfere with games.
 
-```bash
-dsc config set --file findmymouse-gaming.dsc.yaml
-```
+Save the following configuration as `findmymouse-gaming.dsc.config.yaml`:
 
 ```yaml
-# findmymouse-gaming.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Gaming configuration
@@ -235,6 +245,12 @@ resources:
           DoNotActivateOnGameMode: true
         name: FindMyMouse
         version: 1.0
+```
+
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file findmymouse-gaming.dsc.config.yaml
 ```
 
 ## Use cases

--- a/doc/dsc/modules/Hosts.md
+++ b/doc/dsc/modules/Hosts.md
@@ -76,12 +76,10 @@ PowerToys.DSC.exe set --resource 'settings' --module Hosts --input $config
 
 This example enables administrator launch and configures line positioning.
 
-```bash
-dsc config set --file hosts-config.dsc.yaml
-```
+Save the following configuration as `hosts-config.dsc.config.yaml`:
 
 ```yaml
-# hosts-config.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Configure Hosts File Editor
@@ -95,17 +93,21 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file hosts-config.dsc.config.yaml
+```
+
 ### Example 3 - Install and configure with WinGet
 
 This example installs PowerToys and configures the Hosts editor for admin
 launch.
 
-```bash
-winget configure winget-hosts.yaml
-```
+Save the following configuration as `hosts.dsc.config.winget`:
 
 ```yaml
-# winget-hosts.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -128,16 +130,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with WinGet:
+
+```bash
+winget configure hosts.dsc.config.winget
+```
+
 ### Example 4 - Development configuration
 
 This example configures for development use with new entries at the bottom.
 
-```bash
-dsc config set --file hosts-development.dsc.yaml
-```
+Save the following configuration as `hosts-development.dsc.config.yaml`:
 
 ```yaml
-# hosts-development.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Development hosts configuration
@@ -149,6 +155,12 @@ resources:
           AdditionalLinesPosition: 1
         name: Hosts
         version: 1.0
+```
+
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file hosts-development.dsc.config.yaml
 ```
 
 ## Use cases

--- a/doc/dsc/modules/ImageResizer.md
+++ b/doc/dsc/modules/ImageResizer.md
@@ -174,12 +174,10 @@ PowerToys.DSC.exe set --resource 'settings' --module ImageResizer `
 
 This example configures image quality and format options.
 
-```bash
-dsc config set --file imageresizer-quality.dsc.yaml
-```
+Save the following configuration as `imageresizer-quality.dsc.config.yaml`:
 
 ```yaml
-# imageresizer-quality.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Configure Image Resizer quality
@@ -194,17 +192,21 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file imageresizer-quality.dsc.config.yaml
+```
+
 ### Example 3 - Install and configure with WinGet
 
 This example installs PowerToys and configures Image Resizer with
 web-optimized presets.
 
-```bash
-winget configure winget-imageresizer.yaml
-```
+Save the following configuration as `imageresizer.dsc.config.winget`:
 
 ```yaml
-# winget-imageresizer.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -243,17 +245,21 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with WinGet:
+
+```bash
+winget configure imageresizer.dsc.config.winget
+```
+
 ### Example 4 - Photography workflow
 
 This example configures for photography with high quality and metadata
 preservation.
 
-```bash
-dsc config set --file imageresizer-photo.dsc.yaml
-```
+Save the following configuration as `imageresizer-photography.dsc.config.yaml`:
 
 ```yaml
-# imageresizer-photography.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Photography configuration
@@ -267,6 +273,12 @@ resources:
           ImageresizerShrinkOnly: true
         name: ImageResizer
         version: 1.0
+```
+
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file imageresizer-photography.dsc.config.yaml
 ```
 
 ### Example 5 - Social media presets

--- a/doc/dsc/modules/KeyboardManager.md
+++ b/doc/dsc/modules/KeyboardManager.md
@@ -54,12 +54,10 @@ PowerToys.DSC.exe set --resource 'settings' --module KeyboardManager --input $co
 
 This example enables Keyboard Manager through DSC configuration.
 
-```bash
-dsc config set --file keyboardmanager-config.dsc.yaml
-```
+Save the following configuration as `keyboardmanager-config.dsc.config.yaml`:
 
 ```yaml
-# keyboardmanager-config.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Enable Keyboard Manager
@@ -72,16 +70,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file keyboardmanager-config.dsc.config.yaml
+```
+
 ### Example 3 - Install and configure with WinGet
 
 This example installs PowerToys and enables Keyboard Manager.
 
-```bash
-winget configure winget-keyboardmanager.yaml
-```
+Save the following configuration as `keyboardmanager.dsc.config.winget`:
 
 ```yaml
-# winget-keyboardmanager.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -101,6 +103,12 @@ resources:
           Enabled: true
         name: KeyboardManager
         version: 1.0
+```
+
+Apply the configuration with WinGet:
+
+```bash
+winget configure keyboardmanager.dsc.config.winget
 ```
 
 ## Important notes

--- a/doc/dsc/modules/MeasureTool.md
+++ b/doc/dsc/modules/MeasureTool.md
@@ -108,12 +108,10 @@ PowerToys.DSC.exe set --resource 'settings' --module MeasureTool `
 
 This example customizes the crosshair color and measurement behavior.
 
-```bash
-dsc config set --file measuretool-appearance.dsc.yaml
-```
+Save the following configuration as `measuretool-appearance.dsc.config.yaml`:
 
 ```yaml
-# measuretool-appearance.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Configure Measure Tool appearance
@@ -128,17 +126,21 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file measuretool-appearance.dsc.config.yaml
+```
+
 ### Example 3 - Install and configure with WinGet
 
 This example installs PowerToys and configures Measure Tool with edge
 detection.
 
-```bash
-winget configure winget-measuretool.yaml
-```
+Save the following configuration as `measuretool.dsc.config.winget`:
 
 ```yaml
-# winget-measuretool.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -162,16 +164,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with WinGet:
+
+```bash
+winget configure measuretool.dsc.config.winget
+```
+
 ### Example 4 - High contrast configuration
 
 This example configures for high visibility measurements.
 
-```bash
-dsc config set --file measuretool-highcontrast.dsc.yaml
-```
+Save the following configuration as `measuretool-highcontrast.dsc.config.yaml`:
 
 ```yaml
-# measuretool-highcontrast.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: High contrast Measure Tool
@@ -183,6 +189,12 @@ resources:
           DrawFeetOnCross: true
         name: MeasureTool
         version: 1.0
+```
+
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file measuretool-highcontrast.dsc.config.yaml
 ```
 
 ### Example 5 - Continuous capture mode

--- a/doc/dsc/modules/MouseHighlighter.md
+++ b/doc/dsc/modules/MouseHighlighter.md
@@ -121,12 +121,10 @@ PowerToys.DSC.exe set --resource 'settings' --module MouseHighlighter `
 
 This example customizes the animation timing and appearance.
 
-```bash
-dsc config set --file mousehighlighter-animation.dsc.yaml
-```
+Save the following configuration as `mousehighlighter-animation.dsc.config.yaml`:
 
 ```yaml
-# mousehighlighter-animation.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Configure Mouse Highlighter animation
@@ -141,17 +139,21 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file mousehighlighter-animation.dsc.config.yaml
+```
+
 ### Example 3 - Install and configure for presentations with WinGet
 
 This example installs PowerToys and configures Mouse Highlighter for
 presentations.
 
-```bash
-winget configure winget-mousehighlighter.yaml
-```
+Save the following configuration as `mousehighlighter.dsc.config.winget`:
 
 ```yaml
-# winget-mousehighlighter.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -177,16 +179,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with WinGet:
+
+```bash
+winget configure mousehighlighter.dsc.config.winget
+```
+
 ### Example 4 - Subtle highlighting
 
 This example configures subtle, less distracting highlights.
 
-```bash
-dsc config set --file mousehighlighter-subtle.dsc.yaml
-```
+Save the following configuration as `mousehighlighter-subtle.dsc.config.yaml`:
 
 ```yaml
-# mousehighlighter-subtle.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Subtle mouse highlighting
@@ -199,6 +205,12 @@ resources:
           HighlightFadeDelayMs: 300
         name: MouseHighlighter
         version: 1.0
+```
+
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file mousehighlighter-subtle.dsc.config.yaml
 ```
 
 ### Example 5 - High visibility for accessibility

--- a/doc/dsc/modules/MouseJump.md
+++ b/doc/dsc/modules/MouseJump.md
@@ -84,12 +84,10 @@ PowerToys.DSC.exe set --resource 'settings' --module MouseJump `
 
 This example sets a larger thumbnail for better visibility.
 
-```bash
-dsc config set --file mousejump-size.dsc.yaml
-```
+Save the following configuration as `mousejump-size.dsc.config.yaml`:
 
 ```yaml
-# mousejump-size.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Configure Mouse Jump thumbnail
@@ -102,17 +100,21 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file mousejump-size.dsc.config.yaml
+```
+
 ### Example 3 - Install and configure with WinGet
 
 This example installs PowerToys and configures Mouse Jump for multi-monitor
 setups.
 
-```bash
-winget configure winget-mousejump.yaml
-```
+Save the following configuration as `mousejump.dsc.config.winget`:
 
 ```yaml
-# winget-mousejump.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -134,16 +136,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with WinGet:
+
+```bash
+winget configure mousejump.dsc.config.winget
+```
+
 ### Example 4 - Performance-optimized configuration
 
 This example uses a smaller thumbnail for better performance.
 
-```bash
-dsc config set --file mousejump-performance.dsc.yaml
-```
+Save the following configuration as `mousejump-performance.dsc.config.yaml`:
 
 ```yaml
-# mousejump-performance.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Performance-optimized Mouse Jump
@@ -154,6 +160,12 @@ resources:
           ThumbnailSize: small
         name: MouseJump
         version: 1.0
+```
+
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file mousejump-performance.dsc.config.yaml
 ```
 
 ### Example 5 - Large display configuration

--- a/doc/dsc/modules/MousePointerCrosshairs.md
+++ b/doc/dsc/modules/MousePointerCrosshairs.md
@@ -137,12 +137,10 @@ PowerToys.DSC.exe set --resource 'settings' --module MousePointerCrosshairs `
 
 This example adds a border to the crosshairs for better visibility.
 
-```bash
-dsc config set --file mousecrosshairs-border.dsc.yaml
-```
+Save the following configuration as `mousecrosshairs-border.dsc.config.yaml`:
 
 ```yaml
-# mousecrosshairs-border.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Configure crosshairs with border
@@ -158,16 +156,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file mousecrosshairs-border.dsc.config.yaml
+```
+
 ### Example 3 - Install and configure with WinGet
 
 This example installs PowerToys and configures crosshairs for presentations.
 
-```bash
-winget configure winget-mousecrosshairs.yaml
-```
+Save the following configuration as `mousecrosshairs.dsc.config.winget`:
 
 ```yaml
-# winget-mousecrosshairs.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -193,16 +195,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with WinGet:
+
+```bash
+winget configure mousecrosshairs.dsc.config.winget
+```
+
 ### Example 4 - Full-screen crosshairs
 
 This example configures crosshairs that extend to screen edges.
 
-```bash
-dsc config set --file mousecrosshairs-fullscreen.dsc.yaml
-```
+Save the following configuration as `mousecrosshairs-fullscreen.dsc.config.yaml`:
 
 ```yaml
-# mousecrosshairs-fullscreen.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Full-screen crosshairs
@@ -214,6 +220,12 @@ resources:
           CrosshairsOpacity: 60
         name: MousePointerCrosshairs
         version: 1.0
+```
+
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file mousecrosshairs-fullscreen.dsc.config.yaml
 ```
 
 ### Example 5 - Subtle crosshairs with auto-hide

--- a/doc/dsc/modules/Peek.md
+++ b/doc/dsc/modules/Peek.md
@@ -75,12 +75,10 @@ PowerToys.DSC.exe set --resource 'settings' --module Peek --input $config
 
 This example configures Peek to remain open after losing focus.
 
-```bash
-dsc config set --file peek-focus.dsc.yaml
-```
+Save the following configuration as `peek-focus.dsc.config.yaml`:
 
 ```yaml
-# peek-focus.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Configure Peek focus behavior
@@ -93,16 +91,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file peek-focus.dsc.config.yaml
+```
+
 ### Example 3 - Install and configure with WinGet
 
 This example installs PowerToys and configures Peek.
 
-```bash
-winget configure winget-peek.yaml
-```
+Save the following configuration as `peek.dsc.config.winget`:
 
 ```yaml
-# winget-peek.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -124,16 +126,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with WinGet:
+
+```bash
+winget configure peek.dsc.config.winget
+```
+
 ### Example 4 - Alternative activation shortcut
 
 This example uses Ctrl+Shift+Space as the activation shortcut.
 
-```bash
-dsc config set --file peek-altkey.dsc.yaml
-```
+Save the following configuration as `peek-altkey.dsc.config.yaml`:
 
 ```yaml
-# peek-altkey.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Alternative Peek shortcut
@@ -150,6 +156,12 @@ resources:
             key: Space
         name: Peek
         version: 1.0
+```
+
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file peek-altkey.dsc.config.yaml
 ```
 
 ## Use cases

--- a/doc/dsc/modules/PowerAccent.md
+++ b/doc/dsc/modules/PowerAccent.md
@@ -110,12 +110,10 @@ PowerToys.DSC.exe set --resource 'settings' --module PowerAccent `
 
 This example customizes the toolbar position and display options.
 
-```bash
-dsc config set --file poweraccent-toolbar.dsc.yaml
-```
+Save the following configuration as `poweraccent-toolbar.dsc.config.yaml`:
 
 ```yaml
-# poweraccent-toolbar.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Configure Power Accent toolbar
@@ -130,17 +128,21 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file poweraccent-toolbar.dsc.config.yaml
+```
+
 ### Example 3 - Install and configure with WinGet
 
 This example installs PowerToys and configures Power Accent for multilingual
 typing.
 
-```bash
-winget configure winget-poweraccent.yaml
-```
+Save the following configuration as `poweraccent.dsc.config.winget`:
 
 ```yaml
-# winget-poweraccent.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -165,16 +167,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with WinGet:
+
+```bash
+winget configure poweraccent.dsc.config.winget
+```
+
 ### Example 4 - Fast activation configuration
 
 This example configures for quick accent selection.
 
-```bash
-dsc config set --file poweraccent-fast.dsc.yaml
-```
+Save the following configuration as `poweraccent-fast.dsc.config.yaml`:
 
 ```yaml
-# poweraccent-fast.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Fast accent activation
@@ -186,6 +192,12 @@ resources:
           SortByUsageFrequency: true
         name: PowerAccent
         version: 1.0
+```
+
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file poweraccent-fast.dsc.config.yaml
 ```
 
 ### Example 5 - Exclude applications

--- a/doc/dsc/modules/PowerOCR.md
+++ b/doc/dsc/modules/PowerOCR.md
@@ -78,12 +78,10 @@ PowerToys.DSC.exe set --resource 'settings' --module PowerOCR `
 
 This example sets the preferred OCR language.
 
-```bash
-dsc config set --file powerocr-language.dsc.yaml
-```
+Save the following configuration as `powerocr-language.dsc.config.yaml`:
 
 ```yaml
-# powerocr-language.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Configure Power OCR language
@@ -96,16 +94,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file powerocr-language.dsc.config.yaml
+```
+
 ### Example 3 - Install and configure with WinGet
 
 This example installs PowerToys and configures Power OCR.
 
-```bash
-winget configure winget-powerocr.yaml
-```
+Save the following configuration as `powerocr.dsc.config.winget`:
 
 ```yaml
-# winget-powerocr.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -127,16 +129,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with WinGet:
+
+```bash
+winget configure powerocr.dsc.config.winget
+```
+
 ### Example 4 - Multilingual configuration
 
 This example configures for multilingual text extraction.
 
-```bash
-dsc config set --file powerocr-multilingual.dsc.yaml
-```
+Save the following configuration as `powerocr-multilingual.dsc.config.yaml`:
 
 ```yaml
-# powerocr-multilingual.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Multilingual OCR
@@ -147,6 +153,12 @@ resources:
           PreferredLanguage: fr-FR
         name: PowerOCR
         version: 1.0
+```
+
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file powerocr-multilingual.dsc.config.yaml
 ```
 
 ## Use cases

--- a/doc/dsc/modules/PowerRename.md
+++ b/doc/dsc/modules/PowerRename.md
@@ -84,12 +84,10 @@ PowerToys.DSC.exe set --resource 'settings' --module PowerRename --input $config
 This example configures Power Rename to appear in the extended context menu
 only.
 
-```bash
-dsc config set --file powerrename-context.dsc.yaml
-```
+Save the following configuration as `powerrename-context.dsc.config.yaml`:
 
 ```yaml
-# powerrename-context.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Configure Power Rename context menu
@@ -103,16 +101,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file powerrename-context.dsc.config.yaml
+```
+
 ### Example 3 - Install and configure with WinGet
 
 This example installs PowerToys and configures Power Rename.
 
-```bash
-winget configure winget-powerrename.yaml
-```
+Save the following configuration as `powerrename.dsc.config.winget`:
 
 ```yaml
-# winget-powerrename.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -137,16 +139,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with WinGet:
+
+```bash
+winget configure powerrename.dsc.config.winget
+```
+
 ### Example 4 - Clean context menu configuration
 
 This example minimizes context menu clutter.
 
-```bash
-dsc config set --file powerrename-minimal.dsc.yaml
-```
+Save the following configuration as `powerrename-minimal.dsc.config.yaml`:
 
 ```yaml
-# powerrename-minimal.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Minimal context menu
@@ -158,6 +164,12 @@ resources:
           ShowIcon: false
         name: PowerRename
         version: 1.0
+```
+
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file powerrename-minimal.dsc.config.yaml
 ```
 
 ### Example 5 - Advanced regex configuration

--- a/doc/dsc/modules/RegistryPreview.md
+++ b/doc/dsc/modules/RegistryPreview.md
@@ -53,12 +53,10 @@ PowerToys.DSC.exe set --resource 'settings' --module RegistryPreview --input $co
 
 This example configures Registry Preview as the default handler.
 
-```bash
-dsc config set --file registrypreview-default.dsc.yaml
-```
+Save the following configuration as `registrypreview-default.dsc.config.yaml`:
 
 ```yaml
-# registrypreview-default.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Set Registry Preview as default
@@ -71,17 +69,21 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file registrypreview-default.dsc.config.yaml
+```
+
 ### Example 3 - Install and configure with WinGet
 
 This example installs PowerToys and sets Registry Preview as the default .reg
 handler.
 
-```bash
-winget configure winget-registrypreview.yaml
-```
+Save the following configuration as `registrypreview.dsc.config.winget`:
 
 ```yaml
-# winget-registrypreview.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -103,16 +105,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with WinGet:
+
+```bash
+winget configure registrypreview.dsc.config.winget
+```
+
 ### Example 4 - Disable as default handler
 
 This example ensures Registry Preview is not the default .reg handler.
 
-```bash
-dsc config set --file registrypreview-notdefault.dsc.yaml
-```
+Save the following configuration as `registrypreview-notdefault.dsc.config.yaml`:
 
 ```yaml
-# registrypreview-notdefault.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Do not use as default
@@ -123,6 +129,12 @@ resources:
           DefaultRegApp: false
         name: RegistryPreview
         version: 1.0
+```
+
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file registrypreview-notdefault.dsc.config.yaml
 ```
 
 ## Use cases

--- a/doc/dsc/modules/ShortcutGuide.md
+++ b/doc/dsc/modules/ShortcutGuide.md
@@ -111,12 +111,10 @@ PowerToys.DSC.exe set --resource 'settings' --module ShortcutGuide `
 
 This example customizes the overlay appearance.
 
-```bash
-dsc config set --file shortcutguide-appearance.dsc.yaml
-```
+Save the following configuration as `shortcutguide-appearance.dsc.config.yaml`:
 
 ```yaml
-# shortcutguide-appearance.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Configure Shortcut Guide appearance
@@ -130,16 +128,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file shortcutguide-appearance.dsc.config.yaml
+```
+
 ### Example 3 - Install and configure with WinGet
 
 This example installs PowerToys and configures Shortcut Guide.
 
-```bash
-winget configure winget-shortcutguide.yaml
-```
+Save the following configuration as `shortcutguide.dsc.config.winget`:
 
 ```yaml
-# winget-shortcutguide.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -163,16 +165,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with WinGet:
+
+```bash
+winget configure shortcutguide.dsc.config.winget
+```
+
 ### Example 4 - Quick activation
 
 This example configures taskbar indicators with a short hold duration.
 
-```bash
-dsc config set --file shortcutguide-quick.dsc.yaml
-```
+Save the following configuration as `shortcutguide-quick.dsc.config.yaml`:
 
 ```yaml
-# shortcutguide-quick.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Quick activation
@@ -184,6 +190,12 @@ resources:
           PressTime: 400
         name: ShortcutGuide
         version: 1.0
+```
+
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file shortcutguide-quick.dsc.config.yaml
 ```
 
 ### Example 5 - High opacity for visibility
@@ -209,12 +221,10 @@ PowerToys.DSC.exe set --resource 'settings' --module ShortcutGuide --input $conf
 
 This example excludes Shortcut Guide from specific applications.
 
-```bash
-dsc config set --file shortcutguide-exclusions.dsc.yaml
-```
+Save the following configuration as `shortcutguide-exclusions.dsc.config.yaml`:
 
 ```yaml
-# shortcutguide-exclusions.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Exclude apps
@@ -227,6 +237,12 @@ resources:
             FullScreenApp.exe
         name: ShortcutGuide
         version: 1.0
+```
+
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file shortcutguide-exclusions.dsc.config.yaml
 ```
 
 ## Use cases

--- a/doc/dsc/modules/Workspaces.md
+++ b/doc/dsc/modules/Workspaces.md
@@ -83,12 +83,10 @@ PowerToys.DSC.exe set --resource 'settings' --module Workspaces --input $config
 
 This example enables moving existing windows when launching workspaces.
 
-```bash
-dsc config set --file workspaces-behavior.dsc.yaml
-```
+Save the following configuration as `workspaces-behavior.dsc.config.yaml`:
 
 ```yaml
-# workspaces-behavior.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Configure Workspaces window behavior
@@ -102,16 +100,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file workspaces-behavior.dsc.config.yaml
+```
+
 ### Example 3 - Install and configure with WinGet
 
 This example installs PowerToys and configures Workspaces.
 
-```bash
-winget configure winget-workspaces.yaml
-```
+Save the following configuration as `workspaces.dsc.config.winget`:
 
 ```yaml
-# winget-workspaces.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -140,16 +142,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with WinGet:
+
+```bash
+winget configure workspaces.dsc.config.winget
+```
+
 ### Example 4 - Multi-monitor setup
 
 This example configures for multi-monitor workspace management.
 
-```bash
-dsc config set --file workspaces-multimonitor.dsc.yaml
-```
+Save the following configuration as `workspaces-multimonitor.dsc.config.yaml`:
 
 ```yaml
-# workspaces-multimonitor.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Multi-monitor configuration
@@ -161,6 +167,12 @@ resources:
           MoveExistingWindows: true
         name: Workspaces
         version: 1.0
+```
+
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file workspaces-multimonitor.dsc.config.yaml
 ```
 
 ### Example 5 - Simple hotkey

--- a/doc/dsc/modules/ZoomIt.md
+++ b/doc/dsc/modules/ZoomIt.md
@@ -66,12 +66,10 @@ PowerToys.DSC.exe set --resource 'settings' --module ZoomIt --input $config
 
 This example configures the ZoomIt activation shortcut using Microsoft DSC.
 
-```bash
-dsc config set --file zoomit-config.dsc.yaml
-```
+Save the following configuration as `zoomit-config.dsc.config.yaml`:
 
 ```yaml
-# zoomit-config.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Configure ZoomIt shortcut
@@ -90,16 +88,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file zoomit-config.dsc.config.yaml
+```
+
 ### Example 3 - Install and configure with WinGet
 
 This example installs PowerToys and configures ZoomIt using WinGet.
 
-```bash
-winget configure winget-zoomit.yaml
-```
+Save the following configuration as `zoomit.dsc.config.winget`:
 
 ```yaml
-# winget-zoomit.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -127,16 +129,20 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with WinGet:
+
+```bash
+winget configure zoomit.dsc.config.winget
+```
+
 ### Example 4 - Presentation mode hotkey
 
 This example configures an easy-to-remember presentation hotkey.
 
-```bash
-dsc config set --file zoomit-presentation.dsc.yaml
-```
+Save the following configuration as `zoomit-presentation.dsc.config.yaml`:
 
 ```yaml
-# zoomit-presentation.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Presentation hotkey
@@ -153,6 +159,12 @@ resources:
             key: "="
         name: ZoomIt
         version: 1.0
+```
+
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file zoomit-presentation.dsc.config.yaml
 ```
 
 ## Use cases

--- a/doc/dsc/overview.md
+++ b/doc/dsc/overview.md
@@ -53,10 +53,11 @@ For detailed information, see [PowerToys.DSC.exe command reference][01].
 
 ### 2. Microsoft Desired State Configuration (DSC)
 
-Use PowerToys DSC resources in standard DSC configuration documents:
+Use PowerToys DSC resources in standard DSC configuration documents. Save the
+following configuration as `powertoys-config.dsc.config.yaml`:
 
 ```yaml
-# powertoys-config.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Configure Awake
@@ -70,12 +71,19 @@ resources:
         version: 0.0.1
 ```
 
+Apply the configuration with Microsoft DSC:
+
+```bash
+dsc config set --file powertoys-config.dsc.config.yaml
+```
+
 ### 3. WinGet Configuration
 
-Integrate PowerToys configuration with WinGet package installation:
+Integrate PowerToys configuration with WinGet package installation. Save the
+following configuration as `powertoys.dsc.config.winget`:
 
 ```yaml
-# winget-powertoys.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -98,17 +106,25 @@ resources:
         version: 1.0
 ```
 
+Apply the configuration with WinGet:
+
+```bash
+winget configure powertoys.dsc.config.winget
+```
+
 ## Available resources
 
 PowerToys DSC provides the following resources:
 
-| Resource   | Description                                                        |
-| ---------- | ------------------------------------------------------------------ |
-| `settings` | Manages configuration for PowerToys utility modules.               |
-| `profile`  | Manages the Keyboard Manager remapping profile (keys, shortcuts).  |
+| Resource   | Description                                                                     |
+| ---------- | ------------------------------------------------------------------------------- |
+| `settings` | Manages configuration for PowerToys utility modules.                            |
+| `profile`  | Manages the Keyboard Manager remapping profile (keys, shortcuts).               |
+| `layouts`  | Manages the FancyZones layouts (custom layouts, templates, hotkeys, defaults).  |
 
-For detailed information, see the [Settings Resource Reference][03] and the
-[Keyboard Manager Profile Resource Reference][33].
+For detailed information, see the [Settings Resource Reference][03], the
+[Keyboard Manager Profile Resource Reference][33] and the
+[FancyZones Layouts Resource Reference][34].
 
 ## Available modules
 
@@ -244,3 +260,4 @@ For complete examples, see:
 [31]: https://learn.microsoft.com/powershell/dsc/overview
 [32]: https://learn.microsoft.com/windows/package-manager/configuration/
 [33]: ./profile-resource.md
+[34]: ./layouts-resource.md

--- a/doc/dsc/profile-resource.md
+++ b/doc/dsc/profile-resource.md
@@ -132,12 +132,10 @@ PowerToys.DSC.exe schema --resource 'profile' --module KeyboardManager
 
 ### Example 1 - Deploy remappings with DSC
 
-```bash
-dsc config set --file keyboardmanager-profile.dsc.yaml
-```
+Save the following configuration as `keyboardmanager-profile.dsc.config.yaml`:
 
 ```yaml
-# keyboardmanager-profile.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Deploy key remappings
@@ -159,14 +157,18 @@ resources:
           - { from: "Ctrl+Alt+B", openUri: "https://github.com/microsoft/PowerToys" }
 ```
 
-### Example 2 - Install PowerToys and deploy remappings with WinGet
+Apply the configuration with Microsoft DSC:
 
 ```bash
-winget configure winget-kbm-profile.yaml
+dsc config set --file keyboardmanager-profile.dsc.config.yaml
 ```
 
+### Example 2 - Install PowerToys and deploy remappings with WinGet
+
+Save the following configuration as `kbm-profile.dsc.config.winget`:
+
 ```yaml
-# winget-kbm-profile.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -195,6 +197,12 @@ resources:
           - { from: CapsLock, to: LCtrl }
         shortcuts:
           - { from: "Ctrl+Shift+V", toText: "Best regards,\nContoso IT" }
+```
+
+Apply the configuration with WinGet:
+
+```bash
+winget configure kbm-profile.dsc.config.winget
 ```
 
 ### Example 3 - Capture existing remappings

--- a/doc/dsc/settings-resource.md
+++ b/doc/dsc/settings-resource.md
@@ -83,6 +83,7 @@ PowerToys.DSC.exe get --resource 'settings' --module <ModuleName>
 **DSC configuration:**
 
 ```yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Get Awake settings
@@ -93,6 +94,7 @@ resources:
 **WinGet configuration:**
 
 ```yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -140,6 +142,7 @@ PowerToys.DSC.exe set --resource 'settings' --module Awake --input $input
 **DSC configuration:**
 
 ```yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Configure Awake
@@ -156,6 +159,7 @@ resources:
 **WinGet configuration:**
 
 ```yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -206,6 +210,7 @@ configuration matches (`true`) or differs (`false`).
 **DSC configuration:**
 
 ```yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Test Awake configuration
@@ -289,8 +294,10 @@ PowerToys.DSC.exe set --resource 'settings' --module FancyZones `
 This example configures multiple PowerToys utilities in a single DSC
 configuration.
 
+Save the following configuration as `powertoys-multi.dsc.config.yaml`:
+
 ```yaml
-# powertoys-multi.dsc.yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Enable PowerToys utilities
@@ -331,8 +338,10 @@ resources:
 
 This example installs PowerToys and applies configuration using WinGet.
 
+Save the following configuration as `powertoys-setup.dsc.config.winget`:
+
 ```yaml
-# winget-powertoys-setup.yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   winget:
@@ -389,7 +398,7 @@ resources:
 Apply the configuration:
 
 ```powershell
-winget configure winget-powertoys-setup.yaml
+winget configure powertoys-setup.dsc.config.winget
 ```
 
 ### Example 4 - Test configuration drift

--- a/overview.md
+++ b/overview.md
@@ -1,0 +1,140 @@
+---
+title: Configure PowerToys with Desired State Configuration
+description: >-
+  Learn about the two approaches to configure PowerToys using Desired State
+  Configuration: PowerShell DSC for legacy automation and Microsoft DSC for
+  modern declarative configuration.
+ms.date: 10/19/2025
+ms.topic: overview
+no-loc: [PowerToys, Windows, DSC, WinGet]
+# customer intent: As a Windows power user or IT administrator, I want to
+# understand the available DSC options for PowerToys configuration.
+---
+
+# Configure PowerToys with Desired State Configuration
+
+PowerToys supports two Desired State Configuration (DSC) approaches for
+automating and managing PowerToys settings across Windows systems. Each
+approach serves different use cases and is designed for specific workflows.
+
+## Understanding DSC in PowerToys
+
+Desired State Configuration enables you to define, deploy, and enforce
+configuration settings declaratively. Instead of writing scripts that perform
+configuration steps, you describe the desired end state, and DSC ensures the
+system matches that state.
+
+PowerToys offers two distinct DSC implementations:
+
+1. **PowerShell DSC (PSDSC)** - A legacy PowerShell-based module using DSC v2
+2. **Microsoft DSC** - A modern, cross-platform implementation using DSC v3
+
+> [!NOTE]
+> These are two separate implementations with different capabilities, syntaxes, and use cases. Choose the approach that best fits your infrastructure and requirements.
+
+## Choosing the right approach
+
+### Use PowerShell DSC when
+
+- You have existing PowerShell DSC infrastructure and workflows.
+- You're using PowerShell 7.4 or higher with PSDesiredStateConfiguration 2.0.7+.
+- You prefer PowerShell-based configuration management.
+
+**Available since:** PowerToys v0.80.0
+
+### Use Microsoft DSC when
+
+- You need standalone PowerToys configuration without PowerShell dependencies.
+- You're adopting Microsoft DSC standards and tooling.
+- You want direct command-line configuration with `PowerToys.DSC.exe`.
+- You need JSON schema validation and manifest generation.
+- You're building automation with the latest Microsoft DSC ecosystem.
+
+**Available since:** PowerToys v0.95.0
+
+## Key differences
+
+| Feature                  | PowerShell DSC                                      | Microsoft DSC                                                                                                                                    |
+|--------------------------|-----------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| **DSC Version**          | v2                                                  | v3                                                                                                                                               |
+| **Prerequisites**        | PowerShell 7.2+, PSDesiredStateConfiguration 2.0.7+ | None (standalone)                                                                                                                                |
+| **Module Name**          | `Microsoft.PowerToys.Configure`                     | Resource types under `Microsoft.PowerToys/`                                                                                                      |
+| **Command-line tool**    | PowerShell cmdlets                                  | `PowerToys.DSC.exe`                                                                                                                              |
+| **Configuration format** | YAML (WinGet configuration)                         | YAML (Microsoft DSC configuration documents), JSON or Bicep JSON                                                                                 |
+| **Resource model**       | Single `PowerToysConfigure` resource                | One settings resource per utility (for example, `AwakeSettings`), plus data resources such as `KeyboardManagerProfile` and `FancyZonesLayouts` |
+| **Platform support**     | Windows only                                        | Cross-platform ready                                                                                                                             |
+| **Schema support**       | Limited                                             | Full JSON schema generation                                                                                                                      |
+| **Manifest generation**  | No                                                  | Yes                                                                                                                                              |
+
+> [!IMPORTANT]
+> While Microsoft DSC is cross-platform ready and can run on Windows, Linux, and macOS, PowerToys itself is a Windows-only application. The Microsoft DSC implementation provides a modern, cross-platform architecture that aligns with the broader DSC v3 ecosystem, but PowerToys configuration can only be applied on Windows systems where PowerToys is installed.
+
+## Configuration scope
+
+Both approaches manage the settings that you can change in the PowerToys Settings app, such as whether a utility is enabled, its activation shortcuts, and its behavior and appearance options. The approaches differ in which utilities they cover and in whether they can manage the data a utility stores outside of its settings.
+
+### Utility settings
+
+Both approaches manage the settings of the following utilities:
+
+- General application settings (startup, theme, updates, enabled utilities)
+- Advanced Paste
+- Always On Top
+- Awake
+- Color Picker
+- Crop And Lock
+- Environment Variables
+- FancyZones
+- File Locksmith
+- Find My Mouse
+- Hosts File Editor
+- Image Resizer
+- Keyboard Manager
+- Mouse Highlighter
+- Mouse Jump
+- Mouse Pointer Crosshairs
+- Peek
+- PowerRename
+- Quick Accent (PowerAccent)
+- Registry Preview
+- Screen Ruler (MeasureTool)
+- Shortcut Guide
+- Text Extractor (PowerOCR)
+- Workspaces
+- ZoomIt
+
+PowerShell DSC also manages the settings of utilities that Microsoft DSC doesn't expose yet, such as Alt Window Cycle, Cursor Wrap, Grab And Move, Light Switch, and the File Explorer add-ons. Individual settings that aren't suitable for automation are skipped by both approaches.
+
+> [!NOTE]
+> Microsoft DSC intentionally excludes Mouse Without Borders, PowerToys Run, and New+. Their settings contain a connection security key or absolute file paths, which aren't portable between systems.
+
+### Utility data
+
+Some utilities store their configuration in dedicated files rather than in their settings. Microsoft DSC provides resources that manage this data declaratively. PowerShell DSC manages settings only.
+
+| Utility          | Data                                                                  | Microsoft DSC resource                       |
+|------------------|-----------------------------------------------------------------------|----------------------------------------------|
+| Keyboard Manager | Key remappings and shortcut remappings                                | `Microsoft.PowerToys/KeyboardManagerProfile` |
+| FancyZones       | Custom layouts, layout templates, layout hotkeys, and default layouts | `Microsoft.PowerToys/FancyZonesLayouts`      |
+
+When these resources are applied while PowerToys is running, the utility picks up the change immediately. Otherwise, the change takes effect the next time PowerToys starts.
+
+## Next steps
+
+Choose your DSC approach and get started:
+
+- **[Configure with PowerShell DSC][01]** - Learn about the PowerShell-based DSC module and WinGet configuration integration
+- **[Configure with Microsoft DSC][02]** - Explore the modern Microsoft DSC implementation with PowerToys.DSC.exe
+
+## See also
+
+- [PowerToys installation guide][03]
+- [WinGet Configuration documentation][04]
+- [Microsoft DSC documentation][05]
+
+<!-- Link reference definitions -->
+[01]: psdsc.md
+[02]: microsoft-dsc.md
+[03]: ../install.md
+[04]: /windows/package-manager/configuration/
+[05]: /powershell/dsc/overview

--- a/resources.md
+++ b/resources.md
@@ -1,0 +1,450 @@
+---
+title: Configure PowerToys with Microsoft DSC
+description: >-
+  Learn how to configure PowerToys utilities using Microsoft Desired State
+  Configuration v3 with the PowerToys.DSC.exe command-line tool. Modern
+  declarative configuration for PowerToys.
+ms.date: 09/13/2026
+ms.topic: how-to
+no-loc: [PowerToys, Windows, Microsoft DSC, WinGet]
+# customer intent: As a Windows power user or IT administrator, I want to
+# configure PowerToys using Microsoft DSC v3 and PowerToys.DSC.exe.
+---
+
+# Configure PowerToys with Microsoft DSC
+
+PowerToys includes a Microsoft Desired State Configuration (DSC) v3
+implementation through the `PowerToys.DSC.exe` command-line tool, enabling
+modern declarative configuration management of PowerToys settings.
+
+## Overview
+
+The `PowerToys.DSC.exe` command line-tool for PowerToys provides:
+
+- Standalone configuration tool without PowerShell dependencies
+- Individual DSC resource modules for each PowerToys utility
+- Standard DSC v3 operations: get, set, test, export, schema, manifest
+- JSON schema generation for validation
+- DSC manifest generation for resource discovery
+- Integration with WinGet and other orchestrator tools
+
+**Available since:** PowerToys v0.95.0
+
+## Prerequisites
+
+- **PowerToys v0.95.0 or later** - The `PowerToys.DSC.exe` tool is included
+  with PowerToys starting from version 0.95.0
+
+### Optional: Using orchestration tools
+
+If you want to use orchestration tools to manage PowerToys configuration:
+
+- **WinGet v1.6.2631 or later** - Required for WinGet configuration file
+  integration. Download from the [WinGet releases page][07]
+- **Microsoft DSC (dsc.exe) v3.1.1 or later** - Required for using
+  Microsoft DSC configuration documents with the `dsc` command-line tool.
+  Download from the [DSC releases page][08]
+
+> [!NOTE]
+> These orchestration tools are optional. You can use `PowerToys.DSC.exe`
+> directly without WinGet or `dsc.exe` for standalone configuration management.
+
+## Location
+
+The `PowerToys.DSC.exe` executable is installed with PowerToys:
+
+- **Per-user installation:**
+  `%LOCALAPPDATA%\PowerToys\PowerToys.DSC.exe`
+- **Machine-wide installation:**
+  `%ProgramFiles%\PowerToys\PowerToys.DSC.exe`
+
+You can add the PowerToys directory to your `PATH` environment variable for
+easier access, or use the full path to the executable.
+
+## Usage
+
+Microsoft DSC for PowerToys supports three usage patterns:
+
+### 1. Direct command-line execution
+
+Execute DSC operations directly using the `PowerToys.DSC.exe` tool:
+
+```powershell
+# Get current settings for a module
+PowerToys.DSC.exe get --resource 'settings' --module Awake
+
+# Set settings for a module
+$input = '{"settings":{"properties":{"keepDisplayOn":true,"mode":1},"name":"Awake","version":"0.0.1"}}'
+PowerToys.DSC.exe set --resource 'settings' --module Awake --input $input
+
+# Test if settings match desired state
+PowerToys.DSC.exe test --resource 'settings' --module Awake --input $input
+```
+
+### 2. Microsoft DSC configuration documents
+
+Use standard Microsoft DSC configuration documents to define PowerToys settings.
+
+Save the following configuration as `powertoys.dsc.config.yaml`:
+
+```yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
+$schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
+resources:
+  - name: Configure Awake
+    type: Microsoft.PowerToys/AwakeSettings
+    properties:
+      settings:
+        properties:
+          keepDisplayOn: true
+          mode: 1
+        name: Awake
+        version: 0.0.1
+```
+
+Apply the configuration using the `dsc` command-line interface (when
+available) or through WinGet configuration.
+
+### 3. WinGet configuration integration
+
+Integrate PowerToys configuration with WinGet package installation. Save the
+following configuration as `powertoys.dsc.config.winget`:
+
+```yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+metadata:
+  winget:
+    processor: dscv3
+resources:
+  - name: Install PowerToys
+    type: Microsoft.WinGet.DSC/WinGetPackage
+    properties:
+      id: Microsoft.PowerToys
+      source: winget
+  
+  - name: Configure FancyZones
+    type: Microsoft.PowerToys/FancyZonesSettings
+    properties:
+      settings:
+        properties:
+          fancyzones_shiftDrag: true
+          fancyzones_mouseSwitch: true
+        name: FancyZones
+        version: 1.0
+```
+
+Apply with WinGet:
+
+```powershell
+winget configure powertoys.dsc.config.winget
+```
+
+## Common operations
+
+### List supported modules
+
+List all PowerToys utilities that can be configured:
+
+```powershell
+PowerToys.DSC.exe modules --resource 'settings'
+```
+
+### Get current configuration
+
+Retrieve the current state of a module's settings:
+
+```powershell
+# Get settings for a specific module
+PowerToys.DSC.exe get --resource 'settings' --module FancyZones
+
+# Format output for readability
+PowerToys.DSC.exe get --resource 'settings' --module Awake | ConvertFrom-Json | ConvertTo-Json -Depth 10
+```
+
+### Apply configuration
+
+Set the desired configuration for a module:
+
+```powershell
+# Define desired configuration (using PowerShell)
+$config = @{
+    settings = @{
+        properties = @{
+            fancyzones_shiftDrag = $true
+            fancyzones_mouseSwitch = $true
+            fancyzones_overrideSnapHotkeys = $true
+        }
+        name = "FancyZones"
+        version = "1.0"
+    }
+} | ConvertTo-Json -Depth 10 -Compress
+
+# Apply configuration
+PowerToys.DSC.exe set --resource 'settings' --module FancyZones --input $config
+```
+
+### Test configuration
+
+Verify whether current settings match the desired state:
+
+```powershell
+$desired = @{
+    settings = @{
+        properties = @{
+            keepDisplayOn = $true
+            mode = 1
+        }
+        name = "Awake"
+        version = "0.0.1"
+    }
+} | ConvertTo-Json -Depth 10 -Compress
+
+# Test for drift
+$result = PowerToys.DSC.exe test --resource 'settings' --module Awake --input $desired | ConvertFrom-Json
+
+if ($result._inDesiredState) {
+    Write-Host "Configuration matches desired state"
+} else {
+    Write-Host "Configuration has drifted"
+}
+```
+
+### Generate JSON schema
+
+Get the JSON schema for a module to understand available properties:
+
+```powershell
+# Get schema for a module
+PowerToys.DSC.exe schema --resource 'settings' --module ColorPicker
+
+# Format for readability
+PowerToys.DSC.exe schema --resource 'settings' --module ColorPicker | ConvertFrom-Json | ConvertTo-Json -Depth 10
+```
+
+### Generate Microsoft DSC resource manifests
+
+Create Microsoft DSC resource manifest files for PowerToys modules:
+
+```powershell
+# Generate manifest for a specific module
+PowerToys.DSC.exe manifest --resource 'settings' --module Awake --outputDir C:\manifests
+
+# Generate manifests for all modules
+PowerToys.DSC.exe manifest --resource 'settings' --outputDir C:\manifests
+
+# Print manifest to console
+PowerToys.DSC.exe manifest --resource 'settings' --module FancyZones
+```
+
+> [!NOTE]
+> Microsoft DSC discovers resource manifests in directories listed in the `PATH`
+> environment variable by default. Add your output directory to `PATH`, or generate
+> manifests in the PowerToys installation directory if it is already on `PATH`:
+>
+> ```powershell
+> # Get the directory containing the PowerToys executable
+> $powerToysDirectory = Split-Path -Path (Get-Command PowerToys.DSC.exe -ErrorAction Stop).Source -Parent
+>
+> # Generate manifests in that directory
+> PowerToys.DSC.exe manifest --resource 'settings' --outputDir $powerToysDirectory
+> ```
+>
+> This example requires the PowerToys installation directory to be on `PATH` and
+> write permission to that directory. If `DSC_RESOURCE_PATH` is defined, Microsoft
+> DSC searches those directories instead of `PATH`. Include your manifest directory
+> in that variable instead. For more information, see
+> [DSC environment variables][09].
+
+## Configuration examples
+
+### Example 1: Configure FancyZones
+
+Save the following configuration as `fancyzones.dsc.config.yaml`:
+
+```yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
+$schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
+resources:
+  - name: Configure FancyZones window management
+    type: Microsoft.PowerToys/FancyZonesSettings
+    properties:
+      settings:
+        properties:
+          fancyzones_shiftDrag: true
+          fancyzones_mouseSwitch: false
+          fancyzones_overrideSnapHotkeys: true
+          fancyzones_displayOrWorkAreaChange_moveWindows: true
+          fancyzones_zoneSetChange_moveWindows: true
+        name: FancyZones
+        version: 1.0
+```
+
+### Example 2: Configure multiple utilities
+
+Save the following configuration as `multi-utility.dsc.config.yaml`:
+
+```yaml
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
+$schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
+resources:
+  - name: Configure general app settings
+    type: Microsoft.PowerToys/AppSettings
+    properties:
+      settings:
+        properties:
+          Enabled:
+            Awake: true
+            FancyZones: true
+            PowerRename: true
+            ColorPicker: true
+          run_elevated: true
+          startup: true
+        name: App
+        version: 1.0
+  
+  - name: Configure Awake
+    type: Microsoft.PowerToys/AwakeSettings
+    properties:
+      settings:
+        properties:
+          keepDisplayOn: true
+          mode: 1
+        name: Awake
+        version: 0.0.1
+  
+  - name: Configure ColorPicker
+    type: Microsoft.PowerToys/ColorPickerSettings
+    properties:
+      settings:
+        properties:
+          changecursor: true
+          copiedcolorrepresentation: "HEX"
+        name: ColorPicker
+        version: 1.0
+```
+
+### Example 3: Install and configure with WinGet
+
+Save the following configuration as `complete-setup.dsc.config.winget`:
+
+```yaml
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+metadata:
+  winget:
+    processor: dscv3
+resources:
+  - name: Install PowerToys
+    type: Microsoft.WinGet.DSC/WinGetPackage
+    properties:
+      id: Microsoft.PowerToys
+      source: winget
+      ensure: Present
+  
+  - name: Enable utilities
+    type: Microsoft.PowerToys/AppSettings
+    properties:
+      settings:
+        properties:
+          startup: true
+          theme: "dark"
+        name: App
+        version: 1.0
+  
+  - name: Configure PowerToys Run
+    type: Microsoft.PowerToys/PowerLauncherSettings
+    properties:
+      settings:
+        properties:
+          maximum_number_of_results: 8
+          clear_input_on_launch: true
+        name: PowerLauncher
+        version: 1.0
+```
+
+## Available resources
+
+Microsoft DSC for PowerToys provides individual resource types for each
+utility. The resource type naming follows the pattern:
+`Microsoft.PowerToys/<UtilityName>Settings`
+
+Common resources include:
+
+- `Microsoft.PowerToys/AppSettings` - General application settings
+- `Microsoft.PowerToys/AlwaysOnTopSettings` - Always On Top configuration
+- `Microsoft.PowerToys/AwakeSettings` - Awake keep-awake settings
+- `Microsoft.PowerToys/ColorPickerSettings` - Color Picker settings
+- `Microsoft.PowerToys/FancyZonesSettings` - FancyZones window management
+- `Microsoft.PowerToys/PowerLauncherSettings` - PowerToys Run settings
+- `Microsoft.PowerToys/PowerRenameSettings` - PowerRename bulk rename
+- And many more for each PowerToys utility
+
+For a complete list of resources and their properties, see the
+[developer documentation][01].
+
+## Advanced usage
+
+### Backup and restore configuration
+
+Export all module configurations for backup:
+
+```powershell
+# Get list of all modules
+$modules = PowerToys.DSC.exe modules --resource 'settings'
+
+# Export each module
+$backup = @{}
+foreach ($module in $modules) {
+    $config = PowerToys.DSC.exe export --resource 'settings' --module $module | ConvertFrom-Json
+    $backup[$module] = $config
+}
+
+# Save backup
+$backup | ConvertTo-Json -Depth 10 | Out-File powertoys-backup.json
+
+# Restore from backup
+$restore = Get-Content powertoys-backup.json | ConvertFrom-Json
+foreach ($module in $restore.PSObject.Properties.Name) {
+    $input = $restore.$module | ConvertTo-Json -Depth 10 -Compress
+    PowerToys.DSC.exe set --resource 'settings' --module $module --input $input
+}
+```
+
+## Migrating from PowerShell DSC
+
+If you're migrating from the PowerShell DSC module
+(`Microsoft.PowerToys.Configure`), note these key differences:
+
+1. **Resource naming:** PowerShell DSC uses a single `PowerToysConfigure`
+   resource with nested properties. Microsoft DSC uses individual resources
+   per utility (e.g., `AwakeSettings`, `FancyZonesSettings`)
+
+2. **Property format:** Some property names may differ slightly. Use the
+   `schema` command to see available properties for each module
+
+3. **Configuration structure:** Microsoft DSC uses the `settings` wrapper with
+   `properties`, `name`, and `version` fields
+
+4. **No PowerShell required:** Microsoft DSC runs standalone without
+   PowerShell dependencies
+
+## See also
+
+- [Configure PowerToys with DSC overview][02]
+- [Configure with PowerShell DSC][03]
+- [PowerToys DSC developer documentation][01]
+- [PowerToys installation guide][04]
+- [Microsoft DSC documentation][05]
+- [WinGet configuration documentation][06]
+
+<!-- Link reference definitions -->
+[01]: https://github.com/microsoft/PowerToys/tree/main/doc/dsc/overview.md
+[02]: overview.md
+[03]: psdsc.md
+[04]: ../install.md
+[05]: /powershell/dsc/overview
+[06]: /windows/package-manager/configuration/
+[07]: https://github.com/microsoft/winget-cli/releases
+[08]: https://github.com/PowerShell/DSC/releases
+[09]: /powershell/dsc/reference/cli/?view=dsc-3.0&preserve-view=true#environment-variables

--- a/src/dsc/v3/PowerToys.DSC.UnitTests/FancyZones/FzLayoutsConverterTests.cs
+++ b/src/dsc/v3/PowerToys.DSC.UnitTests/FancyZones/FzLayoutsConverterTests.cs
@@ -1,0 +1,531 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using FancyZonesEditorCommon.Data;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PowerToys.DSC.Models.FancyZones;
+
+namespace PowerToys.DSC.UnitTests.FancyZones;
+
+[TestClass]
+public sealed class FzLayoutsConverterTests
+{
+    private const string GridGuid = "{5C4F1A20-9B3E-4C7D-8E2F-1A2B3C4D5E6F}";
+    private const string CanvasGuid = "{8F0B6D3E-2C41-4A5B-9D7E-0F1A2B3C4D5E}";
+
+    private const string EditorCustomLayoutsJson = /*lang=json,strict*/ """
+        {
+          "custom-layouts": [
+            {
+              "uuid": "{5C4F1A20-9B3E-4C7D-8E2F-1A2B3C4D5E6F}",
+              "name": "Two columns",
+              "type": "grid",
+              "info": {
+                "rows": 1,
+                "columns": 2,
+                "rows-percentage": [ 10000 ],
+                "columns-percentage": [ 7000, 3000 ],
+                "cell-child-map": [ [ 0, 1 ] ],
+                "show-spacing": false,
+                "spacing": 4,
+                "sensitivity-radius": 30
+              }
+            },
+            {
+              "uuid": "{8F0B6D3E-2C41-4A5B-9D7E-0F1A2B3C4D5E}",
+              "name": "Reference window",
+              "type": "canvas",
+              "info": {
+                "ref-width": 1920,
+                "ref-height": 1080,
+                "zones": [
+                  { "X": 0, "Y": 0, "width": 1280, "height": 1080 },
+                  { "X": 1280, "Y": 0, "width": 640, "height": 1080 }
+                ],
+                "sensitivity-radius": 20
+              }
+            }
+          ]
+        }
+        """;
+
+    [TestMethod]
+    public void FromCustomLayouts_ConvertsEditorShape()
+    {
+        // Arrange
+        var stored = JsonSerializer.Deserialize(EditorCustomLayoutsJson, FancyZonesJsonContext.Default.CustomLayoutListWrapper);
+        var warnings = new List<string>();
+
+        // Act
+        var layouts = FzLayoutsConverter.FromCustomLayouts(stored, warnings);
+
+        // Assert
+        Assert.AreEqual(0, warnings.Count);
+        Assert.AreEqual(2, layouts.Count);
+
+        var grid = layouts[0];
+        Assert.AreEqual(GridGuid, grid.Uuid);
+        Assert.AreEqual("Two columns", grid.Name);
+        Assert.IsNull(grid.Canvas);
+        Assert.IsNotNull(grid.Grid);
+        Assert.AreEqual(1, grid.Grid.Rows);
+        Assert.AreEqual(2, grid.Grid.Columns);
+        CollectionAssert.AreEqual(new List<int> { 10000 }, grid.Grid.RowsPercentage);
+        CollectionAssert.AreEqual(new List<int> { 7000, 3000 }, grid.Grid.ColumnsPercentage);
+        Assert.AreEqual(1, grid.Grid.CellChildMap.Count);
+        CollectionAssert.AreEqual(new List<int> { 0, 1 }, grid.Grid.CellChildMap[0]);
+        Assert.IsFalse(grid.Grid.ShowSpacing);
+        Assert.AreEqual(4, grid.Grid.Spacing);
+        Assert.AreEqual(30, grid.Grid.SensitivityRadius);
+
+        var canvas = layouts[1];
+        Assert.AreEqual(CanvasGuid, canvas.Uuid);
+        Assert.IsNull(canvas.Grid);
+        Assert.IsNotNull(canvas.Canvas);
+        Assert.AreEqual(1920, canvas.Canvas.RefWidth);
+        Assert.AreEqual(1080, canvas.Canvas.RefHeight);
+        Assert.AreEqual(2, canvas.Canvas.Zones.Count);
+        Assert.AreEqual(1280, canvas.Canvas.Zones[1].X);
+        Assert.AreEqual(640, canvas.Canvas.Zones[1].Width);
+        Assert.AreEqual(20, canvas.Canvas.SensitivityRadius);
+    }
+
+    [TestMethod]
+    public void ToCustomLayouts_ProducesEditorCompatibleShape()
+    {
+        // Arrange
+        var model = CreateSampleModel();
+
+        // Act
+        var stored = FzLayoutsConverter.ToCustomLayouts(model.Custom);
+        var json = JsonNode.Parse(new CustomLayouts().Serialize(stored));
+
+        // Assert: kebab-case keys, upper-case X/Y and braced upper-case GUIDs
+        var layouts = json["custom-layouts"].AsArray();
+        Assert.AreEqual(2, layouts.Count);
+
+        var grid = layouts[0];
+        Assert.AreEqual(GridGuid, grid["uuid"].GetValue<string>());
+        Assert.AreEqual("grid", grid["type"].GetValue<string>());
+        Assert.AreEqual(2, grid["info"]["columns"].GetValue<int>());
+        Assert.AreEqual(3000, grid["info"]["columns-percentage"][1].GetValue<int>());
+        Assert.AreEqual(1, grid["info"]["cell-child-map"][0][1].GetValue<int>());
+        Assert.IsTrue(grid["info"]["show-spacing"].GetValue<bool>());
+        Assert.AreEqual(16, grid["info"]["spacing"].GetValue<int>());
+        Assert.AreEqual(20, grid["info"]["sensitivity-radius"].GetValue<int>());
+
+        var canvas = layouts[1];
+        Assert.AreEqual(CanvasGuid, canvas["uuid"].GetValue<string>());
+        Assert.AreEqual("canvas", canvas["type"].GetValue<string>());
+        Assert.AreEqual(1920, canvas["info"]["ref-width"].GetValue<int>());
+        Assert.AreEqual(1280, canvas["info"]["zones"][1]["X"].GetValue<int>());
+        Assert.AreEqual(0, canvas["info"]["zones"][1]["Y"].GetValue<int>());
+        Assert.AreEqual(640, canvas["info"]["zones"][1]["width"].GetValue<int>());
+        Assert.AreEqual(20, canvas["info"]["sensitivity-radius"].GetValue<int>());
+    }
+
+    [TestMethod]
+    public void ToDefaultLayouts_ProducesEditorCompatibleShape()
+    {
+        // Arrange
+        var model = CreateSampleModel();
+
+        // Act
+        var stored = FzLayoutsConverter.ToDefaultLayouts(model.Defaults, model.Custom);
+        var json = JsonNode.Parse(new DefaultLayouts().Serialize(stored));
+
+        // Assert
+        var defaults = json["default-layouts"].AsArray();
+        Assert.AreEqual(2, defaults.Count);
+
+        var horizontal = defaults[0];
+        Assert.AreEqual("horizontal", horizontal["monitor-configuration"].GetValue<string>());
+        Assert.AreEqual("custom", horizontal["layout"]["type"].GetValue<string>());
+        Assert.AreEqual(GridGuid, horizontal["layout"]["uuid"].GetValue<string>());
+        Assert.IsTrue(horizontal["layout"]["show-spacing"].GetValue<bool>());
+        Assert.AreEqual(16, horizontal["layout"]["spacing"].GetValue<int>());
+        Assert.AreEqual(0, horizontal["layout"]["zone-count"].GetValue<int>());
+        Assert.AreEqual(0, horizontal["layout"]["sensitivity-radius"].GetValue<int>());
+
+        var vertical = defaults[1];
+        Assert.AreEqual("vertical", vertical["monitor-configuration"].GetValue<string>());
+        Assert.AreEqual("rows", vertical["layout"]["type"].GetValue<string>());
+        Assert.AreEqual(string.Empty, vertical["layout"]["uuid"].GetValue<string>());
+        Assert.AreEqual(2, vertical["layout"]["zone-count"].GetValue<int>());
+        Assert.AreEqual(20, vertical["layout"]["sensitivity-radius"].GetValue<int>());
+    }
+
+    [TestMethod]
+    public void Canonicalize_IsIdempotent()
+    {
+        // Arrange
+        var model = CreateSampleModel();
+
+        // Act
+        var first = FzLayoutsConverter.Canonicalize(model);
+        var second = FzLayoutsConverter.Canonicalize(first);
+
+        // Assert
+        AssertLayoutsAreEqual(first, second);
+    }
+
+    [TestMethod]
+    public void Canonicalize_FillsDefaults()
+    {
+        // Act
+        var canonical = FzLayoutsConverter.Canonicalize(CreateSampleModel());
+
+        // Assert: custom layouts
+        Assert.IsTrue(canonical.Custom[0].Grid.ShowSpacing);
+        Assert.AreEqual(16, canonical.Custom[0].Grid.Spacing);
+        Assert.AreEqual(20, canonical.Custom[0].Grid.SensitivityRadius);
+        Assert.AreEqual(20, canonical.Custom[1].Canvas.SensitivityRadius);
+
+        // Templates: grid types get spacing defaults, focus gets none
+        Assert.AreEqual("focus", canonical.Templates[0].Type);
+        Assert.AreEqual(4, canonical.Templates[0].ZoneCount);
+        Assert.IsFalse(canonical.Templates[0].ShowSpacing);
+        Assert.AreEqual(0, canonical.Templates[0].Spacing);
+        Assert.AreEqual(20, canonical.Templates[0].SensitivityRadius);
+        Assert.AreEqual("priority-grid", canonical.Templates[1].Type);
+        Assert.AreEqual(3, canonical.Templates[1].ZoneCount);
+        Assert.IsTrue(canonical.Templates[1].ShowSpacing);
+        Assert.AreEqual(16, canonical.Templates[1].Spacing);
+
+        // Defaults: a template default has no uuid, a custom default copies the grid spacing
+        var vertical = canonical.Defaults.Vertical;
+        Assert.IsNull(vertical.Uuid);
+        Assert.AreEqual(2, vertical.ZoneCount);
+        Assert.IsTrue(vertical.ShowSpacing);
+        Assert.AreEqual(16, vertical.Spacing);
+        Assert.AreEqual(20, vertical.SensitivityRadius);
+
+        var horizontal = canonical.Defaults.Horizontal;
+        Assert.AreEqual(GridGuid, horizontal.Uuid);
+        Assert.IsTrue(horizontal.ShowSpacing);
+        Assert.AreEqual(16, horizontal.Spacing);
+        Assert.AreEqual(0, horizontal.ZoneCount);
+        Assert.AreEqual(0, horizontal.SensitivityRadius);
+    }
+
+    [TestMethod]
+    public void Canonicalize_SortsHotkeysAndTemplates_PreservesCustomOrder()
+    {
+        // Arrange
+        var model = new FzLayoutsModel
+        {
+            Custom = [CreateCanvasLayout(CanvasGuid), CreateGridLayout(GridGuid)],
+            Templates = [new() { Type = "priority-grid" }, new() { Type = "focus" }, new() { Type = "rows" }],
+            Hotkeys =
+            [
+                new() { Key = 3, LayoutId = GridGuid },
+                new() { Key = 1, LayoutId = CanvasGuid },
+            ],
+        };
+
+        // Act
+        var canonical = FzLayoutsConverter.Canonicalize(model);
+
+        // Assert
+        Assert.AreEqual(CanvasGuid, canonical.Custom[0].Uuid);
+        Assert.AreEqual(GridGuid, canonical.Custom[1].Uuid);
+        CollectionAssert.AreEqual(new List<string> { "focus", "rows", "priority-grid" }, canonical.Templates.Select(t => t.Type).ToList());
+        CollectionAssert.AreEqual(new List<int> { 1, 3 }, canonical.Hotkeys.Select(h => h.Key).ToList());
+    }
+
+    [TestMethod]
+    public void Canonicalize_UnsetSectionsStayUnset()
+    {
+        // Arrange
+        var model = new FzLayoutsModel { Hotkeys = [new() { Key = 1, LayoutId = GridGuid }] };
+
+        // Act
+        var canonical = FzLayoutsConverter.Canonicalize(model);
+
+        // Assert
+        Assert.IsNull(canonical.Custom);
+        Assert.IsNull(canonical.Templates);
+        Assert.IsNull(canonical.Defaults);
+        Assert.AreEqual(1, canonical.Hotkeys.Count);
+    }
+
+    [TestMethod]
+    public void Canonicalize_CustomDefault_ResolvesGridFromCurrentLayouts()
+    {
+        // Arrange: the model does not define custom layouts, the current state does
+        var current = new List<FzCustomLayout> { CreateGridLayout(GridGuid) };
+        current[0].Grid.ShowSpacing = false;
+        current[0].Grid.Spacing = 8;
+        var model = new FzLayoutsModel
+        {
+            Defaults = new() { Horizontal = new() { Type = "custom", Uuid = GridGuid } },
+        };
+
+        // Act
+        var canonical = FzLayoutsConverter.Canonicalize(model, current);
+
+        // Assert
+        Assert.IsFalse(canonical.Defaults.Horizontal.ShowSpacing);
+        Assert.AreEqual(8, canonical.Defaults.Horizontal.Spacing);
+    }
+
+    [DataTestMethod]
+    [DataRow("5c4f1a20-9b3e-4c7d-8e2f-1a2b3c4d5e6f", true, GridGuid)]
+    [DataRow("{5C4F1A20-9B3E-4C7D-8E2F-1A2B3C4D5E6F}", true, GridGuid)]
+    [DataRow(" {5c4f1a20-9b3e-4c7d-8e2f-1a2b3c4d5e6f} ", true, GridGuid)]
+    [DataRow("not-a-guid", false, null)]
+    [DataRow("", false, null)]
+    [DataRow(null, false, null)]
+    public void TryNormalizeGuid_NormalizesToEditorForm(string input, bool expectedResult, string expectedGuid)
+    {
+        // Act
+        var result = FzLayoutsConverter.TryNormalizeGuid(input, out var normalized);
+
+        // Assert
+        Assert.AreEqual(expectedResult, result);
+        Assert.AreEqual(expectedGuid, normalized);
+    }
+
+    [TestMethod]
+    public void Validate_ValidModel_NoErrors()
+    {
+        // Arrange
+        var warnings = new List<string>();
+
+        // Act
+        var errors = FzLayoutsConverter.Validate(CreateSampleModel(), null, warnings);
+
+        // Assert
+        Assert.AreEqual(0, errors.Count, string.Join(" | ", errors));
+        Assert.AreEqual(0, warnings.Count);
+    }
+
+    [TestMethod]
+    public void Validate_EmptyModel_Warns()
+    {
+        // Arrange
+        var warnings = new List<string>();
+
+        // Act
+        var errors = FzLayoutsConverter.Validate(new FzLayoutsModel(), null, warnings);
+
+        // Assert
+        Assert.AreEqual(0, errors.Count);
+        Assert.AreEqual(1, warnings.Count);
+        StringAssert.Contains(warnings[0], "nothing is managed");
+    }
+
+    [TestMethod]
+    public void Validate_LayoutReference_ErrorWhenCustomLayoutsDefined()
+    {
+        // Arrange
+        var model = new FzLayoutsModel
+        {
+            Custom = [CreateGridLayout(GridGuid)],
+            Hotkeys = [new() { Key = 1, LayoutId = CanvasGuid }],
+        };
+
+        // Act
+        var errors = FzLayoutsConverter.Validate(model);
+
+        // Assert
+        Assert.AreEqual(1, errors.Count);
+        Assert.AreEqual($"hotkeys[0].layoutId: layout '{CanvasGuid}' is not defined in 'custom'", errors[0]);
+    }
+
+    [TestMethod]
+    public void Validate_LayoutReference_WarnsAgainstCurrentState()
+    {
+        // Arrange
+        var model = new FzLayoutsModel { Hotkeys = [new() { Key = 1, LayoutId = CanvasGuid }] };
+        var current = new FzLayoutsModel { Custom = [CreateGridLayout(GridGuid)] };
+        var warnings = new List<string>();
+
+        // Act
+        var errors = FzLayoutsConverter.Validate(model, current, warnings);
+
+        // Assert
+        Assert.AreEqual(0, errors.Count);
+        Assert.AreEqual(1, warnings.Count);
+        Assert.AreEqual($"hotkeys[0].layoutId: layout '{CanvasGuid}' does not exist in the current custom layouts", warnings[0]);
+    }
+
+    [TestMethod]
+    public void Validate_LayoutReference_NoWarningWithoutCurrentState()
+    {
+        // Arrange
+        var model = new FzLayoutsModel { Hotkeys = [new() { Key = 1, LayoutId = CanvasGuid }] };
+        var warnings = new List<string>();
+
+        // Act
+        var errors = FzLayoutsConverter.Validate(model, null, warnings);
+
+        // Assert
+        Assert.AreEqual(0, errors.Count);
+        Assert.AreEqual(0, warnings.Count);
+    }
+
+    [TestMethod]
+    public void Validate_CanvasWithTooManyZones_Error()
+    {
+        // Arrange
+        var layout = CreateCanvasLayout(CanvasGuid);
+        layout.Canvas.Zones = Enumerable.Range(0, LayoutDefaultSettings.MaxZones + 1)
+            .Select(i => new FzCanvasZone { X = i, Y = 0, Width = 10, Height = 10 })
+            .ToList();
+        var model = new FzLayoutsModel { Custom = [layout] };
+
+        // Act
+        var errors = FzLayoutsConverter.Validate(model);
+
+        // Assert
+        Assert.AreEqual(1, errors.Count);
+        Assert.AreEqual("custom[0].canvas.zones must not contain more than 128 zones", errors[0]);
+    }
+
+    [TestMethod]
+    public void Validate_NegativeValues_Errors()
+    {
+        // Arrange
+        var grid = CreateGridLayout(GridGuid);
+        grid.Grid.Spacing = -1;
+        grid.Grid.SensitivityRadius = -1;
+        var model = new FzLayoutsModel
+        {
+            Custom = [grid],
+            Templates = [new() { Type = "focus", ZoneCount = -1 }],
+            Defaults = new() { Vertical = new() { Type = "blank", Spacing = -5 } },
+        };
+
+        // Act
+        var errors = FzLayoutsConverter.Validate(model);
+
+        // Assert
+        CollectionAssert.AreEquivalent(
+            new List<string>
+            {
+                "custom[0].grid.spacing must not be negative",
+                "custom[0].grid.sensitivityRadius must not be negative",
+                "templates[0].zoneCount must not be negative",
+                "defaults.vertical.spacing must not be negative",
+            },
+            errors.ToList());
+    }
+
+    [TestMethod]
+    public void FromCustomLayouts_SkipsEntriesTheEngineWouldNotLoad()
+    {
+        // Arrange
+        var json = /*lang=json,strict*/ """
+            {
+              "custom-layouts": [
+                { "uuid": "not-a-guid", "name": "Bad id", "type": "grid", "info": { "rows": 1, "columns": 1, "rows-percentage": [ 10000 ], "columns-percentage": [ 10000 ], "cell-child-map": [ [ 0 ] ] } },
+                { "uuid": "{5C4F1A20-9B3E-4C7D-8E2F-1A2B3C4D5E6F}", "name": "No info", "type": "grid" },
+                { "uuid": "{8F0B6D3E-2C41-4A5B-9D7E-0F1A2B3C4D5E}", "name": "Unknown", "type": "hexagons", "info": {} }
+              ]
+            }
+            """;
+        var stored = JsonSerializer.Deserialize(json, FancyZonesJsonContext.Default.CustomLayoutListWrapper);
+        var warnings = new List<string>();
+
+        // Act
+        var layouts = FzLayoutsConverter.FromCustomLayouts(stored, warnings);
+
+        // Assert
+        Assert.AreEqual(0, layouts.Count);
+        Assert.AreEqual(3, warnings.Count);
+        StringAssert.Contains(warnings[0], "invalid uuid 'not-a-guid'");
+        StringAssert.Contains(warnings[1], "without layout info");
+        StringAssert.Contains(warnings[2], "unknown type 'hexagons'");
+    }
+
+    [TestMethod]
+    public void FromDefaultLayouts_UnknownMonitorConfiguration_TreatedAsHorizontal()
+    {
+        // Arrange: mirrors DefaultLayoutsJsonUtils::TypeFromString in the engine
+        var json = /*lang=json,strict*/ """
+            {
+              "default-layouts": [
+                { "monitor-configuration": "diagonal", "layout": { "uuid": "", "type": "columns", "show-spacing": true, "spacing": 16, "zone-count": 3, "sensitivity-radius": 20 } }
+              ]
+            }
+            """;
+        var stored = JsonSerializer.Deserialize(json, FancyZonesJsonContext.Default.DefaultLayoutsListWrapper);
+
+        // Act
+        var defaults = FzLayoutsConverter.FromDefaultLayouts(stored);
+
+        // Assert
+        Assert.IsNull(defaults.Vertical);
+        Assert.IsNotNull(defaults.Horizontal);
+        Assert.AreEqual("columns", defaults.Horizontal.Type);
+        Assert.IsNull(defaults.Horizontal.Uuid);
+    }
+
+    private static FzLayoutsModel CreateSampleModel()
+    {
+        return new FzLayoutsModel
+        {
+            Custom = [CreateGridLayout(GridGuid), CreateCanvasLayout(CanvasGuid)],
+            Templates =
+            [
+                new() { Type = "priority-grid", ZoneCount = 3 },
+                new() { Type = "focus", ZoneCount = 4 },
+            ],
+            Hotkeys = [new() { Key = 1, LayoutId = GridGuid }],
+            Defaults = new()
+            {
+                Horizontal = new() { Type = "custom", Uuid = GridGuid },
+                Vertical = new() { Type = "rows", ZoneCount = 2 },
+            },
+        };
+    }
+
+    private static FzCustomLayout CreateGridLayout(string uuid)
+    {
+        return new FzCustomLayout
+        {
+            Uuid = uuid,
+            Name = "Two columns",
+            Grid = new()
+            {
+                Rows = 1,
+                Columns = 2,
+                RowsPercentage = [10000],
+                ColumnsPercentage = [7000, 3000],
+                CellChildMap = [[0, 1]],
+            },
+        };
+    }
+
+    private static FzCustomLayout CreateCanvasLayout(string uuid)
+    {
+        return new FzCustomLayout
+        {
+            Uuid = uuid,
+            Name = "Reference window",
+            Canvas = new()
+            {
+                RefWidth = 1920,
+                RefHeight = 1080,
+                Zones =
+                [
+                    new() { X = 0, Y = 0, Width = 1280, Height = 1080 },
+                    new() { X = 1280, Y = 0, Width = 640, Height = 1080 },
+                ],
+            },
+        };
+    }
+
+    private static void AssertLayoutsAreEqual(FzLayoutsModel expected, FzLayoutsModel actual)
+    {
+        var expectedJson = JsonSerializer.SerializeToNode(expected);
+        var actualJson = JsonSerializer.SerializeToNode(actual);
+        Assert.IsTrue(JsonNode.DeepEquals(expectedJson, actualJson), $"{expectedJson} != {actualJson}");
+    }
+}

--- a/src/dsc/v3/PowerToys.DSC.UnitTests/LayoutsResourceTests/LayoutsResourceCommandTest.cs
+++ b/src/dsc/v3/PowerToys.DSC.UnitTests/LayoutsResourceTests/LayoutsResourceCommandTest.cs
@@ -1,0 +1,149 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json.Nodes;
+using ManagedCommon;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PowerToys.DSC.Commands;
+using PowerToys.DSC.DSCResources;
+using PowerToys.DSC.Models;
+using PowerToys.DSC.Models.FancyZones;
+using PowerToys.DSC.Models.ResourceObjects;
+
+namespace PowerToys.DSC.UnitTests.LayoutsResourceTests;
+
+[TestClass]
+public sealed class LayoutsResourceCommandTest : BaseDscTest
+{
+    [TestMethod]
+    public void Modules_ListsOnlyFancyZones()
+    {
+        // Act
+        var result = ExecuteDscCommand<ModulesCommand>("--resource", LayoutsResource.ResourceName);
+
+        // Assert
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(nameof(ModuleType.FancyZones), result.Output.Trim());
+    }
+
+    [TestMethod]
+    public void UnsupportedModule_Fail()
+    {
+        // Act
+        var result = ExecuteDscCommand<GetCommand>("--resource", LayoutsResource.ResourceName, "--module", "Awake");
+
+        // Assert: the module check in BaseCommand reports a plain-text line
+        // on the error stream, not a JSON message
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(GetResourceString("ModuleNotSupportedByResource", "Awake", LayoutsResource.ResourceName), result.Error.Trim());
+    }
+
+    [TestMethod]
+    public void Schema_ContainsRequiredLayoutsPropertyWithSections()
+    {
+        // Act
+        var result = ExecuteDscCommand<SchemaCommand>("--resource", LayoutsResource.ResourceName, "--module", nameof(ModuleType.FancyZones));
+
+        // Assert
+        Assert.IsTrue(result.Success);
+        var schema = JsonNode.Parse(result.Output);
+        Assert.IsNotNull(schema);
+        var layouts = schema["properties"]?[LayoutsResourceObject.LayoutsJsonPropertyName];
+        Assert.IsNotNull(layouts);
+        var required = schema["required"]?.AsArray();
+        Assert.IsNotNull(required);
+        Assert.IsTrue(required.ToString().Contains(LayoutsResourceObject.LayoutsJsonPropertyName));
+
+        var sections = ResolveReference(schema, layouts)?["properties"];
+        Assert.IsNotNull(sections);
+        Assert.IsNotNull(sections[FzLayoutsModel.CustomJsonPropertyName]);
+        Assert.IsNotNull(sections[FzLayoutsModel.TemplatesJsonPropertyName]);
+        Assert.IsNotNull(sections[FzLayoutsModel.HotkeysJsonPropertyName]);
+        Assert.IsNotNull(sections[FzLayoutsModel.DefaultsJsonPropertyName]);
+    }
+
+    [TestMethod]
+    public void Set_EmptyInput_Fail()
+    {
+        // Act
+        var result = ExecuteDscCommand<SetCommand>("--resource", LayoutsResource.ResourceName, "--module", nameof(ModuleType.FancyZones));
+        var messages = result.Messages();
+
+        // Assert
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(1, messages.Count);
+        Assert.AreEqual(DscMessageLevel.Error, messages[0].Level);
+        Assert.AreEqual(GetResourceString("InputEmptyOrNullError"), messages[0].Message);
+    }
+
+    [TestMethod]
+    public void Test_EmptyInput_Fail()
+    {
+        // Act
+        var result = ExecuteDscCommand<TestCommand>("--resource", LayoutsResource.ResourceName, "--module", nameof(ModuleType.FancyZones));
+        var messages = result.Messages();
+
+        // Assert
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(1, messages.Count);
+        Assert.AreEqual(DscMessageLevel.Error, messages[0].Level);
+        Assert.AreEqual(GetResourceString("InputEmptyOrNullError"), messages[0].Message);
+    }
+
+    [TestMethod]
+    public void Manifest_WritesFancyZonesLayoutsManifest()
+    {
+        // Arrange
+        var outputDir = Path.Combine(Path.GetTempPath(), "PowerToys.DSC.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outputDir);
+
+        try
+        {
+            // Act
+            var result = ExecuteDscCommand<ManifestCommand>("--resource", LayoutsResource.ResourceName, "--module", nameof(ModuleType.FancyZones), "--outputDir", outputDir);
+
+            // Assert
+            Assert.IsTrue(result.Success);
+            var manifestPath = Path.Combine(outputDir, "microsoft.powertoys.FancyZones.layouts.dsc.resource.json");
+            Assert.IsTrue(File.Exists(manifestPath), $"Manifest not found at {manifestPath}");
+
+            var manifest = JsonNode.Parse(File.ReadAllText(manifestPath));
+            Assert.IsNotNull(manifest);
+            Assert.AreEqual("Microsoft.PowerToys/FancyZonesLayouts", manifest["type"]?.GetValue<string>());
+            var setArgs = manifest["set"]?["args"]?.ToJsonString();
+            Assert.IsNotNull(setArgs);
+            StringAssert.Contains(setArgs, LayoutsResource.ResourceName);
+            StringAssert.Contains(setArgs, nameof(ModuleType.FancyZones));
+        }
+        finally
+        {
+            Directory.Delete(outputDir, true);
+        }
+    }
+
+    /// <summary>
+    /// Resolves a "$ref" to a schema definition, if the node is a reference.
+    /// NJsonSchema emits a nested object property either as a direct
+    /// reference or as a "oneOf" containing the reference.
+    /// </summary>
+    private static JsonNode ResolveReference(JsonNode schema, JsonNode node)
+    {
+        var reference = node?["$ref"]?.GetValue<string>();
+        if (reference == null && node?["oneOf"] is JsonArray alternatives)
+        {
+            reference = alternatives.Select(alternative => alternative?["$ref"]?.GetValue<string>()).FirstOrDefault(r => r != null);
+        }
+
+        if (reference == null)
+        {
+            return node;
+        }
+
+        var name = reference.Substring(reference.LastIndexOf('/') + 1);
+        return schema["definitions"]?[name];
+    }
+}

--- a/src/dsc/v3/PowerToys.DSC.UnitTests/LayoutsResourceTests/LayoutsResourceFancyZonesTest.cs
+++ b/src/dsc/v3/PowerToys.DSC.UnitTests/LayoutsResourceTests/LayoutsResourceFancyZonesTest.cs
@@ -1,0 +1,699 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using ManagedCommon;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PowerToys.DSC.Commands;
+using PowerToys.DSC.DSCResources;
+using PowerToys.DSC.Models;
+using PowerToys.DSC.Models.FancyZones;
+using PowerToys.DSC.Models.FunctionData;
+using PowerToys.DSC.Models.ResourceObjects;
+
+namespace PowerToys.DSC.UnitTests.LayoutsResourceTests;
+
+[TestClass]
+public sealed class LayoutsResourceFancyZonesTest : BaseDscTest
+{
+    private const string GridGuid = "{5C4F1A20-9B3E-4C7D-8E2F-1A2B3C4D5E6F}";
+    private const string CanvasGuid = "{8F0B6D3E-2C41-4A5B-9D7E-0F1A2B3C4D5E}";
+
+    // Placeholders replaced in the data-row inputs, which must be constants
+    private const string GridGuidToken = "$GRID_GUID";
+    private const string CanvasGuidToken = "$CANVAS_GUID";
+    private const string ValidGridToken = "$VALID_GRID";
+    private const string ValidGridJson = /*lang=json,strict*/ """{"rows":1,"columns":2,"rowsPercentage":[10000],"columnsPercentage":[7000,3000],"cellChildMap":[[0,1]]}""";
+
+    // Files in the exact shape written by the FancyZones editor
+    private const string EditorCustomLayoutsJson = /*lang=json,strict*/ """
+        {
+          "custom-layouts": [
+            {
+              "uuid": "{5C4F1A20-9B3E-4C7D-8E2F-1A2B3C4D5E6F}",
+              "name": "Two columns",
+              "type": "grid",
+              "info": {
+                "rows": 1,
+                "columns": 2,
+                "rows-percentage": [ 10000 ],
+                "columns-percentage": [ 7000, 3000 ],
+                "cell-child-map": [ [ 0, 1 ] ],
+                "show-spacing": true,
+                "spacing": 16,
+                "sensitivity-radius": 20
+              }
+            },
+            {
+              "uuid": "{8F0B6D3E-2C41-4A5B-9D7E-0F1A2B3C4D5E}",
+              "name": "Reference window",
+              "type": "canvas",
+              "info": {
+                "ref-width": 1920,
+                "ref-height": 1080,
+                "zones": [
+                  { "X": 0, "Y": 0, "width": 1280, "height": 1080 },
+                  { "X": 1280, "Y": 0, "width": 640, "height": 1080 }
+                ],
+                "sensitivity-radius": 20
+              }
+            }
+          ]
+        }
+        """;
+
+    private const string EditorLayoutTemplatesJson = /*lang=json,strict*/ """
+        {
+          "layout-templates": [
+            { "type": "focus", "show-spacing": false, "spacing": 0, "zone-count": 4, "sensitivity-radius": 20 },
+            { "type": "priority-grid", "show-spacing": true, "spacing": 16, "zone-count": 3, "sensitivity-radius": 20 }
+          ]
+        }
+        """;
+
+    private const string EditorLayoutHotkeysJson = /*lang=json,strict*/ """
+        {
+          "layout-hotkeys": [
+            { "key": 1, "layout-id": "{5C4F1A20-9B3E-4C7D-8E2F-1A2B3C4D5E6F}" }
+          ]
+        }
+        """;
+
+    private const string EditorDefaultLayoutsJson = /*lang=json,strict*/ """
+        {
+          "default-layouts": [
+            {
+              "monitor-configuration": "horizontal",
+              "layout": { "uuid": "{5C4F1A20-9B3E-4C7D-8E2F-1A2B3C4D5E6F}", "type": "custom", "show-spacing": true, "spacing": 16, "zone-count": 0, "sensitivity-radius": 0 }
+            },
+            {
+              "monitor-configuration": "vertical",
+              "layout": { "uuid": "", "type": "rows", "show-spacing": true, "spacing": 16, "zone-count": 2, "sensitivity-radius": 20 }
+            }
+          ]
+        }
+        """;
+
+    private Func<string> _originalDataFolder;
+    private string _dataFolder;
+
+    private static string Module => nameof(ModuleType.FancyZones);
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        // Redirect the layout files to a fresh temporary folder so the tests
+        // never touch the user's FancyZones data. The folder is not created
+        // up front: a missing folder is a valid initial state.
+        _originalDataFolder = LayoutsFunctionData.DataFolder;
+        _dataFolder = Path.Combine(Path.GetTempPath(), "PowerToys.DSC.Tests", Guid.NewGuid().ToString("N"));
+        LayoutsFunctionData.DataFolder = () => _dataFolder;
+    }
+
+    [TestCleanup]
+    public void TestCleanup()
+    {
+        LayoutsFunctionData.DataFolder = _originalDataFolder;
+        if (Directory.Exists(_dataFolder))
+        {
+            Directory.Delete(_dataFolder, true);
+        }
+    }
+
+    [TestMethod]
+    public void Get_NoFiles_ReturnsEmptySections()
+    {
+        // Act
+        var result = ExecuteDscCommand<GetCommand>("--resource", LayoutsResource.ResourceName, "--module", Module);
+        var state = result.OutputState<LayoutsResourceObject>();
+
+        // Assert
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(0, result.Messages().Count);
+        Assert.AreEqual(0, state.Layouts.Custom.Count);
+        Assert.AreEqual(0, state.Layouts.Templates.Count);
+        Assert.AreEqual(0, state.Layouts.Hotkeys.Count);
+        Assert.IsNotNull(state.Layouts.Defaults);
+        Assert.IsNull(state.Layouts.Defaults.Horizontal);
+        Assert.IsNull(state.Layouts.Defaults.Vertical);
+    }
+
+    [TestMethod]
+    public void Get_EditorShapedFiles_Success()
+    {
+        // Arrange
+        WriteEditorFiles();
+
+        // Act
+        var result = ExecuteDscCommand<GetCommand>("--resource", LayoutsResource.ResourceName, "--module", Module);
+        var state = result.OutputState<LayoutsResourceObject>();
+
+        // Assert
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(0, result.Messages().Count);
+        AssertLayoutsAreEqual(FzLayoutsConverter.Canonicalize(CreateSampleModel()), state.Layouts);
+    }
+
+    [TestMethod]
+    public void Export_Success()
+    {
+        // Arrange
+        WriteEditorFiles();
+
+        // Act
+        var result = ExecuteDscCommand<ExportCommand>("--resource", LayoutsResource.ResourceName, "--module", Module);
+        var state = result.OutputState<LayoutsResourceObject>();
+
+        // Assert
+        Assert.IsTrue(result.Success);
+        AssertLayoutsAreEqual(FzLayoutsConverter.Canonicalize(CreateSampleModel()), state.Layouts);
+    }
+
+    [TestMethod]
+    public void SetWithDiff_Success()
+    {
+        // Arrange
+        var input = CreateInput(CreateSampleModel());
+
+        // Act
+        var result = ExecuteDscCommand<SetCommand>("--resource", LayoutsResource.ResourceName, "--module", Module, "--input", input);
+        var (state, diff) = result.OutputStateAndDiff<LayoutsResourceObject>();
+
+        // Assert
+        Assert.IsTrue(result.Success);
+        CollectionAssert.AreEqual(new List<string> { LayoutsResourceObject.LayoutsJsonPropertyName }, diff);
+        AssertLayoutsAreEqual(FzLayoutsConverter.Canonicalize(CreateSampleModel()), state.Layouts);
+
+        // The stored files use the exact editor encoding
+        var customLayouts = ReadFile(LayoutsFunctionData.CustomLayoutsFileName);
+        StringAssert.Contains(customLayouts, "\"custom-layouts\"");
+        StringAssert.Contains(customLayouts, "\"ref-width\"");
+        StringAssert.Contains(customLayouts, "\"X\"");
+        StringAssert.Contains(customLayouts, "\"cell-child-map\"");
+        StringAssert.Contains(customLayouts, GridGuid);
+        StringAssert.Contains(customLayouts, CanvasGuid);
+        Assert.AreEqual(2, JsonNode.Parse(customLayouts)["custom-layouts"].AsArray().Count);
+
+        var templates = ReadFile(LayoutsFunctionData.LayoutTemplatesFileName);
+        StringAssert.Contains(templates, "\"layout-templates\"");
+        StringAssert.Contains(templates, "\"zone-count\"");
+
+        var hotkeys = ReadFile(LayoutsFunctionData.LayoutHotkeysFileName);
+        StringAssert.Contains(hotkeys, "\"layout-hotkeys\"");
+        StringAssert.Contains(hotkeys, "\"layout-id\"");
+        StringAssert.Contains(hotkeys, GridGuid);
+
+        var defaults = ReadFile(LayoutsFunctionData.DefaultLayoutsFileName);
+        StringAssert.Contains(defaults, "\"monitor-configuration\"");
+        StringAssert.Contains(defaults, "\"uuid\": \"\"");
+        StringAssert.Contains(defaults, GridGuid);
+    }
+
+    [TestMethod]
+    public void SetTwice_SecondSetHasNoDiff()
+    {
+        // Arrange
+        var input = CreateInput(CreateSampleModel());
+
+        // Act
+        var firstResult = ExecuteDscCommand<SetCommand>("--resource", LayoutsResource.ResourceName, "--module", Module, "--input", input);
+        var secondResult = ExecuteDscCommand<SetCommand>("--resource", LayoutsResource.ResourceName, "--module", Module, "--input", input);
+        var (_, firstDiff) = firstResult.OutputStateAndDiff<LayoutsResourceObject>();
+        var (_, secondDiff) = secondResult.OutputStateAndDiff<LayoutsResourceObject>();
+
+        // Assert
+        Assert.IsTrue(firstResult.Success);
+        Assert.IsTrue(secondResult.Success);
+        CollectionAssert.AreEqual(new List<string> { LayoutsResourceObject.LayoutsJsonPropertyName }, firstDiff);
+        CollectionAssert.AreEqual(new List<string>(), secondDiff);
+    }
+
+    [TestMethod]
+    public void Set_PartialInput_LeavesOtherFilesUntouched()
+    {
+        // Arrange: only the custom layouts exist on disk
+        WriteEditorFile(LayoutsFunctionData.CustomLayoutsFileName, EditorCustomLayoutsJson);
+        var input = CreateInput(new FzLayoutsModel
+        {
+            Hotkeys = [new() { Key = 2, LayoutId = CanvasGuid }],
+        });
+
+        // Act
+        var result = ExecuteDscCommand<SetCommand>("--resource", LayoutsResource.ResourceName, "--module", Module, "--input", input);
+        var (state, diff) = result.OutputStateAndDiff<LayoutsResourceObject>();
+
+        // Assert
+        Assert.IsTrue(result.Success);
+        CollectionAssert.AreEqual(new List<string> { LayoutsResourceObject.LayoutsJsonPropertyName }, diff);
+        Assert.AreEqual(EditorCustomLayoutsJson, ReadFile(LayoutsFunctionData.CustomLayoutsFileName));
+        Assert.IsTrue(File.Exists(Path.Combine(_dataFolder, LayoutsFunctionData.LayoutHotkeysFileName)));
+        Assert.IsFalse(File.Exists(Path.Combine(_dataFolder, LayoutsFunctionData.LayoutTemplatesFileName)));
+        Assert.IsFalse(File.Exists(Path.Combine(_dataFolder, LayoutsFunctionData.DefaultLayoutsFileName)));
+
+        // The reported state combines the applied hotkeys with the untouched sections
+        Assert.AreEqual(2, state.Layouts.Custom.Count);
+        Assert.AreEqual(1, state.Layouts.Hotkeys.Count);
+        Assert.AreEqual(CanvasGuid, state.Layouts.Hotkeys[0].LayoutId);
+        Assert.AreEqual(0, state.Layouts.Templates.Count);
+    }
+
+    [TestMethod]
+    public void Set_CreatesMissingFolder()
+    {
+        // Arrange
+        Assert.IsFalse(Directory.Exists(_dataFolder));
+        var input = CreateInput(new FzLayoutsModel
+        {
+            Templates = [new() { Type = "columns", ZoneCount = 2 }],
+        });
+
+        // Act
+        var result = ExecuteDscCommand<SetCommand>("--resource", LayoutsResource.ResourceName, "--module", Module, "--input", input);
+
+        // Assert
+        Assert.IsTrue(result.Success);
+        Assert.IsTrue(File.Exists(Path.Combine(_dataFolder, LayoutsFunctionData.LayoutTemplatesFileName)));
+    }
+
+    [TestMethod]
+    public void Set_EmptyArray_ClearsFile()
+    {
+        // Arrange
+        WriteEditorFile(LayoutsFunctionData.CustomLayoutsFileName, EditorCustomLayoutsJson);
+        var input = /*lang=json,strict*/ """{"layouts":{"custom":[]}}""";
+
+        // Act
+        var result = ExecuteDscCommand<SetCommand>("--resource", LayoutsResource.ResourceName, "--module", Module, "--input", input);
+        var (state, diff) = result.OutputStateAndDiff<LayoutsResourceObject>();
+
+        // Assert
+        Assert.IsTrue(result.Success);
+        CollectionAssert.AreEqual(new List<string> { LayoutsResourceObject.LayoutsJsonPropertyName }, diff);
+        Assert.AreEqual(0, state.Layouts.Custom.Count);
+        Assert.AreEqual(0, JsonNode.Parse(ReadFile(LayoutsFunctionData.CustomLayoutsFileName))["custom-layouts"].AsArray().Count);
+    }
+
+    [TestMethod]
+    public void Set_GuidWithoutBraces_IsCanonicalized()
+    {
+        // Arrange
+        var lowerCaseGuid = GridGuid.Trim('{', '}').ToLowerInvariant();
+        var input = CreateInput(new FzLayoutsModel
+        {
+            Custom = [CreateGridLayout(lowerCaseGuid)],
+            Hotkeys = [new() { Key = 1, LayoutId = lowerCaseGuid }],
+        });
+
+        // Act
+        var result = ExecuteDscCommand<SetCommand>("--resource", LayoutsResource.ResourceName, "--module", Module, "--input", input);
+        var (state, _) = result.OutputStateAndDiff<LayoutsResourceObject>();
+
+        // Assert
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(GridGuid, state.Layouts.Custom[0].Uuid);
+        Assert.AreEqual(GridGuid, state.Layouts.Hotkeys[0].LayoutId);
+        StringAssert.Contains(ReadFile(LayoutsFunctionData.CustomLayoutsFileName), GridGuid);
+        StringAssert.Contains(ReadFile(LayoutsFunctionData.LayoutHotkeysFileName), GridGuid);
+    }
+
+    [TestMethod]
+    public void Set_FocusTemplate_NormalizesSpacing()
+    {
+        // Arrange: spacing does not apply to the focus template
+        var input = CreateInput(new FzLayoutsModel
+        {
+            Templates = [new() { Type = "focus", ZoneCount = 4, ShowSpacing = true, Spacing = 16 }],
+        });
+
+        // Act
+        var result = ExecuteDscCommand<SetCommand>("--resource", LayoutsResource.ResourceName, "--module", Module, "--input", input);
+        var (state, _) = result.OutputStateAndDiff<LayoutsResourceObject>();
+
+        // Assert
+        Assert.IsTrue(result.Success);
+        Assert.IsFalse(state.Layouts.Templates[0].ShowSpacing);
+        Assert.AreEqual(0, state.Layouts.Templates[0].Spacing);
+        StringAssert.Contains(ReadFile(LayoutsFunctionData.LayoutTemplatesFileName), "\"show-spacing\": false");
+    }
+
+    [TestMethod]
+    public void Set_CustomDefault_CopiesGridSpacing()
+    {
+        // Arrange: the editor stores the spacing of the referenced grid layout
+        var grid = CreateGridLayout(GridGuid);
+        grid.Grid.Spacing = 24;
+        var input = CreateInput(new FzLayoutsModel
+        {
+            Custom = [grid],
+            Defaults = new() { Horizontal = new() { Type = "custom", Uuid = GridGuid } },
+        });
+
+        // Act
+        var result = ExecuteDscCommand<SetCommand>("--resource", LayoutsResource.ResourceName, "--module", Module, "--input", input);
+        var (state, _) = result.OutputStateAndDiff<LayoutsResourceObject>();
+
+        // Assert
+        Assert.IsTrue(result.Success);
+        var horizontal = state.Layouts.Defaults.Horizontal;
+        Assert.AreEqual("custom", horizontal.Type);
+        Assert.AreEqual(GridGuid, horizontal.Uuid);
+        Assert.IsTrue(horizontal.ShowSpacing);
+        Assert.AreEqual(24, horizontal.Spacing);
+        Assert.AreEqual(0, horizontal.ZoneCount);
+        Assert.AreEqual(0, horizontal.SensitivityRadius);
+        Assert.IsNull(state.Layouts.Defaults.Vertical);
+    }
+
+    [TestMethod]
+    public void TestWithDiff_Success()
+    {
+        // Arrange
+        var input = CreateInput(CreateSampleModel());
+
+        // Act
+        var result = ExecuteDscCommand<TestCommand>("--resource", LayoutsResource.ResourceName, "--module", Module, "--input", input);
+        var (state, diff) = result.OutputStateAndDiff<LayoutsResourceObject>();
+
+        // Assert
+        Assert.IsTrue(result.Success);
+        Assert.IsFalse(state.InDesiredState);
+        CollectionAssert.AreEqual(new List<string> { LayoutsResourceObject.LayoutsJsonPropertyName }, diff);
+
+        // Test must not modify the layouts
+        Assert.IsFalse(Directory.Exists(_dataFolder));
+    }
+
+    [TestMethod]
+    public void TestWithoutDiff_Success()
+    {
+        // Arrange
+        WriteEditorFiles();
+        var input = CreateInput(CreateSampleModel());
+
+        // Act
+        var result = ExecuteDscCommand<TestCommand>("--resource", LayoutsResource.ResourceName, "--module", Module, "--input", input);
+        var (state, diff) = result.OutputStateAndDiff<LayoutsResourceObject>();
+
+        // Assert
+        Assert.IsTrue(result.Success);
+        Assert.IsTrue(state.InDesiredState);
+        CollectionAssert.AreEqual(new List<string>(), diff);
+    }
+
+    [TestMethod]
+    public void Test_CustomOrderDiffers_InDesiredState()
+    {
+        // Arrange: the order of the custom layouts only affects the editor list
+        WriteEditorFiles();
+        var model = CreateSampleModel();
+        model.Custom.Reverse();
+        var input = CreateInput(model);
+
+        // Act
+        var result = ExecuteDscCommand<TestCommand>("--resource", LayoutsResource.ResourceName, "--module", Module, "--input", input);
+        var (state, diff) = result.OutputStateAndDiff<LayoutsResourceObject>();
+
+        // Assert
+        Assert.IsTrue(result.Success);
+        Assert.IsTrue(state.InDesiredState);
+        CollectionAssert.AreEqual(new List<string>(), diff);
+    }
+
+    [TestMethod]
+    public void Test_OmittedSections_NotCompared()
+    {
+        // Arrange
+        WriteEditorFiles();
+        var matching = CreateInput(new FzLayoutsModel { Hotkeys = [new() { Key = 1, LayoutId = GridGuid }] });
+        var differing = CreateInput(new FzLayoutsModel { Hotkeys = [new() { Key = 2, LayoutId = GridGuid }] });
+
+        // Act
+        var matchingResult = ExecuteDscCommand<TestCommand>("--resource", LayoutsResource.ResourceName, "--module", Module, "--input", matching);
+        var differingResult = ExecuteDscCommand<TestCommand>("--resource", LayoutsResource.ResourceName, "--module", Module, "--input", differing);
+        var (matchingState, _) = matchingResult.OutputStateAndDiff<LayoutsResourceObject>();
+        var (differingState, _) = differingResult.OutputStateAndDiff<LayoutsResourceObject>();
+
+        // Assert
+        Assert.IsTrue(matchingResult.Success);
+        Assert.IsTrue(matchingState.InDesiredState);
+        Assert.IsTrue(differingResult.Success);
+        Assert.IsFalse(differingState.InDesiredState);
+    }
+
+    [DataTestMethod]
+    [DataRow(/*lang=json,strict*/ """{}""", "'layouts' is required")]
+    [DataRow(/*lang=json,strict*/ """{"layouts":null}""", "'layouts' is required")]
+    [DataRow(/*lang=json,strict*/ """{"layouts":[]}""", "'layouts' must be an object")]
+    [DataRow(/*lang=json,strict*/ """{"layouts":{"custom":null}}""", "'layouts.custom' must be an array")]
+    [DataRow(/*lang=json,strict*/ """{"layouts":{"hotkeys":[null]}}""", "'layouts.hotkeys[0]' must be an object")]
+    [DataRow(/*lang=json,strict*/ """{"layouts":{"defaults":[]}}""", "'layouts.defaults' must be an object")]
+    [DataRow(/*lang=json,strict*/ """{"layouts":{"defaults":{"horizonal":{}}}}""", "'layouts.defaults.horizonal' is not a valid property")]
+    [DataRow(/*lang=json,strict*/ """{"layouts":{"foo":1}}""", "'layouts.foo' is not a valid property")]
+    [DataRow(/*lang=json,strict*/ """{"layouts":{"hotkeys":[{"key":"one","layoutId":"$GRID_GUID"}]}}""", "could not be converted")]
+    public void Set_MalformedInput_FailsAndLeavesFilesUntouched(string input, string expectedError)
+    {
+        // Arrange: a stored hotkey that a bad input must not erase
+        WriteEditorFile(LayoutsFunctionData.LayoutHotkeysFileName, EditorLayoutHotkeysJson);
+
+        // Act
+        var result = ExecuteDscCommand<SetCommand>("--resource", LayoutsResource.ResourceName, "--module", Module, "--input", ReplaceTokens(input));
+        var messages = result.Messages();
+
+        // Assert
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(1, messages.Count);
+        Assert.AreEqual(DscMessageLevel.Error, messages[0].Level);
+        StringAssert.StartsWith(messages[0].Message, GetResourceString("InvalidLayoutsError", string.Empty));
+        StringAssert.Contains(messages[0].Message, expectedError);
+        Assert.AreEqual(EditorLayoutHotkeysJson, ReadFile(LayoutsFunctionData.LayoutHotkeysFileName));
+    }
+
+    [DataTestMethod]
+    [DataRow(/*lang=json,strict*/ """{"layouts":{"custom":[{"uuid":"$GRID_GUID","name":"A","grid":$VALID_GRID,"canvas":{"refWidth":1,"refHeight":1,"zones":[{"x":0,"y":0,"width":1,"height":1}]}}]}}""", "custom[0] must set exactly one of 'canvas' or 'grid'")]
+    [DataRow(/*lang=json,strict*/ """{"layouts":{"custom":[{"uuid":"$GRID_GUID","name":"A"}]}}""", "custom[0] must set exactly one of 'canvas' or 'grid'")]
+    [DataRow(/*lang=json,strict*/ """{"layouts":{"custom":[{"uuid":"not-a-guid","name":"A","grid":$VALID_GRID}]}}""", "custom[0].uuid: 'not-a-guid' is not a valid GUID")]
+    [DataRow(/*lang=json,strict*/ """{"layouts":{"custom":[{"uuid":"$GRID_GUID","name":"","grid":$VALID_GRID}]}}""", "custom[0].name is required")]
+    [DataRow(/*lang=json,strict*/ """{"layouts":{"custom":[{"uuid":"$GRID_GUID","name":"A","grid":$VALID_GRID},{"uuid":"$GRID_GUID","name":"B","grid":$VALID_GRID}]}}""", "custom[1].uuid: layout '$GRID_GUID' is defined more than once")]
+    [DataRow(/*lang=json,strict*/ """{"layouts":{"custom":[{"uuid":"$GRID_GUID","name":"A","grid":{"rows":1,"columns":2,"rowsPercentage":[10000],"columnsPercentage":[6000,3000],"cellChildMap":[[0,1]]}}]}}""", "custom[0].grid.columnsPercentage must sum to 10000 (100.00%) but sums to 9000")]
+    [DataRow(/*lang=json,strict*/ """{"layouts":{"custom":[{"uuid":"$GRID_GUID","name":"A","grid":{"rows":1,"columns":2,"rowsPercentage":[5000,5000],"columnsPercentage":[7000,3000],"cellChildMap":[[0,1]]}}]}}""", "custom[0].grid.rowsPercentage must contain 1 values, one per row")]
+    [DataRow(/*lang=json,strict*/ """{"layouts":{"custom":[{"uuid":"$GRID_GUID","name":"A","grid":{"rows":1,"columns":2,"rowsPercentage":[10000],"columnsPercentage":[7000,3000],"cellChildMap":[[0]]}}]}}""", "custom[0].grid.cellChildMap[0] must contain 2 values")]
+    [DataRow(/*lang=json,strict*/ """{"layouts":{"custom":[{"uuid":"$GRID_GUID","name":"A","grid":{"rows":1,"columns":2,"rowsPercentage":[10000],"columnsPercentage":[7000,3000],"cellChildMap":[[0,2]]}}]}}""", "custom[0].grid.cellChildMap[0][1]: zone index 2 is out of range (0-1)")]
+    [DataRow(/*lang=json,strict*/ """{"layouts":{"custom":[{"uuid":"$GRID_GUID","name":"A","canvas":{"refWidth":1920,"refHeight":1080,"zones":[]}}]}}""", "custom[0].canvas.zones must contain at least one zone")]
+    [DataRow(/*lang=json,strict*/ """{"layouts":{"custom":[{"uuid":"$GRID_GUID","name":"A","canvas":{"refWidth":1920,"refHeight":1080,"zones":[{"x":0,"y":0,"width":0,"height":100}]}}]}}""", "custom[0].canvas.zones[0].width must be greater than 0")]
+    [DataRow(/*lang=json,strict*/ """{"layouts":{"hotkeys":[{"key":10,"layoutId":"$GRID_GUID"}]}}""", "hotkeys[0].key must be between 0 and 9")]
+    [DataRow(/*lang=json,strict*/ """{"layouts":{"hotkeys":[{"key":1,"layoutId":"$GRID_GUID"},{"key":1,"layoutId":"$CANVAS_GUID"}]}}""", "hotkeys[1].key: key 1 is assigned more than once")]
+    [DataRow(/*lang=json,strict*/ """{"layouts":{"hotkeys":[{"key":1,"layoutId":"$GRID_GUID"},{"key":2,"layoutId":"$GRID_GUID"}]}}""", "hotkeys[1].layoutId: layout '$GRID_GUID' is assigned more than one key")]
+    [DataRow(/*lang=json,strict*/ """{"layouts":{"templates":[{"type":"hexagons"}]}}""", "templates[0].type: invalid value 'hexagons'; allowed values are: blank, focus, rows, columns, grid, priority-grid")]
+    [DataRow(/*lang=json,strict*/ """{"layouts":{"templates":[{"type":"focus"},{"type":"focus"}]}}""", "templates[1].type: template 'focus' is defined more than once")]
+    [DataRow(/*lang=json,strict*/ """{"layouts":{"templates":[{"type":"grid","zoneCount":0}]}}""", "templates[0].zoneCount must be greater than 0")]
+    [DataRow(/*lang=json,strict*/ """{"layouts":{"defaults":{"horizontal":{"type":"custom"}}}}""", "defaults.horizontal.uuid is required when type is 'custom'")]
+    [DataRow(/*lang=json,strict*/ """{"layouts":{"defaults":{"vertical":{"type":"rows","uuid":"$GRID_GUID"}}}}""", "defaults.vertical.uuid must only be set when type is 'custom'")]
+    [DataRow(/*lang=json,strict*/ """{"layouts":{"defaults":{"vertical":{"type":"hexagons"}}}}""", "defaults.vertical.type: invalid value 'hexagons'; allowed values are: blank, focus, rows, columns, grid, priority-grid, custom")]
+    [DataRow(/*lang=json,strict*/ """{"layouts":{"custom":[{"uuid":"$GRID_GUID","name":"A","grid":$VALID_GRID}],"hotkeys":[{"key":1,"layoutId":"$CANVAS_GUID"}]}}""", "hotkeys[0].layoutId: layout '$CANVAS_GUID' is not defined in 'custom'")]
+    [DataRow(/*lang=json,strict*/ """{"layouts":{"custom":[{"uuid":"$GRID_GUID","name":"A","grid":$VALID_GRID}],"defaults":{"horizontal":{"type":"custom","uuid":"$CANVAS_GUID"}}}}""", "defaults.horizontal.uuid: layout '$CANVAS_GUID' is not defined in 'custom'")]
+    public void Set_InvalidLayouts_FailsAndLeavesFilesUntouched(string input, string expectedError)
+    {
+        // Arrange: a stored hotkey that a bad input must not erase
+        WriteEditorFile(LayoutsFunctionData.LayoutHotkeysFileName, EditorLayoutHotkeysJson);
+
+        // Act
+        var result = ExecuteDscCommand<SetCommand>("--resource", LayoutsResource.ResourceName, "--module", Module, "--input", ReplaceTokens(input));
+        var errors = result.Messages().Where(m => m.Level == DscMessageLevel.Error).Select(m => m.Message).ToList();
+
+        // Assert
+        Assert.IsFalse(result.Success);
+        Assert.IsTrue(errors.Count > 0, "Expected at least one error message");
+        Assert.IsTrue(errors.Any(e => e.Contains(ReplaceTokens(expectedError))), $"Expected an error containing '{ReplaceTokens(expectedError)}' but got: {string.Join(" | ", errors)}");
+        Assert.AreEqual(EditorLayoutHotkeysJson, ReadFile(LayoutsFunctionData.LayoutHotkeysFileName));
+        Assert.IsFalse(File.Exists(Path.Combine(_dataFolder, LayoutsFunctionData.CustomLayoutsFileName)));
+    }
+
+    [TestMethod]
+    public void Set_HotkeyToUnknownLayoutOnDisk_Warns()
+    {
+        // Arrange: no custom layouts on disk and none in the input
+        var input = CreateInput(new FzLayoutsModel { Hotkeys = [new() { Key = 1, LayoutId = GridGuid }] });
+
+        // Act
+        var result = ExecuteDscCommand<SetCommand>("--resource", LayoutsResource.ResourceName, "--module", Module, "--input", input);
+        var messages = result.Messages();
+
+        // Assert: the layout may be provisioned separately, so this is a warning only
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, messages.Count);
+        Assert.AreEqual(DscMessageLevel.Warning, messages[0].Level);
+        StringAssert.Contains(messages[0].Message, $"hotkeys[0].layoutId: layout '{GridGuid}' does not exist in the current custom layouts");
+        Assert.IsTrue(File.Exists(Path.Combine(_dataFolder, LayoutsFunctionData.LayoutHotkeysFileName)));
+    }
+
+    [TestMethod]
+    public void Set_NoSections_WarnsAndWritesNothing()
+    {
+        // Act
+        var result = ExecuteDscCommand<SetCommand>("--resource", LayoutsResource.ResourceName, "--module", Module, "--input", /*lang=json,strict*/ """{"layouts":{}}""");
+        var (_, diff) = result.OutputStateAndDiff<LayoutsResourceObject>();
+        var messages = result.Messages();
+
+        // Assert
+        Assert.IsTrue(result.Success);
+        CollectionAssert.AreEqual(new List<string>(), diff);
+        Assert.AreEqual(1, messages.Count);
+        Assert.AreEqual(DscMessageLevel.Warning, messages[0].Level);
+        StringAssert.Contains(messages[0].Message, "no layout sections are specified");
+        Assert.IsFalse(Directory.Exists(_dataFolder));
+    }
+
+    [TestMethod]
+    public void Get_MalformedFile_WarnsAndTreatsAsEmpty()
+    {
+        // Arrange
+        WriteEditorFile(LayoutsFunctionData.CustomLayoutsFileName, "{ this is not json");
+        WriteEditorFile(LayoutsFunctionData.LayoutHotkeysFileName, EditorLayoutHotkeysJson);
+
+        // Act
+        var result = ExecuteDscCommand<GetCommand>("--resource", LayoutsResource.ResourceName, "--module", Module);
+        var state = result.OutputState<LayoutsResourceObject>();
+        var messages = result.Messages();
+
+        // Assert
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(0, state.Layouts.Custom.Count);
+        Assert.AreEqual(1, state.Layouts.Hotkeys.Count);
+        Assert.AreEqual(1, messages.Count);
+        Assert.AreEqual(DscMessageLevel.Warning, messages[0].Level);
+        StringAssert.Contains(messages[0].Message, $"{LayoutsFunctionData.CustomLayoutsFileName} is malformed");
+    }
+
+    [TestMethod]
+    public void Get_CustomLayoutWithoutInfo_SkippedWithWarning()
+    {
+        // Arrange: an entry the engine would skip, next to a valid one
+        var json = /*lang=json,strict*/ """
+            {
+              "custom-layouts": [
+                { "uuid": "{8F0B6D3E-2C41-4A5B-9D7E-0F1A2B3C4D5E}", "name": "Broken", "type": "grid" },
+                { "uuid": "{5C4F1A20-9B3E-4C7D-8E2F-1A2B3C4D5E6F}", "name": "Two columns", "type": "grid", "info": { "rows": 1, "columns": 2, "rows-percentage": [ 10000 ], "columns-percentage": [ 7000, 3000 ], "cell-child-map": [ [ 0, 1 ] ] } }
+              ]
+            }
+            """;
+        WriteEditorFile(LayoutsFunctionData.CustomLayoutsFileName, json);
+
+        // Act
+        var result = ExecuteDscCommand<ExportCommand>("--resource", LayoutsResource.ResourceName, "--module", Module);
+        var state = result.OutputState<LayoutsResourceObject>();
+        var messages = result.Messages();
+
+        // Assert: the good entry is exported with the engine defaults filled in
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, state.Layouts.Custom.Count);
+        Assert.AreEqual(GridGuid, state.Layouts.Custom[0].Uuid);
+        Assert.IsTrue(state.Layouts.Custom[0].Grid.ShowSpacing);
+        Assert.AreEqual(16, state.Layouts.Custom[0].Grid.Spacing);
+        Assert.AreEqual(20, state.Layouts.Custom[0].Grid.SensitivityRadius);
+        Assert.AreEqual(1, messages.Count);
+        Assert.AreEqual(DscMessageLevel.Warning, messages[0].Level);
+        StringAssert.Contains(messages[0].Message, $"Skipping custom layout '{CanvasGuid}' without layout info");
+    }
+
+    /// <summary>
+    /// Creates the sample friendly model matching the editor-shaped files.
+    /// </summary>
+    private static FzLayoutsModel CreateSampleModel()
+    {
+        return new FzLayoutsModel
+        {
+            Custom =
+            [
+                CreateGridLayout(GridGuid),
+                new()
+                {
+                    Uuid = CanvasGuid,
+                    Name = "Reference window",
+                    Canvas = new()
+                    {
+                        RefWidth = 1920,
+                        RefHeight = 1080,
+                        Zones =
+                        [
+                            new() { X = 0, Y = 0, Width = 1280, Height = 1080 },
+                            new() { X = 1280, Y = 0, Width = 640, Height = 1080 },
+                        ],
+                    },
+                },
+            ],
+            Templates =
+            [
+                new() { Type = "priority-grid", ZoneCount = 3 },
+                new() { Type = "focus", ZoneCount = 4 },
+            ],
+            Hotkeys = [new() { Key = 1, LayoutId = GridGuid }],
+            Defaults = new()
+            {
+                Horizontal = new() { Type = "custom", Uuid = GridGuid },
+                Vertical = new() { Type = "rows", ZoneCount = 2 },
+            },
+        };
+    }
+
+    private static FzCustomLayout CreateGridLayout(string uuid)
+    {
+        return new FzCustomLayout
+        {
+            Uuid = uuid,
+            Name = "Two columns",
+            Grid = new()
+            {
+                Rows = 1,
+                Columns = 2,
+                RowsPercentage = [10000],
+                ColumnsPercentage = [7000, 3000],
+                CellChildMap = [[0, 1]],
+            },
+        };
+    }
+
+    private static string CreateInput(FzLayoutsModel layouts)
+    {
+        return JsonSerializer.Serialize(new LayoutsResourceObject { Layouts = layouts });
+    }
+
+    private static string ReplaceTokens(string value)
+    {
+        return value
+            .Replace(ValidGridToken, ValidGridJson)
+            .Replace(GridGuidToken, GridGuid)
+            .Replace(CanvasGuidToken, CanvasGuid);
+    }
+
+    private static void AssertLayoutsAreEqual(FzLayoutsModel expected, FzLayoutsModel actual)
+    {
+        var expectedJson = JsonSerializer.SerializeToNode(expected);
+        var actualJson = JsonSerializer.SerializeToNode(actual);
+        Assert.IsTrue(JsonNode.DeepEquals(expectedJson, actualJson), $"{expectedJson} != {actualJson}");
+    }
+
+    private void WriteEditorFiles()
+    {
+        WriteEditorFile(LayoutsFunctionData.CustomLayoutsFileName, EditorCustomLayoutsJson);
+        WriteEditorFile(LayoutsFunctionData.LayoutTemplatesFileName, EditorLayoutTemplatesJson);
+        WriteEditorFile(LayoutsFunctionData.LayoutHotkeysFileName, EditorLayoutHotkeysJson);
+        WriteEditorFile(LayoutsFunctionData.DefaultLayoutsFileName, EditorDefaultLayoutsJson);
+    }
+
+    private void WriteEditorFile(string fileName, string json)
+    {
+        Directory.CreateDirectory(_dataFolder);
+        File.WriteAllText(Path.Combine(_dataFolder, fileName), json);
+    }
+
+    private string ReadFile(string fileName)
+    {
+        return File.ReadAllText(Path.Combine(_dataFolder, fileName));
+    }
+}

--- a/src/dsc/v3/PowerToys.DSC/Commands/BaseCommand.cs
+++ b/src/dsc/v3/PowerToys.DSC/Commands/BaseCommand.cs
@@ -33,6 +33,7 @@ public abstract class BaseCommand : Command
     {
         { SettingsResource.ResourceName, module => new SettingsResource(module) },
         { ProfileResource.ResourceName, module => new ProfileResource(module) },
+        { LayoutsResource.ResourceName, module => new LayoutsResource(module) },
 
         // Add other resources here
     };

--- a/src/dsc/v3/PowerToys.DSC/DSCResources/LayoutsResource.cs
+++ b/src/dsc/v3/PowerToys.DSC/DSCResources/LayoutsResource.cs
@@ -1,0 +1,228 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using ManagedCommon;
+using PowerToys.DSC.Models;
+using PowerToys.DSC.Models.FunctionData;
+using PowerToys.DSC.Properties;
+
+namespace PowerToys.DSC.DSCResources;
+
+/// <summary>
+/// Represents the DSC resource for managing the FancyZones layouts: custom
+/// layouts, layout templates, layout hotkeys and default layouts. Each section
+/// of the desired state replaces the whole layout file it maps to; sections
+/// that are omitted are left unchanged.
+/// </summary>
+public sealed class LayoutsResource : BaseResource
+{
+    private static readonly CompositeFormat FailedToWriteManifests = CompositeFormat.Parse(Resources.FailedToWriteManifests);
+    private static readonly CompositeFormat InvalidLayoutsError = CompositeFormat.Parse(Resources.InvalidLayoutsError);
+    private static readonly CompositeFormat LayoutsWarning = CompositeFormat.Parse(Resources.LayoutsWarning);
+
+    public const string ResourceName = "layouts";
+
+    public LayoutsResource(string? module)
+        : base(ResourceName, module)
+    {
+    }
+
+    /// <inheritdoc/>
+    public override bool ExportState(string? input)
+    {
+        var data = new LayoutsFunctionData();
+        data.GetState();
+        WriteWarnings(data);
+        WriteJsonOutputLine(data.Output.ToJson());
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public override bool GetState(string? input)
+    {
+        return ExportState(input);
+    }
+
+    /// <inheritdoc/>
+    public override bool SetState(string? input)
+    {
+        var data = CreateFunctionDataWithInput(input);
+        if (data == null)
+        {
+            return false;
+        }
+
+        data.GetState();
+        if (!ValidateInput(data))
+        {
+            return false;
+        }
+
+        // Capture the diff before updating the output
+        var diff = data.GetDiffJson();
+
+        // Only call Set if the desired state is different from the current state
+        if (!data.TestState())
+        {
+            data.SetState();
+
+            // Report the canonical form of the applied layouts as the new state
+            data.Output.Layouts = data.GetDesiredState();
+        }
+
+        WriteJsonOutputLine(data.Output.ToJson());
+        WriteJsonOutputLine(diff);
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public override bool TestState(string? input)
+    {
+        var data = CreateFunctionDataWithInput(input);
+        if (data == null)
+        {
+            return false;
+        }
+
+        data.GetState();
+        if (!ValidateInput(data))
+        {
+            return false;
+        }
+
+        data.Output.InDesiredState = data.TestState();
+
+        WriteJsonOutputLine(data.Output.ToJson());
+        WriteJsonOutputLine(data.GetDiffJson());
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public override bool Schema()
+    {
+        var data = new LayoutsFunctionData();
+        WriteJsonOutputLine(data.Schema());
+        return true;
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// If an output directory is specified, write the manifests to files,
+    /// otherwise output them to the console.
+    /// </remarks>
+    public override bool Manifest(string? outputDir)
+    {
+        var module = string.IsNullOrEmpty(Module) ? nameof(ModuleType.FancyZones) : Module;
+        var manifest = GenerateManifest(module);
+
+        if (!string.IsNullOrEmpty(outputDir))
+        {
+            try
+            {
+                File.WriteAllText(Path.Combine(outputDir, $"microsoft.powertoys.{module}.layouts.dsc.resource.json"), manifest);
+            }
+            catch (Exception ex)
+            {
+                var errorMessage = string.Format(CultureInfo.InvariantCulture, FailedToWriteManifests, outputDir, ex.Message);
+                WriteMessageOutputLine(DscMessageLevel.Error, errorMessage);
+                return false;
+            }
+        }
+        else
+        {
+            WriteJsonOutputLine(manifest);
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public override IList<string> GetSupportedModules()
+    {
+        return [nameof(ModuleType.FancyZones)];
+    }
+
+    /// <summary>
+    /// Creates the function data from the provided input, writing an error
+    /// and returning null when the input is missing or malformed.
+    /// </summary>
+    /// <param name="input">The input string.</param>
+    /// <returns>The function data, or null when the input is invalid.</returns>
+    private LayoutsFunctionData? CreateFunctionDataWithInput(string? input)
+    {
+        if (string.IsNullOrEmpty(input))
+        {
+            WriteMessageOutputLine(DscMessageLevel.Error, Resources.InputEmptyOrNullError);
+            return null;
+        }
+
+        try
+        {
+            return new LayoutsFunctionData(input);
+        }
+        catch (JsonException ex)
+        {
+            WriteMessageOutputLine(DscMessageLevel.Error, string.Format(CultureInfo.InvariantCulture, InvalidLayoutsError, ex.Message));
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Validates the input against the current state, surfacing the warnings
+    /// collected so far and writing the validation errors, if any.
+    /// </summary>
+    /// <param name="data">The function data whose state was read.</param>
+    /// <returns>True when the input is valid; otherwise false.</returns>
+    private bool ValidateInput(LayoutsFunctionData data)
+    {
+        var errors = data.ValidateInput();
+        WriteWarnings(data);
+
+        foreach (var error in errors)
+        {
+            WriteMessageOutputLine(DscMessageLevel.Error, string.Format(CultureInfo.InvariantCulture, InvalidLayoutsError, error));
+        }
+
+        return errors.Count == 0;
+    }
+
+    /// <summary>
+    /// Surfaces the warnings collected while reading the current state
+    /// (entries that could not be loaded and were skipped) and validating
+    /// the input through the DSC warning channel.
+    /// </summary>
+    /// <param name="data">The function data whose state was read.</param>
+    private void WriteWarnings(LayoutsFunctionData data)
+    {
+        foreach (var warning in data.Warnings)
+        {
+            WriteMessageOutputLine(DscMessageLevel.Warning, string.Format(CultureInfo.InvariantCulture, LayoutsWarning, warning));
+        }
+    }
+
+    /// <summary>
+    /// Generate a DSC resource JSON manifest for the specified module.
+    /// </summary>
+    /// <param name="module">The name of the module for which to generate the manifest.</param>
+    /// <returns>A JSON string representing the DSC resource manifest.</returns>
+    private static string GenerateManifest(string module)
+    {
+        // Note: The description is not localized because the generated
+        // manifest file will be part of the package
+        return new DscManifest($"{module}Layouts", "0.1.0")
+            .AddDescription($"Allows management of the {module} layouts (custom layouts, layout templates, layout hotkeys and default layouts) via the DSC v3 command line interface protocol.")
+            .AddStdinMethod("export", ["export", "--module", module, "--resource", ResourceName])
+            .AddStdinMethod("get", ["get", "--module", module, "--resource", ResourceName])
+            .AddJsonInputMethod("set", "--input", ["set", "--module", module, "--resource", ResourceName], implementsPretest: true, stateAndDiff: true)
+            .AddJsonInputMethod("test", "--input", ["test", "--module", module, "--resource", ResourceName], stateAndDiff: true)
+            .AddCommandMethod("schema", ["schema", "--module", module, "--resource", ResourceName])
+            .ToJson();
+    }
+}

--- a/src/dsc/v3/PowerToys.DSC/Models/FancyZones/FzCanvasInfo.cs
+++ b/src/dsc/v3/PowerToys.DSC/Models/FancyZones/FzCanvasInfo.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace PowerToys.DSC.Models.FancyZones;
+
+/// <summary>
+/// The definition of a canvas layout: free-form zones positioned on a
+/// reference work area.
+/// </summary>
+public sealed class FzCanvasInfo
+{
+    /// <summary>
+    /// Gets or sets the width of the reference work area the zones are defined for.
+    /// </summary>
+    [JsonPropertyName("refWidth")]
+    [Required]
+    [Description("The width, in pixels, of the work area the zones are defined for. Zones are scaled to the actual work area.")]
+    public int RefWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets the height of the reference work area the zones are defined for.
+    /// </summary>
+    [JsonPropertyName("refHeight")]
+    [Required]
+    [Description("The height, in pixels, of the work area the zones are defined for. Zones are scaled to the actual work area.")]
+    public int RefHeight { get; set; }
+
+    /// <summary>
+    /// Gets or sets the zones.
+    /// </summary>
+    [JsonPropertyName("zones")]
+    [Required]
+    [Description("The zones of the layout (1 to 128).")]
+    public List<FzCanvasZone> Zones { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the distance from a zone edge at which highlighting starts.
+    /// </summary>
+    [JsonPropertyName("sensitivityRadius")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [Description("The distance, in pixels, from a zone edge at which the zone is highlighted while dragging. Default 20.")]
+    public int? SensitivityRadius { get; set; }
+}

--- a/src/dsc/v3/PowerToys.DSC/Models/FancyZones/FzCanvasZone.cs
+++ b/src/dsc/v3/PowerToys.DSC/Models/FancyZones/FzCanvasZone.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace PowerToys.DSC.Models.FancyZones;
+
+/// <summary>
+/// A zone of a canvas layout.
+/// </summary>
+public sealed class FzCanvasZone
+{
+    /// <summary>
+    /// Gets or sets the horizontal position of the zone.
+    /// </summary>
+    [JsonPropertyName("x")]
+    [Required]
+    [Description("The horizontal position of the zone, in pixels of the reference work area.")]
+    public int X { get; set; }
+
+    /// <summary>
+    /// Gets or sets the vertical position of the zone.
+    /// </summary>
+    [JsonPropertyName("y")]
+    [Required]
+    [Description("The vertical position of the zone, in pixels of the reference work area.")]
+    public int Y { get; set; }
+
+    /// <summary>
+    /// Gets or sets the width of the zone.
+    /// </summary>
+    [JsonPropertyName("width")]
+    [Required]
+    [Description("The width of the zone, in pixels of the reference work area.")]
+    public int Width { get; set; }
+
+    /// <summary>
+    /// Gets or sets the height of the zone.
+    /// </summary>
+    [JsonPropertyName("height")]
+    [Required]
+    [Description("The height of the zone, in pixels of the reference work area.")]
+    public int Height { get; set; }
+}

--- a/src/dsc/v3/PowerToys.DSC/Models/FancyZones/FzCustomLayout.cs
+++ b/src/dsc/v3/PowerToys.DSC/Models/FancyZones/FzCustomLayout.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace PowerToys.DSC.Models.FancyZones;
+
+/// <summary>
+/// A custom layout. Exactly one of <see cref="Canvas"/> or <see cref="Grid"/>
+/// must be set; it determines the layout type.
+/// </summary>
+public sealed class FzCustomLayout
+{
+    /// <summary>
+    /// Gets or sets the layout identifier.
+    /// </summary>
+    [JsonPropertyName("uuid")]
+    [Required]
+    [Description("The layout identifier: a GUID, with or without braces, e.g. \"{5C4F1A20-9B3E-4C7D-8E2F-1A2B3C4D5E6F}\".")]
+    public string Uuid { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the layout name.
+    /// </summary>
+    [JsonPropertyName("name")]
+    [Required]
+    [Description("The layout name shown in the FancyZones editor.")]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the canvas layout definition.
+    /// </summary>
+    [JsonPropertyName("canvas")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [Description("The canvas layout definition (free-form zones). Exactly one of 'canvas' or 'grid' must be set.")]
+    public FzCanvasInfo? Canvas { get; set; }
+
+    /// <summary>
+    /// Gets or sets the grid layout definition.
+    /// </summary>
+    [JsonPropertyName("grid")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [Description("The grid layout definition (rows and columns). Exactly one of 'canvas' or 'grid' must be set.")]
+    public FzGridInfo? Grid { get; set; }
+}

--- a/src/dsc/v3/PowerToys.DSC/Models/FancyZones/FzDefaultLayout.cs
+++ b/src/dsc/v3/PowerToys.DSC/Models/FancyZones/FzDefaultLayout.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace PowerToys.DSC.Models.FancyZones;
+
+/// <summary>
+/// A default layout: either a built-in template with its settings, or a
+/// reference to a custom layout.
+/// </summary>
+public sealed class FzDefaultLayout
+{
+    /// <summary>
+    /// Gets or sets the layout type.
+    /// </summary>
+    [JsonPropertyName("type")]
+    [Required]
+    [Description("The layout type: blank, focus, rows, columns, grid, priority-grid, or custom.")]
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the identifier of the custom layout; required when the type is custom.
+    /// </summary>
+    [JsonPropertyName("uuid")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [Description("The identifier (GUID) of the custom layout. Required when the type is 'custom', not allowed otherwise.")]
+    public string? Uuid { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of zones of a template layout.
+    /// </summary>
+    [JsonPropertyName("zoneCount")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [Description("The number of zones of a template layout. Default 3.")]
+    public int? ZoneCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether space is left between zones.
+    /// </summary>
+    [JsonPropertyName("showSpacing")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [Description("Whether space is left between the zones. Default true for grid templates; for a custom layout the setting of the referenced grid layout.")]
+    public bool? ShowSpacing { get; set; }
+
+    /// <summary>
+    /// Gets or sets the space between zones.
+    /// </summary>
+    [JsonPropertyName("spacing")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [Description("The space between the zones, in pixels. Default 16 for grid templates; for a custom layout the setting of the referenced grid layout.")]
+    public int? Spacing { get; set; }
+
+    /// <summary>
+    /// Gets or sets the distance from a zone edge at which highlighting starts.
+    /// </summary>
+    [JsonPropertyName("sensitivityRadius")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [Description("The distance, in pixels, from a zone edge at which the zone is highlighted while dragging. Default 20 for template layouts.")]
+    public int? SensitivityRadius { get; set; }
+}

--- a/src/dsc/v3/PowerToys.DSC/Models/FancyZones/FzDefaultLayouts.cs
+++ b/src/dsc/v3/PowerToys.DSC/Models/FancyZones/FzDefaultLayouts.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace PowerToys.DSC.Models.FancyZones;
+
+/// <summary>
+/// The default layouts applied to monitors that have no layout assigned yet,
+/// by monitor orientation.
+/// </summary>
+public sealed class FzDefaultLayouts
+{
+    public const string HorizontalJsonPropertyName = "horizontal";
+    public const string VerticalJsonPropertyName = "vertical";
+
+    /// <summary>
+    /// Gets or sets the default layout for horizontal (landscape) monitors.
+    /// </summary>
+    [JsonPropertyName(HorizontalJsonPropertyName)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [Description("The default layout for horizontal (landscape) monitors.")]
+    public FzDefaultLayout? Horizontal { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default layout for vertical (portrait) monitors.
+    /// </summary>
+    [JsonPropertyName(VerticalJsonPropertyName)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [Description("The default layout for vertical (portrait) monitors.")]
+    public FzDefaultLayout? Vertical { get; set; }
+}

--- a/src/dsc/v3/PowerToys.DSC/Models/FancyZones/FzGridInfo.cs
+++ b/src/dsc/v3/PowerToys.DSC/Models/FancyZones/FzGridInfo.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace PowerToys.DSC.Models.FancyZones;
+
+/// <summary>
+/// The definition of a grid layout: rows and columns whose cells are
+/// assigned to zones.
+/// </summary>
+public sealed class FzGridInfo
+{
+    /// <summary>
+    /// Gets or sets the number of rows.
+    /// </summary>
+    [JsonPropertyName("rows")]
+    [Required]
+    [Description("The number of rows.")]
+    public int Rows { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of columns.
+    /// </summary>
+    [JsonPropertyName("columns")]
+    [Required]
+    [Description("The number of columns.")]
+    public int Columns { get; set; }
+
+    /// <summary>
+    /// Gets or sets the height of each row.
+    /// </summary>
+    [JsonPropertyName("rowsPercentage")]
+    [Required]
+    [Description("The height of each row in hundredths of a percent; one value per row, summing to 10000.")]
+    public List<int> RowsPercentage { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the width of each column.
+    /// </summary>
+    [JsonPropertyName("columnsPercentage")]
+    [Required]
+    [Description("The width of each column in hundredths of a percent; one value per column, summing to 10000.")]
+    public List<int> ColumnsPercentage { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the zone index of each cell.
+    /// </summary>
+    [JsonPropertyName("cellChildMap")]
+    [Required]
+    [Description("The zone index of each cell, as one array per row with one value per column. Cells with the same index form one zone.")]
+    public List<List<int>> CellChildMap { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets a value indicating whether space is left between zones.
+    /// </summary>
+    [JsonPropertyName("showSpacing")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [Description("Whether space is left between the zones. Default true.")]
+    public bool? ShowSpacing { get; set; }
+
+    /// <summary>
+    /// Gets or sets the space between zones.
+    /// </summary>
+    [JsonPropertyName("spacing")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [Description("The space between the zones, in pixels. Default 16.")]
+    public int? Spacing { get; set; }
+
+    /// <summary>
+    /// Gets or sets the distance from a zone edge at which highlighting starts.
+    /// </summary>
+    [JsonPropertyName("sensitivityRadius")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [Description("The distance, in pixels, from a zone edge at which the zone is highlighted while dragging. Default 20.")]
+    public int? SensitivityRadius { get; set; }
+}

--- a/src/dsc/v3/PowerToys.DSC/Models/FancyZones/FzLayoutHotkey.cs
+++ b/src/dsc/v3/PowerToys.DSC/Models/FancyZones/FzLayoutHotkey.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace PowerToys.DSC.Models.FancyZones;
+
+/// <summary>
+/// A quick layout hotkey that applies a custom layout when its number key is
+/// pressed together with the quick layout switch modifiers.
+/// </summary>
+public sealed class FzLayoutHotkey
+{
+    /// <summary>
+    /// Gets or sets the number key (0 to 9).
+    /// </summary>
+    [JsonPropertyName("key")]
+    [Required]
+    [Description("The number key, 0 to 9. Each key can be assigned to one layout only.")]
+    public int Key { get; set; }
+
+    /// <summary>
+    /// Gets or sets the identifier of the custom layout to apply.
+    /// </summary>
+    [JsonPropertyName("layoutId")]
+    [Required]
+    [Description("The identifier (GUID) of the custom layout to apply. Each layout can be assigned to one key only.")]
+    public string LayoutId { get; set; } = string.Empty;
+}

--- a/src/dsc/v3/PowerToys.DSC/Models/FancyZones/FzLayoutsConverter.cs
+++ b/src/dsc/v3/PowerToys.DSC/Models/FancyZones/FzLayoutsConverter.cs
@@ -1,0 +1,902 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json;
+using FancyZonesEditorCommon.Data;
+
+namespace PowerToys.DSC.Models.FancyZones;
+
+/// <summary>
+/// Converts between the friendly <see cref="FzLayoutsModel"/> used by the DSC
+/// layouts resource and the FancyZones data file shapes defined in
+/// FancyZonesEditorCommon (custom-layouts.json, layout-templates.json,
+/// layout-hotkeys.json and default-layouts.json).
+/// </summary>
+public static class FzLayoutsConverter
+{
+    /// <summary>
+    /// The layout type of a default layout that references a custom layout.
+    /// </summary>
+    public const string CustomLayoutType = Constants.CustomLayoutJsonTag;
+
+    public const string HorizontalMonitorConfiguration = "horizontal";
+    public const string VerticalMonitorConfiguration = "vertical";
+
+    // Row and column sizes are stored in hundredths of a percent.
+    private const int PercentageTotal = 10000;
+
+    // Template layout type names in editor order (blank, focus, rows, columns, grid, priority-grid).
+    private static readonly string[] _templateTypes = Enum.GetValues<Constants.TemplateLayout>()
+        .Select(type => Constants.TemplateLayoutJsonTags[type])
+        .ToArray();
+
+    // Template types whose zones are separated by spacing; the engine ignores
+    // spacing for the blank and focus templates (Layout::Init).
+    private static readonly string[] _gridTemplateTypes =
+    [
+        Constants.TemplateLayoutJsonTags[Constants.TemplateLayout.Rows],
+        Constants.TemplateLayoutJsonTags[Constants.TemplateLayout.Columns],
+        Constants.TemplateLayoutJsonTags[Constants.TemplateLayout.Grid],
+        Constants.TemplateLayoutJsonTags[Constants.TemplateLayout.PriorityGrid],
+    ];
+
+    private static readonly string[] _defaultLayoutTypes = [.. _templateTypes, CustomLayoutType];
+
+    private static readonly string _canvasType = CustomLayout.Canvas.TypeToString();
+    private static readonly string _gridType = CustomLayout.Grid.TypeToString();
+
+    /// <summary>
+    /// Validates the friendly model and returns the list of validation
+    /// errors; an empty list means the model is valid. The messages are
+    /// intentionally not localized: they quote JSON property paths and values
+    /// that must match the configuration document verbatim, and are presented
+    /// inside the localized InvalidLayoutsError message frame.
+    /// </summary>
+    /// <param name="model">The friendly model to validate.</param>
+    /// <param name="current">The current state, used to check references to
+    /// existing custom layouts when the model does not define custom layouts.</param>
+    /// <param name="warnings">Optional collector for warnings.</param>
+    /// <returns>The list of validation errors.</returns>
+    public static IList<string> Validate(FzLayoutsModel model, FzLayoutsModel? current = null, IList<string>? warnings = null)
+    {
+        var errors = new List<string>();
+
+        if (model.Custom == null && model.Templates == null && model.Hotkeys == null && model.Defaults == null)
+        {
+            warnings?.Add("no layout sections are specified; nothing is managed");
+        }
+
+        ValidateCustomLayouts(model.Custom, errors);
+        ValidateTemplates(model.Templates, errors);
+        ValidateHotkeys(model.Hotkeys, model, current, errors, warnings);
+        ValidateDefaults(model.Defaults, model, current, errors, warnings);
+
+        return errors;
+    }
+
+    /// <summary>
+    /// Normalizes a GUID string to the form written by the FancyZones editor:
+    /// upper-case with braces, e.g. "{5C4F1A20-9B3E-4C7D-8E2F-1A2B3C4D5E6F}".
+    /// The engine parses layout identifiers with CLSIDFromString, which
+    /// requires the braces.
+    /// </summary>
+    /// <param name="value">The GUID string, with or without braces.</param>
+    /// <param name="normalized">The normalized GUID string.</param>
+    /// <returns>True if the value is a valid GUID; otherwise false.</returns>
+    public static bool TryNormalizeGuid(string? value, [NotNullWhen(true)] out string? normalized)
+    {
+        normalized = null;
+        if (string.IsNullOrWhiteSpace(value) || !Guid.TryParse(value.Trim(), out var guid))
+        {
+            return false;
+        }
+
+        normalized = guid.ToString("B").ToUpperInvariant();
+        return true;
+    }
+
+    /// <summary>
+    /// Converts validated custom layouts to the custom-layouts.json shape.
+    /// </summary>
+    /// <param name="layouts">The custom layouts; must have passed <see cref="Validate"/>.</param>
+    /// <returns>The stored custom layouts.</returns>
+    public static CustomLayouts.CustomLayoutListWrapper ToCustomLayouts(List<FzCustomLayout> layouts)
+    {
+        var serializer = new CustomLayouts();
+        var stored = new List<CustomLayouts.CustomLayoutWrapper>(layouts.Count);
+
+        foreach (var entry in layouts)
+        {
+            var wrapper = new CustomLayouts.CustomLayoutWrapper
+            {
+                Uuid = NormalizeGuidOrThrow(entry.Uuid),
+                Name = entry.Name,
+            };
+
+            if (entry.Grid != null)
+            {
+                wrapper.Type = _gridType;
+                wrapper.Info = serializer.ToJsonElement(new CustomLayouts.GridInfoWrapper
+                {
+                    Rows = entry.Grid.Rows,
+                    Columns = entry.Grid.Columns,
+                    RowsPercentage = [.. entry.Grid.RowsPercentage ?? []],
+                    ColumnsPercentage = [.. entry.Grid.ColumnsPercentage ?? []],
+                    CellChildMap = (entry.Grid.CellChildMap ?? []).Select(row => (row ?? []).ToArray()).ToArray(),
+                    ShowSpacing = entry.Grid.ShowSpacing ?? LayoutDefaultSettings.DefaultShowSpacing,
+                    Spacing = entry.Grid.Spacing ?? LayoutDefaultSettings.DefaultSpacing,
+                    SensitivityRadius = entry.Grid.SensitivityRadius ?? LayoutDefaultSettings.DefaultSensitivityRadius,
+                });
+            }
+            else if (entry.Canvas != null)
+            {
+                wrapper.Type = _canvasType;
+                wrapper.Info = serializer.ToJsonElement(new CustomLayouts.CanvasInfoWrapper
+                {
+                    RefWidth = entry.Canvas.RefWidth,
+                    RefHeight = entry.Canvas.RefHeight,
+                    Zones = (entry.Canvas.Zones ?? []).Select(zone => new CustomLayouts.CanvasInfoWrapper.CanvasZoneWrapper
+                    {
+                        X = zone.X,
+                        Y = zone.Y,
+                        Width = zone.Width,
+                        Height = zone.Height,
+                    }).ToList(),
+                    SensitivityRadius = entry.Canvas.SensitivityRadius ?? LayoutDefaultSettings.DefaultSensitivityRadius,
+                });
+            }
+            else
+            {
+                throw new InvalidOperationException($"Custom layout '{entry.Uuid}' must set exactly one of 'canvas' or 'grid'");
+            }
+
+            stored.Add(wrapper);
+        }
+
+        return new CustomLayouts.CustomLayoutListWrapper { CustomLayouts = stored };
+    }
+
+    /// <summary>
+    /// Converts stored custom layouts to the canonical friendly model. Entries
+    /// the engine would not load are skipped with a warning.
+    /// </summary>
+    /// <param name="stored">The stored custom layouts.</param>
+    /// <param name="warnings">Optional collector for warnings about skipped entries.</param>
+    /// <returns>The canonical custom layouts, in stored order.</returns>
+    public static List<FzCustomLayout> FromCustomLayouts(CustomLayouts.CustomLayoutListWrapper stored, IList<string>? warnings = null)
+    {
+        var serializer = new CustomLayouts();
+        var result = new List<FzCustomLayout>();
+
+        foreach (var layout in stored.CustomLayouts ?? [])
+        {
+            if (!TryNormalizeGuid(layout.Uuid, out var uuid))
+            {
+                warnings?.Add($"Skipping custom layout '{layout.Name}' with invalid uuid '{layout.Uuid}'");
+                continue;
+            }
+
+            if (layout.Info.ValueKind != JsonValueKind.Object)
+            {
+                warnings?.Add($"Skipping custom layout '{uuid}' without layout info");
+                continue;
+            }
+
+            var entry = new FzCustomLayout
+            {
+                Uuid = uuid,
+                Name = layout.Name ?? string.Empty,
+            };
+
+            try
+            {
+                if (string.Equals(layout.Type, _gridType, StringComparison.Ordinal))
+                {
+                    var info = serializer.GridFromJsonElement(layout.Info.GetRawText());
+                    entry.Grid = new FzGridInfo
+                    {
+                        Rows = info.Rows,
+                        Columns = info.Columns,
+                        RowsPercentage = [.. info.RowsPercentage ?? []],
+                        ColumnsPercentage = [.. info.ColumnsPercentage ?? []],
+                        CellChildMap = (info.CellChildMap ?? []).Select(row => (row ?? []).ToList()).ToList(),
+                        ShowSpacing = info.ShowSpacing,
+                        Spacing = info.Spacing,
+                        SensitivityRadius = info.SensitivityRadius,
+                    };
+                }
+                else if (string.Equals(layout.Type, _canvasType, StringComparison.Ordinal))
+                {
+                    var info = serializer.CanvasFromJsonElement(layout.Info.GetRawText());
+                    entry.Canvas = new FzCanvasInfo
+                    {
+                        RefWidth = info.RefWidth,
+                        RefHeight = info.RefHeight,
+                        Zones = (info.Zones ?? []).Select(zone => new FzCanvasZone
+                        {
+                            X = zone.X,
+                            Y = zone.Y,
+                            Width = zone.Width,
+                            Height = zone.Height,
+                        }).ToList(),
+                        SensitivityRadius = info.SensitivityRadius,
+                    };
+                }
+                else
+                {
+                    warnings?.Add($"Skipping custom layout '{uuid}' with unknown type '{layout.Type}'");
+                    continue;
+                }
+            }
+            catch (JsonException ex)
+            {
+                warnings?.Add($"Skipping custom layout '{uuid}' with malformed layout info: {ex.Message}");
+                continue;
+            }
+
+            result.Add(entry);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Converts validated layout templates to the layout-templates.json shape.
+    /// </summary>
+    /// <param name="templates">The templates; must have passed <see cref="Validate"/>.</param>
+    /// <returns>The stored templates, in editor order.</returns>
+    public static LayoutTemplates.TemplateLayoutsListWrapper ToLayoutTemplates(List<FzTemplateLayout> templates)
+    {
+        var stored = templates
+            .Select(template => new LayoutTemplates.TemplateLayoutWrapper
+            {
+                Type = template.Type,
+                ZoneCount = template.ZoneCount ?? LayoutDefaultSettings.DefaultZoneCount,
+                SensitivityRadius = template.SensitivityRadius ?? LayoutDefaultSettings.DefaultSensitivityRadius,
+                ShowSpacing = IsGridTemplateType(template.Type) && (template.ShowSpacing ?? LayoutDefaultSettings.DefaultShowSpacing),
+                Spacing = IsGridTemplateType(template.Type) ? template.Spacing ?? LayoutDefaultSettings.DefaultSpacing : 0,
+            })
+            .OrderBy(template => TemplateOrder(template.Type))
+            .ToList();
+
+        return new LayoutTemplates.TemplateLayoutsListWrapper { LayoutTemplates = stored };
+    }
+
+    /// <summary>
+    /// Converts stored layout templates to the canonical friendly model.
+    /// </summary>
+    /// <param name="stored">The stored templates.</param>
+    /// <param name="warnings">Optional collector for warnings about skipped entries.</param>
+    /// <returns>The canonical templates, in editor order.</returns>
+    public static List<FzTemplateLayout> FromLayoutTemplates(LayoutTemplates.TemplateLayoutsListWrapper stored, IList<string>? warnings = null)
+    {
+        var result = new List<FzTemplateLayout>();
+
+        foreach (var template in stored.LayoutTemplates ?? [])
+        {
+            if (!_templateTypes.Contains(template.Type, StringComparer.Ordinal))
+            {
+                warnings?.Add($"Skipping layout template with unknown type '{template.Type}'");
+                continue;
+            }
+
+            result.Add(new FzTemplateLayout
+            {
+                Type = template.Type,
+                ZoneCount = template.ZoneCount,
+                ShowSpacing = template.ShowSpacing,
+                Spacing = template.Spacing,
+                SensitivityRadius = template.SensitivityRadius,
+            });
+        }
+
+        return result.OrderBy(template => TemplateOrder(template.Type)).ToList();
+    }
+
+    /// <summary>
+    /// Converts validated layout hotkeys to the layout-hotkeys.json shape.
+    /// </summary>
+    /// <param name="hotkeys">The hotkeys; must have passed <see cref="Validate"/>.</param>
+    /// <returns>The stored hotkeys, sorted by key.</returns>
+    public static LayoutHotkeys.LayoutHotkeysWrapper ToLayoutHotkeys(List<FzLayoutHotkey> hotkeys)
+    {
+        var stored = hotkeys
+            .Select(hotkey => new LayoutHotkeys.LayoutHotkeyWrapper
+            {
+                Key = hotkey.Key,
+                LayoutId = NormalizeGuidOrThrow(hotkey.LayoutId),
+            })
+            .OrderBy(hotkey => hotkey.Key)
+            .ToList();
+
+        return new LayoutHotkeys.LayoutHotkeysWrapper { LayoutHotkeys = stored };
+    }
+
+    /// <summary>
+    /// Converts stored layout hotkeys to the canonical friendly model.
+    /// </summary>
+    /// <param name="stored">The stored hotkeys.</param>
+    /// <param name="warnings">Optional collector for warnings about skipped entries.</param>
+    /// <returns>The canonical hotkeys, sorted by key.</returns>
+    public static List<FzLayoutHotkey> FromLayoutHotkeys(LayoutHotkeys.LayoutHotkeysWrapper stored, IList<string>? warnings = null)
+    {
+        var result = new List<FzLayoutHotkey>();
+
+        foreach (var hotkey in stored.LayoutHotkeys ?? [])
+        {
+            if (!TryNormalizeGuid(hotkey.LayoutId, out var uuid))
+            {
+                warnings?.Add($"Skipping layout hotkey {Invariant(hotkey.Key)} with invalid layout id '{hotkey.LayoutId}'");
+                continue;
+            }
+
+            result.Add(new FzLayoutHotkey
+            {
+                Key = hotkey.Key,
+                LayoutId = uuid,
+            });
+        }
+
+        return result.OrderBy(hotkey => hotkey.Key).ToList();
+    }
+
+    /// <summary>
+    /// Converts validated default layouts to the default-layouts.json shape.
+    /// </summary>
+    /// <param name="defaults">The default layouts; must have passed <see cref="Validate"/>.</param>
+    /// <param name="customLayouts">The custom layouts a default layout may reference,
+    /// used to copy the spacing settings of a referenced grid layout the way the editor does.</param>
+    /// <returns>The stored default layouts.</returns>
+    public static DefaultLayouts.DefaultLayoutsListWrapper ToDefaultLayouts(FzDefaultLayouts defaults, IReadOnlyList<FzCustomLayout> customLayouts)
+    {
+        var stored = new List<DefaultLayouts.DefaultLayoutWrapper>();
+        AddDefaultLayout(stored, HorizontalMonitorConfiguration, defaults.Horizontal, customLayouts);
+        AddDefaultLayout(stored, VerticalMonitorConfiguration, defaults.Vertical, customLayouts);
+        return new DefaultLayouts.DefaultLayoutsListWrapper { DefaultLayouts = stored };
+    }
+
+    /// <summary>
+    /// Converts stored default layouts to the canonical friendly model.
+    /// </summary>
+    /// <param name="stored">The stored default layouts.</param>
+    /// <param name="warnings">Optional collector for warnings about skipped entries.</param>
+    /// <returns>The canonical default layouts.</returns>
+    public static FzDefaultLayouts FromDefaultLayouts(DefaultLayouts.DefaultLayoutsListWrapper stored, IList<string>? warnings = null)
+    {
+        var result = new FzDefaultLayouts();
+
+        foreach (var defaultLayout in stored.DefaultLayouts ?? [])
+        {
+            var layout = defaultLayout.Layout;
+            var context = $"default layout for '{defaultLayout.MonitorConfiguration}' monitors";
+
+            if (!_defaultLayoutTypes.Contains(layout.Type, StringComparer.Ordinal))
+            {
+                warnings?.Add($"Skipping {context} with unknown type '{layout.Type}'");
+                continue;
+            }
+
+            var entry = new FzDefaultLayout
+            {
+                Type = layout.Type,
+                ZoneCount = layout.ZoneCount,
+                ShowSpacing = layout.ShowSpacing,
+                Spacing = layout.Spacing,
+                SensitivityRadius = layout.SensitivityRadius,
+            };
+
+            if (IsCustomType(layout.Type))
+            {
+                if (!TryNormalizeGuid(layout.Uuid, out var uuid))
+                {
+                    warnings?.Add($"Skipping {context} with invalid uuid '{layout.Uuid}'");
+                    continue;
+                }
+
+                entry.Uuid = uuid;
+            }
+
+            // The engine treats every monitor configuration other than
+            // "vertical" as horizontal (DefaultLayoutsJsonUtils::TypeFromString).
+            if (string.Equals(defaultLayout.MonitorConfiguration, VerticalMonitorConfiguration, StringComparison.Ordinal))
+            {
+                result.Vertical = entry;
+            }
+            else
+            {
+                result.Horizontal = entry;
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Normalizes a friendly model into its canonical form: normalized
+    /// identifiers, defaults filled in, and entries sorted. Sections that are
+    /// not set stay unset. Used to compare desired and current state.
+    /// </summary>
+    /// <param name="model">The friendly model; must have passed <see cref="Validate"/>.</param>
+    /// <param name="customLayouts">The current custom layouts, used to resolve
+    /// default layout references when the model does not define custom layouts.</param>
+    /// <returns>The canonical friendly model.</returns>
+    public static FzLayoutsModel Canonicalize(FzLayoutsModel model, IReadOnlyList<FzCustomLayout>? customLayouts = null)
+    {
+        // Round-tripping through the stored shape guarantees that the desired
+        // state and the state read back from disk normalize identically.
+        IReadOnlyList<FzCustomLayout> knownCustomLayouts = model.Custom ?? customLayouts ?? [];
+
+        return new FzLayoutsModel
+        {
+            Custom = model.Custom == null ? null : FromCustomLayouts(ToCustomLayouts(model.Custom)),
+            Templates = model.Templates == null ? null : FromLayoutTemplates(ToLayoutTemplates(model.Templates)),
+            Hotkeys = model.Hotkeys == null ? null : FromLayoutHotkeys(ToLayoutHotkeys(model.Hotkeys)),
+            Defaults = model.Defaults == null ? null : FromDefaultLayouts(ToDefaultLayouts(model.Defaults, knownCustomLayouts)),
+        };
+    }
+
+    private static void AddDefaultLayout(List<DefaultLayouts.DefaultLayoutWrapper> stored, string monitorConfiguration, FzDefaultLayout? layout, IReadOnlyList<FzCustomLayout> customLayouts)
+    {
+        if (layout == null)
+        {
+            return;
+        }
+
+        DefaultLayouts.DefaultLayoutWrapper.LayoutWrapper layoutWrapper;
+        if (IsCustomType(layout.Type))
+        {
+            // Mirror FancyZonesEditorIO.SerializeDefaultLayouts: a custom
+            // default layout carries the spacing settings of the referenced
+            // grid layout and the struct defaults for everything else.
+            var uuid = NormalizeGuidOrThrow(layout.Uuid);
+            var grid = customLayouts.FirstOrDefault(custom => custom != null && TryNormalizeGuid(custom.Uuid, out var id) && string.Equals(id, uuid, StringComparison.Ordinal))?.Grid;
+            layoutWrapper = new DefaultLayouts.DefaultLayoutWrapper.LayoutWrapper
+            {
+                Uuid = uuid,
+                Type = CustomLayoutType,
+                ZoneCount = layout.ZoneCount ?? 0,
+                SensitivityRadius = layout.SensitivityRadius ?? 0,
+                ShowSpacing = layout.ShowSpacing ?? (grid != null && (grid.ShowSpacing ?? LayoutDefaultSettings.DefaultShowSpacing)),
+                Spacing = layout.Spacing ?? (grid != null ? grid.Spacing ?? LayoutDefaultSettings.DefaultSpacing : 0),
+            };
+        }
+        else
+        {
+            var isGrid = IsGridTemplateType(layout.Type);
+            layoutWrapper = new DefaultLayouts.DefaultLayoutWrapper.LayoutWrapper
+            {
+                Uuid = string.Empty,
+                Type = layout.Type,
+                ZoneCount = layout.ZoneCount ?? LayoutDefaultSettings.DefaultZoneCount,
+                SensitivityRadius = layout.SensitivityRadius ?? LayoutDefaultSettings.DefaultSensitivityRadius,
+                ShowSpacing = isGrid && (layout.ShowSpacing ?? LayoutDefaultSettings.DefaultShowSpacing),
+                Spacing = isGrid ? layout.Spacing ?? LayoutDefaultSettings.DefaultSpacing : 0,
+            };
+        }
+
+        stored.Add(new DefaultLayouts.DefaultLayoutWrapper
+        {
+            MonitorConfiguration = monitorConfiguration,
+            Layout = layoutWrapper,
+        });
+    }
+
+    private static void ValidateCustomLayouts(List<FzCustomLayout>? layouts, IList<string> errors)
+    {
+        if (layouts == null)
+        {
+            return;
+        }
+
+        var seenUuids = new HashSet<string>(StringComparer.Ordinal);
+        for (var i = 0; i < layouts.Count; i++)
+        {
+            var entry = layouts[i];
+            var context = $"custom[{Invariant(i)}]";
+            if (entry == null)
+            {
+                errors.Add($"{context} must be an object");
+                continue;
+            }
+
+            ValidateGuid(entry.Uuid, $"{context}.uuid", errors, out var uuid);
+            if (uuid != null && !seenUuids.Add(uuid))
+            {
+                errors.Add($"{context}.uuid: layout '{uuid}' is defined more than once");
+            }
+
+            if (string.IsNullOrWhiteSpace(entry.Name))
+            {
+                errors.Add($"{context}.name is required");
+            }
+
+            var kinds = (entry.Canvas != null ? 1 : 0) + (entry.Grid != null ? 1 : 0);
+            if (kinds != 1)
+            {
+                errors.Add($"{context} must set exactly one of 'canvas' or 'grid'");
+            }
+
+            if (entry.Canvas != null)
+            {
+                ValidateCanvas(entry.Canvas, $"{context}.canvas", errors);
+            }
+
+            if (entry.Grid != null)
+            {
+                ValidateGrid(entry.Grid, $"{context}.grid", errors);
+            }
+        }
+    }
+
+    private static void ValidateCanvas(FzCanvasInfo canvas, string context, IList<string> errors)
+    {
+        if (canvas.RefWidth <= 0)
+        {
+            errors.Add($"{context}.refWidth must be greater than 0");
+        }
+
+        if (canvas.RefHeight <= 0)
+        {
+            errors.Add($"{context}.refHeight must be greater than 0");
+        }
+
+        var zones = canvas.Zones ?? [];
+        if (zones.Count == 0)
+        {
+            errors.Add($"{context}.zones must contain at least one zone");
+        }
+        else if (zones.Count > LayoutDefaultSettings.MaxZones)
+        {
+            errors.Add($"{context}.zones must not contain more than {Invariant(LayoutDefaultSettings.MaxZones)} zones");
+        }
+
+        for (var i = 0; i < zones.Count; i++)
+        {
+            var zone = zones[i];
+            var zoneContext = $"{context}.zones[{Invariant(i)}]";
+            if (zone == null)
+            {
+                errors.Add($"{zoneContext} must be an object");
+                continue;
+            }
+
+            if (zone.Width <= 0)
+            {
+                errors.Add($"{zoneContext}.width must be greater than 0");
+            }
+
+            if (zone.Height <= 0)
+            {
+                errors.Add($"{zoneContext}.height must be greater than 0");
+            }
+        }
+
+        ValidateNotNegative(canvas.SensitivityRadius, $"{context}.sensitivityRadius", errors);
+    }
+
+    private static void ValidateGrid(FzGridInfo grid, string context, IList<string> errors)
+    {
+        var dimensionsValid = true;
+        if (grid.Rows <= 0)
+        {
+            errors.Add($"{context}.rows must be greater than 0");
+            dimensionsValid = false;
+        }
+
+        if (grid.Columns <= 0)
+        {
+            errors.Add($"{context}.columns must be greater than 0");
+            dimensionsValid = false;
+        }
+
+        ValidateNotNegative(grid.Spacing, $"{context}.spacing", errors);
+        ValidateNotNegative(grid.SensitivityRadius, $"{context}.sensitivityRadius", errors);
+
+        if (!dimensionsValid)
+        {
+            return;
+        }
+
+        ValidatePercentages(grid.RowsPercentage, grid.Rows, "row", $"{context}.rowsPercentage", errors);
+        ValidatePercentages(grid.ColumnsPercentage, grid.Columns, "column", $"{context}.columnsPercentage", errors);
+
+        var cellChildMap = grid.CellChildMap ?? [];
+        var mapContext = $"{context}.cellChildMap";
+        if (cellChildMap.Count != grid.Rows)
+        {
+            errors.Add($"{mapContext} must contain {Invariant(grid.Rows)} rows");
+            return;
+        }
+
+        var maxZoneIndex = (grid.Rows * grid.Columns) - 1;
+        for (var row = 0; row < cellChildMap.Count; row++)
+        {
+            var cells = cellChildMap[row];
+            var rowContext = $"{mapContext}[{Invariant(row)}]";
+            if (cells == null || cells.Count != grid.Columns)
+            {
+                errors.Add($"{rowContext} must contain {Invariant(grid.Columns)} values");
+                continue;
+            }
+
+            for (var column = 0; column < cells.Count; column++)
+            {
+                if (cells[column] < 0 || cells[column] > maxZoneIndex)
+                {
+                    errors.Add($"{rowContext}[{Invariant(column)}]: zone index {Invariant(cells[column])} is out of range (0-{Invariant(maxZoneIndex)})");
+                }
+            }
+        }
+    }
+
+    private static void ValidatePercentages(List<int>? values, int expectedCount, string dimension, string context, IList<string> errors)
+    {
+        values ??= [];
+        if (values.Count != expectedCount)
+        {
+            errors.Add($"{context} must contain {Invariant(expectedCount)} values, one per {dimension}");
+            return;
+        }
+
+        var sum = 0;
+        for (var i = 0; i < values.Count; i++)
+        {
+            if (values[i] <= 0)
+            {
+                errors.Add($"{context}[{Invariant(i)}] must be greater than 0");
+            }
+
+            sum += values[i];
+        }
+
+        if (sum != PercentageTotal)
+        {
+            errors.Add($"{context} must sum to {Invariant(PercentageTotal)} (100.00%) but sums to {Invariant(sum)}");
+        }
+    }
+
+    private static void ValidateTemplates(List<FzTemplateLayout>? templates, IList<string> errors)
+    {
+        if (templates == null)
+        {
+            return;
+        }
+
+        var seenTypes = new HashSet<string>(StringComparer.Ordinal);
+        for (var i = 0; i < templates.Count; i++)
+        {
+            var entry = templates[i];
+            var context = $"templates[{Invariant(i)}]";
+            if (entry == null)
+            {
+                errors.Add($"{context} must be an object");
+                continue;
+            }
+
+            if (ValidateLayoutType(entry.Type, _templateTypes, $"{context}.type", errors) && !seenTypes.Add(entry.Type))
+            {
+                errors.Add($"{context}.type: template '{entry.Type}' is defined more than once");
+            }
+
+            ValidateZoneCount(entry.ZoneCount, entry.Type, $"{context}.zoneCount", errors);
+            ValidateNotNegative(entry.Spacing, $"{context}.spacing", errors);
+            ValidateNotNegative(entry.SensitivityRadius, $"{context}.sensitivityRadius", errors);
+        }
+    }
+
+    private static void ValidateHotkeys(List<FzLayoutHotkey>? hotkeys, FzLayoutsModel model, FzLayoutsModel? current, IList<string> errors, IList<string>? warnings)
+    {
+        if (hotkeys == null)
+        {
+            return;
+        }
+
+        var seenKeys = new HashSet<int>();
+        var seenLayouts = new HashSet<string>(StringComparer.Ordinal);
+        for (var i = 0; i < hotkeys.Count; i++)
+        {
+            var entry = hotkeys[i];
+            var context = $"hotkeys[{Invariant(i)}]";
+            if (entry == null)
+            {
+                errors.Add($"{context} must be an object");
+                continue;
+            }
+
+            if (entry.Key < 0 || entry.Key > 9)
+            {
+                errors.Add($"{context}.key must be between 0 and 9");
+            }
+            else if (!seenKeys.Add(entry.Key))
+            {
+                errors.Add($"{context}.key: key {Invariant(entry.Key)} is assigned more than once");
+            }
+
+            ValidateGuid(entry.LayoutId, $"{context}.layoutId", errors, out var uuid);
+            if (uuid == null)
+            {
+                continue;
+            }
+
+            if (!seenLayouts.Add(uuid))
+            {
+                errors.Add($"{context}.layoutId: layout '{uuid}' is assigned more than one key");
+            }
+
+            ValidateLayoutReference(uuid, $"{context}.layoutId", model, current, errors, warnings);
+        }
+    }
+
+    private static void ValidateDefaults(FzDefaultLayouts? defaults, FzLayoutsModel model, FzLayoutsModel? current, IList<string> errors, IList<string>? warnings)
+    {
+        if (defaults == null)
+        {
+            return;
+        }
+
+        ValidateDefaultLayout(defaults.Horizontal, $"{FzLayoutsModel.DefaultsJsonPropertyName}.{FzDefaultLayouts.HorizontalJsonPropertyName}", model, current, errors, warnings);
+        ValidateDefaultLayout(defaults.Vertical, $"{FzLayoutsModel.DefaultsJsonPropertyName}.{FzDefaultLayouts.VerticalJsonPropertyName}", model, current, errors, warnings);
+    }
+
+    private static void ValidateDefaultLayout(FzDefaultLayout? layout, string context, FzLayoutsModel model, FzLayoutsModel? current, IList<string> errors, IList<string>? warnings)
+    {
+        if (layout == null)
+        {
+            return;
+        }
+
+        if (ValidateLayoutType(layout.Type, _defaultLayoutTypes, $"{context}.type", errors))
+        {
+            if (IsCustomType(layout.Type))
+            {
+                if (string.IsNullOrWhiteSpace(layout.Uuid))
+                {
+                    errors.Add($"{context}.uuid is required when type is '{CustomLayoutType}'");
+                }
+                else
+                {
+                    ValidateGuid(layout.Uuid, $"{context}.uuid", errors, out var uuid);
+                    if (uuid != null)
+                    {
+                        ValidateLayoutReference(uuid, $"{context}.uuid", model, current, errors, warnings);
+                    }
+                }
+            }
+            else if (!string.IsNullOrEmpty(layout.Uuid))
+            {
+                errors.Add($"{context}.uuid must only be set when type is '{CustomLayoutType}'");
+            }
+        }
+
+        ValidateZoneCount(layout.ZoneCount, layout.Type, $"{context}.zoneCount", errors);
+        ValidateNotNegative(layout.Spacing, $"{context}.spacing", errors);
+        ValidateNotNegative(layout.SensitivityRadius, $"{context}.sensitivityRadius", errors);
+    }
+
+    /// <summary>
+    /// Checks that a referenced custom layout exists. When the model defines
+    /// the custom layouts itself the reference must resolve within them; when
+    /// it does not, a reference to a layout missing from the current custom
+    /// layouts is reported as a warning only, because the layout may be
+    /// provisioned by another resource or run.
+    /// </summary>
+    private static void ValidateLayoutReference(string uuid, string context, FzLayoutsModel model, FzLayoutsModel? current, IList<string> errors, IList<string>? warnings)
+    {
+        if (model.Custom != null)
+        {
+            if (!ContainsLayout(model.Custom, uuid))
+            {
+                errors.Add($"{context}: layout '{uuid}' is not defined in '{FzLayoutsModel.CustomJsonPropertyName}'");
+            }
+        }
+        else if (current?.Custom != null && !ContainsLayout(current.Custom, uuid))
+        {
+            warnings?.Add($"{context}: layout '{uuid}' does not exist in the current custom layouts");
+        }
+    }
+
+    private static bool ContainsLayout(List<FzCustomLayout> layouts, string uuid)
+    {
+        return layouts.Any(layout => layout != null && TryNormalizeGuid(layout.Uuid, out var id) && string.Equals(id, uuid, StringComparison.Ordinal));
+    }
+
+    private static void ValidateGuid(string? value, string context, IList<string> errors, out string? uuid)
+    {
+        uuid = null;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            errors.Add($"{context} is required");
+            return;
+        }
+
+        if (!TryNormalizeGuid(value, out var normalized))
+        {
+            errors.Add($"{context}: '{value}' is not a valid GUID");
+            return;
+        }
+
+        uuid = normalized;
+    }
+
+    private static bool ValidateLayoutType(string? type, string[] allowedTypes, string context, IList<string> errors)
+    {
+        if (string.IsNullOrEmpty(type))
+        {
+            errors.Add($"{context} is required");
+            return false;
+        }
+
+        if (!allowedTypes.Contains(type, StringComparer.Ordinal))
+        {
+            errors.Add($"{context}: invalid value '{type}'; allowed values are: {string.Join(", ", allowedTypes)}");
+            return false;
+        }
+
+        return true;
+    }
+
+    private static void ValidateZoneCount(int? zoneCount, string? type, string context, IList<string> errors)
+    {
+        if (zoneCount == null)
+        {
+            return;
+        }
+
+        // The engine rejects a zone count of 0 for the grid-based templates (Layout::Init)
+        if (IsGridTemplateType(type))
+        {
+            if (zoneCount <= 0)
+            {
+                errors.Add($"{context} must be greater than 0");
+            }
+        }
+        else if (zoneCount < 0)
+        {
+            errors.Add($"{context} must not be negative");
+        }
+    }
+
+    private static void ValidateNotNegative(int? value, string context, IList<string> errors)
+    {
+        if (value < 0)
+        {
+            errors.Add($"{context} must not be negative");
+        }
+    }
+
+    private static bool IsGridTemplateType(string? type)
+    {
+        return type != null && _gridTemplateTypes.Contains(type, StringComparer.Ordinal);
+    }
+
+    private static bool IsCustomType(string? type)
+    {
+        return string.Equals(type, CustomLayoutType, StringComparison.Ordinal);
+    }
+
+    private static int TemplateOrder(string? type)
+    {
+        return Array.IndexOf(_templateTypes, type ?? string.Empty);
+    }
+
+    private static string NormalizeGuidOrThrow(string? value)
+    {
+        if (!TryNormalizeGuid(value, out var normalized))
+        {
+            throw new InvalidOperationException($"'{value}' is not a valid GUID");
+        }
+
+        return normalized;
+    }
+
+    private static string Invariant(int value)
+    {
+        return value.ToString(CultureInfo.InvariantCulture);
+    }
+}

--- a/src/dsc/v3/PowerToys.DSC/Models/FancyZones/FzLayoutsModel.cs
+++ b/src/dsc/v3/PowerToys.DSC/Models/FancyZones/FzLayoutsModel.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace PowerToys.DSC.Models.FancyZones;
+
+/// <summary>
+/// Friendly, hand-authorable representation of the FancyZones layout data
+/// managed by the DSC layouts resource.
+/// </summary>
+public sealed class FzLayoutsModel
+{
+    public const string CustomJsonPropertyName = "custom";
+    public const string TemplatesJsonPropertyName = "templates";
+    public const string HotkeysJsonPropertyName = "hotkeys";
+    public const string DefaultsJsonPropertyName = "defaults";
+
+    /// <summary>
+    /// Gets or sets the custom layouts (custom-layouts.json).
+    /// </summary>
+    [JsonPropertyName(CustomJsonPropertyName)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [Description("The custom layouts (custom-layouts.json). Each layout is either a canvas layout or a grid layout.")]
+    public List<FzCustomLayout>? Custom { get; set; }
+
+    /// <summary>
+    /// Gets or sets the layout templates (layout-templates.json).
+    /// </summary>
+    [JsonPropertyName(TemplatesJsonPropertyName)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [Description("The settings of the built-in layout templates (layout-templates.json), one entry per template type.")]
+    public List<FzTemplateLayout>? Templates { get; set; }
+
+    /// <summary>
+    /// Gets or sets the quick layout hotkeys (layout-hotkeys.json).
+    /// </summary>
+    [JsonPropertyName(HotkeysJsonPropertyName)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [Description("The quick layout hotkeys (layout-hotkeys.json) that assign a custom layout to a number key.")]
+    public List<FzLayoutHotkey>? Hotkeys { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default layouts (default-layouts.json).
+    /// </summary>
+    [JsonPropertyName(DefaultsJsonPropertyName)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [Description("The default layouts (default-layouts.json) applied to new horizontal and vertical monitors.")]
+    public FzDefaultLayouts? Defaults { get; set; }
+}

--- a/src/dsc/v3/PowerToys.DSC/Models/FancyZones/FzTemplateLayout.cs
+++ b/src/dsc/v3/PowerToys.DSC/Models/FancyZones/FzTemplateLayout.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace PowerToys.DSC.Models.FancyZones;
+
+/// <summary>
+/// The settings of a built-in layout template.
+/// </summary>
+public sealed class FzTemplateLayout
+{
+    /// <summary>
+    /// Gets or sets the template type.
+    /// </summary>
+    [JsonPropertyName("type")]
+    [Required]
+    [Description("The template type: blank, focus, rows, columns, grid, or priority-grid.")]
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the number of zones.
+    /// </summary>
+    [JsonPropertyName("zoneCount")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [Description("The number of zones. Default 3.")]
+    public int? ZoneCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether space is left between zones.
+    /// </summary>
+    [JsonPropertyName("showSpacing")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [Description("Whether space is left between the zones. Default true; not applicable to the blank and focus templates.")]
+    public bool? ShowSpacing { get; set; }
+
+    /// <summary>
+    /// Gets or sets the space between zones.
+    /// </summary>
+    [JsonPropertyName("spacing")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [Description("The space between the zones, in pixels. Default 16; not applicable to the blank and focus templates.")]
+    public int? Spacing { get; set; }
+
+    /// <summary>
+    /// Gets or sets the distance from a zone edge at which highlighting starts.
+    /// </summary>
+    [JsonPropertyName("sensitivityRadius")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [Description("The distance, in pixels, from a zone edge at which the zone is highlighted while dragging. Default 20.")]
+    public int? SensitivityRadius { get; set; }
+}

--- a/src/dsc/v3/PowerToys.DSC/Models/FunctionData/LayoutsFunctionData.cs
+++ b/src/dsc/v3/PowerToys.DSC/Models/FunctionData/LayoutsFunctionData.cs
@@ -1,0 +1,366 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using FancyZonesEditorCommon.Data;
+using PowerToys.DSC.Models.FancyZones;
+using PowerToys.DSC.Models.ResourceObjects;
+
+namespace PowerToys.DSC.Models.FunctionData;
+
+/// <summary>
+/// Function data for the FancyZones layouts DSC resource. Reads and writes
+/// the FancyZones layout data files. A running FancyZones instance watches
+/// these files and reloads them when they change, so no signal is needed.
+/// </summary>
+public sealed class LayoutsFunctionData : BaseFunctionData
+{
+    public const string CustomLayoutsFileName = "custom-layouts.json";
+    public const string LayoutTemplatesFileName = "layout-templates.json";
+    public const string LayoutHotkeysFileName = "layout-hotkeys.json";
+    public const string DefaultLayoutsFileName = "default-layouts.json";
+
+    // Structural problems with the input JSON (missing or mistyped members)
+    // detected before the model is materialized.
+    private readonly IList<string> _inputErrors;
+
+    /// <summary>
+    /// Gets or sets the resolver of the folder holding the FancyZones data
+    /// files. Defaults to the FancyZones folder in the PowerToys local
+    /// application data; tests replace it with a temporary folder.
+    /// </summary>
+    public static Func<string> DataFolder { get; set; } = GetDefaultDataFolder;
+
+    /// <summary>
+    /// Gets the desired state provided as input, if any.
+    /// </summary>
+    public LayoutsResourceObject Input { get; }
+
+    /// <summary>
+    /// Gets the current state read from the layout files.
+    /// </summary>
+    public LayoutsResourceObject Output { get; }
+
+    /// <summary>
+    /// Gets the warnings collected while reading the current state and
+    /// validating the input.
+    /// </summary>
+    public IList<string> Warnings { get; } = [];
+
+    public LayoutsFunctionData(string? input = null)
+    {
+        Output = new();
+        Input = new();
+        _inputErrors = [];
+
+        if (string.IsNullOrEmpty(input))
+        {
+            return;
+        }
+
+        // Deserialization does not enforce [Required] or non-nullable
+        // annotations; check the shape of the JSON before materializing the
+        // model so that e.g. a null section cannot erase a file on Set.
+        var node = JsonNode.Parse(input);
+        _inputErrors = ValidateInputStructure(node);
+        if (_inputErrors.Count == 0)
+        {
+            Input = node.Deserialize<LayoutsResourceObject>() ?? new();
+        }
+    }
+
+    /// <summary>
+    /// Validates the input layouts. Call after <see cref="GetState"/> so that
+    /// references to existing custom layouts can be checked.
+    /// </summary>
+    /// <returns>The list of validation errors; empty when the input is valid.</returns>
+    public IList<string> ValidateInput()
+    {
+        return _inputErrors.Count > 0 ? _inputErrors : FzLayoutsConverter.Validate(Input.Layouts, Output.Layouts, Warnings);
+    }
+
+    /// <summary>
+    /// Reads the current layout files into the output state. A missing file
+    /// is an empty section; a malformed file is reported as a warning and
+    /// treated as empty, mirroring how the FancyZones engine loads it.
+    /// </summary>
+    public void GetState()
+    {
+        var layouts = Output.Layouts;
+        layouts.Custom = FzLayoutsConverter.FromCustomLayouts(ReadFile(new CustomLayouts(), CustomLayoutsFileName), Warnings);
+        layouts.Templates = FzLayoutsConverter.FromLayoutTemplates(ReadFile(new LayoutTemplates(), LayoutTemplatesFileName), Warnings);
+        layouts.Hotkeys = FzLayoutsConverter.FromLayoutHotkeys(ReadFile(new LayoutHotkeys(), LayoutHotkeysFileName), Warnings);
+        layouts.Defaults = FzLayoutsConverter.FromDefaultLayouts(ReadFile(new DefaultLayouts(), DefaultLayoutsFileName), Warnings);
+    }
+
+    /// <summary>
+    /// Writes the sections of the desired state that differ from the current
+    /// state to their layout files. Each write replaces the whole file.
+    /// </summary>
+    public void SetState()
+    {
+        var desired = Input.Layouts;
+        var sections = GetDifferingSections();
+
+        if (sections.Contains(FzLayoutsModel.CustomJsonPropertyName))
+        {
+            WriteFile(new CustomLayouts(), CustomLayoutsFileName, FzLayoutsConverter.ToCustomLayouts(desired.Custom!));
+        }
+
+        if (sections.Contains(FzLayoutsModel.TemplatesJsonPropertyName))
+        {
+            WriteFile(new LayoutTemplates(), LayoutTemplatesFileName, FzLayoutsConverter.ToLayoutTemplates(desired.Templates!));
+        }
+
+        if (sections.Contains(FzLayoutsModel.HotkeysJsonPropertyName))
+        {
+            WriteFile(new LayoutHotkeys(), LayoutHotkeysFileName, FzLayoutsConverter.ToLayoutHotkeys(desired.Hotkeys!));
+        }
+
+        if (sections.Contains(FzLayoutsModel.DefaultsJsonPropertyName))
+        {
+            WriteFile(new DefaultLayouts(), DefaultLayoutsFileName, FzLayoutsConverter.ToDefaultLayouts(desired.Defaults!, KnownCustomLayouts));
+        }
+    }
+
+    /// <summary>
+    /// Tests whether every section of the desired state matches the current
+    /// state. Sections that are not part of the desired state are not compared.
+    /// </summary>
+    /// <returns>True if the states match; otherwise false.</returns>
+    public bool TestState()
+    {
+        return GetDifferingSections().Count == 0;
+    }
+
+    /// <summary>
+    /// Gets the difference between the desired and the current state.
+    /// </summary>
+    /// <returns>A JSON array with the differing property names.</returns>
+    public JsonArray GetDiffJson()
+    {
+        var diff = new JsonArray();
+        if (!TestState())
+        {
+            diff.Add(LayoutsResourceObject.LayoutsJsonPropertyName);
+        }
+
+        return diff;
+    }
+
+    /// <summary>
+    /// Gets the state after the desired state has been applied: the current
+    /// state with every section of the desired state replaced by its
+    /// canonical form.
+    /// </summary>
+    /// <returns>The merged canonical state.</returns>
+    public FzLayoutsModel GetDesiredState()
+    {
+        var desired = FzLayoutsConverter.Canonicalize(Input.Layouts, KnownCustomLayouts);
+        var current = Output.Layouts;
+        return new FzLayoutsModel
+        {
+            Custom = desired.Custom ?? current.Custom,
+            Templates = desired.Templates ?? current.Templates,
+            Hotkeys = desired.Hotkeys ?? current.Hotkeys,
+            Defaults = desired.Defaults ?? current.Defaults,
+        };
+    }
+
+    /// <summary>
+    /// Gets the schema for the layouts resource object.
+    /// </summary>
+    /// <returns>The JSON schema string.</returns>
+    public string Schema()
+    {
+        return GenerateSchema<LayoutsResourceObject>();
+    }
+
+    /// <summary>
+    /// Gets the custom layouts a default layout may reference: the desired
+    /// custom layouts when they are part of the input, otherwise the current
+    /// ones.
+    /// </summary>
+    private IReadOnlyList<FzCustomLayout> KnownCustomLayouts => Input.Layouts.Custom ?? Output.Layouts.Custom ?? [];
+
+    private static string GetDefaultDataFolder()
+    {
+        return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Microsoft", "PowerToys", "FancyZones");
+    }
+
+    private static void WriteFile<T>(EditorData<T> data, string fileName, T value)
+    {
+        var folder = DataFolder();
+        Directory.CreateDirectory(folder);
+        File.WriteAllText(Path.Combine(folder, fileName), data.Serialize(value));
+    }
+
+    private static bool AreEqual<T>(T expected, T actual)
+    {
+        return JsonNode.DeepEquals(JsonSerializer.SerializeToNode(expected), JsonSerializer.SerializeToNode(actual));
+    }
+
+    private static List<FzCustomLayout> SortByUuid(List<FzCustomLayout> layouts)
+    {
+        return layouts.OrderBy(layout => layout.Uuid, StringComparer.Ordinal).ToList();
+    }
+
+    /// <summary>
+    /// Checks that the input JSON has the required shape: a "layouts" object
+    /// whose optional "custom", "templates" and "hotkeys" members are arrays
+    /// of objects and whose optional "defaults" member is an object with
+    /// optional "horizontal" and "vertical" objects. Unknown members are
+    /// rejected so that a misspelled section cannot be silently ignored. Type
+    /// mismatches inside the entries are left to the deserializer.
+    /// </summary>
+    /// <param name="node">The parsed input JSON.</param>
+    /// <returns>The list of structural errors; empty when the shape is valid.</returns>
+    private static IList<string> ValidateInputStructure(JsonNode? node)
+    {
+        var errors = new List<string>();
+        if (node is not JsonObject root)
+        {
+            errors.Add("input must be a JSON object");
+            return errors;
+        }
+
+        if (!root.TryGetPropertyValue(LayoutsResourceObject.LayoutsJsonPropertyName, out var layoutsNode) || layoutsNode == null)
+        {
+            errors.Add($"'{LayoutsResourceObject.LayoutsJsonPropertyName}' is required");
+            return errors;
+        }
+
+        if (layoutsNode is not JsonObject layouts)
+        {
+            errors.Add($"'{LayoutsResourceObject.LayoutsJsonPropertyName}' must be an object");
+            return errors;
+        }
+
+        foreach (var (name, value) in layouts)
+        {
+            var context = $"{LayoutsResourceObject.LayoutsJsonPropertyName}.{name}";
+            switch (name)
+            {
+                case FzLayoutsModel.CustomJsonPropertyName:
+                case FzLayoutsModel.TemplatesJsonPropertyName:
+                case FzLayoutsModel.HotkeysJsonPropertyName:
+                    ValidateArrayOfObjects(value, context, errors);
+                    break;
+                case FzLayoutsModel.DefaultsJsonPropertyName:
+                    ValidateDefaultsStructure(value, context, errors);
+                    break;
+                default:
+                    errors.Add($"'{context}' is not a valid property; allowed properties are: {FzLayoutsModel.CustomJsonPropertyName}, {FzLayoutsModel.TemplatesJsonPropertyName}, {FzLayoutsModel.HotkeysJsonPropertyName}, {FzLayoutsModel.DefaultsJsonPropertyName}");
+                    break;
+            }
+        }
+
+        return errors;
+    }
+
+    private static void ValidateArrayOfObjects(JsonNode? value, string context, IList<string> errors)
+    {
+        if (value is not JsonArray array)
+        {
+            errors.Add($"'{context}' must be an array");
+            return;
+        }
+
+        for (var i = 0; i < array.Count; i++)
+        {
+            if (array[i] is not JsonObject)
+            {
+                errors.Add($"'{context}[{i.ToString(CultureInfo.InvariantCulture)}]' must be an object");
+            }
+        }
+    }
+
+    private static void ValidateDefaultsStructure(JsonNode? value, string context, IList<string> errors)
+    {
+        if (value is not JsonObject defaults)
+        {
+            errors.Add($"'{context}' must be an object");
+            return;
+        }
+
+        foreach (var (name, layout) in defaults)
+        {
+            var layoutContext = $"{context}.{name}";
+            if (name is not (FzDefaultLayouts.HorizontalJsonPropertyName or FzDefaultLayouts.VerticalJsonPropertyName))
+            {
+                errors.Add($"'{layoutContext}' is not a valid property; allowed properties are: {FzDefaultLayouts.HorizontalJsonPropertyName}, {FzDefaultLayouts.VerticalJsonPropertyName}");
+                continue;
+            }
+
+            if (layout is not JsonObject)
+            {
+                errors.Add($"'{layoutContext}' must be an object");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads a layout file. A missing file yields the default (empty) wrapper;
+    /// a malformed file is reported as a warning and also yields the default.
+    /// </summary>
+    private T ReadFile<T>(EditorData<T> data, string fileName)
+        where T : struct
+    {
+        var path = Path.Combine(DataFolder(), fileName);
+        if (!File.Exists(path))
+        {
+            return default;
+        }
+
+        try
+        {
+            return data.Read(path);
+        }
+        catch (JsonException ex)
+        {
+            Warnings.Add($"{fileName} is malformed and is treated as empty: {ex.Message}");
+            return default;
+        }
+    }
+
+    /// <summary>
+    /// Gets the names of the sections of the desired state whose canonical
+    /// form differs from the current state. Custom layouts are compared
+    /// regardless of their order, as the order only affects the editor list.
+    /// </summary>
+    private List<string> GetDifferingSections()
+    {
+        var desired = FzLayoutsConverter.Canonicalize(Input.Layouts, KnownCustomLayouts);
+        var current = Output.Layouts;
+        var sections = new List<string>();
+
+        if (desired.Custom != null && !AreEqual(SortByUuid(desired.Custom), SortByUuid(current.Custom ?? [])))
+        {
+            sections.Add(FzLayoutsModel.CustomJsonPropertyName);
+        }
+
+        if (desired.Templates != null && !AreEqual(desired.Templates, current.Templates ?? []))
+        {
+            sections.Add(FzLayoutsModel.TemplatesJsonPropertyName);
+        }
+
+        if (desired.Hotkeys != null && !AreEqual(desired.Hotkeys, current.Hotkeys ?? []))
+        {
+            sections.Add(FzLayoutsModel.HotkeysJsonPropertyName);
+        }
+
+        if (desired.Defaults != null && !AreEqual(desired.Defaults, current.Defaults ?? new()))
+        {
+            sections.Add(FzLayoutsModel.DefaultsJsonPropertyName);
+        }
+
+        return sections;
+    }
+}

--- a/src/dsc/v3/PowerToys.DSC/Models/ResourceObjects/LayoutsResourceObject.cs
+++ b/src/dsc/v3/PowerToys.DSC/Models/ResourceObjects/LayoutsResourceObject.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+using PowerToys.DSC.Models.FancyZones;
+
+namespace PowerToys.DSC.Models.ResourceObjects;
+
+/// <summary>
+/// Represents the resource object for the FancyZones layouts.
+/// </summary>
+public sealed class LayoutsResourceObject : BaseResourceObject
+{
+    public const string LayoutsJsonPropertyName = "layouts";
+
+    /// <summary>
+    /// Gets or sets the FancyZones layouts.
+    /// </summary>
+    [JsonPropertyName(LayoutsJsonPropertyName)]
+    [Required]
+    [Description("The FancyZones layouts: custom layouts, layout templates, layout hotkeys and default layouts. Each section is optional; a section that is present replaces the corresponding layout file, a section that is omitted is left unchanged.")]
+    public FzLayoutsModel Layouts { get; set; } = new();
+}

--- a/src/dsc/v3/PowerToys.DSC/PowerToys.DSC.csproj
+++ b/src/dsc/v3/PowerToys.DSC/PowerToys.DSC.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\settings-ui\Settings.UI.Library\Settings.UI.Library.csproj" />
+    <ProjectReference Include="..\..\..\modules\fancyzones\FancyZonesEditorCommon\FancyZonesEditorCommon.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -51,5 +52,8 @@
 
     <Exec Command="&quot;$(TargetDir)$(AssemblyName).exe&quot; manifest --resource profile --outputDir &quot;$(TargetDir)DSCModules&quot;" Condition="'$(SelfContained)' == 'true'" />
     <Exec Command="dotnet &quot;$(TargetPath)&quot; manifest --resource profile --outputDir &quot;$(TargetDir)DSCModules&quot;" Condition="'$(SelfContained)' != 'true'" />
+
+    <Exec Command="&quot;$(TargetDir)$(AssemblyName).exe&quot; manifest --resource layouts --outputDir &quot;$(TargetDir)DSCModules&quot;" Condition="'$(SelfContained)' == 'true'" />
+    <Exec Command="dotnet &quot;$(TargetPath)&quot; manifest --resource layouts --outputDir &quot;$(TargetDir)DSCModules&quot;" Condition="'$(SelfContained)' != 'true'" />
   </Target>
 </Project>

--- a/src/dsc/v3/PowerToys.DSC/Properties/Resources.Designer.cs
+++ b/src/dsc/v3/PowerToys.DSC/Properties/Resources.Designer.cs
@@ -124,6 +124,15 @@ namespace PowerToys.DSC.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid FancyZones layouts: {0}.
+        /// </summary>
+        internal static string InvalidLayoutsError {
+            get {
+                return ResourceManager.GetString("InvalidLayoutsError", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Invalid output directory: {0}.
         /// </summary>
         internal static string InvalidOutputDirectoryError {
@@ -150,6 +159,15 @@ namespace PowerToys.DSC.Properties {
             }
         }
         
+        /// <summary>
+        ///   Looks up a localized string similar to FancyZones layouts: {0}.
+        /// </summary>
+        internal static string LayoutsWarning {
+            get {
+                return ResourceManager.GetString("LayoutsWarning", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Get the manifest of the dsc resource.
         /// </summary>

--- a/src/dsc/v3/PowerToys.DSC/Properties/Resources.resx
+++ b/src/dsc/v3/PowerToys.DSC/Properties/Resources.resx
@@ -192,4 +192,12 @@
     <value>Keyboard Manager profile: {0}</value>
     <comment>{Locked="Keyboard Manager","{0}"}</comment>
   </data>
+  <data name="InvalidLayoutsError" xml:space="preserve">
+    <value>Invalid FancyZones layouts: {0}</value>
+    <comment>{Locked="FancyZones","{0}"}</comment>
+  </data>
+  <data name="LayoutsWarning" xml:space="preserve">
+    <value>FancyZones layouts: {0}</value>
+    <comment>{Locked="FancyZones","{0}"}</comment>
+  </data>
 </root>

--- a/tools/build/generate-dsc-manifests.ps1
+++ b/tools/build/generate-dsc-manifests.ps1
@@ -105,7 +105,7 @@ Write-Host "DSC manifests will be generated to: '$dscOutputDir'"
 Write-Host "Cleaning previously generated DSC manifest files from '$dscOutputDir'."
 Get-ChildItem -Path $dscOutputDir -Filter 'microsoft.powertoys.*.dsc.resource.json' -ErrorAction SilentlyContinue | Remove-Item -Force
 
-foreach ($resource in @('settings', 'profile')) {
+foreach ($resource in @('settings', 'profile', 'layouts')) {
     $arguments = @('manifest', '--resource', $resource, '--outputDir', $dscOutputDir)
     Write-Host "Invoking DSC manifest generator: '$exePath' $($arguments -join ' ')"
     & $exePath @arguments


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Adds a new DSC v3 resource, `layouts` (`Microsoft.PowerToys/FancyZonesLayouts`), to `PowerToys.DSC.exe` that makes FancyZones layouts deployable via `dsc.exe` and `winget configure`. Until now, DSC only controlled the FancyZones settings (activation, appearance, behavior) — the layouts themselves could only be created through the FancyZones editor.

The resource manages the four portable layout files FancyZones keeps next to its settings: custom layouts, layout templates, quick layout hotkeys and default layouts. Layouts are authored with friendly, camel-cased property names, and layout identifiers may be given with or without braces:

```yaml
resources:
  - name: Deploy FancyZones layouts
    type: Microsoft.PowerToys/FancyZonesLayouts
    properties:
      layouts:
        custom:
          - uuid: "{5C4F1A20-9B3E-4C7D-8E2F-1A2B3C4D5E6F}"
            name: Two columns 70/30
            grid:
              rows: 1
              columns: 2
              rowsPercentage: [10000]
              columnsPercentage: [7000, 3000]
              cellChildMap: [[0, 1]]
          - uuid: "{8F0B6D3E-2C41-4A5B-9D7E-0F1A2B3C4D5E}"
            name: Reference window
            canvas:
              refWidth: 1920
              refHeight: 1080
              zones:
                - { x: 0, y: 0, width: 1280, height: 1080 }
                - { x: 1280, y: 0, width: 640, height: 1080 }
        templates:
          - { type: priority-grid, zoneCount: 3 }
        hotkeys:
          - { key: 1, layoutId: "{5C4F1A20-9B3E-4C7D-8E2F-1A2B3C4D5E6F}" }
        defaults:
          horizontal: { type: custom, uuid: "{5C4F1A20-9B3E-4C7D-8E2F-1A2B3C4D5E6F}" }
          vertical: { type: rows, zoneCount: 2 }
```

The resource supports `get`/`set`/`test`/`export`/`schema`/`manifest`. Every section is optional: a section that is present replaces the whole layout file it maps to (declarative desired state), a section that is omitted is left unmanaged, so a configuration can, for example, assign hotkeys without touching the layouts created in the editor. Files are written through the same serialization context the FancyZones editor uses, so DSC-written files are indistinguishable from editor-written ones, and a running FancyZones instance picks them up immediately through its existing file watchers (no restart required).
## PR Checklist

- [x] Closes: #50544 
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass (47 new tests in `PowerToys.DSC.UnitTests`: command tests, end-to-end get/set/test/export tests against a temporary data folder, and converter unit tests; the full DSC suite passes with 179 tests)
- [x] **Localization:** All end-user-facing strings can be localized (new strings `InvalidLayoutsError` and `LayoutsWarning` added to `PowerToys.DSC` `Resources.resx`; the generated DSC manifest description is deliberately not localized, matching the existing `settings` and `profile` resources)
- [x] **Dev docs:** Added/updated (`doc/dsc/layouts-resource.md`, `doc/dsc/overview.md`, `doc/dsc/modules/FancyZones.md`, `doc/devdocs/core/settings/dsc-configure.md`)
- [ ] **New binaries:** Added on the required places — *n/a: no new binaries; the resource lives in the existing `PowerToys.DSC.exe`. `PowerToys.DSC.csproj` gains a project reference to `FancyZonesEditorCommon`, whose `PowerToys.FancyZonesEditorCommon.dll` already ships in the installation root as a dependency of the FancyZones CLI. The additional generated manifest (`microsoft.powertoys.FancyZones.layouts.dsc.resource.json`) is picked up automatically by the installer's unfiltered `DSCModules\` component glob (`generateAllFileComponents.ps1`)*
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries — *n/a*
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder — *n/a*
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects — *n/a: tests were added to the existing `PowerToys.DSC.UnitTests` project. The manifest generation scripts (`.pipelines/generateDscManifests.ps1`, `tools/build/generate-dsc-manifests.ps1`) and the post-build target in `PowerToys.DSC.csproj` now also generate the `layouts` manifest*
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml) — *n/a*
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

